### PR TITLE
Add ::class magic constant to static completions

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -228,6 +228,15 @@ final class CompletionHandler implements HandlerInterface
         // Also try reflection for inherited/built-in
         $items = array_merge($items, $this->getReflectionStaticCompletions($className, $prefix, $items));
 
+        // Always offer ::class magic constant
+        if ($prefix === '' || str_starts_with('class', strtolower($prefix))) {
+            $items[] = [
+                'label' => 'class',
+                'kind' => self::KIND_CONSTANT,
+                'detail' => 'string (fully qualified class name)',
+            ];
+        }
+
         return $items;
     }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -102,8 +102,8 @@ final class CompletionHandler implements HandlerInterface
             return $this->getThisMemberCompletions($prefix, $ast);
         }
 
-        // ClassName:: completion (static)
-        if (preg_match('/([A-Z]\w*)::(\w*)$/', $textBeforeCursor, $matches)) {
+        // ClassName:: completion (static) - also match single : for mid-typing
+        if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches)) {
             $className = $matches[1];
             $prefix = $matches[2];
             return $this->getStaticCompletions($className, $prefix, $ast, $document);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -183,6 +183,8 @@ PHP;
         $labels = array_column($result['items'], 'label');
         self::assertContains('add', $labels);
         self::assertContains('multiply', $labels);
+        // ::class magic constant should always be suggested
+        self::assertContains('class', $labels);
     }
 
     public function testClassConstantCompletion(): void


### PR DESCRIPTION
## Summary
- Adds `class` magic constant to static completion results (`ClassName::class`)
- Handles mid-typing where ALE sends requests with single colon (`Foo:` instead of `Foo::`)

Fixes #26

## Test plan
- [x] Unit test verifies `class` is in static completion results
- [x] Manual test with ALE: `Foo::cl` shows `class` completion
- Note: ALE filters completions with <2 char prefix, so `Foo::c` won't show results (client-side behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)