### PR TITLE
Add completion support

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -1,0 +1,689 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Utility\DocblockParser;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class CompletionHandler implements HandlerInterface
+{
+    // LSP CompletionItemKind constants
+    private const KIND_METHOD = 2;
+    private const KIND_FUNCTION = 3;
+    private const KIND_CLASS = 7;
+    private const KIND_PROPERTY = 10;
+    private const KIND_CONSTANT = 21;
+
+    public function __construct(
+        private readonly DocumentManager $documentManager,
+        private readonly ParserService $parser,
+        private readonly ?ComposerClassLocator $classLocator,
+    ) {
+    }
+
+    public function supports(string $method): bool
+    {
+        return $method === 'textDocument/completion';
+    }
+
+    /**
+     * @return array{isIncomplete: bool, items: list<array{label: string, kind?: int, detail?: string, documentation?: string}>}|null
+     */
+    public function handle(Message $message): ?array
+    {
+        $params = $message->params ?? [];
+
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+        $uri = $textDocument['uri'] ?? '';
+        if (!is_string($uri)) {
+            return null;
+        }
+
+        $position = $params['position'] ?? [];
+        if (!is_array($position)) {
+            return null;
+        }
+        $line = $position['line'] ?? 0;
+        $character = $position['character'] ?? 0;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        $document = $this->documentManager->get($uri);
+        if ($document === null) {
+            return null;
+        }
+
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return null;
+        }
+
+        // Get text before cursor to determine completion context
+        $lineText = $document->getLine($line);
+        $textBeforeCursor = substr($lineText, 0, $character);
+
+        $items = $this->getCompletionItems($textBeforeCursor, $ast, $document);
+
+        return [
+            'isIncomplete' => false,
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getCompletionItems(string $textBeforeCursor, array $ast, TextDocument $document): array
+    {
+        // $this-> completion
+        if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches)) {
+            $prefix = $matches[1];
+            return $this->getThisMemberCompletions($prefix, $ast);
+        }
+
+        // ClassName:: completion (static)
+        if (preg_match('/([A-Z]\w*)::(\w*)$/', $textBeforeCursor, $matches)) {
+            $className = $matches[1];
+            $prefix = $matches[2];
+            return $this->getStaticCompletions($className, $prefix, $ast, $document);
+        }
+
+        // new ClassName completion
+        if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches)) {
+            $prefix = $matches[1];
+            return $this->getClassCompletions($prefix);
+        }
+
+        // Function call completion (at start of expression or after operators)
+        if (preg_match('/(?:^|[(\s=,!&|])(\w+)$/', $textBeforeCursor, $matches)) {
+            $prefix = $matches[1];
+            return $this->getFunctionCompletions($prefix, $ast);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getThisMemberCompletions(string $prefix, array $ast): array
+    {
+        // Find the enclosing class
+        $classNode = $this->findFirstClass($ast);
+        if ($classNode === null) {
+            return [];
+        }
+
+        $items = [];
+
+        foreach ($classNode->stmts as $stmt) {
+            // Methods
+            if ($stmt instanceof Stmt\ClassMethod) {
+                $name = $stmt->name->toString();
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatMethodCompletion($stmt);
+                }
+            }
+
+            // Properties
+            if ($stmt instanceof Stmt\Property) {
+                foreach ($stmt->props as $prop) {
+                    $name = $prop->name->toString();
+                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                        $items[] = $this->formatPropertyCompletion($stmt, $name);
+                    }
+                }
+            }
+        }
+
+        // Also include inherited members via reflection if class exists
+        $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+        if ($className !== null) {
+            $items = array_merge($items, $this->getInheritedMemberCompletions($className, $prefix, $items));
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getStaticCompletions(string $className, string $prefix, array $ast, TextDocument $document): array
+    {
+        $items = [];
+
+        // Try to find class in AST first
+        $classNode = $this->findClassInAst($className, $ast);
+
+        // If not in current file, try Composer
+        if ($classNode === null && $this->classLocator !== null) {
+            $filePath = $this->classLocator->locateClass($className);
+            if ($filePath !== null) {
+                $content = file_get_contents($filePath);
+                if ($content !== false) {
+                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
+                    $externalAst = $this->parser->parse($externalDoc);
+                    if ($externalAst !== null) {
+                        $classNode = $this->findClassInAst($className, $externalAst);
+                    }
+                }
+            }
+        }
+
+        if ($classNode !== null) {
+            foreach ($classNode->stmts as $stmt) {
+                // Static methods
+                if ($stmt instanceof Stmt\ClassMethod && $stmt->isStatic()) {
+                    $name = $stmt->name->toString();
+                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                        $items[] = $this->formatMethodCompletion($stmt);
+                    }
+                }
+
+                // Static properties
+                if ($stmt instanceof Stmt\Property && $stmt->isStatic()) {
+                    foreach ($stmt->props as $prop) {
+                        $name = $prop->name->toString();
+                        if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                            $items[] = $this->formatPropertyCompletion($stmt, $name);
+                        }
+                    }
+                }
+
+                // Constants
+                if ($stmt instanceof Stmt\ClassConst) {
+                    foreach ($stmt->consts as $const) {
+                        $name = $const->name->toString();
+                        if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                            $items[] = $this->formatConstantCompletion($stmt, $name);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Also try reflection for inherited/built-in
+        $items = array_merge($items, $this->getReflectionStaticCompletions($className, $prefix, $items));
+
+        return $items;
+    }
+
+    /**
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getClassCompletions(string $prefix): array
+    {
+        $items = [];
+
+        if ($this->classLocator === null) {
+            return $items;
+        }
+
+        // Get all known classes from Composer
+        $classes = $this->classLocator->getAllClasses();
+
+        foreach ($classes as $className) {
+            $shortName = $this->getShortClassName($className);
+            if ($prefix === '' || str_starts_with(strtolower($shortName), strtolower($prefix))) {
+                $items[] = [
+                    'label' => $shortName,
+                    'kind' => self::KIND_CLASS,
+                    'detail' => $className,
+                ];
+            }
+        }
+
+        // Limit results to prevent overwhelming the client
+        return array_slice($items, 0, 100);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getFunctionCompletions(string $prefix, array $ast): array
+    {
+        $items = [];
+
+        // User-defined functions in current file
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Function_) {
+                $name = $stmt->name->toString();
+                if (str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatFunctionCompletion($stmt);
+                }
+            }
+        }
+
+        // Built-in functions
+        $definedFunctions = get_defined_functions();
+        foreach ($definedFunctions['internal'] as $name) {
+            if (str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = [
+                    'label' => $name,
+                    'kind' => self::KIND_FUNCTION,
+                ];
+            }
+        }
+
+        // Limit results
+        return array_slice($items, 0, 100);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findFirstClass(array $ast): ?Stmt\Class_
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                foreach ($stmt->stmts as $nsStmt) {
+                    if ($nsStmt instanceof Stmt\Class_) {
+                        return $nsStmt;
+                    }
+                }
+            }
+            if ($stmt instanceof Stmt\Class_) {
+                return $stmt;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findClassInAst(string $className, array $ast): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null
+    {
+        $finder = new class ($className) extends NodeVisitorAbstract {
+            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
+            private string $namespace = '';
+
+            public function __construct(private readonly string $className)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Namespace_) {
+                    $this->namespace = $node->name?->toString() ?? '';
+                    return null;
+                }
+
+                if ($node instanceof Stmt\Class_
+                    || $node instanceof Stmt\Interface_
+                    || $node instanceof Stmt\Trait_
+                    || $node instanceof Stmt\Enum_
+                ) {
+                    $name = $node->name?->toString();
+                    if ($name === null) {
+                        return null;
+                    }
+                    $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
+
+                    if ($fqn === $this->className || $name === $this->className) {
+                        $this->found = $node;
+                        return NodeTraverser::STOP_TRAVERSAL;
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        return $finder->found;
+    }
+
+    /**
+     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getInheritedMemberCompletions(string $className, string $prefix, array $existingItems): array
+    {
+        $existingLabels = array_column($existingItems, 'label');
+        $items = [];
+
+        try {
+            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+                return [];
+            }
+
+            $reflection = new ReflectionClass($className);
+
+            // Methods from parent classes
+            foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
+                $name = $method->getName();
+                if (in_array($name, $existingLabels, true)) {
+                    continue;
+                }
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatReflectionMethodCompletion($method);
+                }
+            }
+
+            // Properties from parent classes
+            foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED) as $prop) {
+                $name = $prop->getName();
+                if (in_array($name, $existingLabels, true)) {
+                    continue;
+                }
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatReflectionPropertyCompletion($prop);
+                }
+            }
+        } catch (ReflectionException) {
+            // Class not autoloadable
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getReflectionStaticCompletions(string $className, string $prefix, array $existingItems): array
+    {
+        $existingLabels = array_column($existingItems, 'label');
+        $items = [];
+
+        try {
+            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+                return [];
+            }
+
+            $reflection = new ReflectionClass($className);
+
+            // Static methods
+            foreach ($reflection->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC) as $method) {
+                if (!$method->isStatic()) {
+                    continue;
+                }
+                $name = $method->getName();
+                if (in_array($name, $existingLabels, true)) {
+                    continue;
+                }
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatReflectionMethodCompletion($method);
+                }
+            }
+
+            // Constants
+            foreach ($reflection->getReflectionConstants() as $const) {
+                $name = $const->getName();
+                if (in_array($name, $existingLabels, true)) {
+                    continue;
+                }
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = [
+                        'label' => $name,
+                        'kind' => self::KIND_CONSTANT,
+                        'detail' => 'const ' . $name,
+                    ];
+                }
+            }
+        } catch (ReflectionException) {
+            // Class not autoloadable
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private function formatMethodCompletion(Stmt\ClassMethod $method): array
+    {
+        $params = [];
+        foreach ($method->params as $param) {
+            $paramStr = '';
+            if ($param->type !== null) {
+                $paramStr .= $this->formatType($param->type) . ' ';
+            }
+            $var = $param->var;
+            if ($var instanceof Variable && is_string($var->name)) {
+                $paramStr .= '$' . $var->name;
+            }
+            $params[] = $paramStr;
+        }
+
+        $detail = $method->name->toString() . '(' . implode(', ', $params) . ')';
+        if ($method->returnType !== null) {
+            $detail .= ': ' . $this->formatType($method->returnType);
+        }
+
+        $item = [
+            'label' => $method->name->toString(),
+            'kind' => self::KIND_METHOD,
+            'detail' => $detail,
+        ];
+
+        $docComment = $method->getDocComment();
+        if ($docComment !== null) {
+            $doc = DocblockParser::extractDescription($docComment->getText());
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private function formatPropertyCompletion(Stmt\Property $property, string $name): array
+    {
+        $type = $property->type !== null ? $this->formatType($property->type) : 'mixed';
+
+        $item = [
+            'label' => $name,
+            'kind' => self::KIND_PROPERTY,
+            'detail' => $type . ' $' . $name,
+        ];
+
+        $docComment = $property->getDocComment();
+        if ($docComment !== null) {
+            $doc = DocblockParser::extractDescription($docComment->getText());
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private function formatConstantCompletion(Stmt\ClassConst $const, string $name): array
+    {
+        $item = [
+            'label' => $name,
+            'kind' => self::KIND_CONSTANT,
+            'detail' => 'const ' . $name,
+        ];
+
+        $docComment = $const->getDocComment();
+        if ($docComment !== null) {
+            $doc = DocblockParser::extractDescription($docComment->getText());
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private function formatFunctionCompletion(Stmt\Function_ $func): array
+    {
+        $params = [];
+        foreach ($func->params as $param) {
+            $paramStr = '';
+            if ($param->type !== null) {
+                $paramStr .= $this->formatType($param->type) . ' ';
+            }
+            $var = $param->var;
+            if ($var instanceof Variable && is_string($var->name)) {
+                $paramStr .= '$' . $var->name;
+            }
+            $params[] = $paramStr;
+        }
+
+        $detail = 'function ' . $func->name->toString() . '(' . implode(', ', $params) . ')';
+        if ($func->returnType !== null) {
+            $detail .= ': ' . $this->formatType($func->returnType);
+        }
+
+        $item = [
+            'label' => $func->name->toString(),
+            'kind' => self::KIND_FUNCTION,
+            'detail' => $detail,
+        ];
+
+        $docComment = $func->getDocComment();
+        if ($docComment !== null) {
+            $doc = DocblockParser::extractDescription($docComment->getText());
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private function formatReflectionMethodCompletion(ReflectionMethod $method): array
+    {
+        $params = [];
+        foreach ($method->getParameters() as $param) {
+            $paramStr = '';
+            $type = $param->getType();
+            if ($type !== null) {
+                $paramStr .= $this->formatReflectionType($type) . ' ';
+            }
+            $paramStr .= '$' . $param->getName();
+            $params[] = $paramStr;
+        }
+
+        $detail = $method->getName() . '(' . implode(', ', $params) . ')';
+        $returnType = $method->getReturnType();
+        if ($returnType !== null) {
+            $detail .= ': ' . $this->formatReflectionType($returnType);
+        }
+
+        $item = [
+            'label' => $method->getName(),
+            'kind' => self::KIND_METHOD,
+            'detail' => $detail,
+        ];
+
+        $docComment = $method->getDocComment();
+        if ($docComment !== false) {
+            $doc = DocblockParser::extractDescription($docComment);
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private function formatReflectionPropertyCompletion(ReflectionProperty $prop): array
+    {
+        $type = $prop->getType();
+        $typeStr = $type !== null ? $this->formatReflectionType($type) : 'mixed';
+
+        $item = [
+            'label' => $prop->getName(),
+            'kind' => self::KIND_PROPERTY,
+            'detail' => $typeStr . ' $' . $prop->getName(),
+        ];
+
+        $docComment = $prop->getDocComment();
+        if ($docComment !== false) {
+            $doc = DocblockParser::extractDescription($docComment);
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+
+        return $item;
+    }
+
+    private function formatType(Node $type): string
+    {
+        if ($type instanceof Name) {
+            return $type->toString();
+        }
+        if ($type instanceof Node\Identifier) {
+            return $type->toString();
+        }
+        if ($type instanceof Node\NullableType) {
+            return '?' . $this->formatType($type->type);
+        }
+        if ($type instanceof Node\UnionType) {
+            return implode('|', array_map(fn($t) => $this->formatType($t), $type->types));
+        }
+        if ($type instanceof Node\IntersectionType) {
+            return implode('&', array_map(fn($t) => $this->formatType($t), $type->types));
+        }
+        return '';
+    }
+
+    private function formatReflectionType(\ReflectionType $type): string
+    {
+        if ($type instanceof \ReflectionNamedType) {
+            $name = $type->getName();
+            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
+        }
+        if ($type instanceof \ReflectionUnionType) {
+            return implode('|', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
+        }
+        if ($type instanceof \ReflectionIntersectionType) {
+            return implode('&', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
+        }
+        return (string) $type;
+    }
+
+    private function getShortClassName(string $fqcn): string
+    {
+        $parts = explode('\\', $fqcn);
+        return end($parts);
+    }
+}

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -64,6 +64,9 @@ final class LifecycleHandler implements HandlerInterface
                 'signatureHelpProvider' => [
                     'triggerCharacters' => ['(', ','],
                 ],
+                'completionProvider' => [
+                    'triggerCharacters' => ['>', ':', '$', '\\'],
+                ],
             ],
             'serverInfo' => $this->serverInfo->toArray(),
         ];

--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -15,6 +15,48 @@ final class ComposerClassLocator
         $this->loadFromComposerAutoload($projectRoot);
     }
 
+    /**
+     * Get all known class names from PSR-4 mappings.
+     *
+     * @return list<string>
+     */
+    public function getAllClasses(): array
+    {
+        $classes = [];
+
+        foreach ($this->psr4Mappings as $prefix => $directories) {
+            foreach ($directories as $directory) {
+                if (!is_dir($directory)) {
+                    continue;
+                }
+                $this->scanDirectory($directory, $prefix, $classes);
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * @param list<string> $classes
+     */
+    private function scanDirectory(string $directory, string $namespacePrefix, array &$classes): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relativePath = substr($file->getPathname(), strlen($directory) + 1);
+            $className = str_replace(['/', '.php'], ['\\', ''], $relativePath);
+            $classes[] = $namespacePrefix . $className;
+        }
+    }
+
     public function locateClass(string $fullyQualifiedName): ?string
     {
         // Sort by prefix length descending for most specific match first

--- a/src/Parser/ParserService.php
+++ b/src/Parser/ParserService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Parser;
 
 use Firehed\PhpLsp\Document\TextDocument;
+use PhpParser\ErrorHandler;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
@@ -32,8 +33,11 @@ final class ParserService
      */
     public function parse(TextDocument $document): ?array
     {
+        // Use error-collecting handler for partial/incomplete code
+        $errorHandler = new ErrorHandler\Collecting();
+
         try {
-            $ast = $this->parser->parse($document->getContent());
+            $ast = $this->parser->parse($document->getContent(), $errorHandler);
             if ($ast === null) {
                 return [];
             }

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
 use Firehed\PhpLsp\Handler\HandlerInterface;
 use Firehed\PhpLsp\Handler\HoverHandler;
@@ -49,6 +50,7 @@ final class Server
         $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
         $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator);
         $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator);
+        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $classLocator);
     }
 
     public function run(): int

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Handler;
+
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Handler\CompletionHandler;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CompletionHandler::class)]
+class CompletionHandlerTest extends TestCase
+{
+    private DocumentManager $documents;
+    private ParserService $parser;
+    private CompletionHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->documents = new DocumentManager();
+        $this->parser = new ParserService();
+        $this->handler = new CompletionHandler($this->documents, $this->parser, null);
+    }
+
+    public function testSupports(): void
+    {
+        self::assertTrue($this->handler->supports('textDocument/completion'));
+        self::assertFalse($this->handler->supports('textDocument/hover'));
+    }
+
+    public function testThisMethodCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    public function greet(): string
+    {
+        return "Hello";
+    }
+
+    public function farewell(): string
+    {
+        return "Goodbye";
+    }
+
+    public function test(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 15], // After $this->
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        self::assertNotEmpty($result['items']);
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('greet', $labels);
+        self::assertContains('farewell', $labels);
+        self::assertContains('test', $labels);
+    }
+
+    public function testThisMethodCompletionWithPrefix(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    public function greet(): string { return "Hello"; }
+    public function goodbye(): string { return "Bye"; }
+    public function test(): void
+    {
+        $this->gr
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 17], // After $this->gr
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('greet', $labels);
+        self::assertNotContains('goodbye', $labels);
+    }
+
+    public function testThisPropertyCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    private string $name;
+    protected int $age;
+
+    public function test(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('name', $labels);
+        self::assertContains('age', $labels);
+    }
+
+    public function testStaticMethodCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Math
+{
+    public static function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+
+    public static function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+}
+
+$result = Math::
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 16], // After Math::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('add', $labels);
+        self::assertContains('multiply', $labels);
+    }
+
+    public function testClassConstantCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Status
+{
+    public const ACTIVE = 'active';
+    public const INACTIVE = 'inactive';
+}
+
+$status = Status::
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 18],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('ACTIVE', $labels);
+        self::assertContains('INACTIVE', $labels);
+    }
+
+    public function testFunctionCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+function myCustomFunction(): void {}
+
+$x = arr
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 8], // After "arr"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Should include built-in functions starting with "arr"
+        self::assertContains('array_map', $labels);
+        self::assertContains('array_filter', $labels);
+    }
+
+    public function testCompletionReturnsEmptyForUnknownContext(): void
+    {
+        $code = '<?php $x = 1;';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 12],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
+}

--- a/tests/Parser/ParserServiceTest.php
+++ b/tests/Parser/ParserServiceTest.php
@@ -48,7 +48,7 @@ class ParserServiceTest extends TestCase
         self::assertInstanceOf(Class_::class, $result[0]);
     }
 
-    public function testParseInvalidPhpReturnsNull(): void
+    public function testParseInvalidPhpUsesErrorRecovery(): void
     {
         $parser = new ParserService();
         $doc = new TextDocument(
@@ -60,7 +60,8 @@ class ParserServiceTest extends TestCase
 
         $result = $parser->parse($doc);
 
-        self::assertNull($result);
+        // With error recovery, we get partial results instead of null
+        self::assertIsArray($result);
     }
 
     public function testParseEmptyFile(): void


### PR DESCRIPTION
## Summary
- Implements `textDocument/completion` for autocomplete
- Supports `$this->`, `ClassName::`, `new ClassName`, and global functions
- Enables PHP-Parser error recovery for parsing incomplete code
- Adds `getAllClasses()` to ComposerClassLocator for class enumeration

## Supported contexts
- `$this->` - methods and properties of current class
- `ClassName::` - static methods, properties, constants
- `new ` - class names from Composer autoload
- Global functions - built-in and user-defined

## Not yet supported (needs type inference)
- `$obj->` where `$obj` is not `$this`

## Test plan
- [x] Unit tests for all completion contexts
- [x] All existing tests pass

Generated with Claude Code