### PR TITLE
Remove colon from completion trigger characters

### DIFF
--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -65,7 +65,8 @@ final class LifecycleHandler implements HandlerInterface
                     'triggerCharacters' => ['(', ','],
                 ],
                 'completionProvider' => [
-                    'triggerCharacters' => ['>', ':', '$', '\\'],
+                    // Note: ':' omitted - fires prematurely on first ':' of '::'
+                    'triggerCharacters' => ['>', '$', '\\'],
                 ],
             ],
             'serverInfo' => $this->serverInfo->toArray(),

--- a/tests/Handler/LifecycleHandlerTest.php
+++ b/tests/Handler/LifecycleHandlerTest.php
@@ -47,6 +47,35 @@ class LifecycleHandlerTest extends TestCase
         self::assertSame('0.1.0', $result['serverInfo']['version']);
     }
 
+    public function testCompletionTriggerCharactersExcludeColon(): void
+    {
+        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'initialize',
+            'params' => [],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        $capabilities = $result['capabilities'];
+        self::assertIsArray($capabilities);
+        $completion = $capabilities['completionProvider'];
+        self::assertIsArray($completion);
+        $triggers = $completion['triggerCharacters'];
+        self::assertIsArray($triggers);
+
+        // ':' should NOT be a trigger - it fires prematurely on first ':' of '::'
+        self::assertNotContains(':', $triggers);
+        // These should still be triggers
+        self::assertContains('>', $triggers);
+        self::assertContains('$', $triggers);
+        self::assertContains('\\', $triggers);
+    }
+
     public function testInitializedReturnsNull(): void
     {
         $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));


### PR DESCRIPTION
## Summary
Removes `:` from completion trigger characters. It fires prematurely when typing `::` - completions appear after the first `:` before the user finishes typing the static access operator.

Users can still manually trigger completion after typing `::`.

Fixes #27

## Test plan
- [x] New test verifies `:` is not in trigger characters
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)