### PR TITLE
Context-aware completion filtering

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -130,6 +130,13 @@ final class CompletionHandler implements HandlerInterface
             return $this->deduplicateCompletions($items);
         }
 
+        // Type hint context - after : (return type), in parameters, union/intersection types
+        // Matches: "): str", "(str", ", str", "?str", "|str", "&str", "private str", "public readonly str"
+        if (preg_match('/(?:(?:private|protected|public)(?:\s+readonly)?\s+|[(:,?|&]\s*)(\w*)$/', $textBeforeCursor, $matches)) {
+            $prefix = $matches[1];
+            return $this->getTypeHintCompletions($prefix, $ast);
+        }
+
         // Function/class completion (at start of expression or after operators)
         if (preg_match('/(?:^|[(\s=,!&|])(\w+)$/', $textBeforeCursor, $matches)) {
             $prefix = $matches[1];
@@ -840,5 +847,46 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Get completions for type hint positions.
+     *
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string}>
+     */
+    private function getTypeHintCompletions(string $prefix, array $ast): array
+    {
+        $items = [];
+
+        // Built-in types
+        $builtinTypes = [
+            'string', 'int', 'float', 'bool', 'array', 'object',
+            'mixed', 'null', 'void', 'never', 'callable', 'iterable',
+            'true', 'false', 'self', 'static', 'parent',
+        ];
+
+        foreach ($builtinTypes as $type) {
+            if ($prefix === '' || str_starts_with($type, strtolower($prefix))) {
+                $items[] = [
+                    'label' => $type,
+                    'kind' => self::KIND_CLASS, // Keyword kind would be better but not defined
+                    'detail' => 'builtin type',
+                ];
+            }
+        }
+
+        // Imported classes
+        $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
+
+        // Indexed types (all are valid in type hints)
+        $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
+            SymbolKind::Class_,
+            SymbolKind::Interface_,
+            SymbolKind::Trait_,
+            SymbolKind::Enum_,
+        ]));
+
+        return $this->deduplicateCompletions($items);
     }
 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -8,6 +8,8 @@ use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Utility\DocblockParser;
@@ -34,6 +36,7 @@ final class CompletionHandler implements HandlerInterface
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
+        private readonly SymbolIndex $symbolIndex,
         private readonly ?ComposerClassLocator $classLocator,
     ) {
     }
@@ -119,10 +122,12 @@ final class CompletionHandler implements HandlerInterface
             return $this->getStaticCompletions($className, $prefix, $ast, $document);
         }
 
-        // new ClassName completion - only suggest imported classes
+        // new ClassName completion - suggest imported classes and indexed instantiable types
         if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches)) {
             $prefix = $matches[1];
-            return $this->getImportedClassCompletions($prefix, $ast);
+            $items = $this->getImportedClassCompletions($prefix, $ast);
+            $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [SymbolKind::Class_, SymbolKind::Enum_]));
+            return $this->deduplicateCompletions($items);
         }
 
         // Function/class completion (at start of expression or after operators)
@@ -785,5 +790,49 @@ final class CompletionHandler implements HandlerInterface
                 $imports[$shortName] = $fqcn;
             }
         }
+    }
+
+    /**
+     * Get class completions from the workspace symbol index.
+     *
+     * @param list<SymbolKind> $kinds
+     * @return list<array{label: string, kind: int, detail: string}>
+     */
+    private function getIndexedClassCompletions(string $prefix, array $kinds): array
+    {
+        $symbols = $this->symbolIndex->findByPrefix($prefix, $kinds);
+        $items = [];
+
+        foreach ($symbols as $symbol) {
+            $items[] = [
+                'label' => $symbol->name,
+                'kind' => self::KIND_CLASS,
+                'detail' => $symbol->fullyQualifiedName,
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Remove duplicate completions, preferring items that appear earlier.
+     *
+     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $items
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function deduplicateCompletions(array $items): array
+    {
+        $seen = [];
+        $result = [];
+
+        foreach ($items as $item) {
+            $key = $item['label'];
+            if (!isset($seen[$key])) {
+                $seen[$key] = true;
+                $result[] = $item;
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -135,7 +135,13 @@ final class CompletionHandler implements HandlerInterface
             $prefix = $matches[1];
             $items = $this->getFunctionCompletions($prefix, $ast);
             $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
-            return $items;
+            $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
+                SymbolKind::Class_,
+                SymbolKind::Interface_,
+                SymbolKind::Trait_,
+                SymbolKind::Enum_,
+            ]));
+            return $this->deduplicateCompletions($items);
         }
 
         return [];

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -39,6 +39,29 @@ final class SymbolIndex
         return $this->byName[$name] ?? [];
     }
 
+    /**
+     * Find symbols matching a prefix, optionally filtered by kind.
+     *
+     * @param list<SymbolKind>|null $kinds
+     * @return list<Symbol>
+     */
+    public function findByPrefix(string $prefix, ?array $kinds = null): array
+    {
+        $results = [];
+        $prefixLower = strtolower($prefix);
+
+        foreach ($this->byFqn as $symbol) {
+            if ($kinds !== null && !in_array($symbol->kind, $kinds, true)) {
+                continue;
+            }
+            if (str_starts_with(strtolower($symbol->name), $prefixLower)) {
+                $results[] = $symbol;
+            }
+        }
+
+        return $results;
+    }
+
     public function clearByUri(string $uri): void
     {
         $fqns = $this->byUri[$uri] ?? [];

--- a/src/Server.php
+++ b/src/Server.php
@@ -50,7 +50,7 @@ final class Server
         $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
         $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator);
         $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator);
-        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $classLocator);
+        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
     }
 
     public function run(): int

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -571,6 +571,102 @@ PHP;
         self::assertContains('MyTrait', $labels);
     }
 
+    public function testTypeHintCompletionInReturnType(): void
+    {
+        $code = '<?php function foo(): str';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 25],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('string', $labels);
+        // Should NOT contain functions
+        self::assertNotContains('strlen', $labels);
+        self::assertNotContains('str_replace', $labels);
+    }
+
+    public function testTypeHintCompletionInParameter(): void
+    {
+        $code = '<?php function foo(str';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 22],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('string', $labels);
+    }
+
+    public function testTypeHintCompletionIncludesBuiltinTypes(): void
+    {
+        $code = '<?php function foo(): ';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 22],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('string', $labels);
+        self::assertContains('int', $labels);
+        self::assertContains('bool', $labels);
+        self::assertContains('array', $labels);
+        self::assertContains('void', $labels);
+        self::assertContains('mixed', $labels);
+    }
+
+    public function testTypeHintCompletionForPropertyType(): void
+    {
+        $code = '<?php class Foo { private str';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 29],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('string', $labels);
+    }
+
     public function testCompletionReturnsEmptyForUnknownContext(): void
     {
         $code = '<?php $x = 1;';

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -525,6 +525,52 @@ PHP;
         self::assertNotContains('MyInterface', $labels);
     }
 
+    public function testExpressionCompletionIncludesAllIndexedTypes(): void
+    {
+        // Add various symbol types to the index
+        $this->symbolIndex->add(new Symbol(
+            'MyClass',
+            'App\MyClass',
+            SymbolKind::Class_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+        $this->symbolIndex->add(new Symbol(
+            'MyInterface',
+            'App\MyInterface',
+            SymbolKind::Interface_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+        $this->symbolIndex->add(new Symbol(
+            'MyTrait',
+            'App\MyTrait',
+            SymbolKind::Trait_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+
+        // Expression context (not `new`)
+        $code = '<?php $x = My';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 13],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Expression context should include all types
+        self::assertContains('MyClass', $labels);
+        self::assertContains('MyInterface', $labels);
+        self::assertContains('MyTrait', $labels);
+    }
+
     public function testCompletionReturnsEmptyForUnknownContext(): void
     {
         $code = '<?php $x = 1;';

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -6,6 +6,10 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Index\Symbol;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -16,13 +20,15 @@ class CompletionHandlerTest extends TestCase
 {
     private DocumentManager $documents;
     private ParserService $parser;
+    private SymbolIndex $symbolIndex;
     private CompletionHandler $handler;
 
     protected function setUp(): void
     {
         $this->documents = new DocumentManager();
         $this->parser = new ParserService();
-        $this->handler = new CompletionHandler($this->documents, $this->parser, null);
+        $this->symbolIndex = new SymbolIndex();
+        $this->handler = new CompletionHandler($this->documents, $this->parser, $this->symbolIndex, null);
     }
 
     public function testSupports(): void
@@ -448,6 +454,75 @@ PHP;
         $userItem = reset($userItems);
         self::assertIsArray($userItem);
         self::assertSame('App\Models\User', $userItem['detail'] ?? null);
+    }
+
+    public function testNewCompletionIncludesIndexedClasses(): void
+    {
+        // Add a class to the index
+        $this->symbolIndex->add(new Symbol(
+            'MyIndexedClass',
+            'App\MyIndexedClass',
+            SymbolKind::Class_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+
+        $code = '<?php $x = new MyIn';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 19],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('MyIndexedClass', $labels);
+    }
+
+    public function testNewCompletionExcludesIndexedInterfaces(): void
+    {
+        // Add an interface and a class to the index
+        $this->symbolIndex->add(new Symbol(
+            'MyInterface',
+            'App\MyInterface',
+            SymbolKind::Interface_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+        $this->symbolIndex->add(new Symbol(
+            'MyClass',
+            'App\MyClass',
+            SymbolKind::Class_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+
+        $code = '<?php $x = new My';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 17],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Should include class
+        self::assertContains('MyClass', $labels);
+        // Should NOT include interface
+        self::assertNotContains('MyInterface', $labels);
     }
 
     public function testCompletionReturnsEmptyForUnknownContext(): void


### PR DESCRIPTION
## Summary

Implements context-aware completion filtering per #25:

- **Type hint positions** (return types, parameters, property types, union/intersection): Suggests built-in types and classes, no functions
- **`new` expression**: Suggests only instantiable types (classes and enums), excludes interfaces and traits  
- **General expressions**: Suggests all types (classes, interfaces, traits, enums) plus functions

Also wires up the SymbolIndex to CompletionHandler, enabling workspace-wide class suggestions beyond just imported classes.

## Changes

- Add `SymbolIndex` dependency to `CompletionHandler`
- Add `findByPrefix()` method to `SymbolIndex` for prefix-based lookups with kind filtering
- Add type hint context detection via regex
- Add built-in PHP type suggestions (string, int, bool, array, void, mixed, etc.)
- Filter completion results by context

## Not included

- `use` statement completions (namespace suggestions) - would need additional infrastructure
- Abstract class detection (abstract classes still suggested in `new` context)
- Variable suggestions (#17)

## Test plan

- [x] Tests pass for type hint completions (return types, parameters, property types)
- [x] Tests pass for `new` context filtering (interfaces excluded)
- [x] Tests pass for expression context (all types included)
- [x] PHPStan passes

🤖 Generated with [Claude Code](https://claude.ai/code)