### PR TITLE
Add hover support

### DIFF
--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -12,11 +12,21 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionProperty;
 
 final class HoverHandler implements HandlerInterface
 {
@@ -93,20 +103,54 @@ final class HoverHandler implements HandlerInterface
         // Name node - could be class reference or function call
         if ($node instanceof Name) {
             $parent = $node->getAttribute('parent');
-            // Function call: check for function definition first
+
+            // Function call: check for user-defined function first, then built-in
             if ($parent instanceof FuncCall) {
                 $functionHover = $this->getFunctionHover($node->toString(), $ast);
                 if ($functionHover !== null) {
                     return $functionHover;
                 }
+                return $this->getBuiltinFunctionHover($node->toString());
             }
+
+            // Static method call: ClassName::method()
+            if ($parent instanceof StaticCall) {
+                return $this->getClassHover($node, $ast, $document);
+            }
+
+            // Static property fetch: ClassName::$property
+            if ($parent instanceof StaticPropertyFetch) {
+                return $this->getClassHover($node, $ast, $document);
+            }
+
             // Fall through to class hover for class references
             return $this->getClassHover($node, $ast, $document);
         }
 
-        // Method name in a method call (Identifier node)
+        // Identifier node - could be method name, property name, or function call
         if ($node instanceof Identifier) {
             $parent = $node->getAttribute('parent');
+
+            // Method call: $obj->method() or $this->method()
+            if ($parent instanceof MethodCall) {
+                return $this->getMethodHover($parent, $ast, $document);
+            }
+
+            // Static method call: ClassName::method()
+            if ($parent instanceof StaticCall) {
+                return $this->getStaticMethodHover($parent, $ast, $document);
+            }
+
+            // Property fetch: $obj->property or $this->property
+            if ($parent instanceof PropertyFetch) {
+                return $this->getPropertyHover($parent, $ast, $document);
+            }
+
+            // Static property fetch: ClassName::$property
+            if ($parent instanceof StaticPropertyFetch) {
+                return $this->getStaticPropertyHover($parent, $ast, $document);
+            }
+
             if ($parent instanceof FuncCall) {
                 return $this->getFunctionHover($node->toString(), $ast);
             }
@@ -305,6 +349,481 @@ final class HoverHandler implements HandlerInterface
         $parts[] = '```php' . "\n" . $signature . "\n```";
 
         return implode("\n\n", $parts);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getMethodHover(MethodCall $call, array $ast, TextDocument $document): ?string
+    {
+        $methodName = $call->name;
+        if (!$methodName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveExpressionClass($call->var, $ast);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->getMethodHoverForClass($className, $methodName->toString(), $ast, $document);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getStaticMethodHover(StaticCall $call, array $ast, TextDocument $document): ?string
+    {
+        $methodName = $call->name;
+        if (!$methodName instanceof Identifier) {
+            return null;
+        }
+
+        $class = $call->class;
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        $resolvedName = $class->getAttribute('resolvedName');
+        $className = $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $class->toString();
+
+        return $this->getMethodHoverForClass($className, $methodName->toString(), $ast, $document);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getPropertyHover(PropertyFetch $fetch, array $ast, TextDocument $document): ?string
+    {
+        $propertyName = $fetch->name;
+        if (!$propertyName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveExpressionClass($fetch->var, $ast);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->getPropertyHoverForClass($className, $propertyName->toString(), $ast, $document);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getStaticPropertyHover(StaticPropertyFetch $fetch, array $ast, TextDocument $document): ?string
+    {
+        $propertyName = $fetch->name;
+        if (!$propertyName instanceof Node\VarLikeIdentifier) {
+            return null;
+        }
+
+        $class = $fetch->class;
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        $resolvedName = $class->getAttribute('resolvedName');
+        $className = $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $class->toString();
+
+        return $this->getPropertyHoverForClass($className, $propertyName->toString(), $ast, $document);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getMethodHoverForClass(string $className, string $methodName, array $ast, TextDocument $document): ?string
+    {
+        // Try to find in AST first (current file or via Composer)
+        $methodNode = $this->findMethodInClass($className, $methodName, $ast, $document);
+        if ($methodNode !== null) {
+            return $this->formatMethodHover($methodNode);
+        }
+
+        // Fall back to reflection for built-in or autoloaded classes
+        return $this->getReflectionMethodHover($className, $methodName);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getPropertyHoverForClass(string $className, string $propertyName, array $ast, TextDocument $document): ?string
+    {
+        // Try to find in AST first
+        $propertyNode = $this->findPropertyInClass($className, $propertyName, $ast, $document);
+        if ($propertyNode !== null) {
+            return $this->formatPropertyHover($propertyNode, $propertyName);
+        }
+
+        // Fall back to reflection
+        return $this->getReflectionPropertyHover($className, $propertyName);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveExpressionClass(Node\Expr $expr, array $ast): ?string
+    {
+        // $this refers to the enclosing class
+        if ($expr instanceof Variable && $expr->name === 'this') {
+            return $this->findEnclosingClassName($expr, $ast);
+        }
+
+        // For other expressions, we'd need type inference - skip for now
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findEnclosingClassName(Node $node, array $ast): ?string
+    {
+        // Walk up through parent nodes to find enclosing class
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if ($current instanceof Stmt\Class_ && $current->name !== null) {
+                // Get the fully qualified name if available
+                $namespacedName = $current->namespacedName;
+                if ($namespacedName instanceof Name) {
+                    return $namespacedName->toString();
+                }
+                return $current->name->toString();
+            }
+            $current = $current->getAttribute('parent');
+        }
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findMethodInClass(string $className, string $methodName, array $ast, TextDocument $document): ?Stmt\ClassMethod
+    {
+        // First check current file
+        $classNode = $this->findClassInAst($className, $ast);
+
+        // If not found, try Composer
+        if ($classNode === null && $this->classLocator !== null) {
+            $filePath = $this->classLocator->locateClass($className);
+            if ($filePath !== null) {
+                $content = file_get_contents($filePath);
+                if ($content !== false) {
+                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
+                    $externalAst = $this->parser->parse($externalDoc);
+                    if ($externalAst !== null) {
+                        $classNode = $this->findClassInAst($className, $externalAst);
+                    }
+                }
+            }
+        }
+
+        if ($classNode === null) {
+            return null;
+        }
+
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
+                return $stmt;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findPropertyInClass(string $className, string $propertyName, array $ast, TextDocument $document): ?Stmt\Property
+    {
+        // First check current file
+        $classNode = $this->findClassInAst($className, $ast);
+
+        // If not found, try Composer
+        if ($classNode === null && $this->classLocator !== null) {
+            $filePath = $this->classLocator->locateClass($className);
+            if ($filePath !== null) {
+                $content = file_get_contents($filePath);
+                if ($content !== false) {
+                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
+                    $externalAst = $this->parser->parse($externalDoc);
+                    if ($externalAst !== null) {
+                        $classNode = $this->findClassInAst($className, $externalAst);
+                    }
+                }
+            }
+        }
+
+        if ($classNode === null) {
+            return null;
+        }
+
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\Property) {
+                foreach ($stmt->props as $prop) {
+                    if ($prop->name->toString() === $propertyName) {
+                        return $stmt;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function formatMethodHover(Stmt\ClassMethod $method): string
+    {
+        $parts = [];
+
+        $docComment = $method->getDocComment();
+        if ($docComment !== null) {
+            $parts[] = $this->formatDocblock($docComment->getText());
+        }
+
+        $visibility = $this->getVisibility($method);
+        $static = $method->isStatic() ? 'static ' : '';
+
+        $params = [];
+        foreach ($method->params as $param) {
+            $paramStr = '';
+            if ($param->type !== null) {
+                $paramStr .= $this->formatType($param->type) . ' ';
+            }
+            $var = $param->var;
+            if ($var instanceof Variable && is_string($var->name)) {
+                $paramStr .= '$' . $var->name;
+            }
+            $params[] = $paramStr;
+        }
+
+        $signature = $visibility . $static . 'function ' . $method->name->toString() . '(' . implode(', ', $params) . ')';
+
+        if ($method->returnType !== null) {
+            $signature .= ': ' . $this->formatType($method->returnType);
+        }
+
+        $parts[] = '```php' . "\n" . $signature . "\n```";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function formatPropertyHover(Stmt\Property $property, string $propertyName): string
+    {
+        $parts = [];
+
+        $docComment = $property->getDocComment();
+        if ($docComment !== null) {
+            $parts[] = $this->formatDocblock($docComment->getText());
+        }
+
+        $visibility = $this->getPropertyVisibility($property);
+        $static = $property->isStatic() ? 'static ' : '';
+        $readonly = $property->isReadonly() ? 'readonly ' : '';
+
+        $type = '';
+        if ($property->type !== null) {
+            $type = $this->formatType($property->type) . ' ';
+        }
+
+        $signature = $visibility . $static . $readonly . $type . '$' . $propertyName;
+
+        $parts[] = '```php' . "\n" . $signature . "\n```";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function getVisibility(Stmt\ClassMethod $method): string
+    {
+        if ($method->isPrivate()) {
+            return 'private ';
+        }
+        if ($method->isProtected()) {
+            return 'protected ';
+        }
+        return 'public ';
+    }
+
+    private function getPropertyVisibility(Stmt\Property $property): string
+    {
+        if ($property->isPrivate()) {
+            return 'private ';
+        }
+        if ($property->isProtected()) {
+            return 'protected ';
+        }
+        return 'public ';
+    }
+
+    private function getBuiltinFunctionHover(string $functionName): ?string
+    {
+        try {
+            $reflection = new ReflectionFunction($functionName);
+            return $this->formatReflectionFunction($reflection);
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    private function getReflectionMethodHover(string $className, string $methodName): ?string
+    {
+        try {
+            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+                return null;
+            }
+            $classReflection = new ReflectionClass($className);
+            if (!$classReflection->hasMethod($methodName)) {
+                return null;
+            }
+            $reflection = $classReflection->getMethod($methodName);
+            return $this->formatReflectionMethod($reflection);
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    private function getReflectionPropertyHover(string $className, string $propertyName): ?string
+    {
+        try {
+            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+                return null;
+            }
+            $classReflection = new ReflectionClass($className);
+            if (!$classReflection->hasProperty($propertyName)) {
+                return null;
+            }
+            $reflection = $classReflection->getProperty($propertyName);
+            return $this->formatReflectionProperty($reflection);
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    private function formatReflectionFunction(ReflectionFunction $func): string
+    {
+        $parts = [];
+
+        $docComment = $func->getDocComment();
+        if ($docComment !== false) {
+            $parts[] = $this->formatDocblock($docComment);
+        }
+
+        $params = [];
+        foreach ($func->getParameters() as $param) {
+            $paramStr = '';
+            $type = $param->getType();
+            if ($type !== null) {
+                $paramStr .= $this->formatReflectionType($type) . ' ';
+            }
+            if ($param->isVariadic()) {
+                $paramStr .= '...';
+            }
+            $paramStr .= '$' . $param->getName();
+            if ($param->isOptional() && !$param->isVariadic()) {
+                $paramStr .= ' = ...';
+            }
+            $params[] = $paramStr;
+        }
+
+        $signature = 'function ' . $func->getName() . '(' . implode(', ', $params) . ')';
+
+        $returnType = $func->getReturnType();
+        if ($returnType !== null) {
+            $signature .= ': ' . $this->formatReflectionType($returnType);
+        }
+
+        $parts[] = '```php' . "\n" . $signature . "\n```";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function formatReflectionMethod(ReflectionMethod $method): string
+    {
+        $parts = [];
+
+        $docComment = $method->getDocComment();
+        if ($docComment !== false) {
+            $parts[] = $this->formatDocblock($docComment);
+        }
+
+        $visibility = match (true) {
+            $method->isPrivate() => 'private ',
+            $method->isProtected() => 'protected ',
+            default => 'public ',
+        };
+        $static = $method->isStatic() ? 'static ' : '';
+
+        $params = [];
+        foreach ($method->getParameters() as $param) {
+            $paramStr = '';
+            $type = $param->getType();
+            if ($type !== null) {
+                $paramStr .= $this->formatReflectionType($type) . ' ';
+            }
+            if ($param->isVariadic()) {
+                $paramStr .= '...';
+            }
+            $paramStr .= '$' . $param->getName();
+            if ($param->isOptional() && !$param->isVariadic()) {
+                $paramStr .= ' = ...';
+            }
+            $params[] = $paramStr;
+        }
+
+        $signature = $visibility . $static . 'function ' . $method->getName() . '(' . implode(', ', $params) . ')';
+
+        $returnType = $method->getReturnType();
+        if ($returnType !== null) {
+            $signature .= ': ' . $this->formatReflectionType($returnType);
+        }
+
+        $parts[] = '```php' . "\n" . $signature . "\n```";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function formatReflectionProperty(ReflectionProperty $property): string
+    {
+        $parts = [];
+
+        $docComment = $property->getDocComment();
+        if ($docComment !== false) {
+            $parts[] = $this->formatDocblock($docComment);
+        }
+
+        $visibility = match (true) {
+            $property->isPrivate() => 'private ',
+            $property->isProtected() => 'protected ',
+            default => 'public ',
+        };
+        $static = $property->isStatic() ? 'static ' : '';
+        $readonly = $property->isReadOnly() ? 'readonly ' : '';
+
+        $type = $property->getType();
+        $typeStr = $type !== null ? $this->formatReflectionType($type) . ' ' : '';
+
+        $signature = $visibility . $static . $readonly . $typeStr . '$' . $property->getName();
+
+        $parts[] = '```php' . "\n" . $signature . "\n```";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function formatReflectionType(\ReflectionType $type): string
+    {
+        if ($type instanceof \ReflectionNamedType) {
+            $name = $type->getName();
+            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
+        }
+        if ($type instanceof \ReflectionUnionType) {
+            return implode('|', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
+        }
+        if ($type instanceof \ReflectionIntersectionType) {
+            return implode('&', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
+        }
+        return (string) $type;
     }
 
     private function formatDocblock(string $docblock): string

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Index\NodeAtPosition;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\Message;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+final class HoverHandler implements HandlerInterface
+{
+    public function __construct(
+        private readonly DocumentManager $documentManager,
+        private readonly ParserService $parser,
+        private readonly ?ComposerClassLocator $classLocator,
+    ) {
+    }
+
+    public function supports(string $method): bool
+    {
+        return $method === 'textDocument/hover';
+    }
+
+    /**
+     * @return array{contents: string}|null
+     */
+    public function handle(Message $message): ?array
+    {
+        $params = $message->params ?? [];
+
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+        $uri = $textDocument['uri'] ?? '';
+        if (!is_string($uri)) {
+            return null;
+        }
+
+        $position = $params['position'] ?? [];
+        if (!is_array($position)) {
+            return null;
+        }
+        $line = $position['line'] ?? 0;
+        $character = $position['character'] ?? 0;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        $document = $this->documentManager->get($uri);
+        if ($document === null) {
+            return null;
+        }
+
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return null;
+        }
+
+        $offset = $document->offsetAt($line, $character);
+        $nodeFinder = new NodeAtPosition();
+        $node = $nodeFinder->find($ast, $offset);
+
+        if ($node === null) {
+            return null;
+        }
+
+        $hoverContent = $this->getHoverContent($node, $ast, $document);
+
+        if ($hoverContent === null) {
+            return null;
+        }
+
+        return ['contents' => $hoverContent];
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getHoverContent(Node $node, array $ast, TextDocument $document): ?string
+    {
+        // Name node - could be class reference or function call
+        if ($node instanceof Name) {
+            $parent = $node->getAttribute('parent');
+            // Function call: check for function definition first
+            if ($parent instanceof FuncCall) {
+                $functionHover = $this->getFunctionHover($node->toString(), $ast);
+                if ($functionHover !== null) {
+                    return $functionHover;
+                }
+            }
+            // Fall through to class hover for class references
+            return $this->getClassHover($node, $ast, $document);
+        }
+
+        // Method name in a method call (Identifier node)
+        if ($node instanceof Identifier) {
+            $parent = $node->getAttribute('parent');
+            if ($parent instanceof FuncCall) {
+                return $this->getFunctionHover($node->toString(), $ast);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getClassHover(Name $node, array $ast, TextDocument $document): ?string
+    {
+        $resolvedName = $node->getAttribute('resolvedName');
+        $className = $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $node->toString();
+
+        // First look in current file
+        $classNode = $this->findClassInAst($className, $ast);
+
+        // If not found, try to locate via Composer
+        if ($classNode === null && $this->classLocator !== null) {
+            $filePath = $this->classLocator->locateClass($className);
+            if ($filePath !== null) {
+                $content = file_get_contents($filePath);
+                if ($content !== false) {
+                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
+                    $externalAst = $this->parser->parse($externalDoc);
+                    if ($externalAst !== null) {
+                        $classNode = $this->findClassInAst($className, $externalAst);
+                    }
+                }
+            }
+        }
+
+        if ($classNode === null) {
+            return null;
+        }
+
+        return $this->formatClassHover($classNode);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findClassInAst(string $className, array $ast): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null
+    {
+        $finder = new class ($className) extends NodeVisitorAbstract {
+            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
+            private string $namespace = '';
+
+            public function __construct(private readonly string $className)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Namespace_) {
+                    $this->namespace = $node->name?->toString() ?? '';
+                    return null;
+                }
+
+                if ($node instanceof Stmt\Class_
+                    || $node instanceof Stmt\Interface_
+                    || $node instanceof Stmt\Trait_
+                    || $node instanceof Stmt\Enum_
+                ) {
+                    $name = $node->name?->toString();
+                    if ($name === null) {
+                        return null;
+                    }
+                    $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
+
+                    // Match by FQN or short name
+                    if ($fqn === $this->className || $name === $this->className) {
+                        $this->found = $node;
+                        return NodeTraverser::STOP_TRAVERSAL;
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        return $finder->found;
+    }
+
+    private function formatClassHover(Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $node): string
+    {
+        $parts = [];
+
+        // Add docblock if present
+        $docComment = $node->getDocComment();
+        if ($docComment !== null) {
+            $parts[] = $this->formatDocblock($docComment->getText());
+        }
+
+        // Add signature
+        $keyword = match (true) {
+            $node instanceof Stmt\Interface_ => 'interface',
+            $node instanceof Stmt\Trait_ => 'trait',
+            $node instanceof Stmt\Enum_ => 'enum',
+            default => 'class',
+        };
+
+        $signature = $keyword . ' ' . $node->name;
+
+        if ($node instanceof Stmt\Class_) {
+            if ($node->extends !== null) {
+                $signature .= ' extends ' . $node->extends->toString();
+            }
+            if ($node->implements !== []) {
+                $implements = array_map(fn($n) => $n->toString(), $node->implements);
+                $signature .= ' implements ' . implode(', ', $implements);
+            }
+        }
+
+        if ($node instanceof Stmt\Interface_ && $node->extends !== []) {
+            $extends = array_map(fn($n) => $n->toString(), $node->extends);
+            $signature .= ' extends ' . implode(', ', $extends);
+        }
+
+        $parts[] = '```php' . "\n" . $signature . "\n```";
+
+        return implode("\n\n", $parts);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function getFunctionHover(string $functionName, array $ast): ?string
+    {
+        $finder = new class ($functionName) extends NodeVisitorAbstract {
+            public ?Stmt\Function_ $found = null;
+
+            public function __construct(private readonly string $functionName)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Function_ && $node->name->toString() === $this->functionName) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        if ($finder->found === null) {
+            return null;
+        }
+
+        return $this->formatFunctionHover($finder->found);
+    }
+
+    private function formatFunctionHover(Stmt\Function_ $node): string
+    {
+        $parts = [];
+
+        // Add docblock if present
+        $docComment = $node->getDocComment();
+        if ($docComment !== null) {
+            $parts[] = $this->formatDocblock($docComment->getText());
+        }
+
+        // Build signature
+        $params = [];
+        foreach ($node->params as $param) {
+            $paramStr = '';
+            if ($param->type !== null) {
+                $paramStr .= $this->formatType($param->type) . ' ';
+            }
+            $var = $param->var;
+            if ($var instanceof Node\Expr\Variable && is_string($var->name)) {
+                $paramStr .= '$' . $var->name;
+            }
+            $params[] = $paramStr;
+        }
+
+        $signature = 'function ' . $node->name->toString() . '(' . implode(', ', $params) . ')';
+
+        if ($node->returnType !== null) {
+            $signature .= ': ' . $this->formatType($node->returnType);
+        }
+
+        $parts[] = '```php' . "\n" . $signature . "\n```";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function formatDocblock(string $docblock): string
+    {
+        // Strip /** and */ and clean up
+        $lines = explode("\n", $docblock);
+        $cleaned = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            $line = preg_replace('/^\/\*\*\s*/', '', $line) ?? '';
+            $line = preg_replace('/^\*\/\s*$/', '', $line) ?? '';
+            $line = preg_replace('/^\*\s?/', '', $line) ?? '';
+
+            if ($line !== '') {
+                $cleaned[] = $line;
+            }
+        }
+
+        return implode("\n", $cleaned);
+    }
+
+    private function formatType(Node $type): string
+    {
+        if ($type instanceof Name) {
+            return $type->toString();
+        }
+        if ($type instanceof Identifier) {
+            return $type->toString();
+        }
+        if ($type instanceof Node\NullableType) {
+            return '?' . $this->formatType($type->type);
+        }
+        if ($type instanceof Node\UnionType) {
+            return implode('|', array_map(fn($t) => $this->formatType($t), $type->types));
+        }
+        if ($type instanceof Node\IntersectionType) {
+            return implode('&', array_map(fn($t) => $this->formatType($t), $type->types));
+        }
+        return '';
+    }
+}

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -60,6 +60,7 @@ final class LifecycleHandler implements HandlerInterface
                 // TextDocumentSyncKind.Full = 1 (send full document on change)
                 'textDocumentSync' => 1,
                 'definitionProvider' => true,
+                'hoverProvider' => true,
             ],
             'serverInfo' => $this->serverInfo->toArray(),
         ];

--- a/src/Parser/ParserService.php
+++ b/src/Parser/ParserService.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\TextDocument;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 
@@ -20,6 +21,8 @@ final class ParserService
     {
         $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
         $this->traverser = new NodeTraverser();
+        // ParentConnectingVisitor adds 'parent' attribute to all nodes
+        $this->traverser->addVisitor(new ParentConnectingVisitor());
         // NameResolver adds 'resolvedName' attribute to Name nodes
         $this->traverser->addVisitor(new NameResolver());
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
 use Firehed\PhpLsp\Handler\HandlerInterface;
+use Firehed\PhpLsp\Handler\HoverHandler;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
@@ -45,6 +46,7 @@ final class Server
         $this->handlers[] = $this->lifecycleHandler;
         $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
         $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
+        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator);
     }
 
     public function run(): int

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Handler\HoverHandler;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HoverHandler::class)]
+class HoverHandlerTest extends TestCase
+{
+    private DocumentManager $documents;
+    private ParserService $parser;
+    private HoverHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->documents = new DocumentManager();
+        $this->parser = new ParserService();
+        $this->handler = new HoverHandler($this->documents, $this->parser, null);
+    }
+
+    public function testSupports(): void
+    {
+        self::assertTrue($this->handler->supports('textDocument/hover'));
+        self::assertFalse($this->handler->supports('textDocument/definition'));
+    }
+
+    public function testHoverOnClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+/**
+ * A sample class for testing.
+ */
+class MyClass
+{
+    public function doSomething(): void {}
+}
+
+$x = new MyClass();
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 12], // On "MyClass"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('contents', $result);
+        self::assertStringContainsString('MyClass', $result['contents']);
+    }
+
+    public function testHoverOnClassWithDocblock(): void
+    {
+        $code = <<<'PHP'
+<?php
+/**
+ * Represents a user in the system.
+ *
+ * @author Test
+ */
+class User {}
+
+$u = new User();
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 10], // On "User"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('Represents a user', $result['contents']);
+    }
+
+    public function testHoverReturnsNullForUnknownPosition(): void
+    {
+        $code = '<?php // just a comment';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 10],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertNull($result);
+    }
+
+    public function testHoverOnFunction(): void
+    {
+        $code = <<<'PHP'
+<?php
+/**
+ * Adds two numbers together.
+ */
+function add(int $a, int $b): int
+{
+    return $a + $b;
+}
+
+$sum = add(1, 2);
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 8], // On "add"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('add', $result['contents']);
+        self::assertStringContainsString('int', $result['contents']);
+    }
+}

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -148,4 +148,140 @@ PHP;
         self::assertStringContainsString('add', $result['contents']);
         self::assertStringContainsString('int', $result['contents']);
     }
+
+    public function testHoverOnMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Multiplies two numbers.
+     */
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+
+    public function test(): void
+    {
+        $this->multiply(2, 3);
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 13, 'character' => 16], // On "multiply"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('multiply', $result['contents']);
+        self::assertStringContainsString('Multiplies two numbers', $result['contents']);
+    }
+
+    public function testHoverOnProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Person
+{
+    /**
+     * The person's full name.
+     */
+    public string $name;
+
+    public function greet(): string
+    {
+        return 'Hello, ' . $this->name;
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 35], // On "name"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$name', $result['contents']);
+        self::assertStringContainsString('string', $result['contents']);
+    }
+
+    public function testHoverOnBuiltinFunction(): void
+    {
+        $code = <<<'PHP'
+<?php
+$arr = [3, 1, 2];
+sort($arr);
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 2, 'character' => 2], // On "sort"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('sort', $result['contents']);
+    }
+
+    public function testHoverOnStaticMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Math
+{
+    /**
+     * Returns the absolute value.
+     */
+    public static function abs(int $n): int
+    {
+        return $n < 0 ? -$n : $n;
+    }
+}
+
+$result = Math::abs(-5);
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 16], // On "abs"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('abs', $result['contents']);
+        self::assertStringContainsString('Returns the absolute value', $result['contents']);
+    }
 }


### PR DESCRIPTION
## Summary
- Implements `textDocument/hover` for classes, interfaces, traits, enums, and user-defined functions
- Displays docblock comments and type signatures on hover
- Adds `ParentConnectingVisitor` to parser for parent node lookups needed for hover context detection

## Test plan
- [x] Unit tests for HoverHandler
- [x] All existing tests pass (`composer check`)
- [ ] Manual testing in Vim/ALE

🤖 Generated with [Claude Code](https://claude.com/claude-code)