### PR TITLE
Skip completions inside comments, strings, and heredocs

### DIFF
--- a/src/Completion/ContextDetector.php
+++ b/src/Completion/ContextDetector.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use Throwable;
+
+/**
+ * Detects whether a given position in PHP code is a valid context for
+ * code completion. Returns false for positions inside comments, strings,
+ * heredocs, and nowdocs where completions would be inappropriate.
+ */
+final class ContextDetector
+{
+    // Token types where completions should NOT be offered
+    private const NON_COMPLETABLE_TOKENS = [
+        T_COMMENT,
+        T_DOC_COMMENT,
+        T_CONSTANT_ENCAPSED_STRING,
+        T_ENCAPSED_AND_WHITESPACE,
+    ];
+
+    /**
+     * Check if the given offset in the code is a valid position for completions.
+     *
+     * @param string $code The full PHP source code
+     * @param int $offset The byte offset position in the code (0-indexed)
+     * @return bool True if completions should be offered, false otherwise
+     */
+    public static function isCompletable(string $code, int $offset): bool
+    {
+        try {
+            return self::detectContext($code, $offset);
+        } catch (Throwable) {
+            // If tokenizer fails for any reason, assume completable
+            // (let later phases filter if needed)
+            return true;
+        }
+    }
+
+    private static function detectContext(string $code, int $offset): bool
+    {
+        if ($code === '') {
+            return true;
+        }
+
+        // Clamp offset to valid range
+        $offset = max(0, min($offset, strlen($code)));
+
+        $tokens = token_get_all($code);
+
+        $currentPosition = 0;
+
+        foreach ($tokens as $token) {
+            if (is_array($token)) {
+                $tokenType = $token[0];
+                $tokenText = $token[1];
+                $tokenLength = strlen($tokenText);
+
+                $tokenStart = $currentPosition;
+                $tokenEnd = $currentPosition + $tokenLength;
+
+                // Check if offset falls within this token
+                if ($offset >= $tokenStart && $offset <= $tokenEnd) {
+                    if (in_array($tokenType, self::NON_COMPLETABLE_TOKENS, true)) {
+                        return false;
+                    }
+
+                    // Check for heredoc/nowdoc content
+                    if (self::isInsideHeredoc($tokenType, $offset, $tokenStart, $tokenEnd, $tokens, $currentPosition)) {
+                        return false;
+                    }
+                }
+
+                $currentPosition += $tokenLength;
+            } else {
+                // Single character token
+                $currentPosition += strlen($token);
+            }
+        }
+
+        // Check if we're in an unclosed string or comment at end of file
+        if ($offset >= $currentPosition) {
+            return self::checkUnfinishedContext($tokens);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private static function isInsideHeredoc(
+        int $tokenType,
+        int $offset,
+        int $tokenStart,
+        int $tokenEnd,
+        array $tokens,
+        int $currentPosition,
+    ): bool {
+        // T_START_HEREDOC starts a heredoc/nowdoc
+        // The actual content would be in following tokens
+        if ($tokenType === T_START_HEREDOC) {
+            // We're on the heredoc start line itself, which is completable
+            return false;
+        }
+
+        // Check if we're in heredoc content by looking back for T_START_HEREDOC
+        // without seeing T_END_HEREDOC
+        return self::isInHeredocContent($tokens, $currentPosition);
+    }
+
+    /**
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private static function isInHeredocContent(array $tokens, int $upToPosition): bool
+    {
+        $inHeredoc = false;
+        $pos = 0;
+
+        foreach ($tokens as $token) {
+            if ($pos >= $upToPosition) {
+                break;
+            }
+
+            if (is_array($token)) {
+                if ($token[0] === T_START_HEREDOC) {
+                    $inHeredoc = true;
+                } elseif ($token[0] === T_END_HEREDOC) {
+                    $inHeredoc = false;
+                }
+                $pos += strlen($token[1]);
+            } else {
+                $pos += strlen($token);
+            }
+        }
+
+        return $inHeredoc;
+    }
+
+    /**
+     * Check if the last token indicates we're in an unclosed context.
+     *
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private static function checkUnfinishedContext(array $tokens): bool
+    {
+        if (empty($tokens)) {
+            return true;
+        }
+
+        $lastToken = end($tokens);
+
+        if (is_array($lastToken)) {
+            $tokenType = $lastToken[0];
+
+            // If last token is a non-completable type and isn't properly closed
+            if (in_array($tokenType, self::NON_COMPLETABLE_TOKENS, true)) {
+                return false;
+            }
+
+            // Unclosed heredoc
+            if ($tokenType === T_START_HEREDOC) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Handler;
 
+use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
@@ -71,6 +72,15 @@ final class CompletionHandler implements HandlerInterface
         $document = $this->documentManager->get($uri);
         if ($document === null) {
             return null;
+        }
+
+        // Skip completions inside comments, strings, heredocs
+        $offset = $document->offsetAt($line, $character);
+        if (!ContextDetector::isCompletable($document->getContent(), $offset)) {
+            return [
+                'isIncomplete' => false,
+                'items' => [],
+            ];
         }
 
         $ast = $this->parser->parse($document);

--- a/tests/Completion/ContextDetectorTest.php
+++ b/tests/Completion/ContextDetectorTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Completion;
+
+use Firehed\PhpLsp\Completion\ContextDetector;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContextDetector::class)]
+class ContextDetectorTest extends TestCase
+{
+    // =========================================================================
+    // Valid completion contexts
+    // =========================================================================
+
+    public function testCompletableInNormalCode(): void
+    {
+        $code = '<?php $this->';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testCompletableAfterMemberAccess(): void
+    {
+        $code = '<?php $foo->bar->';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testCompletableInFunctionBody(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(): void
+{
+    $x = new
+PHP;
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testCompletableInTypeHintPosition(): void
+    {
+        $code = '<?php function test(str';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testCompletableInUseStatement(): void
+    {
+        $code = '<?php use Psr\Log\\';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    // =========================================================================
+    // Invalid completion contexts - Comments
+    // =========================================================================
+
+    public function testNotCompletableInSingleLineComment(): void
+    {
+        $code = '<?php // this is a comment $this->';
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testNotCompletableInSingleLineHashComment(): void
+    {
+        $code = '<?php # hash comment $this->';
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testNotCompletableInMultiLineComment(): void
+    {
+        $code = <<<'PHP'
+<?php
+/*
+ * Comment $this->
+PHP;
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testNotCompletableInDocblock(): void
+    {
+        $code = <<<'PHP'
+<?php
+/**
+ * @param string $var
+PHP;
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    // =========================================================================
+    // Invalid completion contexts - Strings
+    // =========================================================================
+
+    public function testNotCompletableInSingleQuotedString(): void
+    {
+        $code = "<?php \$x = 'hello \$this->";
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testNotCompletableInDoubleQuotedString(): void
+    {
+        $code = '<?php $x = "hello ';
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testNotCompletableInInterpolatedString(): void
+    {
+        // Inside the string content portion
+        $code = '<?php $x = "hello {$name} world ';
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testCompletableInsideInterpolationBraces(): void
+    {
+        // Inside {$...} blocks, completions should work (variable interpolation)
+        $code = '<?php $x = "Hello {$user->}";';
+        $pos = strpos($code, '->}');
+        self::assertIsInt($pos);
+        // Position right after -> (before the closing })
+        self::assertTrue(ContextDetector::isCompletable($code, $pos + 2));
+    }
+
+    // =========================================================================
+    // Invalid completion contexts - Heredoc/Nowdoc
+    // =========================================================================
+
+    public function testNotCompletableInHeredoc(): void
+    {
+        $code = <<<'PHP'
+<?php
+$x = <<<HTML
+<div>Some content
+PHP;
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testNotCompletableInNowdoc(): void
+    {
+        $code = <<<'PHP'
+<?php
+$x = <<<'TEXT'
+Some text content
+PHP;
+        self::assertFalse(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    // =========================================================================
+    // Edge cases - Completable after closing constructs
+    // =========================================================================
+
+    public function testCompletableAfterClosedString(): void
+    {
+        $code = '<?php $x = "hello"; $this->';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testCompletableAfterClosedComment(): void
+    {
+        $code = '<?php /* comment */ $this->';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testCompletableAfterClosedHeredoc(): void
+    {
+        $code = <<<'PHP'
+<?php
+$x = <<<HTML
+content
+HTML;
+$this->
+PHP;
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    // =========================================================================
+    // Robustness tests - Broken/Invalid syntax
+    // =========================================================================
+
+    public function testReturnsCompletableForCompletelyBrokenSyntax(): void
+    {
+        // Assume completable (fallback) for completely broken code
+        $code = '<?php function foo( $';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testHandlesUnclosedBrace(): void
+    {
+        $code = '<?php class Foo { public function bar() { $this->';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testHandlesUnclosedParenthesis(): void
+    {
+        $code = '<?php $result = array_map(function($x) { return $x->';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testHandlesMidEditIncompleteStatement(): void
+    {
+        $code = '<?php $foo = $bar->';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testHandlesEmptyCode(): void
+    {
+        $code = '';
+        self::assertTrue(ContextDetector::isCompletable($code, 0));
+    }
+
+    public function testHandlesCodeWithOnlyPhpTag(): void
+    {
+        $code = '<?php ';
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testNeverThrowsException(): void
+    {
+        $testCases = [
+            '',
+            '<?php',
+            '<?php $',
+            '<?php "unclosed',
+            "<?php 'unclosed",
+            '<?php /* unclosed',
+            '<?php /** unclosed',
+            '<?php // comment',
+            "<?php <<<EOF\nunclosed",
+            '<?php function(',
+            '<?php class {',
+            '<?php if (true',
+            "\x00\x01\x02", // Binary garbage
+            str_repeat('a', 10000), // Large input
+        ];
+
+        foreach ($testCases as $code) {
+            // Should never throw - if it does, the test fails
+            ContextDetector::isCompletable($code, strlen($code));
+        }
+        // If we reached here, no exceptions were thrown - count as a success
+        $this->addToAssertionCount(1);
+    }
+
+    // =========================================================================
+    // Position-specific tests
+    // =========================================================================
+
+    public function testPositionInMiddleOfComment(): void
+    {
+        $code = '<?php // comment $this-> more';
+        $position = strpos($code, '$this->');
+        self::assertIsInt($position);
+        self::assertFalse(ContextDetector::isCompletable($code, $position + 7));
+    }
+
+    public function testPositionBeforeComment(): void
+    {
+        $code = '<?php $foo->bar // comment';
+        $position = strpos($code, '$foo->bar');
+        self::assertIsInt($position);
+        self::assertTrue(ContextDetector::isCompletable($code, $position + 9));
+    }
+
+    public function testPositionAfterComment(): void
+    {
+        $code = "<?php // comment\n\$this->";
+        self::assertTrue(ContextDetector::isCompletable($code, strlen($code)));
+    }
+
+    public function testZeroOffset(): void
+    {
+        $code = '<?php $x = 1;';
+        self::assertTrue(ContextDetector::isCompletable($code, 0));
+    }
+
+    public function testOffsetBeyondCodeLength(): void
+    {
+        $code = '<?php $x = 1;';
+        // Should handle gracefully
+        self::assertTrue(ContextDetector::isCompletable($code, 1000));
+    }
+}


### PR DESCRIPTION
## Summary
Adds `ContextDetector` that uses PHP's tokenizer to detect non-completable contexts:
- Single-line comments (`//`, `#`)
- Multi-line comments (`/* */`)
- Doc comments (`/** */`) - note: #21 will add PHPDoc completions later
- Single and double-quoted strings
- Heredocs and nowdocs

Returns empty completions early, before parsing AST.

**Note:** Variable interpolation in strings (`"Hello {$user->}"`) correctly allows completions inside the `{$...}` blocks - these are tokenized as normal PHP, not string content.

Fixes #24

## Test plan
- [x] 30 new tests covering all context types
- [x] Edge cases: unclosed strings, broken syntax, position boundaries
- [x] Interpolation blocks allow completions (verified with test)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)