### PR TITLE
Initial LSP server implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.3', '8.4']
+    name: PHP ${{ matrix.php }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run checks
+        run: composer check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.3', '8.4', '8.5']
     name: PHP ${{ matrix.php }}
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.lock
+/.phpunit.cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eric Stern
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# php-lsp
+
+A minimal Language Server Protocol (LSP) server for PHP.
+
+## Requirements
+
+- PHP 8.3+
+
+## Installation
+
+```bash
+composer require firehed/php-lsp
+```
+
+## Usage
+
+The server communicates via stdio:
+
+```bash
+./vendor/bin/php-lsp
+```
+
+## Current Capabilities
+
+This is an MVP implementation supporting only the basic LSP lifecycle:
+
+- `initialize` - Returns server capabilities and info
+- `initialized` - Notification acknowledgment
+- `shutdown` - Prepares server for exit
+- `exit` - Terminates the server
+
+## Development
+
+```bash
+# Install dependencies
+composer install
+
+# Run tests and static analysis
+composer check
+
+# Run just tests
+composer test
+
+# Run just static analysis
+composer analyze
+```
+
+## Editor Integration
+
+See the [docs](docs/) directory for editor-specific setup guides.
+
+## License
+
+MIT

--- a/bin/php-lsp
+++ b/bin/php-lsp
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Firehed\PhpLsp\Server;
+use Firehed\PhpLsp\ServerInfo;
+use Firehed\PhpLsp\Transport\StdioTransport;
+
+$serverInfo = new ServerInfo('php-lsp', '0.1.0');
+$transport = new StdioTransport();
+$server = new Server($transport, $serverInfo);
+
+exit($server->run());

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,8 @@
         "amphp/byte-stream": "^2.0"
     },
     "require-dev": {
-        "amphp/phpunit-util": "^3.0",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,46 @@
+{
+    "name": "firehed/php-lsp",
+    "description": "A minimal, performant Language Server Protocol server for PHP",
+    "type": "project",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Eric Stern",
+            "email": "eric@ericstern.com"
+        }
+    ],
+    "require": {
+        "php": "^8.3",
+        "amphp/amp": "^3.0",
+        "amphp/byte-stream": "^2.0"
+    },
+    "require-dev": {
+        "amphp/phpunit-util": "^3.0",
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^9.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "Firehed\\PhpLsp\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Firehed\\PhpLsp\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "analyze": "phpstan analyze",
+        "check": [
+            "@analyze",
+            "@test"
+        ]
+    },
+    "bin": [
+        "bin/php-lsp"
+    ],
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/docs/vim-ale.md
+++ b/docs/vim-ale.md
@@ -1,0 +1,36 @@
+# Vim + ALE Integration
+
+This guide covers integrating php-lsp with [ALE](https://github.com/dense-analysis/ale) in Vim/Neovim.
+
+## Setup
+
+Add the following to your `.vimrc` or `init.vim`:
+
+```vim
+" Register php-lsp as a linter for PHP files
+let g:ale_linters = {
+\   'php': ['php-lsp'],
+\}
+
+" Set the executable path
+let g:ale_php_php_lsp_executable = '/path/to/vendor/bin/php-lsp'
+```
+
+## Custom ALE Linter Definition
+
+If ALE doesn't recognize `php-lsp` as a built-in linter, you may need to define it manually:
+
+```vim
+call ale#linter#Define('php', {
+\   'name': 'php-lsp',
+\   'lsp': 'stdio',
+\   'executable': '/path/to/vendor/bin/php-lsp',
+\   'project_root': function('ale_linters#php#langserver#GetProjectRoot'),
+\})
+```
+
+## Verifying the Connection
+
+1. Open a PHP file
+2. Run `:ALEInfo` to see the active linters and any error messages
+3. Check `:messages` for LSP communication logs

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: max
+    paths:
+        - src
+        - tests

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResultFile=".phpunit.cache/test-results">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,15 +3,15 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheResultFile=".phpunit.cache/test-results">
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory>src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/Handler/HandlerInterface.php
+++ b/src/Handler/HandlerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+use Firehed\PhpLsp\Protocol\Message;
+
+interface HandlerInterface
+{
+    public function supports(string $method): bool;
+
+    public function handle(Message $message): mixed;
+}

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\ServerInfo;
+
+final class LifecycleHandler implements HandlerInterface
+{
+    private const array METHODS = [
+        'initialize',
+        'initialized',
+        'shutdown',
+        'exit',
+    ];
+
+    private bool $shutdownRequested = false;
+    private ?int $exitCode = null;
+
+    public function __construct(
+        private readonly ServerInfo $serverInfo,
+    ) {
+    }
+
+    public function supports(string $method): bool
+    {
+        return in_array($method, self::METHODS, true);
+    }
+
+    public function handle(Message $message): mixed
+    {
+        return match ($message->method) {
+            'initialize' => $this->handleInitialize(),
+            'initialized' => null,
+            'shutdown' => $this->handleShutdown(),
+            'exit' => $this->handleExit(),
+            default => null,
+        };
+    }
+
+    public function isShutdownRequested(): bool
+    {
+        return $this->shutdownRequested;
+    }
+
+    public function getExitCode(): ?int
+    {
+        return $this->exitCode;
+    }
+
+    /**
+     * @return array{capabilities: array<string, mixed>, serverInfo: array{name: string, version: string}}
+     */
+    private function handleInitialize(): array
+    {
+        return [
+            'capabilities' => [],
+            'serverInfo' => $this->serverInfo->toArray(),
+        ];
+    }
+
+    private function handleShutdown(): null
+    {
+        $this->shutdownRequested = true;
+        return null;
+    }
+
+    private function handleExit(): null
+    {
+        $this->exitCode = $this->shutdownRequested ? 0 : 1;
+        return null;
+    }
+}

--- a/src/Protocol/Message.php
+++ b/src/Protocol/Message.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+abstract readonly class Message
+{
+    /**
+     * @param array<array-key, mixed>|null $params
+     */
+    public function __construct(
+        public string $method,
+        public ?array $params,
+    ) {
+    }
+
+    abstract public function isNotification(): bool;
+}

--- a/src/Protocol/NotificationMessage.php
+++ b/src/Protocol/NotificationMessage.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+final readonly class NotificationMessage extends Message
+{
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        assert(is_string($data['method']));
+        $params = $data['params'] ?? null;
+        assert($params === null || is_array($params));
+
+        return new self(
+            method: $data['method'],
+            params: $params,
+        );
+    }
+
+    public function isNotification(): bool
+    {
+        return true;
+    }
+}

--- a/src/Protocol/RequestMessage.php
+++ b/src/Protocol/RequestMessage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+final readonly class RequestMessage extends Message
+{
+    /**
+     * @param array<array-key, mixed>|null $params
+     */
+    public function __construct(
+        public int|string $id,
+        string $method,
+        ?array $params,
+    ) {
+        parent::__construct($method, $params);
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        assert(is_int($data['id']) || is_string($data['id']));
+        assert(is_string($data['method']));
+        $params = $data['params'] ?? null;
+        assert($params === null || is_array($params));
+
+        return new self(
+            id: $data['id'],
+            method: $data['method'],
+            params: $params,
+        );
+    }
+
+    public function isNotification(): bool
+    {
+        return false;
+    }
+}

--- a/src/Protocol/ResponseError.php
+++ b/src/Protocol/ResponseError.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+use JsonSerializable;
+
+final readonly class ResponseError implements JsonSerializable
+{
+    public function __construct(
+        public int $code,
+        public string $message,
+        public mixed $data = null,
+    ) {
+    }
+
+    public static function parseError(?string $data = null): self
+    {
+        return new self(-32700, 'Parse error', $data);
+    }
+
+    public static function invalidRequest(?string $data = null): self
+    {
+        return new self(-32600, 'Invalid Request', $data);
+    }
+
+    public static function methodNotFound(?string $method = null): self
+    {
+        $message = $method !== null
+            ? "Method not found: $method"
+            : 'Method not found';
+        return new self(-32601, $message);
+    }
+
+    public static function invalidParams(?string $data = null): self
+    {
+        return new self(-32602, 'Invalid params', $data);
+    }
+
+    public static function internalError(?string $data = null): self
+    {
+        return new self(-32603, 'Internal error', $data);
+    }
+
+    /**
+     * @return array{code: int, message: string, data?: mixed}
+     */
+    public function jsonSerialize(): array
+    {
+        $result = [
+            'code' => $this->code,
+            'message' => $this->message,
+        ];
+        if ($this->data !== null) {
+            $result['data'] = $this->data;
+        }
+        return $result;
+    }
+}

--- a/src/Protocol/ResponseMessage.php
+++ b/src/Protocol/ResponseMessage.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+use JsonSerializable;
+
+final readonly class ResponseMessage implements JsonSerializable
+{
+    private function __construct(
+        private int|string|null $id,
+        private mixed $result,
+        private ?ResponseError $error,
+    ) {
+    }
+
+    public static function success(int|string $id, mixed $result): self
+    {
+        return new self($id, $result, null);
+    }
+
+    public static function error(int|string|null $id, ResponseError $error): self
+    {
+        return new self($id, null, $error);
+    }
+
+    /**
+     * @return array{jsonrpc: string, id: int|string|null, result?: mixed, error?: ResponseError}
+     */
+    public function jsonSerialize(): array
+    {
+        $response = [
+            'jsonrpc' => '2.0',
+            'id' => $this->id,
+        ];
+
+        if ($this->error !== null) {
+            $response['error'] = $this->error;
+        } else {
+            $response['result'] = $this->result;
+        }
+
+        return $response;
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp;
+
+use Firehed\PhpLsp\Handler\HandlerInterface;
+use Firehed\PhpLsp\Handler\LifecycleHandler;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Protocol\ResponseError;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+use Firehed\PhpLsp\Transport\TransportInterface;
+
+final class Server
+{
+    private LifecycleHandler $lifecycleHandler;
+
+    /** @var list<HandlerInterface> */
+    private array $handlers = [];
+
+    public function __construct(
+        private TransportInterface $transport,
+        ServerInfo $serverInfo,
+    ) {
+        $this->lifecycleHandler = new LifecycleHandler($serverInfo);
+        $this->handlers[] = $this->lifecycleHandler;
+    }
+
+    public function run(): int
+    {
+        while (($message = $this->transport->read()) !== null) {
+            $result = null;
+            $error = null;
+
+            $handler = $this->findHandler($message->method);
+
+            if ($handler !== null) {
+                $result = $handler->handle($message);
+            } elseif ($message instanceof RequestMessage) {
+                $error = ResponseError::methodNotFound($message->method);
+            }
+
+            // Send response for requests (not notifications)
+            if ($message instanceof RequestMessage) {
+                if ($error !== null) {
+                    $response = ResponseMessage::error($message->id, $error);
+                } else {
+                    $response = ResponseMessage::success($message->id, $result);
+                }
+                $this->transport->write($response);
+            }
+
+            // Check for exit
+            $exitCode = $this->lifecycleHandler->getExitCode();
+            if ($exitCode !== null) {
+                $this->transport->close();
+                return $exitCode;
+            }
+        }
+
+        $this->transport->close();
+        return 1;
+    }
+
+    private function findHandler(string $method): ?HandlerInterface
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler->supports($method)) {
+                return $handler;
+            }
+        }
+        return null;
+    }
+}

--- a/src/ServerInfo.php
+++ b/src/ServerInfo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp;
+
+final readonly class ServerInfo
+{
+    public function __construct(
+        public string $name,
+        public string $version,
+    ) {
+    }
+
+    /**
+     * @return array{name: string, version: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'version' => $this->version,
+        ];
+    }
+}

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Transport;
+
+use Amp\ByteStream\ReadableStream;
+use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\NotificationMessage;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+
+final class MessageReader
+{
+    private string $buffer = '';
+
+    public function __construct(
+        private ReadableStream $stream,
+    ) {
+    }
+
+    public function read(): ?Message
+    {
+        $contentLength = $this->readHeaders();
+        if ($contentLength === null) {
+            return null;
+        }
+
+        $body = $this->readBody($contentLength);
+        if ($body === null) {
+            return null;
+        }
+
+        $data = json_decode($body, associative: true, flags: JSON_THROW_ON_ERROR);
+        assert(is_array($data));
+
+        if (array_key_exists('id', $data)) {
+            return RequestMessage::fromArray($data);
+        }
+
+        return NotificationMessage::fromArray($data);
+    }
+
+    private function readHeaders(): ?int
+    {
+        $contentLength = null;
+
+        while (true) {
+            $headerEnd = strpos($this->buffer, "\r\n\r\n");
+            if ($headerEnd !== false) {
+                $headerSection = substr($this->buffer, 0, $headerEnd);
+                $this->buffer = substr($this->buffer, $headerEnd + 4);
+
+                foreach (explode("\r\n", $headerSection) as $header) {
+                    if (str_starts_with(strtolower($header), 'content-length:')) {
+                        $contentLength = (int) trim(substr($header, 15));
+                    }
+                }
+
+                return $contentLength;
+            }
+
+            $chunk = $this->stream->read();
+            if ($chunk === null) {
+                return null;
+            }
+            $this->buffer .= $chunk;
+        }
+    }
+
+    private function readBody(int $length): ?string
+    {
+        while (strlen($this->buffer) < $length) {
+            $chunk = $this->stream->read();
+            if ($chunk === null) {
+                return null;
+            }
+            $this->buffer .= $chunk;
+        }
+
+        $body = substr($this->buffer, 0, $length);
+        $this->buffer = substr($this->buffer, $length);
+
+        return $body;
+    }
+}

--- a/src/Transport/MessageWriter.php
+++ b/src/Transport/MessageWriter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Transport;
+
+use Amp\ByteStream\WritableStream;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+
+final class MessageWriter
+{
+    public function __construct(
+        private WritableStream $stream,
+    ) {
+    }
+
+    public function write(ResponseMessage $response): void
+    {
+        $json = json_encode($response, JSON_THROW_ON_ERROR);
+        $header = "Content-Length: " . strlen($json) . "\r\n\r\n";
+        $this->stream->write($header . $json);
+    }
+}

--- a/src/Transport/StdioTransport.php
+++ b/src/Transport/StdioTransport.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Transport;
+
+use Amp\ByteStream\ReadableResourceStream;
+use Amp\ByteStream\WritableResourceStream;
+use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+
+use const STDIN;
+use const STDOUT;
+
+final class StdioTransport implements TransportInterface
+{
+    private MessageReader $reader;
+    private MessageWriter $writer;
+    private ReadableResourceStream $stdin;
+    private WritableResourceStream $stdout;
+
+    public function __construct()
+    {
+        $this->stdin = new ReadableResourceStream(STDIN);
+        $this->stdout = new WritableResourceStream(STDOUT);
+        $this->reader = new MessageReader($this->stdin);
+        $this->writer = new MessageWriter($this->stdout);
+    }
+
+    public function read(): ?Message
+    {
+        return $this->reader->read();
+    }
+
+    public function write(ResponseMessage $response): void
+    {
+        $this->writer->write($response);
+    }
+
+    public function close(): void
+    {
+        $this->stdin->close();
+        $this->stdout->close();
+    }
+}

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Transport;
+
+use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+
+interface TransportInterface
+{
+    public function read(): ?Message;
+
+    public function write(ResponseMessage $response): void;
+
+    public function close(): void;
+}

--- a/tests/Handler/LifecycleHandlerTest.php
+++ b/tests/Handler/LifecycleHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Handler;
+
+use Firehed\PhpLsp\Handler\LifecycleHandler;
+use Firehed\PhpLsp\Protocol\NotificationMessage;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\ServerInfo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LifecycleHandler::class)]
+#[CoversClass(ServerInfo::class)]
+class LifecycleHandlerTest extends TestCase
+{
+    public function testSupportsLifecycleMethods(): void
+    {
+        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+
+        self::assertTrue($handler->supports('initialize'));
+        self::assertTrue($handler->supports('initialized'));
+        self::assertTrue($handler->supports('shutdown'));
+        self::assertTrue($handler->supports('exit'));
+        self::assertFalse($handler->supports('textDocument/hover'));
+    }
+
+    public function testInitializeReturnsCapabilities(): void
+    {
+        $handler = new LifecycleHandler(new ServerInfo('php-lsp', '0.1.0'));
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => ['processId' => 1234, 'capabilities' => []],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('capabilities', $result);
+        self::assertArrayHasKey('serverInfo', $result);
+        self::assertIsArray($result['serverInfo']);
+        self::assertSame('php-lsp', $result['serverInfo']['name']);
+        self::assertSame('0.1.0', $result['serverInfo']['version']);
+    }
+
+    public function testInitializedReturnsNull(): void
+    {
+        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'initialized',
+            'params' => [],
+        ]);
+
+        $result = $handler->handle($notification);
+
+        self::assertNull($result);
+    }
+
+    public function testShutdownSetsFlag(): void
+    {
+        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+
+        self::assertFalse($handler->isShutdownRequested());
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'method' => 'shutdown',
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertNull($result);
+        self::assertTrue($handler->isShutdownRequested());
+    }
+
+    public function testExitCodeAfterShutdown(): void
+    {
+        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+
+        // Shutdown first
+        $handler->handle(RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'shutdown',
+        ]));
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'exit',
+        ]);
+
+        $result = $handler->handle($notification);
+
+        self::assertSame(0, $handler->getExitCode());
+    }
+
+    public function testExitCodeWithoutShutdown(): void
+    {
+        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'exit',
+        ]);
+
+        $result = $handler->handle($notification);
+
+        self::assertSame(1, $handler->getExitCode());
+    }
+}

--- a/tests/Protocol/NotificationMessageTest.php
+++ b/tests/Protocol/NotificationMessageTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\NotificationMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NotificationMessage::class)]
+class NotificationMessageTest extends TestCase
+{
+    public function testParseValidNotification(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'method' => 'initialized',
+            'params' => [],
+        ];
+
+        $notification = NotificationMessage::fromArray($data);
+
+        self::assertSame('initialized', $notification->method);
+        self::assertSame([], $notification->params);
+    }
+
+    public function testParseNotificationWithoutParams(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'method' => 'exit',
+        ];
+
+        $notification = NotificationMessage::fromArray($data);
+
+        self::assertSame('exit', $notification->method);
+        self::assertNull($notification->params);
+    }
+
+    public function testIsNotification(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'method' => 'initialized',
+        ];
+
+        $notification = NotificationMessage::fromArray($data);
+
+        self::assertTrue($notification->isNotification());
+    }
+}

--- a/tests/Protocol/RequestMessageTest.php
+++ b/tests/Protocol/RequestMessageTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RequestMessage::class)]
+class RequestMessageTest extends TestCase
+{
+    public function testParseValidRequest(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => ['processId' => 1234],
+        ];
+
+        $request = RequestMessage::fromArray($data);
+
+        self::assertSame(1, $request->id);
+        self::assertSame('initialize', $request->method);
+        self::assertSame(['processId' => 1234], $request->params);
+    }
+
+    public function testParseRequestWithStringId(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 'req-abc',
+            'method' => 'textDocument/hover',
+            'params' => [],
+        ];
+
+        $request = RequestMessage::fromArray($data);
+
+        self::assertSame('req-abc', $request->id);
+        self::assertSame('textDocument/hover', $request->method);
+    }
+
+    public function testParseRequestWithoutParams(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'method' => 'shutdown',
+        ];
+
+        $request = RequestMessage::fromArray($data);
+
+        self::assertSame(2, $request->id);
+        self::assertSame('shutdown', $request->method);
+        self::assertNull($request->params);
+    }
+
+    public function testParseRequestWithNullParams(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'method' => 'shutdown',
+            'params' => null,
+        ];
+
+        $request = RequestMessage::fromArray($data);
+
+        self::assertNull($request->params);
+    }
+
+    public function testIsNotification(): void
+    {
+        $data = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+        ];
+
+        $request = RequestMessage::fromArray($data);
+
+        self::assertFalse($request->isNotification());
+    }
+}

--- a/tests/Protocol/ResponseMessageTest.php
+++ b/tests/Protocol/ResponseMessageTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\ResponseError;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResponseMessage::class)]
+#[CoversClass(ResponseError::class)]
+class ResponseMessageTest extends TestCase
+{
+    public function testSuccessResponseJsonFormat(): void
+    {
+        $response = ResponseMessage::success(1, ['capabilities' => []]);
+
+        $decoded = $this->encodeAndDecode($response);
+
+        self::assertSame('2.0', $decoded['jsonrpc']);
+        self::assertSame(1, $decoded['id']);
+        self::assertSame(['capabilities' => []], $decoded['result']);
+        self::assertArrayNotHasKey('error', $decoded);
+    }
+
+    public function testSuccessResponseWithStringId(): void
+    {
+        $response = ResponseMessage::success('req-123', ['data' => 'value']);
+
+        $decoded = $this->encodeAndDecode($response);
+
+        self::assertSame('2.0', $decoded['jsonrpc']);
+        self::assertSame('req-123', $decoded['id']);
+        self::assertSame(['data' => 'value'], $decoded['result']);
+    }
+
+    public function testSuccessResponseWithNullResult(): void
+    {
+        $response = ResponseMessage::success(1, null);
+
+        $decoded = $this->encodeAndDecode($response);
+
+        self::assertSame('2.0', $decoded['jsonrpc']);
+        self::assertSame(1, $decoded['id']);
+        self::assertNull($decoded['result']);
+        self::assertArrayNotHasKey('error', $decoded);
+    }
+
+    public function testErrorResponseJsonFormat(): void
+    {
+        $error = new ResponseError(-32601, 'Method not found');
+        $response = ResponseMessage::error(1, $error);
+
+        $decoded = $this->encodeAndDecode($response);
+
+        self::assertSame('2.0', $decoded['jsonrpc']);
+        self::assertSame(1, $decoded['id']);
+        self::assertArrayNotHasKey('result', $decoded);
+        self::assertIsArray($decoded['error']);
+        self::assertSame(-32601, $decoded['error']['code']);
+        self::assertSame('Method not found', $decoded['error']['message']);
+        self::assertArrayNotHasKey('data', $decoded['error']);
+    }
+
+    public function testErrorResponseWithData(): void
+    {
+        $error = new ResponseError(-32602, 'Invalid params', ['expected' => 'string']);
+        $response = ResponseMessage::error(2, $error);
+
+        $decoded = $this->encodeAndDecode($response);
+
+        self::assertIsArray($decoded['error']);
+        self::assertSame(-32602, $decoded['error']['code']);
+        self::assertSame('Invalid params', $decoded['error']['message']);
+        self::assertSame(['expected' => 'string'], $decoded['error']['data']);
+    }
+
+    public function testErrorResponseWithNullId(): void
+    {
+        $error = new ResponseError(-32700, 'Parse error');
+        $response = ResponseMessage::error(null, $error);
+
+        $decoded = $this->encodeAndDecode($response);
+
+        self::assertSame('2.0', $decoded['jsonrpc']);
+        self::assertNull($decoded['id']);
+        self::assertArrayHasKey('error', $decoded);
+    }
+
+    #[DataProvider('errorCodesProvider')]
+    public function testStandardErrorCodes(int $code, string $expectedMessage): void
+    {
+        $error = ResponseError::$expectedMessage();
+        assert($error instanceof ResponseError);
+
+        self::assertSame($code, $error->code);
+    }
+
+    /**
+     * @return array<string, array{int, string}>
+     */
+    public static function errorCodesProvider(): array
+    {
+        return [
+            'parseError' => [-32700, 'parseError'],
+            'invalidRequest' => [-32600, 'invalidRequest'],
+            'methodNotFound' => [-32601, 'methodNotFound'],
+            'invalidParams' => [-32602, 'invalidParams'],
+            'internalError' => [-32603, 'internalError'],
+        ];
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function encodeAndDecode(ResponseMessage $response): array
+    {
+        $json = json_encode($response, JSON_THROW_ON_ERROR);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        assert(is_array($decoded));
+        return $decoded;
+    }
+}

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests;
+
+use Amp\ByteStream\ReadableBuffer;
+use Amp\ByteStream\WritableBuffer;
+use Firehed\PhpLsp\Protocol\ResponseError;
+use Firehed\PhpLsp\Server;
+use Firehed\PhpLsp\ServerInfo;
+use Firehed\PhpLsp\Transport\MessageReader;
+use Firehed\PhpLsp\Transport\MessageWriter;
+use Firehed\PhpLsp\Transport\TransportInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Server::class)]
+class ServerTest extends TestCase
+{
+    public function testFullLifecycle(): void
+    {
+        $initializeJson = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1234,"capabilities":{}}}';
+        $initializedJson = '{"jsonrpc":"2.0","method":"initialized"}';
+        $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
+        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
+
+        $input = $this->buildMessages($initializeJson, $initializedJson, $shutdownJson, $exitJson);
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        $exitCode = $server->run();
+
+        self::assertSame(0, $exitCode);
+
+        $output = $outputBuffer->buffer();
+
+        // Verify initialize response
+        self::assertStringContainsString('"jsonrpc":"2.0"', $output);
+        self::assertStringContainsString('"id":1', $output);
+        self::assertStringContainsString('"capabilities"', $output);
+        self::assertStringContainsString('"serverInfo"', $output);
+
+        // Verify shutdown response
+        self::assertStringContainsString('"id":2', $output);
+    }
+
+    public function testUnknownMethodReturnsError(): void
+    {
+        $unknownJson = '{"jsonrpc":"2.0","id":1,"method":"unknown/method"}';
+        $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
+        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
+
+        $input = $this->buildMessages($unknownJson, $shutdownJson, $exitJson);
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        $server->run();
+
+        $output = $outputBuffer->buffer();
+
+        // Should contain method not found error
+        self::assertStringContainsString('"error"', $output);
+        self::assertStringContainsString((string) ResponseError::methodNotFound()->code, $output);
+    }
+
+    public function testExitWithoutShutdownReturnsOne(): void
+    {
+        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
+
+        $input = $this->buildMessages($exitJson);
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        $exitCode = $server->run();
+
+        self::assertSame(1, $exitCode);
+    }
+
+    private function buildMessages(string ...$jsonMessages): string
+    {
+        $result = '';
+        foreach ($jsonMessages as $json) {
+            $result .= "Content-Length: " . strlen($json) . "\r\n\r\n" . $json;
+        }
+        return $result;
+    }
+
+    private function createTransport(string $input, WritableBuffer $outputBuffer): TransportInterface
+    {
+        $inputBuffer = new ReadableBuffer($input);
+        $reader = new MessageReader($inputBuffer);
+        $writer = new MessageWriter($outputBuffer);
+
+        return new class ($reader, $writer, $outputBuffer) implements TransportInterface {
+            public function __construct(
+                private MessageReader $reader,
+                private MessageWriter $writer,
+                private WritableBuffer $outputBuffer,
+            ) {
+            }
+
+            public function read(): ?\Firehed\PhpLsp\Protocol\Message
+            {
+                return $this->reader->read();
+            }
+
+            public function write(\Firehed\PhpLsp\Protocol\ResponseMessage $response): void
+            {
+                $this->writer->write($response);
+            }
+
+            public function close(): void
+            {
+                $this->outputBuffer->close();
+            }
+        };
+    }
+}

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Transport;
+
+use Amp\ByteStream\ReadableBuffer;
+use Firehed\PhpLsp\Protocol\NotificationMessage;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Transport\MessageReader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MessageReader::class)]
+class MessageReaderTest extends TestCase
+{
+    public function testReadRequest(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1234}}';
+        $message = "Content-Length: " . strlen($json) . "\r\n\r\n" . $json;
+
+        $buffer = new ReadableBuffer($message);
+        $reader = new MessageReader($buffer);
+
+        $request = $reader->read();
+
+        self::assertInstanceOf(RequestMessage::class, $request);
+        self::assertSame(1, $request->id);
+        self::assertSame('initialize', $request->method);
+        self::assertSame(['processId' => 1234], $request->params);
+    }
+
+    public function testReadNotification(): void
+    {
+        $json = '{"jsonrpc":"2.0","method":"initialized","params":{}}';
+        $message = "Content-Length: " . strlen($json) . "\r\n\r\n" . $json;
+
+        $buffer = new ReadableBuffer($message);
+        $reader = new MessageReader($buffer);
+
+        $notification = $reader->read();
+
+        self::assertInstanceOf(NotificationMessage::class, $notification);
+        self::assertSame('initialized', $notification->method);
+    }
+
+    public function testReadMultipleMessages(): void
+    {
+        $json1 = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}';
+        $json2 = '{"jsonrpc":"2.0","method":"initialized"}';
+
+        $message = "Content-Length: " . strlen($json1) . "\r\n\r\n" . $json1;
+        $message .= "Content-Length: " . strlen($json2) . "\r\n\r\n" . $json2;
+
+        $buffer = new ReadableBuffer($message);
+        $reader = new MessageReader($buffer);
+
+        $request = $reader->read();
+        $notification = $reader->read();
+
+        self::assertInstanceOf(RequestMessage::class, $request);
+        self::assertInstanceOf(NotificationMessage::class, $notification);
+    }
+
+    public function testReadReturnsNullOnEof(): void
+    {
+        $buffer = new ReadableBuffer('');
+        $reader = new MessageReader($buffer);
+
+        $result = $reader->read();
+
+        self::assertNull($result);
+    }
+
+    public function testReadWithContentTypeHeader(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"method":"test"}';
+        $message = "Content-Length: " . strlen($json) . "\r\n";
+        $message .= "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n";
+        $message .= "\r\n" . $json;
+
+        $buffer = new ReadableBuffer($message);
+        $reader = new MessageReader($buffer);
+
+        $request = $reader->read();
+
+        self::assertInstanceOf(RequestMessage::class, $request);
+        self::assertSame('test', $request->method);
+    }
+}

--- a/tests/Transport/MessageWriterTest.php
+++ b/tests/Transport/MessageWriterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Transport;
+
+use Amp\ByteStream\WritableBuffer;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+use Firehed\PhpLsp\Transport\MessageWriter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MessageWriter::class)]
+class MessageWriterTest extends TestCase
+{
+    public function testWriteResponseMessage(): void
+    {
+        $buffer = new WritableBuffer();
+        $writer = new MessageWriter($buffer);
+
+        $response = ResponseMessage::success(1, ['capabilities' => []]);
+        $writer->write($response);
+        $buffer->close();
+
+        $output = $buffer->buffer();
+        $json = '{"jsonrpc":"2.0","id":1,"result":{"capabilities":[]}}';
+        $expected = "Content-Length: " . strlen($json) . "\r\n\r\n" . $json;
+
+        self::assertSame($expected, $output);
+    }
+
+    public function testWriteMultipleMessages(): void
+    {
+        $buffer = new WritableBuffer();
+        $writer = new MessageWriter($buffer);
+
+        $response1 = ResponseMessage::success(1, null);
+        $response2 = ResponseMessage::success(2, ['data' => 'value']);
+
+        $writer->write($response1);
+        $writer->write($response2);
+        $buffer->close();
+
+        $output = $buffer->buffer();
+
+        $json1 = '{"jsonrpc":"2.0","id":1,"result":null}';
+        $json2 = '{"jsonrpc":"2.0","id":2,"result":{"data":"value"}}';
+
+        self::assertStringContainsString("Content-Length: " . strlen($json1), $output);
+        self::assertStringContainsString($json1, $output);
+        self::assertStringContainsString("Content-Length: " . strlen($json2), $output);
+        self::assertStringContainsString($json2, $output);
+    }
+}


### PR DESCRIPTION
## Summary

- Project setup with PHPUnit 11, PHPStan max, PHP 8.3-8.5 support
- JSON-RPC protocol message classes (Request, Notification, Response)
- Async transport layer using Amp v3 (stdio with abstraction for future TCP)
- Lifecycle handler (initialize, initialized, shutdown, exit)
- Server with method dispatch loop
- Documentation (README, Vim/ALE guide)

## Test plan

- [x] `composer check` passes (PHPStan + PHPUnit)
- [x] Manual test with an LSP client

🤖 Generated with [Claude Code](https://claude.ai/code)