### PR TITLE
Add go-to-definition support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "WebFetch(domain:microsoft.github.io)",
+      "Bash(git checkout:*)",
+      "Bash(composer install:*)",
+      "Bash(git add:*)",
+      "Bash(composer test:*)",
+      "Bash(composer analyze:*)",
+      "Bash(composer check:*)",
+      "Bash(git branch:*)",
+      "Bash(composer require:*)"
+    ]
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": "^8.3",
         "amphp/amp": "^3.0",
-        "amphp/byte-stream": "^2.0"
+        "amphp/byte-stream": "^2.0",
+        "nikic/php-parser": "^5.7"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/Document/DocumentManager.php
+++ b/src/Document/DocumentManager.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Document;
+
+final class DocumentManager
+{
+    /** @var array<string, TextDocument> */
+    private array $documents = [];
+
+    public function open(string $uri, string $languageId, int $version, string $content): void
+    {
+        $this->documents[$uri] = new TextDocument($uri, $languageId, $version, $content);
+    }
+
+    public function update(string $uri, string $content, int $version): void
+    {
+        $doc = $this->documents[$uri] ?? null;
+        if ($doc === null) {
+            return;
+        }
+
+        $this->documents[$uri] = $doc->withContent($content, $version);
+    }
+
+    public function close(string $uri): void
+    {
+        unset($this->documents[$uri]);
+    }
+
+    public function get(string $uri): ?TextDocument
+    {
+        return $this->documents[$uri] ?? null;
+    }
+
+    public function isOpen(string $uri): bool
+    {
+        return isset($this->documents[$uri]);
+    }
+}

--- a/src/Document/TextDocument.php
+++ b/src/Document/TextDocument.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Document;
+
+final class TextDocument
+{
+    /** @var list<int> Byte offsets of line starts */
+    private array $lineOffsets;
+
+    public function __construct(
+        public readonly string $uri,
+        public readonly string $languageId,
+        public readonly int $version,
+        private readonly string $content,
+    ) {
+        $this->lineOffsets = $this->computeLineOffsets();
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function withContent(string $content, int $version): self
+    {
+        return new self($this->uri, $this->languageId, $version, $content);
+    }
+
+    public function getLine(int $line): string
+    {
+        if ($line < 0 || $line >= count($this->lineOffsets)) {
+            return '';
+        }
+
+        $start = $this->lineOffsets[$line];
+        $end = $line + 1 < count($this->lineOffsets)
+            ? $this->lineOffsets[$line + 1] - 1 // -1 to exclude newline
+            : strlen($this->content);
+
+        return substr($this->content, $start, $end - $start);
+    }
+
+    public function offsetAt(int $line, int $character): int
+    {
+        if ($line < 0 || $line >= count($this->lineOffsets)) {
+            return 0;
+        }
+
+        $lineStart = $this->lineOffsets[$line];
+        $lineEnd = $line + 1 < count($this->lineOffsets)
+            ? $this->lineOffsets[$line + 1]
+            : strlen($this->content);
+
+        return min($lineStart + $character, $lineEnd);
+    }
+
+    /**
+     * @return array{line: int, character: int}
+     */
+    public function positionAt(int $offset): array
+    {
+        $offset = max(0, min($offset, strlen($this->content)));
+
+        $line = 0;
+        foreach ($this->lineOffsets as $i => $lineOffset) {
+            if ($lineOffset > $offset) {
+                break;
+            }
+            $line = $i;
+        }
+
+        return [
+            'line' => $line,
+            'character' => $offset - $this->lineOffsets[$line],
+        ];
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function computeLineOffsets(): array
+    {
+        $offsets = [0];
+        $length = strlen($this->content);
+
+        for ($i = 0; $i < $length; $i++) {
+            if ($this->content[$i] === "\n") {
+                $offsets[] = $i + 1;
+            }
+        }
+
+        return $offsets;
+    }
+}

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\NodeAtPosition;
+use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
@@ -17,6 +21,7 @@ final class DefinitionHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
+        private readonly ?ComposerClassLocator $classLocator = null,
     ) {
     }
 
@@ -73,28 +78,66 @@ final class DefinitionHandler implements HandlerInterface
         }
 
         // Extract the symbol name we're looking for
-        $symbolName = null;
-
-        if ($node instanceof Name) {
-            // Class name reference (new MyClass, extends MyClass, etc)
-            $symbolName = $node->toString();
-        }
-
-        if ($symbolName === null) {
+        if (!$node instanceof Name) {
             return null;
         }
 
-        // Look up in index - try FQN first, then by name
+        // Use the resolved name if available (handles use statements)
+        $resolvedName = $node->getAttribute('resolvedName');
+        $symbolName = $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $node->toString();
+
+        // Look up in index first (for open files)
         $symbol = $this->symbolIndex->findByFqn($symbolName);
         if ($symbol === null) {
             $matches = $this->symbolIndex->findByName($symbolName);
             $symbol = $matches[0] ?? null;
         }
 
-        if ($symbol === null) {
+        if ($symbol !== null) {
+            return $symbol->location->toLspLocation();
+        }
+
+        // Not in index - try to locate via Composer autoload
+        return $this->locateViaComposer($symbolName)?->toLspLocation();
+    }
+
+    private function locateViaComposer(string $className): ?Location
+    {
+        if ($this->classLocator === null) {
             return null;
         }
 
-        return $symbol->location->toLspLocation();
+        $filePath = $this->classLocator->locateClass($className);
+        if ($filePath === null) {
+            return null;
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            return null;
+        }
+
+        $uri = 'file://' . $filePath;
+        $document = new TextDocument($uri, 'php', 0, $content);
+
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return null;
+        }
+
+        // Extract symbols and find our class
+        $extractor = new SymbolExtractor();
+        $symbols = $extractor->extract($document, $ast);
+
+        foreach ($symbols as $symbol) {
+            if ($symbol->fullyQualifiedName === $className) {
+                return $symbol->location;
+            }
+        }
+
+        // Fallback: return start of file
+        return new Location($uri, 0, 0, 0, 0);
     }
 }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Index\NodeAtPosition;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\Message;
+use PhpParser\Node\Name;
+
+final class DefinitionHandler implements HandlerInterface
+{
+    public function __construct(
+        private readonly DocumentManager $documentManager,
+        private readonly ParserService $parser,
+        private readonly SymbolIndex $symbolIndex,
+    ) {
+    }
+
+    public function supports(string $method): bool
+    {
+        return $method === 'textDocument/definition';
+    }
+
+    /**
+     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}|null
+     */
+    public function handle(Message $message): ?array
+    {
+        $params = $message->params ?? [];
+
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+        $uri = $textDocument['uri'] ?? '';
+        if (!is_string($uri)) {
+            return null;
+        }
+
+        $position = $params['position'] ?? [];
+        if (!is_array($position)) {
+            return null;
+        }
+        $line = $position['line'] ?? 0;
+        $character = $position['character'] ?? 0;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        // Get the document
+        $document = $this->documentManager->get($uri);
+        if ($document === null) {
+            return null;
+        }
+
+        // Parse the document
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return null;
+        }
+
+        // Find node at position
+        $offset = $document->offsetAt($line, $character);
+        $nodeFinder = new NodeAtPosition();
+        $node = $nodeFinder->find($ast, $offset);
+
+        if ($node === null) {
+            return null;
+        }
+
+        // Extract the symbol name we're looking for
+        $symbolName = null;
+
+        if ($node instanceof Name) {
+            // Class name reference (new MyClass, extends MyClass, etc)
+            $symbolName = $node->toString();
+        }
+
+        if ($symbolName === null) {
+            return null;
+        }
+
+        // Look up in index - try FQN first, then by name
+        $symbol = $this->symbolIndex->findByFqn($symbolName);
+        if ($symbol === null) {
+            $matches = $this->symbolIndex->findByName($symbolName);
+            $symbol = $matches[0] ?? null;
+        }
+
+        if ($symbol === null) {
+            return null;
+        }
+
+        return $symbol->location->toLspLocation();
+    }
+}

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -59,6 +59,7 @@ final class LifecycleHandler implements HandlerInterface
             'capabilities' => [
                 // TextDocumentSyncKind.Full = 1 (send full document on change)
                 'textDocumentSync' => 1,
+                'definitionProvider' => true,
             ],
             'serverInfo' => $this->serverInfo->toArray(),
         ];

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -56,7 +56,10 @@ final class LifecycleHandler implements HandlerInterface
     private function handleInitialize(): array
     {
         return [
-            'capabilities' => [],
+            'capabilities' => [
+                // TextDocumentSyncKind.Full = 1 (send full document on change)
+                'textDocumentSync' => 1,
+            ],
             'serverInfo' => $this->serverInfo->toArray(),
         ];
     }

--- a/src/Handler/TextDocumentSyncHandler.php
+++ b/src/Handler/TextDocumentSyncHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Protocol\Message;
+
+final class TextDocumentSyncHandler implements HandlerInterface
+{
+    private const array METHODS = [
+        'textDocument/didOpen',
+        'textDocument/didChange',
+        'textDocument/didClose',
+    ];
+
+    public function __construct(
+        private readonly DocumentManager $documentManager,
+    ) {
+    }
+
+    public function supports(string $method): bool
+    {
+        return in_array($method, self::METHODS, true);
+    }
+
+    public function handle(Message $message): mixed
+    {
+        $params = $message->params ?? [];
+
+        return match ($message->method) {
+            'textDocument/didOpen' => $this->handleDidOpen($params),
+            'textDocument/didChange' => $this->handleDidChange($params),
+            'textDocument/didClose' => $this->handleDidClose($params),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<array-key, mixed> $params
+     */
+    private function handleDidOpen(array $params): null
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        assert(is_array($textDocument));
+
+        $uri = $textDocument['uri'] ?? '';
+        $languageId = $textDocument['languageId'] ?? '';
+        $version = $textDocument['version'] ?? 0;
+        $text = $textDocument['text'] ?? '';
+
+        assert(is_string($uri));
+        assert(is_string($languageId));
+        assert(is_int($version));
+        assert(is_string($text));
+
+        $this->documentManager->open($uri, $languageId, $version, $text);
+
+        return null;
+    }
+
+    /**
+     * @param array<array-key, mixed> $params
+     */
+    private function handleDidChange(array $params): null
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        assert(is_array($textDocument));
+
+        $uri = $textDocument['uri'] ?? '';
+        $version = $textDocument['version'] ?? 0;
+
+        assert(is_string($uri));
+        assert(is_int($version));
+
+        $contentChanges = $params['contentChanges'] ?? [];
+        assert(is_array($contentChanges));
+
+        // Full sync: use last change's text
+        $lastChange = end($contentChanges);
+        if (is_array($lastChange) && isset($lastChange['text'])) {
+            assert(is_string($lastChange['text']));
+            $this->documentManager->update($uri, $lastChange['text'], $version);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<array-key, mixed> $params
+     */
+    private function handleDidClose(array $params): null
+    {
+        $textDocument = $params['textDocument'] ?? [];
+        assert(is_array($textDocument));
+
+        $uri = $textDocument['uri'] ?? '';
+        assert(is_string($uri));
+
+        $this->documentManager->close($uri);
+
+        return null;
+    }
+}

--- a/src/Handler/TextDocumentSyncHandler.php
+++ b/src/Handler/TextDocumentSyncHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Protocol\Message;
 
 final class TextDocumentSyncHandler implements HandlerInterface
@@ -17,6 +18,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
 
     public function __construct(
         private readonly DocumentManager $documentManager,
+        private readonly ?DocumentIndexer $indexer = null,
     ) {
     }
 
@@ -56,6 +58,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         assert(is_string($text));
 
         $this->documentManager->open($uri, $languageId, $version, $text);
+        $this->indexDocument($uri);
 
         return null;
     }
@@ -82,6 +85,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         if (is_array($lastChange) && isset($lastChange['text'])) {
             assert(is_string($lastChange['text']));
             $this->documentManager->update($uri, $lastChange['text'], $version);
+            $this->indexDocument($uri);
         }
 
         return null;
@@ -98,8 +102,17 @@ final class TextDocumentSyncHandler implements HandlerInterface
         $uri = $textDocument['uri'] ?? '';
         assert(is_string($uri));
 
+        $this->indexer?->remove($uri);
         $this->documentManager->close($uri);
 
         return null;
+    }
+
+    private function indexDocument(string $uri): void
+    {
+        $document = $this->documentManager->get($uri);
+        if ($document !== null && $this->indexer !== null) {
+            $this->indexer->index($document);
+        }
     }
 }

--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+final class ComposerClassLocator
+{
+    /** @var array<string, string> namespace prefix => directory */
+    private array $psr4Mappings = [];
+    private string $basePath;
+
+    public function __construct(string $projectRoot)
+    {
+        $this->basePath = rtrim($projectRoot, '/');
+        $this->loadComposerJson();
+    }
+
+    public function locateClass(string $fullyQualifiedName): ?string
+    {
+        // Try PSR-4 mappings
+        foreach ($this->psr4Mappings as $prefix => $directory) {
+            if (str_starts_with($fullyQualifiedName, $prefix)) {
+                $relativeClass = substr($fullyQualifiedName, strlen($prefix));
+                $relativePath = str_replace('\\', '/', $relativeClass) . '.php';
+                $fullPath = $this->basePath . '/' . $directory . $relativePath;
+
+                if (file_exists($fullPath)) {
+                    return $fullPath;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function loadComposerJson(): void
+    {
+        $composerPath = $this->basePath . '/composer.json';
+        if (!file_exists($composerPath)) {
+            return;
+        }
+
+        $content = file_get_contents($composerPath);
+        if ($content === false) {
+            return;
+        }
+
+        $data = json_decode($content, true);
+        if (!is_array($data)) {
+            return;
+        }
+
+        // Load PSR-4 from autoload
+        $autoload = $data['autoload'] ?? [];
+        if (is_array($autoload)) {
+            $psr4 = $autoload['psr-4'] ?? [];
+            if (is_array($psr4)) {
+                $this->loadPsr4($psr4);
+            }
+        }
+
+        // Also load from autoload-dev for test classes
+        $autoloadDev = $data['autoload-dev'] ?? [];
+        if (is_array($autoloadDev)) {
+            $psr4Dev = $autoloadDev['psr-4'] ?? [];
+            if (is_array($psr4Dev)) {
+                $this->loadPsr4($psr4Dev);
+            }
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $psr4
+     */
+    private function loadPsr4(array $psr4): void
+    {
+        foreach ($psr4 as $prefix => $paths) {
+            if (!is_string($prefix)) {
+                continue;
+            }
+            // Normalize prefix to end with backslash
+            $prefix = rtrim($prefix, '\\') . '\\';
+
+            // Paths can be string or array
+            if (is_string($paths)) {
+                $this->psr4Mappings[$prefix] = rtrim($paths, '/') . '/';
+            } elseif (is_array($paths)) {
+                foreach ($paths as $path) {
+                    if (is_string($path)) {
+                        $this->psr4Mappings[$prefix] = rtrim($path, '/') . '/';
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -6,25 +6,31 @@ namespace Firehed\PhpLsp\Index;
 
 final class ComposerClassLocator
 {
-    /** @var array<string, string> namespace prefix => directory */
+    /** @var array<string, list<string>> namespace prefix => directories */
     private array $psr4Mappings = [];
-    private string $basePath;
 
     public function __construct(string $projectRoot)
     {
-        $this->basePath = rtrim($projectRoot, '/');
-        $this->loadComposerJson();
+        $projectRoot = rtrim($projectRoot, '/');
+        $this->loadFromComposerAutoload($projectRoot);
     }
 
     public function locateClass(string $fullyQualifiedName): ?string
     {
-        // Try PSR-4 mappings
-        foreach ($this->psr4Mappings as $prefix => $directory) {
-            if (str_starts_with($fullyQualifiedName, $prefix)) {
-                $relativeClass = substr($fullyQualifiedName, strlen($prefix));
-                $relativePath = str_replace('\\', '/', $relativeClass) . '.php';
-                $fullPath = $this->basePath . '/' . $directory . $relativePath;
+        // Sort by prefix length descending for most specific match first
+        $prefixes = array_keys($this->psr4Mappings);
+        usort($prefixes, fn($a, $b) => strlen($b) <=> strlen($a));
 
+        foreach ($prefixes as $prefix) {
+            if (!str_starts_with($fullyQualifiedName, $prefix)) {
+                continue;
+            }
+
+            $relativeClass = substr($fullyQualifiedName, strlen($prefix));
+            $relativePath = str_replace('\\', '/', $relativeClass) . '.php';
+
+            foreach ($this->psr4Mappings[$prefix] as $directory) {
+                $fullPath = $directory . '/' . $relativePath;
                 if (file_exists($fullPath)) {
                     return $fullPath;
                 }
@@ -34,9 +40,37 @@ final class ComposerClassLocator
         return null;
     }
 
-    private function loadComposerJson(): void
+    private function loadFromComposerAutoload(string $projectRoot): void
     {
-        $composerPath = $this->basePath . '/composer.json';
+        // Use Composer's generated autoload which includes all vendor mappings
+        $autoloadFile = $projectRoot . '/vendor/composer/autoload_psr4.php';
+
+        if (file_exists($autoloadFile)) {
+            $mappings = require $autoloadFile;
+            if (is_array($mappings)) {
+                foreach ($mappings as $prefix => $dirs) {
+                    if (!is_string($prefix) || !is_array($dirs)) {
+                        continue;
+                    }
+                    $prefix = rtrim($prefix, '\\') . '\\';
+                    $this->psr4Mappings[$prefix] = [];
+                    foreach ($dirs as $dir) {
+                        if (is_string($dir)) {
+                            $this->psr4Mappings[$prefix][] = rtrim($dir, '/');
+                        }
+                    }
+                }
+            }
+        }
+
+        // Also load project's own composer.json for paths not in vendor
+        // (in case autoload hasn't been dumped recently)
+        $this->loadFromComposerJson($projectRoot);
+    }
+
+    private function loadFromComposerJson(string $projectRoot): void
+    {
+        $composerPath = $projectRoot . '/composer.json';
         if (!file_exists($composerPath)) {
             return;
         }
@@ -56,7 +90,7 @@ final class ComposerClassLocator
         if (is_array($autoload)) {
             $psr4 = $autoload['psr-4'] ?? [];
             if (is_array($psr4)) {
-                $this->loadPsr4($psr4);
+                $this->loadPsr4($psr4, $projectRoot);
             }
         }
 
@@ -65,7 +99,7 @@ final class ComposerClassLocator
         if (is_array($autoloadDev)) {
             $psr4Dev = $autoloadDev['psr-4'] ?? [];
             if (is_array($psr4Dev)) {
-                $this->loadPsr4($psr4Dev);
+                $this->loadPsr4($psr4Dev, $projectRoot);
             }
         }
     }
@@ -73,22 +107,24 @@ final class ComposerClassLocator
     /**
      * @param array<array-key, mixed> $psr4
      */
-    private function loadPsr4(array $psr4): void
+    private function loadPsr4(array $psr4, string $basePath): void
     {
         foreach ($psr4 as $prefix => $paths) {
             if (!is_string($prefix)) {
                 continue;
             }
-            // Normalize prefix to end with backslash
             $prefix = rtrim($prefix, '\\') . '\\';
 
-            // Paths can be string or array
+            if (!isset($this->psr4Mappings[$prefix])) {
+                $this->psr4Mappings[$prefix] = [];
+            }
+
             if (is_string($paths)) {
-                $this->psr4Mappings[$prefix] = rtrim($paths, '/') . '/';
+                $this->psr4Mappings[$prefix][] = $basePath . '/' . rtrim($paths, '/');
             } elseif (is_array($paths)) {
                 foreach ($paths as $path) {
                     if (is_string($path)) {
-                        $this->psr4Mappings[$prefix] = rtrim($path, '/') . '/';
+                        $this->psr4Mappings[$prefix][] = $basePath . '/' . rtrim($path, '/');
                     }
                 }
             }

--- a/src/Index/DocumentIndexer.php
+++ b/src/Index/DocumentIndexer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Parser\ParserService;
+
+final class DocumentIndexer
+{
+    public function __construct(
+        private readonly ParserService $parser,
+        private readonly SymbolExtractor $extractor,
+        private readonly SymbolIndex $index,
+    ) {
+    }
+
+    public function index(TextDocument $document): void
+    {
+        // Clear old symbols from this file
+        $this->index->clearByUri($document->uri);
+
+        // Parse
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return; // Parse error, skip indexing
+        }
+
+        // Extract and index symbols
+        $symbols = $this->extractor->extract($document, $ast);
+        foreach ($symbols as $symbol) {
+            $this->index->add($symbol);
+        }
+    }
+
+    public function remove(string $uri): void
+    {
+        $this->index->clearByUri($uri);
+    }
+}

--- a/src/Index/Location.php
+++ b/src/Index/Location.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+final readonly class Location
+{
+    public function __construct(
+        public string $uri,
+        public int $startLine,
+        public int $startCharacter,
+        public int $endLine,
+        public int $endCharacter,
+    ) {
+    }
+
+    /**
+     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}
+     */
+    public function toLspLocation(): array
+    {
+        return [
+            'uri' => $this->uri,
+            'range' => [
+                'start' => ['line' => $this->startLine, 'character' => $this->startCharacter],
+                'end' => ['line' => $this->endLine, 'character' => $this->endCharacter],
+            ],
+        ];
+    }
+}

--- a/src/Index/NodeAtPosition.php
+++ b/src/Index/NodeAtPosition.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+final class NodeAtPosition extends NodeVisitorAbstract
+{
+    private int $offset;
+    private ?Node $found = null;
+
+    /**
+     * @param array<Node> $ast
+     */
+    public function find(array $ast, int $offset): ?Node
+    {
+        $this->offset = $offset;
+        $this->found = null;
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($this);
+        $traverser->traverse($ast);
+
+        return $this->found;
+    }
+
+    public function enterNode(Node $node): null
+    {
+        $startPos = $node->getStartFilePos();
+        $endPos = $node->getEndFilePos();
+
+        if ($startPos <= $this->offset && $this->offset <= $endPos) {
+            // This node contains the position, keep drilling down
+            // The last (most specific) match will be kept
+            $this->found = $node;
+        }
+
+        return null;
+    }
+}

--- a/src/Index/Symbol.php
+++ b/src/Index/Symbol.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+final readonly class Symbol
+{
+    public function __construct(
+        public string $name,
+        public string $fullyQualifiedName,
+        public SymbolKind $kind,
+        public Location $location,
+        public ?string $containerName = null,
+    ) {
+    }
+}

--- a/src/Index/SymbolExtractor.php
+++ b/src/Index/SymbolExtractor.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+final class SymbolExtractor extends NodeVisitorAbstract
+{
+    /** @var list<Symbol> */
+    private array $symbols = [];
+    private string $uri = '';
+    private string $namespace = '';
+    private ?string $currentClass = null;
+    private TextDocument $document;
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<Symbol>
+     */
+    public function extract(TextDocument $document, array $ast): array
+    {
+        $this->symbols = [];
+        $this->uri = $document->uri;
+        $this->namespace = '';
+        $this->currentClass = null;
+        $this->document = $document;
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($this);
+        $traverser->traverse($ast);
+
+        return $this->symbols;
+    }
+
+    public function enterNode(Node $node): null
+    {
+        if ($node instanceof Stmt\Namespace_) {
+            $this->namespace = $node->name?->toString() ?? '';
+            return null;
+        }
+
+        if ($node instanceof Stmt\Class_) {
+            $this->addClassLikeSymbol($node, SymbolKind::Class_);
+            $this->currentClass = $node->name?->toString();
+            return null;
+        }
+
+        if ($node instanceof Stmt\Interface_) {
+            $this->addClassLikeSymbol($node, SymbolKind::Interface_);
+            $this->currentClass = $node->name?->toString();
+            return null;
+        }
+
+        if ($node instanceof Stmt\Trait_) {
+            $this->addClassLikeSymbol($node, SymbolKind::Trait_);
+            $this->currentClass = $node->name?->toString();
+            return null;
+        }
+
+        if ($node instanceof Stmt\Enum_) {
+            $this->addClassLikeSymbol($node, SymbolKind::Enum_);
+            $this->currentClass = $node->name?->toString();
+            return null;
+        }
+
+        if ($node instanceof Stmt\Function_) {
+            $name = $node->name->toString();
+            $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
+            $this->symbols[] = new Symbol(
+                name: $name,
+                fullyQualifiedName: $fqn,
+                kind: SymbolKind::Function_,
+                location: $this->createLocation($node),
+            );
+            return null;
+        }
+
+        if ($node instanceof Stmt\ClassMethod && $this->currentClass !== null) {
+            $name = $node->name->toString();
+            $fqn = ($this->namespace !== '' ? $this->namespace . '\\' : '')
+                . $this->currentClass . '::' . $name;
+            $this->symbols[] = new Symbol(
+                name: $name,
+                fullyQualifiedName: $fqn,
+                kind: SymbolKind::Method,
+                location: $this->createLocation($node),
+                containerName: $this->currentClass,
+            );
+            return null;
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): null
+    {
+        if ($node instanceof Stmt\Class_
+            || $node instanceof Stmt\Interface_
+            || $node instanceof Stmt\Trait_
+            || $node instanceof Stmt\Enum_
+        ) {
+            $this->currentClass = null;
+        }
+
+        return null;
+    }
+
+    private function addClassLikeSymbol(
+        Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $node,
+        SymbolKind $kind,
+    ): void {
+        $name = $node->name?->toString();
+        if ($name === null) {
+            return; // Anonymous class
+        }
+
+        $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
+        $this->symbols[] = new Symbol(
+            name: $name,
+            fullyQualifiedName: $fqn,
+            kind: $kind,
+            location: $this->createLocation($node),
+        );
+    }
+
+    private function createLocation(Node $node): Location
+    {
+        $startLine = $node->getStartLine() - 1; // LSP is 0-indexed
+        $endLine = $node->getEndLine() - 1;
+
+        // Get character positions from the document
+        $startPos = $this->document->positionAt($node->getStartFilePos());
+        $endPos = $this->document->positionAt($node->getEndFilePos() + 1);
+
+        return new Location(
+            uri: $this->uri,
+            startLine: $startLine,
+            startCharacter: $startPos['character'],
+            endLine: $endLine,
+            endCharacter: $endPos['character'],
+        );
+    }
+}

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+final class SymbolIndex
+{
+    /** @var array<string, Symbol> FQN -> Symbol */
+    private array $byFqn = [];
+
+    /** @var array<string, list<Symbol>> Name -> Symbols */
+    private array $byName = [];
+
+    /** @var array<string, list<string>> URI -> FQNs */
+    private array $byUri = [];
+
+    public function add(Symbol $symbol): void
+    {
+        $this->byFqn[$symbol->fullyQualifiedName] = $symbol;
+
+        $this->byName[$symbol->name] ??= [];
+        $this->byName[$symbol->name][] = $symbol;
+
+        $this->byUri[$symbol->location->uri] ??= [];
+        $this->byUri[$symbol->location->uri][] = $symbol->fullyQualifiedName;
+    }
+
+    public function findByFqn(string $fqn): ?Symbol
+    {
+        return $this->byFqn[$fqn] ?? null;
+    }
+
+    /**
+     * @return list<Symbol>
+     */
+    public function findByName(string $name): array
+    {
+        return $this->byName[$name] ?? [];
+    }
+
+    public function clearByUri(string $uri): void
+    {
+        $fqns = $this->byUri[$uri] ?? [];
+
+        foreach ($fqns as $fqn) {
+            $symbol = $this->byFqn[$fqn] ?? null;
+            if ($symbol !== null) {
+                unset($this->byFqn[$fqn]);
+
+                // Remove from byName
+                $this->byName[$symbol->name] = array_values(array_filter(
+                    $this->byName[$symbol->name] ?? [],
+                    fn(Symbol $s) => $s->fullyQualifiedName !== $fqn,
+                ));
+                if (empty($this->byName[$symbol->name])) {
+                    unset($this->byName[$symbol->name]);
+                }
+            }
+        }
+
+        unset($this->byUri[$uri]);
+    }
+}

--- a/src/Index/SymbolKind.php
+++ b/src/Index/SymbolKind.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+enum SymbolKind: int
+{
+    case Class_ = 5;
+    case Method = 6;
+    case Property = 7;
+    case Function_ = 12;
+    case Constant = 14;
+    case Interface_ = 11;
+    case Trait_ = 10; // Using Class in LSP since there's no Trait
+    case Enum_ = 13;
+}

--- a/src/Index/WorkspaceIndexer.php
+++ b/src/Index/WorkspaceIndexer.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Parser\ParserService;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+final class WorkspaceIndexer
+{
+    public function __construct(
+        private readonly ParserService $parser,
+        private readonly SymbolExtractor $extractor,
+        private readonly SymbolIndex $index,
+    ) {
+    }
+
+    public function indexDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS),
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            // Skip vendor directory
+            $realPath = $file->getRealPath();
+            if ($realPath === false) {
+                continue;
+            }
+            if (str_contains($realPath, '/vendor/')) {
+                continue;
+            }
+
+            $this->indexFile($realPath);
+        }
+    }
+
+    private function indexFile(string $path): void
+    {
+        $content = file_get_contents($path);
+        if ($content === false) {
+            return;
+        }
+
+        $uri = 'file://' . $path;
+        $document = new TextDocument($uri, 'php', 0, $content);
+
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return;
+        }
+
+        $symbols = $this->extractor->extract($document, $ast);
+        foreach ($symbols as $symbol) {
+            $this->index->add($symbol);
+        }
+    }
+}

--- a/src/Parser/ParserService.php
+++ b/src/Parser/ParserService.php
@@ -6,16 +6,22 @@ namespace Firehed\PhpLsp\Parser;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 
 final class ParserService
 {
     private Parser $parser;
+    private NodeTraverser $traverser;
 
     public function __construct()
     {
         $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $this->traverser = new NodeTraverser();
+        // NameResolver adds 'resolvedName' attribute to Name nodes
+        $this->traverser->addVisitor(new NameResolver());
     }
 
     /**
@@ -24,7 +30,13 @@ final class ParserService
     public function parse(TextDocument $document): ?array
     {
         try {
-            return $this->parser->parse($document->getContent()) ?? [];
+            $ast = $this->parser->parse($document->getContent());
+            if ($ast === null) {
+                return [];
+            }
+            // Resolve names (handles use statements)
+            /** @var array<Stmt> */
+            return $this->traverser->traverse($ast);
         } catch (\PhpParser\Error) {
             return null;
         }

--- a/src/Parser/ParserService.php
+++ b/src/Parser/ParserService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Parser;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use PhpParser\Node\Stmt;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+final class ParserService
+{
+    private Parser $parser;
+
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+    }
+
+    /**
+     * @return array<Stmt>|null
+     */
+    public function parse(TextDocument $document): ?array
+    {
+        try {
+            return $this->parser->parse($document->getContent()) ?? [];
+        } catch (\PhpParser\Error) {
+            return null;
+        }
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Handler\DefinitionHandler;
 use Firehed\PhpLsp\Handler\HandlerInterface;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
@@ -29,16 +30,21 @@ final class Server
     public function __construct(
         private TransportInterface $transport,
         ServerInfo $serverInfo,
+        ?string $projectRoot = null,
     ) {
+        // Use provided root, or fall back to cwd
+        $projectRoot ??= getcwd() ?: null;
+
         $this->documentManager = new DocumentManager();
         $parser = new ParserService();
         $symbolIndex = new SymbolIndex();
         $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
+        $classLocator = $projectRoot !== null ? new ComposerClassLocator($projectRoot) : null;
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
         $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
-        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex);
+        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
     }
 
     public function run(): int

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp;
 
+use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\HandlerInterface;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
@@ -14,6 +16,7 @@ use Firehed\PhpLsp\Transport\TransportInterface;
 final class Server
 {
     private LifecycleHandler $lifecycleHandler;
+    private DocumentManager $documentManager;
 
     /** @var list<HandlerInterface> */
     private array $handlers = [];
@@ -22,8 +25,10 @@ final class Server
         private TransportInterface $transport,
         ServerInfo $serverInfo,
     ) {
+        $this->documentManager = new DocumentManager();
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
+        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager);
     }
 
     public function run(): int

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Handler\DefinitionHandler;
 use Firehed\PhpLsp\Handler\HandlerInterface;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
@@ -26,9 +31,14 @@ final class Server
         ServerInfo $serverInfo,
     ) {
         $this->documentManager = new DocumentManager();
+        $parser = new ParserService();
+        $symbolIndex = new SymbolIndex();
+        $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
+
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
-        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager);
+        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
+        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex);
     }
 
     public function run(): int

--- a/tests/Document/DocumentManagerTest.php
+++ b/tests/Document/DocumentManagerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Document;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Document\TextDocument;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DocumentManager::class)]
+class DocumentManagerTest extends TestCase
+{
+    public function testOpenAndGet(): void
+    {
+        $manager = new DocumentManager();
+
+        $manager->open(
+            uri: 'file:///test.php',
+            languageId: 'php',
+            version: 1,
+            content: '<?php echo "test";',
+        );
+
+        $doc = $manager->get('file:///test.php');
+
+        self::assertInstanceOf(TextDocument::class, $doc);
+        self::assertSame('<?php echo "test";', $doc->getContent());
+    }
+
+    public function testGetReturnsNullForUnknown(): void
+    {
+        $manager = new DocumentManager();
+
+        self::assertNull($manager->get('file:///unknown.php'));
+    }
+
+    public function testUpdate(): void
+    {
+        $manager = new DocumentManager();
+
+        $manager->open('file:///test.php', 'php', 1, '<?php echo "v1";');
+        $manager->update('file:///test.php', '<?php echo "v2";', 2);
+
+        $doc = $manager->get('file:///test.php');
+
+        self::assertNotNull($doc);
+        self::assertSame('<?php echo "v2";', $doc->getContent());
+        self::assertSame(2, $doc->version);
+    }
+
+    public function testClose(): void
+    {
+        $manager = new DocumentManager();
+
+        $manager->open('file:///test.php', 'php', 1, '<?php');
+        $manager->close('file:///test.php');
+
+        self::assertNull($manager->get('file:///test.php'));
+    }
+
+    public function testIsOpen(): void
+    {
+        $manager = new DocumentManager();
+
+        self::assertFalse($manager->isOpen('file:///test.php'));
+
+        $manager->open('file:///test.php', 'php', 1, '<?php');
+
+        self::assertTrue($manager->isOpen('file:///test.php'));
+
+        $manager->close('file:///test.php');
+
+        self::assertFalse($manager->isOpen('file:///test.php'));
+    }
+}

--- a/tests/Document/TextDocumentTest.php
+++ b/tests/Document/TextDocumentTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Document;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TextDocument::class)]
+class TextDocumentTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $doc = new TextDocument(
+            uri: 'file:///path/to/file.php',
+            languageId: 'php',
+            version: 1,
+            content: '<?php echo "hello";',
+        );
+
+        self::assertSame('file:///path/to/file.php', $doc->uri);
+        self::assertSame('php', $doc->languageId);
+        self::assertSame(1, $doc->version);
+        self::assertSame('<?php echo "hello";', $doc->getContent());
+    }
+
+    public function testApplyFullChange(): void
+    {
+        $doc = new TextDocument(
+            uri: 'file:///path/to/file.php',
+            languageId: 'php',
+            version: 1,
+            content: '<?php echo "hello";',
+        );
+
+        $updated = $doc->withContent('<?php echo "world";', 2);
+
+        self::assertSame('<?php echo "world";', $updated->getContent());
+        self::assertSame(2, $updated->version);
+        // Original unchanged
+        self::assertSame('<?php echo "hello";', $doc->getContent());
+        self::assertSame(1, $doc->version);
+    }
+
+    public function testGetLineAtPosition(): void
+    {
+        $content = "<?php\necho 'line 2';\necho 'line 3';";
+        $doc = new TextDocument('file:///test.php', 'php', 1, $content);
+
+        self::assertSame("<?php", $doc->getLine(0));
+        self::assertSame("echo 'line 2';", $doc->getLine(1));
+        self::assertSame("echo 'line 3';", $doc->getLine(2));
+    }
+
+    public function testOffsetAtPosition(): void
+    {
+        $content = "<?php\necho 'test';";
+        $doc = new TextDocument('file:///test.php', 'php', 1, $content);
+
+        // Line 0, char 0 = offset 0
+        self::assertSame(0, $doc->offsetAt(line: 0, character: 0));
+        // Line 0, char 5 = offset 5 (the newline)
+        self::assertSame(5, $doc->offsetAt(line: 0, character: 5));
+        // Line 1, char 0 = offset 6 (after newline)
+        self::assertSame(6, $doc->offsetAt(line: 1, character: 0));
+        // Line 1, char 4 = offset 10 (the space in "echo ")
+        self::assertSame(10, $doc->offsetAt(line: 1, character: 4));
+    }
+
+    public function testPositionAtOffset(): void
+    {
+        $content = "<?php\necho 'test';";
+        $doc = new TextDocument('file:///test.php', 'php', 1, $content);
+
+        // Offset 0 = line 0, char 0
+        self::assertSame(['line' => 0, 'character' => 0], $doc->positionAt(0));
+        // Offset 5 = line 0, char 5
+        self::assertSame(['line' => 0, 'character' => 5], $doc->positionAt(5));
+        // Offset 6 = line 1, char 0
+        self::assertSame(['line' => 1, 'character' => 0], $doc->positionAt(6));
+        // Offset 10 = line 1, char 4
+        self::assertSame(['line' => 1, 'character' => 4], $doc->positionAt(10));
+    }
+}

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Handler\DefinitionHandler;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DefinitionHandler::class)]
+class DefinitionHandlerTest extends TestCase
+{
+    private DocumentManager $documents;
+    private SymbolIndex $index;
+    private ParserService $parser;
+    private DefinitionHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->documents = new DocumentManager();
+        $this->index = new SymbolIndex();
+        $this->parser = new ParserService();
+        $indexer = new DocumentIndexer(
+            $this->parser,
+            new SymbolExtractor(),
+            $this->index,
+        );
+        $this->handler = new DefinitionHandler(
+            $this->documents,
+            $this->parser,
+            $this->index,
+        );
+    }
+
+    public function testSupports(): void
+    {
+        self::assertTrue($this->handler->supports('textDocument/definition'));
+        self::assertFalse($this->handler->supports('textDocument/hover'));
+    }
+
+    public function testGoToClassDefinition(): void
+    {
+        // Set up a class definition
+        $classCode = '<?php class MyClass {}';
+        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
+        $classDoc = $this->documents->get('file:///MyClass.php');
+        self::assertNotNull($classDoc);
+        $ast = $this->parser->parse($classDoc);
+        self::assertNotNull($ast);
+        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
+        foreach ($symbols as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Set up usage
+        $usageCode = '<?php new MyClass();';
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "MyClass" in usage (position after "new ")
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 0, 'character' => 10], // On "MyClass"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertArrayHasKey('range', $result);
+    }
+
+    public function testReturnsNullForUnknownSymbol(): void
+    {
+        $code = '<?php new UnknownClass();';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 10],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertNull($result);
+    }
+
+    public function testReturnsNullForUnknownDocument(): void
+    {
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///unknown.php'],
+                'position' => ['line' => 0, 'character' => 0],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertNull($result);
+    }
+}

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Protocol\NotificationMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TextDocumentSyncHandler::class)]
+class TextDocumentSyncHandlerTest extends TestCase
+{
+    public function testSupports(): void
+    {
+        $handler = new TextDocumentSyncHandler(new DocumentManager());
+
+        self::assertTrue($handler->supports('textDocument/didOpen'));
+        self::assertTrue($handler->supports('textDocument/didChange'));
+        self::assertTrue($handler->supports('textDocument/didClose'));
+        self::assertFalse($handler->supports('textDocument/hover'));
+    }
+
+    public function testDidOpen(): void
+    {
+        $manager = new DocumentManager();
+        $handler = new TextDocumentSyncHandler($manager);
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didOpen',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                    'languageId' => 'php',
+                    'version' => 1,
+                    'text' => '<?php echo "hello";',
+                ],
+            ],
+        ]);
+
+        $handler->handle($notification);
+
+        $doc = $manager->get('file:///test.php');
+        self::assertNotNull($doc);
+        self::assertSame('<?php echo "hello";', $doc->getContent());
+    }
+
+    public function testDidChange(): void
+    {
+        $manager = new DocumentManager();
+        $handler = new TextDocumentSyncHandler($manager);
+
+        // First open
+        $manager->open('file:///test.php', 'php', 1, '<?php echo "v1";');
+
+        // Then change (full sync)
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didChange',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                    'version' => 2,
+                ],
+                'contentChanges' => [
+                    ['text' => '<?php echo "v2";'],
+                ],
+            ],
+        ]);
+
+        $handler->handle($notification);
+
+        $doc = $manager->get('file:///test.php');
+        self::assertNotNull($doc);
+        self::assertSame('<?php echo "v2";', $doc->getContent());
+        self::assertSame(2, $doc->version);
+    }
+
+    public function testDidClose(): void
+    {
+        $manager = new DocumentManager();
+        $handler = new TextDocumentSyncHandler($manager);
+
+        $manager->open('file:///test.php', 'php', 1, '<?php');
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didClose',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                ],
+            ],
+        ]);
+
+        $handler->handle($notification);
+
+        self::assertNull($manager->get('file:///test.php'));
+    }
+}

--- a/tests/Index/NodeAtPositionTest.php
+++ b/tests/Index/NodeAtPositionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\NodeAtPosition;
+use Firehed\PhpLsp\Parser\ParserService;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NodeAtPosition::class)]
+class NodeAtPositionTest extends TestCase
+{
+    private ParserService $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new ParserService();
+    }
+
+    public function testFindClassName(): void
+    {
+        $code = '<?php new MyClass();';
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        // Position on "MyClass" (line 0, char 10)
+        $finder = new NodeAtPosition();
+        $node = $finder->find($ast, $doc->offsetAt(0, 10));
+
+        self::assertInstanceOf(Name::class, $node);
+        self::assertSame('MyClass', $node->toString());
+    }
+
+    public function testFindMethodName(): void
+    {
+        $code = '<?php $obj->doSomething();';
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        // Position on "doSomething" (line 0, char 12)
+        $finder = new NodeAtPosition();
+        $node = $finder->find($ast, $doc->offsetAt(0, 12));
+
+        // Returns the Identifier node for the method name
+        self::assertInstanceOf(Identifier::class, $node);
+        self::assertSame('doSomething', $node->toString());
+    }
+
+    public function testFindStaticMethodCall(): void
+    {
+        $code = '<?php MyClass::staticMethod();';
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        // Position on "MyClass" (line 0, char 8)
+        $finder = new NodeAtPosition();
+        $node = $finder->find($ast, $doc->offsetAt(0, 8));
+
+        self::assertInstanceOf(Name::class, $node);
+        self::assertSame('MyClass', $node->toString());
+    }
+
+    public function testReturnsNullOutsideCode(): void
+    {
+        $code = '<?php // comment';
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $finder = new NodeAtPosition();
+        $node = $finder->find($ast, $doc->offsetAt(0, 10));
+
+        self::assertNull($node);
+    }
+}

--- a/tests/Index/SymbolExtractorTest.php
+++ b/tests/Index/SymbolExtractorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Parser\ParserService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SymbolExtractor::class)]
+class SymbolExtractorTest extends TestCase
+{
+    private ParserService $parser;
+    private SymbolExtractor $extractor;
+
+    protected function setUp(): void
+    {
+        $this->parser = new ParserService();
+        $this->extractor = new SymbolExtractor();
+    }
+
+    public function testExtractFunction(): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, '<?php function myFunc() {}');
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $symbols = $this->extractor->extract($doc, $ast);
+
+        self::assertCount(1, $symbols);
+        self::assertSame('myFunc', $symbols[0]->name);
+        self::assertSame('myFunc', $symbols[0]->fullyQualifiedName);
+        self::assertSame(SymbolKind::Function_, $symbols[0]->kind);
+    }
+
+    public function testExtractClass(): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, '<?php class MyClass {}');
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $symbols = $this->extractor->extract($doc, $ast);
+
+        self::assertCount(1, $symbols);
+        self::assertSame('MyClass', $symbols[0]->name);
+        self::assertSame('MyClass', $symbols[0]->fullyQualifiedName);
+        self::assertSame(SymbolKind::Class_, $symbols[0]->kind);
+    }
+
+    public function testExtractNamespacedClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Service;
+
+class UserService {}
+PHP;
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $symbols = $this->extractor->extract($doc, $ast);
+
+        self::assertCount(1, $symbols);
+        self::assertSame('UserService', $symbols[0]->name);
+        self::assertSame('App\\Service\\UserService', $symbols[0]->fullyQualifiedName);
+    }
+
+    public function testExtractMethod(): void
+    {
+        $code = '<?php class MyClass { public function myMethod() {} }';
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $symbols = $this->extractor->extract($doc, $ast);
+
+        self::assertCount(2, $symbols);
+        // Class
+        self::assertSame('MyClass', $symbols[0]->name);
+        // Method
+        self::assertSame('myMethod', $symbols[1]->name);
+        self::assertSame('MyClass::myMethod', $symbols[1]->fullyQualifiedName);
+        self::assertSame(SymbolKind::Method, $symbols[1]->kind);
+        self::assertSame('MyClass', $symbols[1]->containerName);
+    }
+
+    public function testExtractInterface(): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, '<?php interface MyInterface {}');
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $symbols = $this->extractor->extract($doc, $ast);
+
+        self::assertCount(1, $symbols);
+        self::assertSame('MyInterface', $symbols[0]->name);
+        self::assertSame(SymbolKind::Interface_, $symbols[0]->kind);
+    }
+
+    public function testExtractTrait(): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, '<?php trait MyTrait {}');
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $symbols = $this->extractor->extract($doc, $ast);
+
+        self::assertCount(1, $symbols);
+        self::assertSame('MyTrait', $symbols[0]->name);
+        self::assertSame(SymbolKind::Trait_, $symbols[0]->kind);
+    }
+
+    public function testExtractEnum(): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, '<?php enum Status { case Active; }');
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $symbols = $this->extractor->extract($doc, $ast);
+
+        // Enum + EnumCase
+        self::assertGreaterThanOrEqual(1, count($symbols));
+        self::assertSame('Status', $symbols[0]->name);
+        self::assertSame(SymbolKind::Enum_, $symbols[0]->kind);
+    }
+}

--- a/tests/Index/SymbolIndexTest.php
+++ b/tests/Index/SymbolIndexTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Index\Symbol;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SymbolIndex::class)]
+class SymbolIndexTest extends TestCase
+{
+    public function testAddAndFind(): void
+    {
+        $index = new SymbolIndex();
+        $location = new Location('file:///test.php', 0, 0, 0, 10);
+        $symbol = new Symbol('MyClass', 'App\\MyClass', SymbolKind::Class_, $location);
+
+        $index->add($symbol);
+
+        $found = $index->findByFqn('App\\MyClass');
+        self::assertNotNull($found);
+        self::assertSame('MyClass', $found->name);
+    }
+
+    public function testFindReturnsNullForUnknown(): void
+    {
+        $index = new SymbolIndex();
+
+        self::assertNull($index->findByFqn('Unknown\\Class'));
+    }
+
+    public function testClearByUri(): void
+    {
+        $index = new SymbolIndex();
+        $location1 = new Location('file:///a.php', 0, 0, 0, 10);
+        $location2 = new Location('file:///b.php', 0, 0, 0, 10);
+
+        $index->add(new Symbol('ClassA', 'ClassA', SymbolKind::Class_, $location1));
+        $index->add(new Symbol('ClassB', 'ClassB', SymbolKind::Class_, $location2));
+
+        $index->clearByUri('file:///a.php');
+
+        self::assertNull($index->findByFqn('ClassA'));
+        self::assertNotNull($index->findByFqn('ClassB'));
+    }
+
+    public function testFindByName(): void
+    {
+        $index = new SymbolIndex();
+        $location = new Location('file:///test.php', 0, 0, 0, 10);
+
+        $index->add(new Symbol('MyClass', 'App\\MyClass', SymbolKind::Class_, $location));
+        $index->add(new Symbol('MyClass', 'Other\\MyClass', SymbolKind::Class_, $location));
+
+        $found = $index->findByName('MyClass');
+
+        self::assertCount(2, $found);
+    }
+}

--- a/tests/Integration/DefinitionIntegrationTest.php
+++ b/tests/Integration/DefinitionIntegrationTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Integration;
+
+use Amp\ByteStream\ReadableBuffer;
+use Amp\ByteStream\WritableBuffer;
+use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+use Firehed\PhpLsp\Server;
+use Firehed\PhpLsp\ServerInfo;
+use Firehed\PhpLsp\Transport\MessageReader;
+use Firehed\PhpLsp\Transport\MessageWriter;
+use Firehed\PhpLsp\Transport\TransportInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Server::class)]
+class DefinitionIntegrationTest extends TestCase
+{
+    public function testGoToDefinitionEndToEnd(): void
+    {
+        // Simulate full LSP interaction:
+        // 1. Initialize
+        // 2. Open file with class definition
+        // 3. Open file with class usage
+        // 4. Request definition
+        // 5. Shutdown + exit
+
+        $messages = [
+            // Initialize
+            $this->makeRequest(1, 'initialize', [
+                'processId' => getmypid(),
+                'capabilities' => [],
+                'rootUri' => 'file:///project',
+            ]),
+            // Initialized notification
+            $this->makeNotification('initialized', []),
+            // Open class definition file
+            $this->makeNotification('textDocument/didOpen', [
+                'textDocument' => [
+                    'uri' => 'file:///project/src/MyClass.php',
+                    'languageId' => 'php',
+                    'version' => 1,
+                    'text' => '<?php class MyClass { public function hello() {} }',
+                ],
+            ]),
+            // Open usage file
+            $this->makeNotification('textDocument/didOpen', [
+                'textDocument' => [
+                    'uri' => 'file:///project/src/usage.php',
+                    'languageId' => 'php',
+                    'version' => 1,
+                    'text' => '<?php $x = new MyClass();',
+                ],
+            ]),
+            // Request definition at "MyClass" in usage.php
+            $this->makeRequest(2, 'textDocument/definition', [
+                'textDocument' => ['uri' => 'file:///project/src/usage.php'],
+                'position' => ['line' => 0, 'character' => 15], // On "MyClass"
+            ]),
+            // Shutdown
+            $this->makeRequest(3, 'shutdown', null),
+            // Exit
+            $this->makeNotification('exit', null),
+        ];
+
+        $input = implode('', array_map(fn($m) => $this->encode($m), $messages));
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        $exitCode = $server->run();
+
+        self::assertSame(0, $exitCode);
+
+        $output = $outputBuffer->buffer();
+
+        // Parse responses
+        self::assertStringContainsString('"id":2', $output, 'Should have response to definition request');
+        // JSON escapes / as \/ so check for that
+        self::assertStringContainsString('MyClass.php', $output, 'Definition should point to MyClass.php');
+    }
+
+    /**
+     * @param array<string, mixed>|null $params
+     * @return array<string, mixed>
+     */
+    private function makeRequest(int $id, string $method, ?array $params): array
+    {
+        $msg = [
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'method' => $method,
+        ];
+        if ($params !== null) {
+            $msg['params'] = $params;
+        }
+        return $msg;
+    }
+
+    /**
+     * @param array<string, mixed>|null $params
+     * @return array<string, mixed>
+     */
+    private function makeNotification(string $method, ?array $params): array
+    {
+        $msg = [
+            'jsonrpc' => '2.0',
+            'method' => $method,
+        ];
+        if ($params !== null) {
+            $msg['params'] = $params;
+        }
+        return $msg;
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    private function encode(array $message): string
+    {
+        $json = json_encode($message, JSON_THROW_ON_ERROR);
+        return "Content-Length: " . strlen($json) . "\r\n\r\n" . $json;
+    }
+
+    private function createTransport(string $input, WritableBuffer $outputBuffer): TransportInterface
+    {
+        $inputBuffer = new ReadableBuffer($input);
+        $reader = new MessageReader($inputBuffer);
+        $writer = new MessageWriter($outputBuffer);
+
+        return new class ($reader, $writer, $outputBuffer) implements TransportInterface {
+            public function __construct(
+                private MessageReader $reader,
+                private MessageWriter $writer,
+                private WritableBuffer $outputBuffer,
+            ) {
+            }
+
+            public function read(): ?Message
+            {
+                return $this->reader->read();
+            }
+
+            public function write(ResponseMessage $response): void
+            {
+                $this->writer->write($response);
+            }
+
+            public function close(): void
+            {
+                $this->outputBuffer->close();
+            }
+        };
+    }
+}

--- a/tests/Parser/ParserServiceTest.php
+++ b/tests/Parser/ParserServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Parser;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Parser\ParserService;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Function_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ParserService::class)]
+class ParserServiceTest extends TestCase
+{
+    public function testParseValidPhp(): void
+    {
+        $parser = new ParserService();
+        $doc = new TextDocument(
+            'file:///test.php',
+            'php',
+            1,
+            '<?php function foo() {}',
+        );
+
+        $result = $parser->parse($doc);
+
+        self::assertNotNull($result);
+        self::assertCount(1, $result);
+        self::assertInstanceOf(Function_::class, $result[0]);
+    }
+
+    public function testParseClass(): void
+    {
+        $parser = new ParserService();
+        $doc = new TextDocument(
+            'file:///test.php',
+            'php',
+            1,
+            '<?php class MyClass { public function bar() {} }',
+        );
+
+        $result = $parser->parse($doc);
+
+        self::assertNotNull($result);
+        self::assertCount(1, $result);
+        self::assertInstanceOf(Class_::class, $result[0]);
+    }
+
+    public function testParseInvalidPhpReturnsNull(): void
+    {
+        $parser = new ParserService();
+        $doc = new TextDocument(
+            'file:///test.php',
+            'php',
+            1,
+            '<?php function foo( { }', // syntax error
+        );
+
+        $result = $parser->parse($doc);
+
+        self::assertNull($result);
+    }
+
+    public function testParseEmptyFile(): void
+    {
+        $parser = new ParserService();
+        $doc = new TextDocument(
+            'file:///test.php',
+            'php',
+            1,
+            '',
+        );
+
+        $result = $parser->parse($doc);
+
+        self::assertNotNull($result);
+        self::assertCount(0, $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Document sync (didOpen/didChange/didClose) with full text sync
- PHP parsing with nikic/php-parser and name resolution
- Symbol extraction and indexing for open files
- Go-to-definition for class/interface names
- Composer PSR-4 autoload integration for cross-file and vendor lookups

## Current Scope

**Works:**
- Class names (new Foo, extends Bar, implements Baz, type hints)
- Interface names
- Vendor classes (via Composer autoload)

**Not yet supported:**
- Method calls
- Function calls
- Properties
- Constants

## Test plan

- [x] composer check passes
- [x] Manual testing in Vim with ALE

Generated with Claude Code