### PR TITLE
Extract TypeFormatter utility

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
@@ -507,7 +508,7 @@ final class CompletionHandler implements HandlerInterface
         foreach ($method->params as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= $this->formatType($param->type) . ' ';
+                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
             }
             $var = $param->var;
             if ($var instanceof Variable && is_string($var->name)) {
@@ -518,7 +519,7 @@ final class CompletionHandler implements HandlerInterface
 
         $detail = $method->name->toString() . '(' . implode(', ', $params) . ')';
         if ($method->returnType !== null) {
-            $detail .= ': ' . $this->formatType($method->returnType);
+            $detail .= ': ' . TypeFormatter::formatNode($method->returnType);
         }
 
         $item = [
@@ -543,7 +544,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatPropertyCompletion(Stmt\Property $property, string $name): array
     {
-        $type = $property->type !== null ? $this->formatType($property->type) : 'mixed';
+        $type = $property->type !== null ? TypeFormatter::formatNode($property->type) : 'mixed';
 
         $item = [
             'label' => $name,
@@ -593,7 +594,7 @@ final class CompletionHandler implements HandlerInterface
         foreach ($func->params as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= $this->formatType($param->type) . ' ';
+                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
             }
             $var = $param->var;
             if ($var instanceof Variable && is_string($var->name)) {
@@ -604,7 +605,7 @@ final class CompletionHandler implements HandlerInterface
 
         $detail = 'function ' . $func->name->toString() . '(' . implode(', ', $params) . ')';
         if ($func->returnType !== null) {
-            $detail .= ': ' . $this->formatType($func->returnType);
+            $detail .= ': ' . TypeFormatter::formatNode($func->returnType);
         }
 
         $item = [
@@ -634,7 +635,7 @@ final class CompletionHandler implements HandlerInterface
             $paramStr = '';
             $type = $param->getType();
             if ($type !== null) {
-                $paramStr .= $this->formatReflectionType($type) . ' ';
+                $paramStr .= TypeFormatter::formatReflection($type) . ' ';
             }
             $paramStr .= '$' . $param->getName();
             $params[] = $paramStr;
@@ -643,7 +644,7 @@ final class CompletionHandler implements HandlerInterface
         $detail = $method->getName() . '(' . implode(', ', $params) . ')';
         $returnType = $method->getReturnType();
         if ($returnType !== null) {
-            $detail .= ': ' . $this->formatReflectionType($returnType);
+            $detail .= ': ' . TypeFormatter::formatReflection($returnType);
         }
 
         $item = [
@@ -669,7 +670,7 @@ final class CompletionHandler implements HandlerInterface
     private function formatReflectionPropertyCompletion(ReflectionProperty $prop): array
     {
         $type = $prop->getType();
-        $typeStr = $type !== null ? $this->formatReflectionType($type) : 'mixed';
+        $typeStr = $type !== null ? TypeFormatter::formatReflection($type) : 'mixed';
 
         $item = [
             'label' => $prop->getName(),
@@ -686,41 +687,6 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $item;
-    }
-
-    private function formatType(Node $type): string
-    {
-        if ($type instanceof Name) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\Identifier) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\NullableType) {
-            return '?' . $this->formatType($type->type);
-        }
-        if ($type instanceof Node\UnionType) {
-            return implode('|', array_map(fn($t) => $this->formatType($t), $type->types));
-        }
-        if ($type instanceof Node\IntersectionType) {
-            return implode('&', array_map(fn($t) => $this->formatType($t), $type->types));
-        }
-        return '';
-    }
-
-    private function formatReflectionType(\ReflectionType $type): string
-    {
-        if ($type instanceof \ReflectionNamedType) {
-            $name = $type->getName();
-            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
-        }
-        if ($type instanceof \ReflectionUnionType) {
-            return implode('|', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
-        }
-        if ($type instanceof \ReflectionIntersectionType) {
-            return implode('&', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
-        }
-        return (string) $type;
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -11,6 +11,7 @@ use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -332,7 +333,7 @@ final class HoverHandler implements HandlerInterface
         foreach ($node->params as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= $this->formatType($param->type) . ' ';
+                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
             }
             $var = $param->var;
             if ($var instanceof Node\Expr\Variable && is_string($var->name)) {
@@ -344,7 +345,7 @@ final class HoverHandler implements HandlerInterface
         $signature = 'function ' . $node->name->toString() . '(' . implode(', ', $params) . ')';
 
         if ($node->returnType !== null) {
-            $signature .= ': ' . $this->formatType($node->returnType);
+            $signature .= ': ' . TypeFormatter::formatNode($node->returnType);
         }
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
@@ -591,7 +592,7 @@ final class HoverHandler implements HandlerInterface
         foreach ($method->params as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= $this->formatType($param->type) . ' ';
+                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
             }
             $var = $param->var;
             if ($var instanceof Variable && is_string($var->name)) {
@@ -603,7 +604,7 @@ final class HoverHandler implements HandlerInterface
         $signature = $visibility . $static . 'function ' . $method->name->toString() . '(' . implode(', ', $params) . ')';
 
         if ($method->returnType !== null) {
-            $signature .= ': ' . $this->formatType($method->returnType);
+            $signature .= ': ' . TypeFormatter::formatNode($method->returnType);
         }
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
@@ -626,7 +627,7 @@ final class HoverHandler implements HandlerInterface
 
         $type = '';
         if ($property->type !== null) {
-            $type = $this->formatType($property->type) . ' ';
+            $type = TypeFormatter::formatNode($property->type) . ' ';
         }
 
         $signature = $visibility . $static . $readonly . $type . '$' . $propertyName;
@@ -716,7 +717,7 @@ final class HoverHandler implements HandlerInterface
             $paramStr = '';
             $type = $param->getType();
             if ($type !== null) {
-                $paramStr .= $this->formatReflectionType($type) . ' ';
+                $paramStr .= TypeFormatter::formatReflection($type) . ' ';
             }
             if ($param->isVariadic()) {
                 $paramStr .= '...';
@@ -732,7 +733,7 @@ final class HoverHandler implements HandlerInterface
 
         $returnType = $func->getReturnType();
         if ($returnType !== null) {
-            $signature .= ': ' . $this->formatReflectionType($returnType);
+            $signature .= ': ' . TypeFormatter::formatReflection($returnType);
         }
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
@@ -761,7 +762,7 @@ final class HoverHandler implements HandlerInterface
             $paramStr = '';
             $type = $param->getType();
             if ($type !== null) {
-                $paramStr .= $this->formatReflectionType($type) . ' ';
+                $paramStr .= TypeFormatter::formatReflection($type) . ' ';
             }
             if ($param->isVariadic()) {
                 $paramStr .= '...';
@@ -777,7 +778,7 @@ final class HoverHandler implements HandlerInterface
 
         $returnType = $method->getReturnType();
         if ($returnType !== null) {
-            $signature .= ': ' . $this->formatReflectionType($returnType);
+            $signature .= ': ' . TypeFormatter::formatReflection($returnType);
         }
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
@@ -803,47 +804,12 @@ final class HoverHandler implements HandlerInterface
         $readonly = $property->isReadOnly() ? 'readonly ' : '';
 
         $type = $property->getType();
-        $typeStr = $type !== null ? $this->formatReflectionType($type) . ' ' : '';
+        $typeStr = $type !== null ? TypeFormatter::formatReflection($type) . ' ' : '';
 
         $signature = $visibility . $static . $readonly . $typeStr . '$' . $property->getName();
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
 
         return implode("\n\n", $parts);
-    }
-
-    private function formatReflectionType(\ReflectionType $type): string
-    {
-        if ($type instanceof \ReflectionNamedType) {
-            $name = $type->getName();
-            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
-        }
-        if ($type instanceof \ReflectionUnionType) {
-            return implode('|', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
-        }
-        if ($type instanceof \ReflectionIntersectionType) {
-            return implode('&', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
-        }
-        return (string) $type;
-    }
-
-    private function formatType(Node $type): string
-    {
-        if ($type instanceof Name) {
-            return $type->toString();
-        }
-        if ($type instanceof Identifier) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\NullableType) {
-            return '?' . $this->formatType($type->type);
-        }
-        if ($type instanceof Node\UnionType) {
-            return implode('|', array_map(fn($t) => $this->formatType($t), $type->types));
-        }
-        if ($type instanceof Node\IntersectionType) {
-            return implode('&', array_map(fn($t) => $this->formatType($t), $type->types));
-        }
-        return '';
     }
 }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -457,7 +458,7 @@ final class SignatureHelpHandler implements HandlerInterface
         foreach ($func->params as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= $this->formatType($param->type) . ' ';
+                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
             }
             $var = $param->var;
             if ($var instanceof Variable && is_string($var->name)) {
@@ -469,7 +470,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
         $label = 'function ' . $func->name->toString() . '(' . implode(', ', $paramLabels) . ')';
         if ($func->returnType !== null) {
-            $label .= ': ' . $this->formatType($func->returnType);
+            $label .= ': ' . TypeFormatter::formatNode($func->returnType);
         }
 
         $result = [
@@ -496,7 +497,7 @@ final class SignatureHelpHandler implements HandlerInterface
         foreach ($method->params as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= $this->formatType($param->type) . ' ';
+                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
             }
             $var = $param->var;
             if ($var instanceof Variable && is_string($var->name)) {
@@ -508,7 +509,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
         $label = $method->name->toString() . '(' . implode(', ', $paramLabels) . ')';
         if ($method->returnType !== null) {
-            $label .= ': ' . $this->formatType($method->returnType);
+            $label .= ': ' . TypeFormatter::formatNode($method->returnType);
         }
 
         $result = [
@@ -546,7 +547,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
         $returnType = $func->getReturnType();
         if ($returnType !== null) {
-            $label .= ': ' . $this->formatReflectionType($returnType);
+            $label .= ': ' . TypeFormatter::formatReflection($returnType);
         }
 
         $result = [
@@ -567,7 +568,7 @@ final class SignatureHelpHandler implements HandlerInterface
         $paramStr = '';
         $type = $param->getType();
         if ($type !== null) {
-            $paramStr .= $this->formatReflectionType($type) . ' ';
+            $paramStr .= TypeFormatter::formatReflection($type) . ' ';
         }
         if ($param->isVariadic()) {
             $paramStr .= '...';
@@ -575,40 +576,5 @@ final class SignatureHelpHandler implements HandlerInterface
         $paramStr .= '$' . $param->getName();
 
         return $paramStr;
-    }
-
-    private function formatType(Node $type): string
-    {
-        if ($type instanceof Name) {
-            return $type->toString();
-        }
-        if ($type instanceof Identifier) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\NullableType) {
-            return '?' . $this->formatType($type->type);
-        }
-        if ($type instanceof Node\UnionType) {
-            return implode('|', array_map(fn($t) => $this->formatType($t), $type->types));
-        }
-        if ($type instanceof Node\IntersectionType) {
-            return implode('&', array_map(fn($t) => $this->formatType($t), $type->types));
-        }
-        return '';
-    }
-
-    private function formatReflectionType(\ReflectionType $type): string
-    {
-        if ($type instanceof \ReflectionNamedType) {
-            $name = $type->getName();
-            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
-        }
-        if ($type instanceof \ReflectionUnionType) {
-            return implode('|', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
-        }
-        if ($type instanceof \ReflectionIntersectionType) {
-            return implode('&', array_map(fn($t) => $this->formatReflectionType($t), $type->getTypes()));
-        }
-        return (string) $type;
     }
 }

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -11,6 +11,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ReflectionClass;
 use ReflectionException;
+use Firehed\PhpLsp\Utility\TypeFormatter;
 use ReflectionNamedType;
 
 /**
@@ -107,7 +108,7 @@ final class BasicTypeResolver implements TypeResolverInterface
                 && is_string($param->var->name)
                 && $param->var->name === $variableName
             ) {
-                return $this->formatType($param->type);
+                return TypeFormatter::formatNode($param->type);
             }
         }
 
@@ -191,32 +192,6 @@ final class BasicTypeResolver implements TypeResolverInterface
         $traverser->traverse($stmts);
 
         return $visitor->foundType;
-    }
-
-    private function formatType(?Node $type): ?string
-    {
-        if ($type === null) {
-            return null;
-        }
-        if ($type instanceof Node\Identifier) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\Name) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\NullableType) {
-            $inner = $this->formatType($type->type);
-            return $inner !== null ? '?' . $inner : null;
-        }
-        if ($type instanceof Node\UnionType) {
-            $types = array_filter(array_map(fn($t) => $this->formatType($t), $type->types));
-            return count($types) > 0 ? implode('|', $types) : null;
-        }
-        if ($type instanceof Node\IntersectionType) {
-            $types = array_filter(array_map(fn($t) => $this->formatType($t), $type->types));
-            return count($types) > 0 ? implode('&', $types) : null;
-        }
-        return null;
     }
 
     private function getMethodReturnType(string $className, string $methodName): ?string

--- a/src/Utility/TypeFormatter.php
+++ b/src/Utility/TypeFormatter.php
@@ -17,8 +17,11 @@ final class TypeFormatter
     /**
      * Format a PhpParser type node to its string representation.
      */
-    public static function formatNode(Node $type): string
+    public static function formatNode(?Node $type): ?string
     {
+        if ($type === null) {
+            return null;
+        }
         if ($type instanceof Name) {
             return $type->toString();
         }
@@ -34,7 +37,7 @@ final class TypeFormatter
         if ($type instanceof Node\IntersectionType) {
             return implode('&', array_map(self::formatNode(...), $type->types));
         }
-        return '';
+        return null;
     }
 
     /**

--- a/src/Utility/TypeFormatter.php
+++ b/src/Utility/TypeFormatter.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+final class TypeFormatter
+{
+    /**
+     * Format a PhpParser type node to its string representation.
+     */
+    public static function formatNode(Node $type): string
+    {
+        if ($type instanceof Name) {
+            return $type->toString();
+        }
+        if ($type instanceof Identifier) {
+            return $type->toString();
+        }
+        if ($type instanceof Node\NullableType) {
+            return '?' . self::formatNode($type->type);
+        }
+        if ($type instanceof Node\UnionType) {
+            return implode('|', array_map(self::formatNode(...), $type->types));
+        }
+        if ($type instanceof Node\IntersectionType) {
+            return implode('&', array_map(self::formatNode(...), $type->types));
+        }
+        return '';
+    }
+
+    /**
+     * Format a reflection type to its string representation.
+     */
+    public static function formatReflection(ReflectionType $type): string
+    {
+        if ($type instanceof ReflectionNamedType) {
+            $name = $type->getName();
+            return $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' . $name : $name;
+        }
+        if ($type instanceof ReflectionUnionType) {
+            return implode('|', array_map(self::formatReflection(...), $type->getTypes()));
+        }
+        if ($type instanceof ReflectionIntersectionType) {
+            return implode('&', array_map(self::formatReflection(...), $type->getTypes()));
+        }
+        return (string) $type;
+    }
+}

--- a/tests/Utility/TypeFormatterTest.php
+++ b/tests/Utility/TypeFormatterTest.php
@@ -116,11 +116,14 @@ class TypeFormatterTest extends TestCase
 
     public function testFormatReflectionWithIntersectionType(): void
     {
-        // Use eval to create a function with intersection type
-        // since we can't use intersection types in closure return types easily
-        eval('function _typeFormatterTestIntersection(): \Countable&\Traversable { return new \ArrayObject(); }');
-        $fn = new ReflectionFunction('_typeFormatterTestIntersection');
-        $type = $fn->getReturnType();
+        $obj = new class {
+            public function test(): \Countable&\Traversable
+            {
+                return new \ArrayObject();
+            }
+        };
+        $method = new ReflectionMethod($obj, 'test');
+        $type = $method->getReturnType();
         assert($type !== null);
         self::assertSame('Countable&Traversable', TypeFormatter::formatReflection($type));
     }

--- a/tests/Utility/TypeFormatterTest.php
+++ b/tests/Utility/TypeFormatterTest.php
@@ -117,6 +117,7 @@ class TypeFormatterTest extends TestCase
     public function testFormatReflectionWithIntersectionType(): void
     {
         $obj = new class {
+            /** @return \Countable&\Traversable<mixed, mixed> */
             public function test(): \Countable&\Traversable
             {
                 return new \ArrayObject();

--- a/tests/Utility/TypeFormatterTest.php
+++ b/tests/Utility/TypeFormatterTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Utility\TypeFormatter;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionMethod;
+
+#[CoversClass(TypeFormatter::class)]
+class TypeFormatterTest extends TestCase
+{
+    public function testFormatNodeWithNull(): void
+    {
+        self::assertNull(TypeFormatter::formatNode(null));
+    }
+
+    public function testFormatNodeWithName(): void
+    {
+        $node = new Name('SomeClass');
+        self::assertSame('SomeClass', TypeFormatter::formatNode($node));
+    }
+
+    public function testFormatNodeWithFullyQualifiedName(): void
+    {
+        $node = new Name\FullyQualified('Some\\Namespace\\SomeClass');
+        self::assertSame('Some\\Namespace\\SomeClass', TypeFormatter::formatNode($node));
+    }
+
+    public function testFormatNodeWithIdentifier(): void
+    {
+        $node = new Identifier('string');
+        self::assertSame('string', TypeFormatter::formatNode($node));
+    }
+
+    public function testFormatNodeWithNullableType(): void
+    {
+        $node = new Node\NullableType(new Identifier('string'));
+        self::assertSame('?string', TypeFormatter::formatNode($node));
+    }
+
+    public function testFormatNodeWithUnionType(): void
+    {
+        $node = new Node\UnionType([
+            new Identifier('string'),
+            new Identifier('int'),
+        ]);
+        self::assertSame('string|int', TypeFormatter::formatNode($node));
+    }
+
+    public function testFormatNodeWithIntersectionType(): void
+    {
+        $node = new Node\IntersectionType([
+            new Name('Countable'),
+            new Name('Iterator'),
+        ]);
+        self::assertSame('Countable&Iterator', TypeFormatter::formatNode($node));
+    }
+
+    public function testFormatNodeWithUnionTypeIncludingNull(): void
+    {
+        $node = new Node\UnionType([
+            new Identifier('string'),
+            new Identifier('int'),
+            new Identifier('null'),
+        ]);
+        self::assertSame('string|int|null', TypeFormatter::formatNode($node));
+    }
+
+    public function testFormatReflectionWithNamedType(): void
+    {
+        $fn = new ReflectionFunction(fn(): string => 'test');
+        $type = $fn->getReturnType();
+        assert($type !== null);
+        self::assertSame('string', TypeFormatter::formatReflection($type));
+    }
+
+    public function testFormatReflectionWithNullableType(): void
+    {
+        $fn = new ReflectionFunction(fn(): ?string => null);
+        $type = $fn->getReturnType();
+        assert($type !== null);
+        self::assertSame('?string', TypeFormatter::formatReflection($type));
+    }
+
+    public function testFormatReflectionWithUnionType(): void
+    {
+        $fn = new ReflectionFunction(fn(bool $b): string|int => $b ? 'test' : 1);
+        $type = $fn->getReturnType();
+        assert($type !== null);
+        self::assertSame('string|int', TypeFormatter::formatReflection($type));
+    }
+
+    public function testFormatReflectionWithMixedDoesNotAddNullable(): void
+    {
+        $fn = new ReflectionFunction(fn(): mixed => null);
+        $type = $fn->getReturnType();
+        assert($type !== null);
+        self::assertSame('mixed', TypeFormatter::formatReflection($type));
+    }
+
+    public function testFormatReflectionWithNullDoesNotAddNullable(): void
+    {
+        $fn = new ReflectionFunction(fn(): null => null);
+        $type = $fn->getReturnType();
+        assert($type !== null);
+        self::assertSame('null', TypeFormatter::formatReflection($type));
+    }
+
+    public function testFormatReflectionWithIntersectionType(): void
+    {
+        // Use eval to create a function with intersection type
+        // since we can't use intersection types in closure return types easily
+        eval('function _typeFormatterTestIntersection(): \Countable&\Traversable { return new \ArrayObject(); }');
+        $fn = new ReflectionFunction('_typeFormatterTestIntersection');
+        $type = $fn->getReturnType();
+        assert($type !== null);
+        self::assertSame('Countable&Traversable', TypeFormatter::formatReflection($type));
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts duplicated `formatType()` and `formatReflectionType()` methods into `src/Utility/TypeFormatter.php`
- `formatNode(?Node): ?string` - formats PhpParser type nodes (handles null input)
- `formatReflection(ReflectionType): string` - formats reflection types
- Removes ~140 lines of duplicated code across four files

Fixes #50

## Test plan

- [x] Added 14 unit tests for TypeFormatter
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)