### PR TITLE
Add project documentation for AI-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,6 @@ composer test -- --filter X # Run specific tests
 ## Project Structure
 
 - `src/Handler/` — LSP request handlers (completion, hover, definition, etc.)
-- `src/Completion/` — Completion provider architecture
 - `src/Index/` — Symbol indexing and workspace scanning
 - `src/Document/` — Open document management
 - `docs/features/` — Feature status documentation
@@ -25,7 +24,7 @@ composer test -- --filter X # Run specific tests
 
 See `docs/features/completion.md` for current capabilities.
 
-Architecture: provider-based system in `src/Completion/`. Context detection determines what kind of completion (type hint, new expression, member access, etc.), then delegates to appropriate provider.
+Architecture: regex-based context detection in `CompletionHandler`. Determines completion type ($this->, static, new, function) and delegates to internal methods.
 
 ## LSP Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+## Quick Start
+
+```bash
+composer check              # PHPStan + tests (run before commits)
+composer test -- --filter X # Run specific tests
+```
+
+## Project Structure
+
+- `src/Handler/` — LSP request handlers (completion, hover, definition, etc.)
+- `src/Completion/` — Completion provider architecture
+- `src/Index/` — Symbol indexing and workspace scanning
+- `src/Document/` — Open document management
+- `docs/features/` — Feature status documentation
+
+## Development Workflow
+
+- GitHub issues are the source of truth for feature specs
+- Update `docs/features/*.md` when merging features
+- Run `composer check` before commits
+
+## Completion System
+
+See `docs/features/completion.md` for current capabilities.
+
+Architecture: provider-based system in `src/Completion/`. Context detection determines what kind of completion (type hint, new expression, member access, etc.), then delegates to appropriate provider.
+
+## LSP Protocol
+
+Server communicates over stdio. Test with any LSP client; `docs/vim-ale.md` has Vim setup notes.

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -1,0 +1,43 @@
+# Completion Features
+
+This document tracks the current state of code completion in php-lsp.
+
+## Supported Completions
+
+| Context | Trigger | What's Suggested | Status |
+|---------|---------|------------------|--------|
+| `$this->` member access | `$this->` or `$this->prefix` | Methods and properties from current class + inherited via reflection | ✅ Working |
+| Static access | `ClassName::` | Static methods, constants, static properties | ✅ Working |
+| `new` expression | `new ` | Classes from composer classmap | ✅ Working |
+| Function calls | identifier at expression start | Built-in PHP functions + file-local functions | ✅ Working |
+
+## Not Yet Supported
+
+| Context | Example | Notes |
+|---------|---------|-------|
+| Variable completions | `$log` → `$logger` | No local variable or parameter suggestions |
+| Member access on variables | `$logger->` | Only `$this->` works, not arbitrary typed variables |
+| Keywords | `fore` → `foreach` | No language keyword suggestions |
+| Array keys | `$config['` | No key suggestions from array shapes |
+| Docblock tags | `@par` → `@param` | No PHPDoc completion |
+| Snippets | Method inserting `()` | No snippet support in completion items |
+| Auto-import | Suggesting FQCN with use statement insertion | No additional text edits |
+
+## Architecture
+
+```
+CompletionHandler
+└── Regex-based context detection in getCompletionItems()
+    ├── $this-> member completions
+    ├── ClassName:: static completions
+    ├── new ClassName completions
+    └── Function name completions
+```
+
+## Testing
+
+```bash
+composer test                    # Run all tests
+composer test -- --filter Completion  # Run completion tests only
+composer check                   # PHPStan + tests
+```


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project structure, workflow guidelines, and quick start commands
- Adds `docs/features/completion.md` to track completion feature status and gaps
- Sets up documentation structure for tracking feature development

## Test plan
- [x] Files render correctly in GitHub
- [ ] Verify docs match current main branch capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)