### PR TITLE
Resolve imported class names for static completions

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -185,19 +185,22 @@ final class CompletionHandler implements HandlerInterface
     {
         $items = [];
 
+        // Resolve short name to FQCN using imports
+        $resolvedClassName = $this->resolveClassName($className, $ast);
+
         // Try to find class in AST first
-        $classNode = $this->findClassInAst($className, $ast);
+        $classNode = $this->findClassInAst($resolvedClassName, $ast);
 
         // If not in current file, try Composer
         if ($classNode === null && $this->classLocator !== null) {
-            $filePath = $this->classLocator->locateClass($className);
+            $filePath = $this->classLocator->locateClass($resolvedClassName);
             if ($filePath !== null) {
                 $content = file_get_contents($filePath);
                 if ($content !== false) {
                     $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
                     $externalAst = $this->parser->parse($externalDoc);
                     if ($externalAst !== null) {
-                        $classNode = $this->findClassInAst($className, $externalAst);
+                        $classNode = $this->findClassInAst($resolvedClassName, $externalAst);
                     }
                 }
             }
@@ -236,7 +239,7 @@ final class CompletionHandler implements HandlerInterface
         }
 
         // Also try reflection for inherited/built-in
-        $items = array_merge($items, $this->getReflectionStaticCompletions($className, $prefix, $items));
+        $items = array_merge($items, $this->getReflectionStaticCompletions($resolvedClassName, $prefix, $items));
 
         // Always offer ::class magic constant
         if ($prefix === '' || str_starts_with('class', strtolower($prefix))) {
@@ -704,5 +707,48 @@ final class CompletionHandler implements HandlerInterface
     {
         $parts = explode('\\', $fqcn);
         return end($parts);
+    }
+
+    /**
+     * Resolve a short class name to its FQCN using use statements.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function resolveClassName(string $shortName, array $ast): string
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                foreach ($stmt->stmts as $nsStmt) {
+                    $resolved = $this->checkUseStatement($nsStmt, $shortName);
+                    if ($resolved !== null) {
+                        return $resolved;
+                    }
+                }
+            } else {
+                $resolved = $this->checkUseStatement($stmt, $shortName);
+                if ($resolved !== null) {
+                    return $resolved;
+                }
+            }
+        }
+
+        // Not found in imports, return as-is (might be FQCN or in same namespace)
+        return $shortName;
+    }
+
+    private function checkUseStatement(Stmt $stmt, string $shortName): ?string
+    {
+        if (!$stmt instanceof Stmt\Use_) {
+            return null;
+        }
+
+        foreach ($stmt->uses as $use) {
+            $alias = $use->alias?->toString() ?? $use->name->getLast();
+            if ($alias === $shortName) {
+                return $use->name->toString();
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -219,6 +219,96 @@ PHP;
         self::assertContains('INACTIVE', $labels);
     }
 
+    public function testStaticCompletionResolvesImportedClassName(): void
+    {
+        // Class defined in a namespace, then imported via use statement
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class User
+{
+    public const STATUS_ACTIVE = 'active';
+    public static function findById(int $id): self {}
+}
+
+namespace App\Controllers;
+
+use App\Models\User;
+
+class UserController
+{
+    public function show(): void
+    {
+        User::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 17, 'character' => 14], // After User::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Should resolve User to App\Models\User and find its members
+        self::assertContains('STATUS_ACTIVE', $labels);
+        self::assertContains('findById', $labels);
+        self::assertContains('class', $labels);
+    }
+
+    public function testStaticCompletionResolvesAliasedImport(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class UserModel
+{
+    public const ROLE_ADMIN = 'admin';
+}
+
+namespace App\Controllers;
+
+use App\Models\UserModel as User;
+
+class Controller
+{
+    public function test(): void
+    {
+        User::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 16, 'character' => 14], // After User::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Should resolve User alias to App\Models\UserModel
+        self::assertContains('ROLE_ADMIN', $labels);
+    }
+
     public function testFunctionCompletion(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
When typing `ClassName::`, resolves the short name to its FQCN using use statements before looking up the class.

Example:
```php
use App\Models\User;

User::  // Now shows User's static members
```

- Handles aliased imports (`use Foo as Bar`)
- Checks all namespaces in file for use statements

Fixes #28

## Test plan
- [x] New test: imported class static completion
- [x] New test: aliased import static completion
- [x] All 131 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)