### PR TITLE
Add variable completions after $

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -29,6 +29,7 @@ final class CompletionHandler implements HandlerInterface
     // LSP CompletionItemKind constants
     private const KIND_METHOD = 2;
     private const KIND_FUNCTION = 3;
+    private const KIND_VARIABLE = 6;
     private const KIND_CLASS = 7;
     private const KIND_PROPERTY = 10;
     private const KIND_KEYWORD = 14;
@@ -96,7 +97,7 @@ final class CompletionHandler implements HandlerInterface
         $lineText = $document->getLine($line);
         $textBeforeCursor = substr($lineText, 0, $character);
 
-        $items = $this->getCompletionItems($textBeforeCursor, $ast, $document);
+        $items = $this->getCompletionItems($textBeforeCursor, $ast, $document, $line);
 
         return [
             'isIncomplete' => false,
@@ -108,12 +109,18 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
      */
-    private function getCompletionItems(string $textBeforeCursor, array $ast, TextDocument $document): array
+    private function getCompletionItems(string $textBeforeCursor, array $ast, TextDocument $document, int $line): array
     {
         // $this-> completion
         if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches)) {
             $prefix = $matches[1];
             return $this->getThisMemberCompletions($prefix, $ast);
+        }
+
+        // Variable completion ($var)
+        if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches)) {
+            $prefix = $matches[1];
+            return $this->getVariableCompletions($prefix, $ast, $line);
         }
 
         // ClassName:: completion (static) - also match single : for mid-typing
@@ -1045,5 +1052,210 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $items;
+    }
+
+    /**
+     * Get variable completions for the current scope.
+     *
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind: int, detail?: string}>
+     */
+    private function getVariableCompletions(string $prefix, array $ast, int $cursorLine): array
+    {
+        // Find the innermost function/method/closure containing the cursor
+        $enclosingScope = $this->findEnclosingScope($ast, $cursorLine);
+        if ($enclosingScope === null) {
+            return [];
+        }
+
+        $inMethod = $enclosingScope instanceof Stmt\ClassMethod;
+        $variables = $this->collectScopeVariables($enclosingScope);
+
+        // Build completion items
+        $items = [];
+        $prefixLower = strtolower($prefix);
+
+        // Add $this if we're in a method
+        if ($inMethod && ($prefix === '' || str_starts_with('this', $prefixLower))) {
+            $items[] = [
+                'label' => '$this',
+                'kind' => self::KIND_VARIABLE,
+                'detail' => 'self',
+            ];
+        }
+
+        foreach ($variables as $name => $type) {
+            if ($prefix === '' || str_starts_with(strtolower($name), $prefixLower)) {
+                $items[] = [
+                    'label' => '$' . $name,
+                    'kind' => self::KIND_VARIABLE,
+                    'detail' => $type,
+                ];
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Find the innermost function/method/closure containing the given line.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function findEnclosingScope(array $ast, int $cursorLine): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null
+    {
+        $found = null;
+
+        $visitor = new class ($cursorLine, $found) extends NodeVisitorAbstract {
+            /** @var Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null */
+            public $found = null;
+            private int $cursorLine;
+
+            /**
+             * @param Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null $found
+             */
+            public function __construct(int $cursorLine, &$found)
+            {
+                $this->cursorLine = $cursorLine;
+                $this->found = &$found;
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Function_
+                    || $node instanceof Stmt\ClassMethod
+                    || $node instanceof Node\Expr\Closure
+                    || $node instanceof Node\Expr\ArrowFunction
+                ) {
+                    $startLine = $node->getStartLine();
+                    $endLine = $node->getEndLine();
+
+                    // Check if cursor is within this scope (1-based lines from parser)
+                    if ($startLine !== -1 && $endLine !== -1
+                        && $this->cursorLine >= $startLine - 1
+                        && $this->cursorLine <= $endLine - 1
+                    ) {
+                        // Keep the innermost (last found) scope
+                        $this->found = $node;
+                    }
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->found;
+    }
+
+    /**
+     * Collect variables from a function/method/closure scope.
+     *
+     * @return array<string, string> Variable name => type
+     */
+    private function collectScopeVariables(Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction $scope): array
+    {
+        $variables = [];
+
+        // Collect parameters
+        foreach ($scope->params as $param) {
+            if ($param->var instanceof Variable && is_string($param->var->name)) {
+                $variables[$param->var->name] = $this->formatParamType($param->type);
+            }
+        }
+
+        // Collect use() variables from closures
+        if ($scope instanceof Node\Expr\Closure) {
+            foreach ($scope->uses as $use) {
+                if (is_string($use->var->name)) {
+                    $variables[$use->var->name] = 'mixed';
+                }
+            }
+        }
+
+        // Traverse the scope body to find assignments and foreach variables
+        $stmts = $scope instanceof Node\Expr\ArrowFunction ? [] : ($scope->stmts ?? []);
+
+        $collector = new class ($variables) extends NodeVisitorAbstract {
+            /** @var array<string, string> */
+            public array $variables;
+
+            /**
+             * @param array<string, string> $variables
+             */
+            public function __construct(array &$variables)
+            {
+                $this->variables = &$variables;
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                // Skip nested function scopes
+                if ($node instanceof Stmt\Function_
+                    || $node instanceof Stmt\ClassMethod
+                    || $node instanceof Node\Expr\Closure
+                    || $node instanceof Node\Expr\ArrowFunction
+                ) {
+                    return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                }
+
+                // Collect assignments
+                if ($node instanceof Node\Expr\Assign) {
+                    if ($node->var instanceof Variable && is_string($node->var->name)) {
+                        if (!isset($this->variables[$node->var->name])) {
+                            $this->variables[$node->var->name] = 'mixed';
+                        }
+                    }
+                }
+
+                // Collect foreach variables
+                if ($node instanceof Stmt\Foreach_) {
+                    if ($node->valueVar instanceof Variable && is_string($node->valueVar->name)) {
+                        $this->variables[$node->valueVar->name] = 'mixed';
+                    }
+                    if ($node->keyVar instanceof Variable && is_string($node->keyVar->name)) {
+                        $this->variables[$node->keyVar->name] = 'mixed';
+                    }
+                }
+
+                // Collect catch variables
+                if ($node instanceof Stmt\Catch_) {
+                    if ($node->var !== null && is_string($node->var->name)) {
+                        $this->variables[$node->var->name] = 'Exception';
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($collector);
+        $traverser->traverse($stmts);
+
+        return $collector->variables;
+    }
+
+    private function formatParamType(?Node $type): string
+    {
+        if ($type === null) {
+            return 'mixed';
+        }
+        if ($type instanceof Node\Identifier) {
+            return $type->toString();
+        }
+        if ($type instanceof Node\Name) {
+            return $type->toString();
+        }
+        if ($type instanceof Node\NullableType) {
+            return '?' . $this->formatParamType($type->type);
+        }
+        if ($type instanceof Node\UnionType) {
+            $types = array_map(fn($t) => $this->formatParamType($t), $type->types);
+            return implode('|', $types);
+        }
+        return 'mixed';
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -829,6 +829,171 @@ PHP;
         self::assertNotContains('return', $labels);
     }
 
+    public function testVariableCompletionSuggestsParameters(): void
+    {
+        $code = '<?php function foo(string $name, int $age) { $n; }';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 47], // After $n
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('$name', $labels);
+        self::assertNotContains('$age', $labels); // doesn't match prefix
+    }
+
+    public function testVariableCompletionSuggestsLocalVariables(): void
+    {
+        $code = '<?php function foo() { $logger = new Logger(); $l; }';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 49], // After $l
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('$logger', $labels);
+    }
+
+    public function testVariableCompletionSuggestsThisInMethod(): void
+    {
+        $code = '<?php class Foo { public function bar() { $t; } }';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 44], // After $t
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('$this', $labels);
+    }
+
+    public function testVariableCompletionWorksInClosures(): void
+    {
+        $code = '<?php $fn = function ($param) { $localVar = 1; $l; };';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 49], // After $l
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('$localVar', $labels);
+    }
+
+    public function testVariableCompletionSuggestsForeachVariables(): void
+    {
+        $code = '<?php function foo() { foreach ([1,2] as $item) { $i; } }';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 52], // After $i
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('$item', $labels);
+    }
+
+    public function testVariableCompletionIsolatesScopes(): void
+    {
+        // Two closures - variables from one should not leak to the other
+        $code = <<<'PHP'
+<?php
+$a = [
+    'x' => function () { $logger = 1; return $logger; },
+    'y' => function () { $siteDir = 2; $s; },
+];
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 41], // After $s in second closure
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('$siteDir', $labels);
+        self::assertNotContains('$logger', $labels); // From other closure
+    }
+
+    public function testVariableCompletionShowsTypeInDetail(): void
+    {
+        $code = '<?php function foo(string $name) { $x; }';
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 36], // After $
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $nameItems = array_filter($result['items'], fn($item) => $item['label'] === '$name');
+        self::assertNotEmpty($nameItems);
+        $nameItem = reset($nameItems);
+        self::assertSame('string', $nameItem['detail'] ?? null);
+    }
+
     public function testCompletionReturnsEmptyForUnknownContext(): void
     {
         $code = '<?php $x = 1;';


### PR DESCRIPTION
## Summary

Suggests variables in scope when typing `$` or `$prefix`:

- Function/method parameters (with their types shown)
- Variables assigned in the current scope
- `$this` when inside a class method

## Examples

```php
function foo(string $name, int $age) {
    $logger = new Logger();
    $n|  // suggests $name
    $l|  // suggests $logger
}

class Bar {
    public function baz() {
        $t|  // suggests $this
    }
}
```

## Implementation

Uses a NodeVisitor to traverse the AST and collect:
1. Parameters from enclosing function/method
2. Variable assignments within the scope
3. Tracks whether we are in a method (for `$this`)

Fixes #17

## Test plan

- [x] Parameters suggested with prefix filtering
- [x] Local variables suggested
- [x] `$this` suggested in methods
- [x] Type shown in detail field

Generated with Claude Code