### PR TITLE
Add type inference for enhanced LSP features

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -219,6 +219,59 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getClassMemberCompletions(string $className, string $prefix): array
     {
+        // Handle union types like "ClassName|false" or "ClassName|null"
+        $classNames = $this->extractClassNamesFromType($className);
+        if (empty($classNames)) {
+            return [];
+        }
+
+        $items = [];
+        $seenLabels = [];
+
+        foreach ($classNames as $singleClassName) {
+            $classItems = $this->getClassMemberCompletionsForSingleClass($singleClassName, $prefix, $seenLabels);
+            foreach ($classItems as $item) {
+                $seenLabels[$item['label']] = true;
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Extract class names from a type string, filtering out scalar types.
+     *
+     * @return list<string>
+     */
+    private function extractClassNamesFromType(string $type): array
+    {
+        // Remove nullable prefix
+        $type = ltrim($type, '?');
+
+        // Split union types
+        $parts = explode('|', $type);
+
+        $classNames = [];
+        $scalarTypes = ['int', 'string', 'float', 'bool', 'array', 'object', 'null', 'false', 'true', 'mixed', 'void', 'never', 'callable', 'iterable', 'resource'];
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part === '' || in_array(strtolower($part), $scalarTypes, true)) {
+                continue;
+            }
+            $classNames[] = $part;
+        }
+
+        return $classNames;
+    }
+
+    /**
+     * @param array<string, bool> $seenLabels
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getClassMemberCompletionsForSingleClass(string $className, string $prefix, array $seenLabels): array
+    {
         $items = [];
 
         try {
@@ -234,6 +287,9 @@ final class CompletionHandler implements HandlerInterface
                     continue;
                 }
                 $name = $method->getName();
+                if (isset($seenLabels[$name])) {
+                    continue;
+                }
                 if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
                     $items[] = $this->formatReflectionMethodCompletion($method);
                 }
@@ -245,6 +301,9 @@ final class CompletionHandler implements HandlerInterface
                     continue;
                 }
                 $name = $prop->getName();
+                if (isset($seenLabels[$name])) {
+                    continue;
+                }
                 if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
                     $items[] = $this->formatReflectionPropertyCompletion($prop);
                 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeInferenceInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
@@ -34,6 +35,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ?ComposerClassLocator $classLocator,
+        private readonly ?TypeInferenceInterface $typeInference = null,
     ) {
     }
 
@@ -102,6 +104,13 @@ final class CompletionHandler implements HandlerInterface
             return $this->getThisMemberCompletions($prefix, $ast);
         }
 
+        // $variable-> completion (non-$this variables)
+        if (preg_match('/\$(\w+)->(\w*)$/', $textBeforeCursor, $matches)) {
+            $variableName = $matches[1];
+            $prefix = $matches[2];
+            return $this->getVariableMemberCompletions($variableName, $prefix, $document);
+        }
+
         // ClassName:: completion (static)
         if (preg_match('/([A-Z]\w*)::(\w*)$/', $textBeforeCursor, $matches)) {
             $className = $matches[1];
@@ -162,6 +171,86 @@ final class CompletionHandler implements HandlerInterface
         $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
         if ($className !== null) {
             $items = array_merge($items, $this->getInheritedMemberCompletions($className, $prefix, $items));
+        }
+
+        return $items;
+    }
+
+    /**
+     * Get completions for $variable-> where variable type is inferred.
+     *
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getVariableMemberCompletions(string $variableName, string $prefix, TextDocument $document): array
+    {
+        if ($this->typeInference === null) {
+            return [];
+        }
+
+        // We need to find the line where this variable is used
+        // For simplicity, search for the variable in the document and use its line
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        $variableLine = null;
+
+        // Find the last occurrence of $variable-> in the document
+        foreach ($lines as $lineNum => $lineText) {
+            if (str_contains($lineText, '$' . $variableName . '->')) {
+                $variableLine = $lineNum + 1; // 1-indexed
+            }
+        }
+
+        if ($variableLine === null) {
+            return [];
+        }
+
+        $className = $this->typeInference->getVariableType($document, $variableName, $variableLine);
+        if ($className === null) {
+            return [];
+        }
+
+        return $this->getClassMemberCompletions($className, $prefix);
+    }
+
+    /**
+     * Get completions for a class's methods and properties via reflection.
+     *
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getClassMemberCompletions(string $className, string $prefix): array
+    {
+        $items = [];
+
+        try {
+            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+                return [];
+            }
+
+            $reflection = new ReflectionClass($className);
+
+            // Public methods
+            foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->isStatic()) {
+                    continue;
+                }
+                $name = $method->getName();
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatReflectionMethodCompletion($method);
+                }
+            }
+
+            // Public properties
+            foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $prop) {
+                if ($prop->isStatic()) {
+                    continue;
+                }
+                $name = $prop->getName();
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatReflectionPropertyCompletion($prop);
+                }
+            }
+        } catch (ReflectionException) {
+            // Class not autoloadable
         }
 
         return $items;

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -98,6 +98,11 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getCompletionItems(string $textBeforeCursor, array $ast, TextDocument $document): array
     {
+        // Skip completions inside comments or strings
+        if ($this->isInsideCommentOrString($textBeforeCursor)) {
+            return [];
+        }
+
         // $this-> completion
         if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches)) {
             $prefix = $matches[1];
@@ -131,6 +136,55 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return [];
+    }
+
+    /**
+     * Check if the cursor is inside a string or comment.
+     */
+    private function isInsideCommentOrString(string $textBeforeCursor): bool
+    {
+        // Check for line comment (// before cursor)
+        if (preg_match('#//[^"\'\n]*$#', $textBeforeCursor)) {
+            return true;
+        }
+
+        // Check for unclosed block comment (/* without matching */)
+        $lastBlockOpen = strrpos($textBeforeCursor, '/*');
+        if ($lastBlockOpen !== false) {
+            $lastBlockClose = strrpos($textBeforeCursor, '*/');
+            if ($lastBlockClose === false || $lastBlockClose < $lastBlockOpen) {
+                return true;
+            }
+        }
+
+        // Check for unclosed string - count quotes to see if we're inside a string
+        // This is a simplified check that handles most common cases
+        $singleQuotes = 0;
+        $doubleQuotes = 0;
+        $len = strlen($textBeforeCursor);
+        $i = 0;
+
+        while ($i < $len) {
+            $char = $textBeforeCursor[$i];
+
+            // Handle escape sequences
+            if ($char === '\\' && $i + 1 < $len) {
+                $i += 2;
+                continue;
+            }
+
+            // Track quotes, but only when not inside the other quote type
+            if ($char === "'" && $doubleQuotes % 2 === 0) {
+                $singleQuotes++;
+            } elseif ($char === '"' && $singleQuotes % 2 === 0) {
+                $doubleQuotes++;
+            }
+
+            $i++;
+        }
+
+        // If odd number of quotes, we're inside a string
+        return ($singleQuotes % 2 !== 0) || ($doubleQuotes % 2 !== 0);
     }
 
     /**

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -13,7 +13,13 @@ use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeInferenceInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
 
 final class DefinitionHandler implements HandlerInterface
 {
@@ -22,6 +28,7 @@ final class DefinitionHandler implements HandlerInterface
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
         private readonly ?ComposerClassLocator $classLocator = null,
+        private readonly ?TypeInferenceInterface $typeInference = null,
     ) {
     }
 
@@ -77,7 +84,22 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        // Extract the symbol name we're looking for
+        // Handle Identifier nodes (method names, property names)
+        if ($node instanceof Identifier) {
+            $parent = $node->getAttribute('parent');
+
+            // Method call: $obj->method()
+            if ($parent instanceof MethodCall) {
+                return $this->handleMethodDefinition($parent, $document);
+            }
+
+            // Property fetch: $obj->property
+            if ($parent instanceof PropertyFetch) {
+                return $this->handlePropertyDefinition($parent, $document);
+            }
+        }
+
+        // Handle Name nodes (class references)
         if (!$node instanceof Name) {
             return null;
         }
@@ -101,6 +123,226 @@ final class DefinitionHandler implements HandlerInterface
 
         // Not in index - try to locate via Composer autoload
         return $this->locateViaComposer($symbolName)?->toLspLocation();
+    }
+
+    /**
+     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}|null
+     */
+    private function handleMethodDefinition(MethodCall $call, TextDocument $document): ?array
+    {
+        $methodName = $call->name;
+        if (!$methodName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveObjectType($call->var, $document);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->locateMethodInClass($className, $methodName->toString());
+    }
+
+    /**
+     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}|null
+     */
+    private function handlePropertyDefinition(PropertyFetch $fetch, TextDocument $document): ?array
+    {
+        $propertyName = $fetch->name;
+        if (!$propertyName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveObjectType($fetch->var, $document);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->locatePropertyInClass($className, $propertyName->toString());
+    }
+
+    /**
+     * Resolve the type of an expression (variable).
+     */
+    private function resolveObjectType(\PhpParser\Node\Expr $expr, TextDocument $document): ?string
+    {
+        if ($expr instanceof Variable && is_string($expr->name) && $this->typeInference !== null) {
+            $line = $expr->getStartLine();
+            return $this->typeInference->getVariableType($document, $expr->name, $line);
+        }
+
+        return null;
+    }
+
+    /**
+     * Locate a method definition in a class.
+     *
+     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}|null
+     */
+    private function locateMethodInClass(string $className, string $methodName): ?array
+    {
+        if ($this->classLocator === null) {
+            return null;
+        }
+
+        $filePath = $this->classLocator->locateClass($className);
+        if ($filePath === null) {
+            return null;
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            return null;
+        }
+
+        $uri = 'file://' . $filePath;
+        $tempDoc = new TextDocument($uri, 'php', 0, $content);
+        $ast = $this->parser->parse($tempDoc);
+        if ($ast === null) {
+            return null;
+        }
+
+        // Find the method in the class
+        $methodLocation = $this->findMethodLocation($ast, $className, $methodName, $uri);
+        if ($methodLocation !== null) {
+            return $methodLocation->toLspLocation();
+        }
+
+        return null;
+    }
+
+    /**
+     * Locate a property definition in a class.
+     *
+     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}|null
+     */
+    private function locatePropertyInClass(string $className, string $propertyName): ?array
+    {
+        if ($this->classLocator === null) {
+            return null;
+        }
+
+        $filePath = $this->classLocator->locateClass($className);
+        if ($filePath === null) {
+            return null;
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            return null;
+        }
+
+        $uri = 'file://' . $filePath;
+        $tempDoc = new TextDocument($uri, 'php', 0, $content);
+        $ast = $this->parser->parse($tempDoc);
+        if ($ast === null) {
+            return null;
+        }
+
+        // Find the property in the class
+        $propertyLocation = $this->findPropertyLocation($ast, $className, $propertyName, $uri);
+        if ($propertyLocation !== null) {
+            return $propertyLocation->toLspLocation();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findMethodLocation(array $ast, string $className, string $methodName, string $uri): ?Location
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                $result = $this->findMethodLocation($stmt->stmts, $className, $methodName, $uri);
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+
+            if ($stmt instanceof Stmt\Class_ || $stmt instanceof Stmt\Interface_ || $stmt instanceof Stmt\Trait_) {
+                $classShortName = $stmt->name?->toString();
+                $namespacedName = $stmt->namespacedName;
+                $fqn = $namespacedName instanceof Name ? $namespacedName->toString() : $classShortName;
+
+                if ($fqn === $className || $classShortName === $className) {
+                    foreach ($stmt->stmts as $member) {
+                        if ($member instanceof Stmt\ClassMethod && $member->name->toString() === $methodName) {
+                            return new Location(
+                                $uri,
+                                $member->getStartLine() - 1,
+                                0,
+                                $member->getEndLine() - 1,
+                                0,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findPropertyLocation(array $ast, string $className, string $propertyName, string $uri): ?Location
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                $result = $this->findPropertyLocation($stmt->stmts, $className, $propertyName, $uri);
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+
+            if ($stmt instanceof Stmt\Class_ || $stmt instanceof Stmt\Trait_) {
+                $classShortName = $stmt->name?->toString();
+                $namespacedName = $stmt->namespacedName;
+                $fqn = $namespacedName instanceof Name ? $namespacedName->toString() : $classShortName;
+
+                if ($fqn === $className || $classShortName === $className) {
+                    foreach ($stmt->stmts as $member) {
+                        // Traditional property declaration
+                        if ($member instanceof Stmt\Property) {
+                            foreach ($member->props as $prop) {
+                                if ($prop->name->toString() === $propertyName) {
+                                    return new Location(
+                                        $uri,
+                                        $member->getStartLine() - 1,
+                                        0,
+                                        $member->getEndLine() - 1,
+                                        0,
+                                    );
+                                }
+                            }
+                        }
+
+                        // Constructor-promoted properties
+                        if ($member instanceof Stmt\ClassMethod && $member->name->toString() === '__construct') {
+                            foreach ($member->params as $param) {
+                                if ($param->flags !== 0) { // Has visibility modifier = promoted property
+                                    $var = $param->var;
+                                    if ($var instanceof Variable && is_string($var->name) && $var->name === $propertyName) {
+                                        return new Location(
+                                            $uri,
+                                            $param->getStartLine() - 1,
+                                            0,
+                                            $param->getEndLine() - 1,
+                                            0,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 
     private function locateViaComposer(string $className): ?Location

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeInferenceInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -35,6 +36,7 @@ final class HoverHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ?ComposerClassLocator $classLocator,
+        private readonly ?TypeInferenceInterface $typeInference = null,
     ) {
     }
 
@@ -129,6 +131,11 @@ final class HoverHandler implements HandlerInterface
         }
 
         // Identifier node - could be method name, property name, or function call
+        // Variable node - show inferred type
+        if ($node instanceof Variable && is_string($node->name)) {
+            return $this->getVariableHover($node, $document);
+        }
+
         if ($node instanceof Identifier) {
             $parent = $node->getAttribute('parent');
 
@@ -158,6 +165,27 @@ final class HoverHandler implements HandlerInterface
         }
 
         return null;
+    }
+
+    private function getVariableHover(Variable $variable, TextDocument $document): ?string
+    {
+        if ($this->typeInference === null) {
+            return null;
+        }
+
+        $variableName = $variable->name;
+        if (!is_string($variableName)) {
+            return null;
+        }
+
+        $line = $variable->getStartLine();
+        $type = $this->typeInference->getVariableType($document, $variableName, $line);
+
+        if ($type === null) {
+            return null;
+        }
+
+        return '```php' . "\n" . $type . ' $' . $variableName . "\n```";
     }
 
     /**
@@ -362,7 +390,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = $this->resolveExpressionClass($call->var, $ast);
+        $className = $this->resolveExpressionClass($call->var, $ast, $document);
         if ($className === null) {
             return null;
         }
@@ -403,7 +431,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = $this->resolveExpressionClass($fetch->var, $ast);
+        $className = $this->resolveExpressionClass($fetch->var, $ast, $document);
         if ($className === null) {
             return null;
         }
@@ -467,14 +495,19 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function resolveExpressionClass(Node\Expr $expr, array $ast): ?string
+    private function resolveExpressionClass(Node\Expr $expr, array $ast, TextDocument $document): ?string
     {
         // $this refers to the enclosing class
         if ($expr instanceof Variable && $expr->name === 'this') {
             return $this->findEnclosingClassName($expr, $ast);
         }
 
-        // For other expressions, we'd need type inference - skip for now
+        // Use type inference for other variables
+        if ($expr instanceof Variable && is_string($expr->name) && $this->typeInference !== null) {
+            $line = $expr->getStartLine();
+            return $this->typeInference->getVariableType($document, $expr->name, $line);
+        }
+
         return null;
     }
 

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeInferenceInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -34,6 +35,7 @@ final class SignatureHelpHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ?ComposerClassLocator $classLocator,
+        private readonly ?TypeInferenceInterface $typeInference = null,
     ) {
     }
 
@@ -223,13 +225,18 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        // Only support $this for now
         $var = $call->var;
-        if (!$var instanceof Variable || $var->name !== 'this') {
-            return null;
+        $className = null;
+
+        // $this refers to enclosing class
+        if ($var instanceof Variable && $var->name === 'this') {
+            $className = $this->findEnclosingClassName($call, $ast);
+        } elseif ($var instanceof Variable && is_string($var->name) && $this->typeInference !== null) {
+            // Use type inference for other variables
+            $line = $var->getStartLine();
+            $className = $this->typeInference->getVariableType($document, $var->name, $line);
         }
 
-        $className = $this->findEnclosingClassName($call, $ast);
         if ($className === null) {
             return null;
         }

--- a/src/Handler/TextDocumentSyncHandler.php
+++ b/src/Handler/TextDocumentSyncHandler.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeInferenceInterface;
 
 final class TextDocumentSyncHandler implements HandlerInterface
 {
@@ -19,6 +20,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ?DocumentIndexer $indexer = null,
+        private readonly ?TypeInferenceInterface $typeInference = null,
     ) {
     }
 
@@ -86,6 +88,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
             assert(is_string($lastChange['text']));
             $this->documentManager->update($uri, $lastChange['text'], $version);
             $this->indexDocument($uri);
+            $this->typeInference?->invalidate($uri);
         }
 
         return null;
@@ -103,6 +106,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         assert(is_string($uri));
 
         $this->indexer?->remove($uri);
+        $this->typeInference?->invalidate($uri);
         $this->documentManager->close($uri);
 
         return null;

--- a/src/Server.php
+++ b/src/Server.php
@@ -44,7 +44,7 @@ final class Server
         $symbolIndex = new SymbolIndex();
         $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
         $classLocator = $projectRoot !== null ? new ComposerClassLocator($projectRoot) : null;
-        $typeInference = new PhpStanTypeInferenceService();
+        $typeInference = new PhpStanTypeInferenceService($projectRoot);
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;

--- a/src/Server.php
+++ b/src/Server.php
@@ -21,6 +21,7 @@ use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
 use Firehed\PhpLsp\Transport\TransportInterface;
+use Firehed\PhpLsp\TypeInference\PhpStanTypeInferenceService;
 
 final class Server
 {
@@ -43,14 +44,15 @@ final class Server
         $symbolIndex = new SymbolIndex();
         $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
         $classLocator = $projectRoot !== null ? new ComposerClassLocator($projectRoot) : null;
+        $typeInference = new PhpStanTypeInferenceService();
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
-        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
-        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
-        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator);
-        $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator);
-        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $classLocator);
+        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer, $typeInference);
+        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator, $typeInference);
+        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator, $typeInference);
+        $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator, $typeInference);
+        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $classLocator, $typeInference);
     }
 
     public function run(): int

--- a/src/Server.php
+++ b/src/Server.php
@@ -27,32 +27,17 @@ final class Server
 {
     private LifecycleHandler $lifecycleHandler;
     private DocumentManager $documentManager;
+    private bool $initialized = false;
 
     /** @var list<HandlerInterface> */
     private array $handlers = [];
 
     public function __construct(
         private TransportInterface $transport,
-        ServerInfo $serverInfo,
-        ?string $projectRoot = null,
+        private ServerInfo $serverInfo,
     ) {
-        // Use provided root, or fall back to cwd
-        $projectRoot ??= getcwd() ?: null;
-
         $this->documentManager = new DocumentManager();
-        $parser = new ParserService();
-        $symbolIndex = new SymbolIndex();
-        $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
-        $classLocator = $projectRoot !== null ? new ComposerClassLocator($projectRoot) : null;
-        $typeInference = new PhpStanTypeInferenceService($projectRoot);
-
-        $this->lifecycleHandler = new LifecycleHandler($serverInfo);
-        $this->handlers[] = $this->lifecycleHandler;
-        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer, $typeInference);
-        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator, $typeInference);
-        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator, $typeInference);
-        $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator, $typeInference);
-        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $classLocator, $typeInference);
+        $this->lifecycleHandler = new LifecycleHandler($this->serverInfo);
     }
 
     public function run(): int
@@ -61,12 +46,17 @@ final class Server
             $result = null;
             $error = null;
 
-            $handler = $this->findHandler($message->method);
+            // Handle initialize specially to set up handlers with project root
+            if ($message->method === 'initialize' && $message instanceof RequestMessage) {
+                $result = $this->handleInitialize($message);
+            } else {
+                $handler = $this->findHandler($message->method);
 
-            if ($handler !== null) {
-                $result = $handler->handle($message);
-            } elseif ($message instanceof RequestMessage) {
-                $error = ResponseError::methodNotFound($message->method);
+                if ($handler !== null) {
+                    $result = $handler->handle($message);
+                } elseif ($message instanceof RequestMessage) {
+                    $error = ResponseError::methodNotFound($message->method);
+                }
             }
 
             // Send response for requests (not notifications)
@@ -91,8 +81,64 @@ final class Server
         return 1;
     }
 
+    /**
+     * Handle the initialize request and set up handlers with the project root.
+     *
+     * @return array{capabilities: array<string, mixed>, serverInfo: array{name: string, version: string}}
+     */
+    private function handleInitialize(RequestMessage $message): array
+    {
+        $params = $message->params ?? [];
+
+        // Extract project root from initialize params
+        $projectRoot = null;
+        if (isset($params['rootUri']) && is_string($params['rootUri'])) {
+            // Convert file:// URI to path
+            $projectRoot = preg_replace('#^file://#', '', $params['rootUri']);
+        } elseif (isset($params['rootPath']) && is_string($params['rootPath'])) {
+            $projectRoot = $params['rootPath'];
+        }
+
+        // Fall back to cwd if not provided
+        $projectRoot ??= getcwd() ?: null;
+
+        // Now initialize all handlers with the correct project root
+        $this->initializeHandlers($projectRoot);
+        $this->initialized = true;
+
+        // Return capabilities (delegated to lifecycle handler for consistency)
+        /** @var array{capabilities: array<string, mixed>, serverInfo: array{name: string, version: string}} */
+        $result = $this->lifecycleHandler->handle($message);
+        return $result;
+    }
+
+    private function initializeHandlers(?string $projectRoot): void
+    {
+        $parser = new ParserService();
+        $symbolIndex = new SymbolIndex();
+        $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
+        $classLocator = $projectRoot !== null ? new ComposerClassLocator($projectRoot) : null;
+        $typeInference = new PhpStanTypeInferenceService($projectRoot);
+
+        $this->handlers = [];
+        $this->handlers[] = $this->lifecycleHandler;
+        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer, $typeInference);
+        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator, $typeInference);
+        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator, $typeInference);
+        $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator, $typeInference);
+        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $classLocator, $typeInference);
+    }
+
     private function findHandler(string $method): ?HandlerInterface
     {
+        // Before initialization, only lifecycle handler is available
+        if (!$this->initialized && $method !== 'initialized') {
+            if ($this->lifecycleHandler->supports($method)) {
+                return $this->lifecycleHandler;
+            }
+            return null;
+        }
+
         foreach ($this->handlers as $handler) {
             if ($handler->supports($method)) {
                 return $handler;

--- a/src/TypeInference/PhpStanTypeInferenceService.php
+++ b/src/TypeInference/PhpStanTypeInferenceService.php
@@ -29,6 +29,7 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
     private ParserService $parser;
     private ?Container $container = null;
     private ?ReflectionProvider $reflectionProvider = null;
+    private bool $containerInitAttempted = false;
     private string $tempDir;
     private string $projectRoot;
 
@@ -174,6 +175,43 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
             return $this->reflectionProvider->hasClass($className);
         } catch (\Throwable) {
             return false;
+        }
+    }
+
+    /**
+     * Get the return type of a function.
+     */
+    public function getFunctionReturnType(string $functionName): ?string
+    {
+        $this->ensureContainerInitialized();
+
+        if ($this->reflectionProvider === null) {
+            return null;
+        }
+
+        try {
+            $nameNode = new Name($functionName);
+            if (!$this->reflectionProvider->hasFunction($nameNode, null)) {
+                return null;
+            }
+
+            $function = $this->reflectionProvider->getFunction($nameNode, null);
+            $variants = $function->getVariants();
+
+            if (empty($variants)) {
+                return null;
+            }
+
+            $returnType = $variants[0]->getReturnType();
+            $description = $returnType->describe(VerbosityLevel::typeOnly());
+
+            if ($description === 'mixed') {
+                return null;
+            }
+
+            return $description;
+        } catch (\Throwable) {
+            return null;
         }
     }
 
@@ -406,6 +444,12 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
                     }
                 }
 
+                // Function call functionName()
+                if ($expr instanceof Expr\FuncCall && $expr->name instanceof Name) {
+                    $funcName = $expr->name->toString();
+                    return $this->service->getFunctionReturnType($funcName);
+                }
+
                 return null;
             }
         };
@@ -417,11 +461,18 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
 
     private function ensureContainerInitialized(): void
     {
-        if ($this->container !== null) {
+        if ($this->container !== null || $this->containerInitAttempted) {
             return;
         }
+        $this->containerInitAttempted = true;
 
         try {
+            // Load the project's autoloader if available
+            $projectAutoloader = $this->projectRoot . '/vendor/autoload.php';
+            if (file_exists($projectAutoloader)) {
+                require_once $projectAutoloader;
+            }
+
             $containerFactory = new ContainerFactory($this->projectRoot);
 
             // Find phpstan.neon if it exists

--- a/src/TypeInference/PhpStanTypeInferenceService.php
+++ b/src/TypeInference/PhpStanTypeInferenceService.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\TypeInference;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Parser\ParserService;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * Type inference service combining AST analysis with reflection.
+ *
+ * Uses php-parser for AST analysis and PHP reflection for type lookups.
+ * Handles common patterns for variable type inference without requiring
+ * external tools or temp files.
+ */
+final class PhpStanTypeInferenceService
+{
+    private ParserService $parser;
+
+    /** @var array<string, VariableTypeCache> */
+    private array $fileCache = [];
+
+    public function __construct()
+    {
+        $this->parser = new ParserService();
+    }
+
+    /**
+     * Get the type of a variable at a specific line.
+     *
+     * @return string|null The type description, or null if not determinable
+     */
+    public function getVariableType(TextDocument $document, string $variableName, int $line): ?string
+    {
+        $cache = $this->analyzeDocument($document);
+        return $cache->getVariableTypeAtLine($variableName, $line);
+    }
+
+    /**
+     * Get the type of an expression.
+     *
+     * @return string|null The type description, or null if not determinable
+     */
+    public function getExpressionType(TextDocument $document, Expr $expr, int $line): ?string
+    {
+        // For method calls, resolve the object type and look up return type
+        if ($expr instanceof Expr\MethodCall) {
+            $objectType = $this->resolveExpressionType($document, $expr->var, $line);
+            if ($objectType === null) {
+                return null;
+            }
+            $methodName = $expr->name;
+            if (!$methodName instanceof Identifier) {
+                return null;
+            }
+            return $this->getMethodReturnType($objectType, $methodName->toString());
+        }
+
+        // For property fetches, resolve the object type and look up property type
+        if ($expr instanceof Expr\PropertyFetch) {
+            $objectType = $this->resolveExpressionType($document, $expr->var, $line);
+            if ($objectType === null) {
+                return null;
+            }
+            $propertyName = $expr->name;
+            if (!$propertyName instanceof Identifier) {
+                return null;
+            }
+            return $this->getPropertyType($objectType, $propertyName->toString());
+        }
+
+        // For new expressions, the type is the class name
+        if ($expr instanceof Expr\New_) {
+            if ($expr->class instanceof Name) {
+                return $expr->class->toString();
+            }
+        }
+
+        // For variables, look up in cache
+        if ($expr instanceof Expr\Variable && is_string($expr->name)) {
+            return $this->getVariableType($document, $expr->name, $line);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the return type of a method.
+     *
+     * @param string $className The fully qualified class name
+     * @param string $methodName The method name
+     * @return string|null The return type, or null if not found
+     */
+    public function getMethodReturnType(string $className, string $methodName): ?string
+    {
+        try {
+            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+                return null;
+            }
+
+            $reflection = new ReflectionClass($className);
+            if (!$reflection->hasMethod($methodName)) {
+                return null;
+            }
+
+            $method = $reflection->getMethod($methodName);
+            $returnType = $method->getReturnType();
+
+            if ($returnType === null) {
+                return null;
+            }
+
+            return $this->formatReflectionType($returnType);
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    /**
+     * Get the type of a property.
+     *
+     * @param string $className The fully qualified class name
+     * @param string $propertyName The property name
+     * @return string|null The property type, or null if not found
+     */
+    public function getPropertyType(string $className, string $propertyName): ?string
+    {
+        try {
+            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+                return null;
+            }
+
+            $reflection = new ReflectionClass($className);
+            if (!$reflection->hasProperty($propertyName)) {
+                return null;
+            }
+
+            $property = $reflection->getProperty($propertyName);
+            $type = $property->getType();
+
+            if ($type === null) {
+                return null;
+            }
+
+            return $this->formatReflectionType($type);
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    /**
+     * Check if a class exists (via autoloading).
+     */
+    public function hasClass(string $className): bool
+    {
+        return class_exists($className) || interface_exists($className) || trait_exists($className);
+    }
+
+    /**
+     * Invalidate cache for a document.
+     */
+    public function invalidate(string $uri): void
+    {
+        unset($this->fileCache[$uri]);
+    }
+
+    /**
+     * Resolve the type of an expression (helper for chained lookups).
+     */
+    private function resolveExpressionType(TextDocument $document, Expr $expr, int $line): ?string
+    {
+        if ($expr instanceof Expr\Variable) {
+            if ($expr->name === 'this') {
+                // Find enclosing class from AST
+                return $this->findEnclosingClass($document, $line);
+            }
+            if (is_string($expr->name)) {
+                return $this->getVariableType($document, $expr->name, $line);
+            }
+        }
+
+        return $this->getExpressionType($document, $expr, $line);
+    }
+
+    /**
+     * Find the enclosing class at a given line.
+     */
+    private function findEnclosingClass(TextDocument $document, int $line): ?string
+    {
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return null;
+        }
+
+        $finder = new class ($line) extends NodeVisitorAbstract {
+            public ?string $className = null;
+            private ?string $currentNamespace = null;
+
+            public function __construct(private readonly int $line)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Namespace_) {
+                    $this->currentNamespace = $node->name?->toString();
+                }
+
+                if ($node instanceof Stmt\Class_) {
+                    $startLine = $node->getStartLine();
+                    $endLine = $node->getEndLine();
+
+                    if ($startLine <= $this->line && $this->line <= $endLine) {
+                        $name = $node->name?->toString();
+                        if ($name !== null) {
+                            $this->className = $this->currentNamespace !== null
+                                ? $this->currentNamespace . '\\' . $name
+                                : $name;
+                        }
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        return $finder->className;
+    }
+
+    /**
+     * Analyze a document and cache variable type information.
+     */
+    private function analyzeDocument(TextDocument $document): VariableTypeCache
+    {
+        $uri = $document->uri;
+
+        if (isset($this->fileCache[$uri])) {
+            return $this->fileCache[$uri];
+        }
+
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            return $this->fileCache[$uri] = new VariableTypeCache();
+        }
+
+        $cache = new VariableTypeCache();
+        $this->extractVariableTypes($ast, $cache);
+
+        $this->fileCache[$uri] = $cache;
+        return $cache;
+    }
+
+    /**
+     * Extract variable type information from AST.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function extractVariableTypes(array $ast, VariableTypeCache $cache): void
+    {
+        $extractor = new class ($cache, $this) extends NodeVisitorAbstract {
+            private ?string $currentNamespace = null;
+            private ?string $currentClass = null;
+
+            public function __construct(
+                private readonly VariableTypeCache $cache,
+                private readonly PhpStanTypeInferenceService $service,
+            ) {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Namespace_) {
+                    $this->currentNamespace = $node->name?->toString();
+                }
+
+                if ($node instanceof Stmt\Class_) {
+                    $name = $node->name?->toString();
+                    if ($name !== null) {
+                        $this->currentClass = $this->currentNamespace !== null
+                            ? $this->currentNamespace . '\\' . $name
+                            : $name;
+                    }
+                }
+
+                // Track method parameters
+                if ($node instanceof Stmt\ClassMethod || $node instanceof Stmt\Function_) {
+                    foreach ($node->params as $param) {
+                        $var = $param->var;
+                        if ($var instanceof Expr\Variable && is_string($var->name) && $param->type !== null) {
+                            $type = $this->resolveTypeNode($param->type);
+                            if ($type !== null) {
+                                $startLine = $node->getStartLine();
+                                $endLine = $node->getEndLine();
+                                $this->cache->addVariableType($var->name, $type, $startLine, $endLine);
+                            }
+                        }
+                    }
+                }
+
+                // Track variable assignments
+                if ($node instanceof Expr\Assign) {
+                    $var = $node->var;
+                    if ($var instanceof Expr\Variable && is_string($var->name)) {
+                        $line = $node->getStartLine();
+                        $type = $this->inferExpressionType($node->expr, $line);
+                        if ($type !== null) {
+                            // Variable is available from this line until end of scope
+                            // For simplicity, use a large end line
+                            $this->cache->addVariableType($var->name, $type, $line, PHP_INT_MAX);
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            public function leaveNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Class_) {
+                    $this->currentClass = null;
+                }
+                if ($node instanceof Stmt\Namespace_) {
+                    $this->currentNamespace = null;
+                }
+                return null;
+            }
+
+            private function resolveTypeNode(Node $type): ?string
+            {
+                if ($type instanceof Name) {
+                    $resolved = $type->getAttribute('resolvedName');
+                    return $resolved instanceof Name ? $resolved->toString() : $type->toString();
+                }
+                if ($type instanceof Identifier) {
+                    return $type->toString();
+                }
+                if ($type instanceof Node\NullableType) {
+                    $inner = $this->resolveTypeNode($type->type);
+                    return $inner !== null ? '?' . $inner : null;
+                }
+                return null;
+            }
+
+            private function inferExpressionType(Expr $expr, int $line): ?string
+            {
+                // new ClassName() -> ClassName
+                if ($expr instanceof Expr\New_) {
+                    if ($expr->class instanceof Name) {
+                        $resolved = $expr->class->getAttribute('resolvedName');
+                        return $resolved instanceof Name ? $resolved->toString() : $expr->class->toString();
+                    }
+                }
+
+                // $obj->method() -> look up return type
+                if ($expr instanceof Expr\MethodCall) {
+                    $objectType = $this->inferExpressionType($expr->var, $line);
+                    if ($objectType !== null && $expr->name instanceof Identifier) {
+                        return $this->service->getMethodReturnType($objectType, $expr->name->toString());
+                    }
+                }
+
+                // $this -> current class
+                if ($expr instanceof Expr\Variable && $expr->name === 'this') {
+                    return $this->currentClass;
+                }
+
+                // Other variables -> look up in cache
+                if ($expr instanceof Expr\Variable && is_string($expr->name)) {
+                    return $this->cache->getVariableTypeAtLine($expr->name, $line);
+                }
+
+                // Static method call ClassName::method()
+                if ($expr instanceof Expr\StaticCall) {
+                    if ($expr->class instanceof Name && $expr->name instanceof Identifier) {
+                        $className = $expr->class->getAttribute('resolvedName');
+                        $className = $className instanceof Name ? $className->toString() : $expr->class->toString();
+                        return $this->service->getMethodReturnType($className, $expr->name->toString());
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($extractor);
+        $traverser->traverse($ast);
+    }
+
+    private function formatReflectionType(\ReflectionType $type): string
+    {
+        if ($type instanceof \ReflectionNamedType) {
+            $name = $type->getName();
+            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
+        }
+        if ($type instanceof \ReflectionUnionType) {
+            return implode('|', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
+        }
+        if ($type instanceof \ReflectionIntersectionType) {
+            return implode('&', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
+        }
+        return (string) $type;
+    }
+}
+
+/**
+ * Cache for variable type information within a file.
+ */
+final class VariableTypeCache
+{
+    /** @var array<string, list<array{type: string, startLine: int, endLine: int}>> */
+    private array $variableTypes = [];
+
+    public function addVariableType(string $variableName, string $type, int $startLine, int $endLine): void
+    {
+        $this->variableTypes[$variableName][] = [
+            'type' => $type,
+            'startLine' => $startLine,
+            'endLine' => $endLine,
+        ];
+    }
+
+    public function getVariableTypeAtLine(string $variableName, int $line): ?string
+    {
+        if (!isset($this->variableTypes[$variableName])) {
+            return null;
+        }
+
+        // Find the most recent assignment before or at this line
+        $bestMatch = null;
+        $bestStartLine = -1;
+
+        foreach ($this->variableTypes[$variableName] as $entry) {
+            if ($entry['startLine'] <= $line && $line <= $entry['endLine']) {
+                if ($entry['startLine'] > $bestStartLine) {
+                    $bestMatch = $entry['type'];
+                    $bestStartLine = $entry['startLine'];
+                }
+            }
+        }
+
+        return $bestMatch;
+    }
+}

--- a/src/TypeInference/PhpStanTypeInferenceService.php
+++ b/src/TypeInference/PhpStanTypeInferenceService.php
@@ -13,44 +13,41 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use ReflectionClass;
-use ReflectionException;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\DependencyInjection\ContainerFactory;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\VerbosityLevel;
 
 /**
- * Type inference service combining AST analysis with reflection.
+ * Type inference service using PHPStan's reflection system.
  *
- * Uses php-parser for AST analysis and PHP reflection for type lookups.
- * Handles common patterns for variable type inference without requiring
- * external tools or temp files.
+ * Combines AST-based variable tracking with PHPStan's ReflectionProvider
+ * for accurate class, method, and property type resolution.
  */
 final class PhpStanTypeInferenceService implements TypeInferenceInterface
 {
     private ParserService $parser;
+    private ?Container $container = null;
+    private ?ReflectionProvider $reflectionProvider = null;
+    private string $tempDir;
+    private string $projectRoot;
 
     /** @var array<string, VariableTypeCache> */
     private array $fileCache = [];
 
-    public function __construct()
+    public function __construct(?string $projectRoot = null)
     {
+        $this->projectRoot = $projectRoot ?? getcwd() ?: __DIR__;
+        $this->tempDir = sys_get_temp_dir() . '/phpstan-lsp-' . md5($this->projectRoot);
         $this->parser = new ParserService();
     }
 
-    /**
-     * Get the type of a variable at a specific line.
-     *
-     * @return string|null The type description, or null if not determinable
-     */
     public function getVariableType(TextDocument $document, string $variableName, int $line): ?string
     {
         $cache = $this->analyzeDocument($document);
         return $cache->getVariableTypeAtLine($variableName, $line);
     }
 
-    /**
-     * Get the type of an expression.
-     *
-     * @return string|null The type description, or null if not determinable
-     */
     public function getExpressionType(TextDocument $document, Expr $expr, int $line): ?string
     {
         // For method calls, resolve the object type and look up return type
@@ -82,7 +79,8 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
         // For new expressions, the type is the class name
         if ($expr instanceof Expr\New_) {
             if ($expr->class instanceof Name) {
-                return $expr->class->toString();
+                $resolved = $expr->class->getAttribute('resolvedName');
+                return $resolved instanceof Name ? $resolved->toString() : $expr->class->toString();
             }
         }
 
@@ -94,94 +92,100 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
         return null;
     }
 
-    /**
-     * Get the return type of a method.
-     *
-     * @param string $className The fully qualified class name
-     * @param string $methodName The method name
-     * @return string|null The return type, or null if not found
-     */
     public function getMethodReturnType(string $className, string $methodName): ?string
     {
+        $this->ensureContainerInitialized();
+
+        if ($this->reflectionProvider === null) {
+            return null;
+        }
+
         try {
-            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+            if (!$this->reflectionProvider->hasClass($className)) {
                 return null;
             }
 
-            $reflection = new ReflectionClass($className);
-            if (!$reflection->hasMethod($methodName)) {
+            $classReflection = $this->reflectionProvider->getClass($className);
+            if (!$classReflection->hasNativeMethod($methodName)) {
                 return null;
             }
 
-            $method = $reflection->getMethod($methodName);
-            $returnType = $method->getReturnType();
+            $method = $classReflection->getNativeMethod($methodName);
+            $variants = $method->getVariants();
 
-            if ($returnType === null) {
+            if (empty($variants)) {
                 return null;
             }
 
-            return $this->formatReflectionType($returnType);
-        } catch (ReflectionException) {
+            $returnType = $variants[0]->getReturnType();
+            $description = $returnType->describe(VerbosityLevel::typeOnly());
+
+            if ($description === 'mixed') {
+                return null;
+            }
+
+            return $description;
+        } catch (\Throwable) {
             return null;
         }
     }
 
-    /**
-     * Get the type of a property.
-     *
-     * @param string $className The fully qualified class name
-     * @param string $propertyName The property name
-     * @return string|null The property type, or null if not found
-     */
     public function getPropertyType(string $className, string $propertyName): ?string
     {
+        $this->ensureContainerInitialized();
+
+        if ($this->reflectionProvider === null) {
+            return null;
+        }
+
         try {
-            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+            if (!$this->reflectionProvider->hasClass($className)) {
                 return null;
             }
 
-            $reflection = new ReflectionClass($className);
-            if (!$reflection->hasProperty($propertyName)) {
+            $classReflection = $this->reflectionProvider->getClass($className);
+            if (!$classReflection->hasNativeProperty($propertyName)) {
                 return null;
             }
 
-            $property = $reflection->getProperty($propertyName);
-            $type = $property->getType();
+            $property = $classReflection->getNativeProperty($propertyName);
+            $type = $property->getReadableType();
+            $description = $type->describe(VerbosityLevel::typeOnly());
 
-            if ($type === null) {
+            if ($description === 'mixed') {
                 return null;
             }
 
-            return $this->formatReflectionType($type);
-        } catch (ReflectionException) {
+            return $description;
+        } catch (\Throwable) {
             return null;
         }
     }
 
-    /**
-     * Check if a class exists (via autoloading).
-     */
     public function hasClass(string $className): bool
     {
-        return class_exists($className) || interface_exists($className) || trait_exists($className);
+        $this->ensureContainerInitialized();
+
+        if ($this->reflectionProvider === null) {
+            return false;
+        }
+
+        try {
+            return $this->reflectionProvider->hasClass($className);
+        } catch (\Throwable) {
+            return false;
+        }
     }
 
-    /**
-     * Invalidate cache for a document.
-     */
     public function invalidate(string $uri): void
     {
         unset($this->fileCache[$uri]);
     }
 
-    /**
-     * Resolve the type of an expression (helper for chained lookups).
-     */
     private function resolveExpressionType(TextDocument $document, Expr $expr, int $line): ?string
     {
         if ($expr instanceof Expr\Variable) {
             if ($expr->name === 'this') {
-                // Find enclosing class from AST
                 return $this->findEnclosingClass($document, $line);
             }
             if (is_string($expr->name)) {
@@ -192,9 +196,6 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
         return $this->getExpressionType($document, $expr, $line);
     }
 
-    /**
-     * Find the enclosing class at a given line.
-     */
     private function findEnclosingClass(TextDocument $document, int $line): ?string
     {
         $ast = $this->parser->parse($document);
@@ -241,9 +242,6 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
         return $finder->className;
     }
 
-    /**
-     * Analyze a document and cache variable type information.
-     */
     private function analyzeDocument(TextDocument $document): VariableTypeCache
     {
         $uri = $document->uri;
@@ -265,12 +263,12 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
     }
 
     /**
-     * Extract variable type information from AST.
-     *
      * @param array<Stmt> $ast
      */
     private function extractVariableTypes(array $ast, VariableTypeCache $cache): void
     {
+        $this->ensureContainerInitialized();
+
         $extractor = new class ($cache, $this) extends NodeVisitorAbstract {
             private ?string $currentNamespace = null;
             private ?string $currentClass = null;
@@ -296,7 +294,7 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
                     }
                 }
 
-                // Track method parameters
+                // Track method/function parameters
                 if ($node instanceof Stmt\ClassMethod || $node instanceof Stmt\Function_) {
                     foreach ($node->params as $param) {
                         $var = $param->var;
@@ -318,8 +316,6 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
                         $line = $node->getStartLine();
                         $type = $this->inferExpressionType($node->expr, $line);
                         if ($type !== null) {
-                            // Variable is available from this line until end of scope
-                            // For simplicity, use a large end line
                             $this->cache->addVariableType($var->name, $type, $line, PHP_INT_MAX);
                         }
                     }
@@ -352,6 +348,16 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
                     $inner = $this->resolveTypeNode($type->type);
                     return $inner !== null ? '?' . $inner : null;
                 }
+                if ($type instanceof Node\UnionType) {
+                    $types = [];
+                    foreach ($type->types as $t) {
+                        $resolved = $this->resolveTypeNode($t);
+                        if ($resolved !== null) {
+                            $types[] = $resolved;
+                        }
+                    }
+                    return !empty($types) ? implode('|', $types) : null;
+                }
                 return null;
             }
 
@@ -365,7 +371,7 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
                     }
                 }
 
-                // $obj->method() -> look up return type
+                // $obj->method() -> look up return type via PHPStan
                 if ($expr instanceof Expr\MethodCall) {
                     $objectType = $this->inferExpressionType($expr->var, $line);
                     if ($objectType !== null && $expr->name instanceof Identifier) {
@@ -392,6 +398,14 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
                     }
                 }
 
+                // Property fetch $obj->property
+                if ($expr instanceof Expr\PropertyFetch) {
+                    $objectType = $this->inferExpressionType($expr->var, $line);
+                    if ($objectType !== null && $expr->name instanceof Identifier) {
+                        return $this->service->getPropertyType($objectType, $expr->name->toString());
+                    }
+                }
+
                 return null;
             }
         };
@@ -401,19 +415,36 @@ final class PhpStanTypeInferenceService implements TypeInferenceInterface
         $traverser->traverse($ast);
     }
 
-    private function formatReflectionType(\ReflectionType $type): string
+    private function ensureContainerInitialized(): void
     {
-        if ($type instanceof \ReflectionNamedType) {
-            $name = $type->getName();
-            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
+        if ($this->container !== null) {
+            return;
         }
-        if ($type instanceof \ReflectionUnionType) {
-            return implode('|', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
+
+        try {
+            $containerFactory = new ContainerFactory($this->projectRoot);
+
+            // Find phpstan.neon if it exists
+            $configFiles = [];
+            $phpstanNeon = $this->projectRoot . '/phpstan.neon';
+            $phpstanNeonDist = $this->projectRoot . '/phpstan.neon.dist';
+            if (file_exists($phpstanNeon)) {
+                $configFiles[] = $phpstanNeon;
+            } elseif (file_exists($phpstanNeonDist)) {
+                $configFiles[] = $phpstanNeonDist;
+            }
+
+            $this->container = $containerFactory->create(
+                $this->tempDir,
+                $configFiles,
+                [],
+            );
+
+            $this->reflectionProvider = $this->container->getByType(ReflectionProvider::class);
+        } catch (\Throwable) {
+            // PHPStan initialization failed, service will be degraded
+            $this->container = null;
         }
-        if ($type instanceof \ReflectionIntersectionType) {
-            return implode('&', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
-        }
-        return (string) $type;
     }
 }
 

--- a/src/TypeInference/PhpStanTypeInferenceService.php
+++ b/src/TypeInference/PhpStanTypeInferenceService.php
@@ -23,7 +23,7 @@ use ReflectionException;
  * Handles common patterns for variable type inference without requiring
  * external tools or temp files.
  */
-final class PhpStanTypeInferenceService
+final class PhpStanTypeInferenceService implements TypeInferenceInterface
 {
     private ParserService $parser;
 

--- a/src/TypeInference/TypeInferenceInterface.php
+++ b/src/TypeInference/TypeInferenceInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\TypeInference;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use PhpParser\Node\Expr;
+
+/**
+ * Interface for type inference services.
+ */
+interface TypeInferenceInterface
+{
+    /**
+     * Get the type of a variable at a specific line.
+     */
+    public function getVariableType(TextDocument $document, string $variableName, int $line): ?string;
+
+    /**
+     * Get the type of an expression.
+     */
+    public function getExpressionType(TextDocument $document, Expr $expr, int $line): ?string;
+
+    /**
+     * Get the return type of a method.
+     */
+    public function getMethodReturnType(string $className, string $methodName): ?string;
+
+    /**
+     * Get the type of a property.
+     */
+    public function getPropertyType(string $className, string $propertyName): ?string;
+
+    /**
+     * Check if a class exists.
+     */
+    public function hasClass(string $className): bool;
+
+    /**
+     * Invalidate cache for a document.
+     */
+    public function invalidate(string $uri): void;
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -385,4 +385,100 @@ PHP;
         $labels = array_column($result['items'], 'label');
         self::assertContains('greet', $labels);
     }
+
+    public function testNoCompletionInsideLineComment(): void
+    {
+        $code = <<<'PHP'
+<?php
+// Call arr
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 1, 'character' => 11], // After "arr" in comment
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
+
+    public function testNoCompletionInsideBlockComment(): void
+    {
+        $code = <<<'PHP'
+<?php
+/* Call arr
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 1, 'character' => 11], // After "arr" in comment
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
+
+    public function testNoCompletionInsideString(): void
+    {
+        $code = <<<'PHP'
+<?php
+$x = "call arr
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 1, 'character' => 14], // After "arr" in string
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
+
+    public function testNoCompletionInsideSingleQuotedString(): void
+    {
+        $code = <<<'PHP'
+<?php
+$x = 'call arr
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 1, 'character' => 14], // After "arr" in string
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\PhpStanTypeInferenceService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -265,5 +266,123 @@ PHP;
 
         self::assertIsArray($result);
         self::assertEmpty($result['items']);
+    }
+
+    public function testVariableMemberCompletion(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+        $typeInference = new PhpStanTypeInferenceService();
+        $handler = new CompletionHandler($documents, $parser, null, $typeInference);
+
+        // Use a real autoloaded class
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        $doc->
+    }
+}
+PHP;
+        $documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 14], // After $doc->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        self::assertNotEmpty($result['items']);
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getContent', $labels);
+        self::assertContains('getLine', $labels);
+        self::assertContains('uri', $labels);
+    }
+
+    public function testVariableMemberCompletionWithPrefix(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+        $typeInference = new PhpStanTypeInferenceService();
+        $handler = new CompletionHandler($documents, $parser, null, $typeInference);
+
+        // Use a real autoloaded class
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        $doc->get
+    }
+}
+PHP;
+        $documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 17], // After $doc->get
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getContent', $labels);
+        self::assertContains('getLine', $labels);
+        // uri doesn't start with 'get'
+        self::assertNotContains('uri', $labels);
+    }
+
+    public function testCompletionFallsBackWithoutTypeInference(): void
+    {
+        // Handler without type inference should still work for $this-> cases
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    public function greet(): string { return "Hello"; }
+
+    public function test(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('greet', $labels);
     }
 }

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\PhpStanTypeInferenceService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -116,5 +119,124 @@ class DefinitionHandlerTest extends TestCase
         $result = $this->handler->handle($request);
 
         self::assertNull($result);
+    }
+
+    public function testGoToDefinitionForMethodCallOnVariable(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+        $index = new SymbolIndex();
+        $typeInference = new PhpStanTypeInferenceService();
+
+        // Use the project root to enable ComposerClassLocator
+        $projectRoot = dirname(__DIR__, 2);
+        $classLocator = new ComposerClassLocator($projectRoot);
+
+        $handler = new DefinitionHandler($documents, $parser, $index, $classLocator, $typeInference);
+
+        // Use a real autoloaded class
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        $content = $doc->getContent();
+    }
+}
+PHP;
+        $documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 25], // On "getContent"
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('uri', $result);
+        self::assertStringContainsString('TextDocument.php', $result['uri']);
+        self::assertArrayHasKey('range', $result);
+    }
+
+    public function testGoToDefinitionForPropertyFetchOnVariable(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+        $index = new SymbolIndex();
+        $typeInference = new PhpStanTypeInferenceService();
+
+        $projectRoot = dirname(__DIR__, 2);
+        $classLocator = new ComposerClassLocator($projectRoot);
+
+        $handler = new DefinitionHandler($documents, $parser, $index, $classLocator, $typeInference);
+
+        // Use a real autoloaded class
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        echo $doc->uri;
+    }
+}
+PHP;
+        $documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 20], // On "uri"
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('uri', $result);
+        self::assertStringContainsString('TextDocument.php', $result['uri']);
+    }
+
+    public function testDefinitionFallsBackWithoutTypeInference(): void
+    {
+        // Handler without type inference should still work for class references
+        $classCode = '<?php class TestClass {}';
+        $this->documents->open('file:///TestClass.php', 'php', 1, $classCode);
+        $classDoc = $this->documents->get('file:///TestClass.php');
+        self::assertNotNull($classDoc);
+        $ast = $this->parser->parse($classDoc);
+        self::assertNotNull($ast);
+        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
+        foreach ($symbols as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        $usageCode = '<?php new TestClass();';
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 0, 'character' => 10],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///TestClass.php', $result['uri']);
     }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Handler\HoverHandler;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\PhpStanTypeInferenceService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -283,5 +285,116 @@ PHP;
         self::assertIsArray($result);
         self::assertStringContainsString('abs', $result['contents']);
         self::assertStringContainsString('Returns the absolute value', $result['contents']);
+    }
+
+    public function testHoverOnVariableShowsInferredType(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+        $typeInference = new PhpStanTypeInferenceService();
+        $handler = new HoverHandler($documents, $parser, null, $typeInference);
+
+        // Use a real autoloaded class
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        echo $doc->uri;
+    }
+}
+PHP;
+        $documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 14], // On "$doc"
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('contents', $result);
+        self::assertStringContainsString('TextDocument', $result['contents']);
+    }
+
+    public function testHoverOnMethodCallOnVariable(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+        $typeInference = new PhpStanTypeInferenceService();
+        $handler = new HoverHandler($documents, $parser, null, $typeInference);
+
+        // Use a real autoloaded class
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        $content = $doc->getContent();
+    }
+}
+PHP;
+        $documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 25], // On "getContent"
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('contents', $result);
+        self::assertStringContainsString('getContent', $result['contents']);
+        self::assertStringContainsString('string', $result['contents']);
+    }
+
+    public function testHoverFallsBackWithoutTypeInference(): void
+    {
+        // Handler without type inference should still work for $this-> cases
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+
+    public function test(): void
+    {
+        $this->multiply(2, 3);
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 16], // On "multiply"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('multiply', $result['contents']);
     }
 }

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\PhpStanTypeInferenceService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -243,5 +244,80 @@ PHP;
         $result = $this->handler->handle($request);
 
         self::assertNull($result);
+    }
+
+    public function testSignatureHelpForMethodCallOnVariable(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+        $typeInference = new PhpStanTypeInferenceService();
+        $handler = new SignatureHelpHandler($documents, $parser, null, $typeInference);
+
+        // Use a real autoloaded class
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        $line = $doc->getLine(0);
+    }
+}
+PHP;
+        $documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/signatureHelp',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 26], // Inside getLine(|0)
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('signatures', $result);
+        self::assertCount(1, $result['signatures']);
+        self::assertStringContainsString('getLine', $result['signatures'][0]['label']);
+        self::assertStringContainsString('int $line', $result['signatures'][0]['label']);
+    }
+
+    public function testSignatureHelpFallsBackWithoutTypeInference(): void
+    {
+        // Handler without type inference should still work for $this-> cases
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+
+    public function test(): void
+    {
+        $this->multiply(2, 3);
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/signatureHelp',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 24],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('multiply', $result['signatures'][0]['label']);
     }
 }

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
+use Firehed\PhpLsp\TypeInference\TypeInferenceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -99,5 +100,59 @@ class TextDocumentSyncHandlerTest extends TestCase
         $handler->handle($notification);
 
         self::assertNull($manager->get('file:///test.php'));
+    }
+
+    public function testDidChangeInvalidatesTypeInferenceCache(): void
+    {
+        $manager = new DocumentManager();
+        $typeInference = $this->createMock(TypeInferenceInterface::class);
+        $handler = new TextDocumentSyncHandler($manager, null, $typeInference);
+
+        $manager->open('file:///test.php', 'php', 1, '<?php echo "v1";');
+
+        $typeInference->expects($this->once())
+            ->method('invalidate')
+            ->with('file:///test.php');
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didChange',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                    'version' => 2,
+                ],
+                'contentChanges' => [
+                    ['text' => '<?php echo "v2";'],
+                ],
+            ],
+        ]);
+
+        $handler->handle($notification);
+    }
+
+    public function testDidCloseInvalidatesTypeInferenceCache(): void
+    {
+        $manager = new DocumentManager();
+        $typeInference = $this->createMock(TypeInferenceInterface::class);
+        $handler = new TextDocumentSyncHandler($manager, null, $typeInference);
+
+        $manager->open('file:///test.php', 'php', 1, '<?php');
+
+        $typeInference->expects($this->once())
+            ->method('invalidate')
+            ->with('file:///test.php');
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didClose',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                ],
+            ],
+        ]);
+
+        $handler->handle($notification);
     }
 }

--- a/tests/TypeInference/PhpStanTypeInferenceServiceTest.php
+++ b/tests/TypeInference/PhpStanTypeInferenceServiceTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\TypeInference;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\TypeInference\PhpStanTypeInferenceService;
+use PhpParser\Node;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PhpStanTypeInferenceService::class)]
+class PhpStanTypeInferenceServiceTest extends TestCase
+{
+    private PhpStanTypeInferenceService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new PhpStanTypeInferenceService();
+    }
+
+    public function testGetVariableTypeInfersFromAssignment(): void
+    {
+        // Use a real class that's autoloaded
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        echo $doc->uri;
+    }
+}
+PHP;
+
+        $document = new TextDocument('file:///test.php', 'php', 1, $code);
+
+        // Line 5 is where $doc is assigned
+        $type = $this->service->getVariableType($document, 'doc', 5);
+
+        self::assertNotNull($type);
+        self::assertStringContainsString('TextDocument', $type);
+    }
+
+    public function testGetVariableTypeInfersFromMethodReturn(): void
+    {
+        // Use DocumentManager which has a method returning TextDocument|null
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(\Firehed\PhpLsp\Document\DocumentManager $manager): void {
+        $doc = $manager->get('file:///test.php');
+        if ($doc !== null) {
+            echo $doc->uri;
+        }
+    }
+}
+PHP;
+
+        $document = new TextDocument('file:///test.php', 'php', 1, $code);
+
+        // Line 5 is where $doc is assigned
+        $type = $this->service->getVariableType($document, 'doc', 5);
+
+        self::assertNotNull($type);
+        // get() returns TextDocument|null
+        self::assertStringContainsString('TextDocument', $type);
+    }
+
+    public function testGetExpressionTypeForMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        $content = $doc->getContent();
+    }
+}
+PHP;
+
+        $document = new TextDocument('file:///test.php', 'php', 1, $code);
+
+        // Parse and find the MethodCall node
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+        self::assertNotNull($ast);
+
+        $methodCall = $this->findNode($ast, Node\Expr\MethodCall::class);
+        self::assertNotNull($methodCall);
+
+        // Line 6 is where the method call happens
+        $type = $this->service->getExpressionType($document, $methodCall, 6);
+
+        self::assertNotNull($type);
+        self::assertSame('string', $type);
+    }
+
+    public function testGetExpressionTypeForPropertyFetch(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $doc = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+        $uri = $doc->uri;
+    }
+}
+PHP;
+
+        $document = new TextDocument('file:///test.php', 'php', 1, $code);
+
+        // Parse and find the PropertyFetch node
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+        self::assertNotNull($ast);
+
+        $propertyFetch = $this->findNode($ast, Node\Expr\PropertyFetch::class);
+        self::assertNotNull($propertyFetch);
+
+        // Line 6 is where the property fetch happens
+        $type = $this->service->getExpressionType($document, $propertyFetch, 6);
+
+        self::assertNotNull($type);
+        self::assertSame('string', $type);
+    }
+
+    public function testInvalidateClearsCache(): void
+    {
+        $code1 = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $value = 'hello';
+    }
+}
+PHP;
+
+        $code2 = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $value = new \Firehed\PhpLsp\Document\TextDocument('uri', 'php', 1, 'content');
+    }
+}
+PHP;
+
+        $uri = 'file:///test.php';
+        $document1 = new TextDocument($uri, 'php', 1, $code1);
+
+        // First analysis - $value is not typed (string literal)
+        $type1 = $this->service->getVariableType($document1, 'value', 5);
+        // String literals aren't tracked, so this will be null
+        self::assertNull($type1);
+
+        // Invalidate cache
+        $this->service->invalidate($uri);
+
+        // Second analysis with different code - $value is TextDocument
+        $document2 = new TextDocument($uri, 'php', 2, $code2);
+        $type2 = $this->service->getVariableType($document2, 'value', 5);
+
+        self::assertNotNull($type2);
+        self::assertStringContainsString('TextDocument', $type2);
+    }
+
+    public function testReturnsNullForUnknownVariable(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(): void {
+        $known = new \stdClass();
+    }
+}
+PHP;
+
+        $document = new TextDocument('file:///test.php', 'php', 1, $code);
+
+        $type = $this->service->getVariableType($document, 'unknown', 5);
+
+        self::assertNull($type);
+    }
+
+    public function testGetMethodReturnType(): void
+    {
+        // Use a real autoloaded class
+        $type = $this->service->getMethodReturnType(
+            TextDocument::class,
+            'getContent',
+        );
+
+        self::assertNotNull($type);
+        self::assertSame('string', $type);
+    }
+
+    public function testGetPropertyType(): void
+    {
+        // Use a real autoloaded class
+        $type = $this->service->getPropertyType(
+            TextDocument::class,
+            'uri',
+        );
+
+        self::assertNotNull($type);
+        self::assertSame('string', $type);
+    }
+
+    public function testHasClass(): void
+    {
+        self::assertTrue($this->service->hasClass(TextDocument::class));
+        self::assertFalse($this->service->hasClass('NonExistent\\FakeClass'));
+    }
+
+    public function testGetVariableTypeFromMethodParameter(): void
+    {
+        $code = <<<'PHP'
+<?php
+
+class Example {
+    public function test(\Firehed\PhpLsp\Document\TextDocument $doc): void {
+        echo $doc->uri;
+    }
+}
+PHP;
+
+        $document = new TextDocument('file:///test.php', 'php', 1, $code);
+
+        // $doc is a parameter, available throughout the method
+        $type = $this->service->getVariableType($document, 'doc', 5);
+
+        self::assertNotNull($type);
+        self::assertStringContainsString('TextDocument', $type);
+    }
+
+    /**
+     * Helper to find a node of a specific type in the AST.
+     *
+     * @template T of Node
+     * @param array<Node\Stmt> $ast
+     * @param class-string<T> $nodeClass
+     * @return T|null
+     */
+    private function findNode(array $ast, string $nodeClass): ?Node
+    {
+        foreach ($ast as $stmt) {
+            $found = $this->findNodeRecursive($stmt, $nodeClass);
+            if ($found !== null) {
+                return $found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @template T of Node
+     * @param class-string<T> $nodeClass
+     * @return T|null
+     */
+    private function findNodeRecursive(Node $node, string $nodeClass): ?Node
+    {
+        if ($node instanceof $nodeClass) {
+            return $node;
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+            $subNode = $node->$subNodeName;
+            if ($subNode instanceof Node) {
+                $found = $this->findNodeRecursive($subNode, $nodeClass);
+                if ($found !== null) {
+                    return $found;
+                }
+            } elseif (is_array($subNode)) {
+                foreach ($subNode as $item) {
+                    if ($item instanceof Node) {
+                        $found = $this->findNodeRecursive($item, $nodeClass);
+                        if ($found !== null) {
+                            return $found;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- Integrate PHPStan's ReflectionProvider for accurate type resolution
- AST-based variable tracking for assignments (`$x = new Foo()`)
- Method return types via PHPStan (supports PHPDoc, generics, union types)
- Property types via PHPStan's reflection
- Enable hover to show inferred types for variables
- Enable `$variable->` completions for any typed variable
- Enable signature help for method calls on any variable
- Enable go-to-definition for methods and properties on typed variables
- Cache invalidation when documents change

## How it works

1. **Variable tracking**: AST traversal captures variable assignments
2. **Type resolution**: PHPStan's ReflectionProvider resolves method return types and property types
3. **Handlers**: All LSP handlers (hover, completion, signature help, definition) use the type inference service

## Test plan

- [x] Unit tests added for type inference service
- [x] Unit tests added for all handler integrations
- [x] All 121 tests pass
- [x] PHPStan static analysis clean
- [ ] Manual testing in editor with LSP

🤖 Generated with [Claude Code](https://claude.com/claude-code)