### PR TITLE
Use TextDocumentSyncOptions for explicit capability declaration

### DIFF
--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -57,8 +57,11 @@ final class LifecycleHandler implements HandlerInterface
     {
         return [
             'capabilities' => [
-                // TextDocumentSyncKind.Full = 1 (send full document on change)
-                'textDocumentSync' => 1,
+                'textDocumentSync' => [
+                    'openClose' => true,
+                    'change' => 1, // TextDocumentSyncKind.Full
+                    'save' => false,
+                ],
                 'definitionProvider' => true,
                 'hoverProvider' => true,
                 'signatureHelpProvider' => [

--- a/tests/Handler/LifecycleHandlerTest.php
+++ b/tests/Handler/LifecycleHandlerTest.php
@@ -45,6 +45,15 @@ class LifecycleHandlerTest extends TestCase
         self::assertIsArray($result['serverInfo']);
         self::assertSame('php-lsp', $result['serverInfo']['name']);
         self::assertSame('0.1.0', $result['serverInfo']['version']);
+
+        // Verify textDocumentSync uses options object, not bare number
+        $capabilities = $result['capabilities'];
+        self::assertIsArray($capabilities);
+        $sync = $capabilities['textDocumentSync'];
+        self::assertIsArray($sync);
+        self::assertTrue($sync['openClose']);
+        self::assertSame(1, $sync['change']);
+        self::assertFalse($sync['save']);
     }
 
     public function testInitializedReturnsNull(): void


### PR DESCRIPTION
## Summary
- Uses TextDocumentSyncOptions object instead of bare sync kind number
- Explicitly declares `save: false` so clients know didSave is not needed
- Adds test coverage for textDocumentSync structure

Fixes #30

## Test plan
- [x] Existing tests pass
- [x] New assertions verify textDocumentSync structure
- [ ] Manual test with ALE to verify restart behavior improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)