### PR TITLE
Refactor: Extract ClassFinder utility

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -13,6 +13,7 @@ use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
+use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
@@ -238,23 +239,7 @@ final class CompletionHandler implements HandlerInterface
         // Resolve short name to FQCN using imports
         $resolvedClassName = $this->resolveClassName($className, $ast);
 
-        // Try to find class in AST first
-        $classNode = $this->findClassInAst($resolvedClassName, $ast);
-
-        // If not in current file, try Composer
-        if ($classNode === null && $this->classLocator !== null) {
-            $filePath = $this->classLocator->locateClass($resolvedClassName);
-            if ($filePath !== null) {
-                $content = file_get_contents($filePath);
-                if ($content !== false) {
-                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
-                    $externalAst = $this->parser->parse($externalDoc);
-                    if ($externalAst !== null) {
-                        $classNode = $this->findClassInAst($resolvedClassName, $externalAst);
-                    }
-                }
-            }
-        }
+        $classNode = ClassFinder::findWithLocator($resolvedClassName, $ast, $this->classLocator, $this->parser);
 
         if ($classNode !== null) {
             foreach ($classNode->stmts as $stmt) {
@@ -354,54 +339,6 @@ final class CompletionHandler implements HandlerInterface
             }
         }
         return null;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findClassInAst(string $className, array $ast): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null
-    {
-        $finder = new class ($className) extends NodeVisitorAbstract {
-            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
-            private string $namespace = '';
-
-            public function __construct(private readonly string $className)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Namespace_) {
-                    $this->namespace = $node->name?->toString() ?? '';
-                    return null;
-                }
-
-                if ($node instanceof Stmt\Class_
-                    || $node instanceof Stmt\Interface_
-                    || $node instanceof Stmt\Trait_
-                    || $node instanceof Stmt\Enum_
-                ) {
-                    $name = $node->name?->toString();
-                    if ($name === null) {
-                        return null;
-                    }
-                    $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
-
-                    if ($fqn === $this->className || $name === $this->className) {
-                        $this->found = $node;
-                        return NodeTraverser::STOP_TRAVERSAL;
-                    }
-                }
-
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        return $finder->found;
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
@@ -171,78 +172,13 @@ final class HoverHandler implements HandlerInterface
             ? $resolvedName->toString()
             : $node->toString();
 
-        // First look in current file
-        $classNode = $this->findClassInAst($className, $ast);
-
-        // If not found, try to locate via Composer
-        if ($classNode === null && $this->classLocator !== null) {
-            $filePath = $this->classLocator->locateClass($className);
-            if ($filePath !== null) {
-                $content = file_get_contents($filePath);
-                if ($content !== false) {
-                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
-                    $externalAst = $this->parser->parse($externalDoc);
-                    if ($externalAst !== null) {
-                        $classNode = $this->findClassInAst($className, $externalAst);
-                    }
-                }
-            }
-        }
+        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
 
         if ($classNode === null) {
             return null;
         }
 
         return $this->formatClassHover($classNode);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findClassInAst(string $className, array $ast): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null
-    {
-        $finder = new class ($className) extends NodeVisitorAbstract {
-            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
-            private string $namespace = '';
-
-            public function __construct(private readonly string $className)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Namespace_) {
-                    $this->namespace = $node->name?->toString() ?? '';
-                    return null;
-                }
-
-                if ($node instanceof Stmt\Class_
-                    || $node instanceof Stmt\Interface_
-                    || $node instanceof Stmt\Trait_
-                    || $node instanceof Stmt\Enum_
-                ) {
-                    $name = $node->name?->toString();
-                    if ($name === null) {
-                        return null;
-                    }
-                    $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
-
-                    // Match by FQN or short name
-                    if ($fqn === $this->className || $name === $this->className) {
-                        $this->found = $node;
-                        return NodeTraverser::STOP_TRAVERSAL;
-                    }
-                }
-
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        return $finder->found;
     }
 
     private function formatClassHover(Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $node): string
@@ -505,24 +441,7 @@ final class HoverHandler implements HandlerInterface
      */
     private function findMethodInClass(string $className, string $methodName, array $ast, TextDocument $document): ?Stmt\ClassMethod
     {
-        // First check current file
-        $classNode = $this->findClassInAst($className, $ast);
-
-        // If not found, try Composer
-        if ($classNode === null && $this->classLocator !== null) {
-            $filePath = $this->classLocator->locateClass($className);
-            if ($filePath !== null) {
-                $content = file_get_contents($filePath);
-                if ($content !== false) {
-                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
-                    $externalAst = $this->parser->parse($externalDoc);
-                    if ($externalAst !== null) {
-                        $classNode = $this->findClassInAst($className, $externalAst);
-                    }
-                }
-            }
-        }
-
+        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
             return null;
         }
@@ -541,24 +460,7 @@ final class HoverHandler implements HandlerInterface
      */
     private function findPropertyInClass(string $className, string $propertyName, array $ast, TextDocument $document): ?Stmt\Property
     {
-        // First check current file
-        $classNode = $this->findClassInAst($className, $ast);
-
-        // If not found, try Composer
-        if ($classNode === null && $this->classLocator !== null) {
-            $filePath = $this->classLocator->locateClass($className);
-            if ($filePath !== null) {
-                $content = file_get_contents($filePath);
-                if ($content !== false) {
-                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
-                    $externalAst = $this->parser->parse($externalDoc);
-                    if ($externalAst !== null) {
-                        $classNode = $this->findClassInAst($className, $externalAst);
-                    }
-                }
-            }
-        }
-
+        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
             return null;
         }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
@@ -371,22 +372,7 @@ final class SignatureHelpHandler implements HandlerInterface
      */
     private function findMethodInClass(string $className, string $methodName, array $ast, TextDocument $document): ?Stmt\ClassMethod
     {
-        $classNode = $this->findClassInAst($className, $ast);
-
-        if ($classNode === null && $this->classLocator !== null) {
-            $filePath = $this->classLocator->locateClass($className);
-            if ($filePath !== null) {
-                $content = file_get_contents($filePath);
-                if ($content !== false) {
-                    $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
-                    $externalAst = $this->parser->parse($externalDoc);
-                    if ($externalAst !== null) {
-                        $classNode = $this->findClassInAst($className, $externalAst);
-                    }
-                }
-            }
-        }
-
+        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
             return null;
         }
@@ -398,53 +384,6 @@ final class SignatureHelpHandler implements HandlerInterface
         }
 
         return null;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findClassInAst(string $className, array $ast): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|null
-    {
-        $finder = new class ($className) extends NodeVisitorAbstract {
-            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|null $found = null;
-            private string $namespace = '';
-
-            public function __construct(private readonly string $className)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Namespace_) {
-                    $this->namespace = $node->name?->toString() ?? '';
-                    return null;
-                }
-
-                if ($node instanceof Stmt\Class_
-                    || $node instanceof Stmt\Interface_
-                    || $node instanceof Stmt\Trait_
-                ) {
-                    $name = $node->name?->toString();
-                    if ($name === null) {
-                        return null;
-                    }
-                    $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
-
-                    if ($fqn === $this->className || $name === $this->className) {
-                        $this->found = $node;
-                        return NodeTraverser::STOP_TRAVERSAL;
-                    }
-                }
-
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        return $finder->found;
     }
 
     /**

--- a/src/Utility/ClassFinder.php
+++ b/src/Utility/ClassFinder.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Parser\ParserService;
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+final class ClassFinder
+{
+    /**
+     * Find a class, interface, trait, or enum in the given AST by name.
+     *
+     * Matches by fully-qualified name or short name.
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function findInAst(string $className, array $ast): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null
+    {
+        $finder = new class ($className) extends NodeVisitorAbstract {
+            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
+            private string $namespace = '';
+
+            public function __construct(private readonly string $className)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Namespace_) {
+                    $this->namespace = $node->name?->toString() ?? '';
+                    return null;
+                }
+
+                if ($node instanceof Stmt\Class_
+                    || $node instanceof Stmt\Interface_
+                    || $node instanceof Stmt\Trait_
+                    || $node instanceof Stmt\Enum_
+                ) {
+                    $name = $node->name?->toString();
+                    if ($name === null) {
+                        return null;
+                    }
+                    $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
+
+                    if ($fqn === $this->className || $name === $this->className) {
+                        $this->found = $node;
+                        return NodeTraverser::STOP_TRAVERSAL;
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        return $finder->found;
+    }
+
+    /**
+     * Find a class by first checking the given AST, then falling back to
+     * locating the class file via Composer and parsing it.
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function findWithLocator(
+        string $className,
+        array $ast,
+        ?ComposerClassLocator $locator,
+        ParserService $parser,
+    ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
+        // First check the provided AST
+        $found = self::findInAst($className, $ast);
+        if ($found !== null) {
+            return $found;
+        }
+
+        // If not found and we have a locator, try to find the class file
+        if ($locator === null) {
+            return null;
+        }
+
+        $filePath = $locator->locateClass($className);
+        if ($filePath === null) {
+            return null;
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            return null;
+        }
+
+        $externalDoc = new TextDocument('file://' . $filePath, 'php', 0, $content);
+        $externalAst = $parser->parse($externalDoc);
+        if ($externalAst === null) {
+            return null;
+        }
+
+        return self::findInAst($className, $externalAst);
+    }
+}

--- a/tests/Utility/ClassFinderTest.php
+++ b/tests/Utility/ClassFinderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Utility\ClassFinder;
+use PhpParser\Node\Stmt;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClassFinder::class)]
+class ClassFinderTest extends TestCase
+{
+    private static function parse(string $code): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        return $parser->parse($code) ?? [];
+    }
+
+    public function testFindClassByShortName(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('MyClass', $ast);
+
+        self::assertInstanceOf(Stmt\Class_::class, $result);
+        self::assertSame('MyClass', $result->name->toString());
+    }
+
+    public function testFindClassByFqn(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+class User {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('App\\Models\\User', $ast);
+
+        self::assertInstanceOf(Stmt\Class_::class, $result);
+        self::assertSame('User', $result->name->toString());
+    }
+
+    public function testFindInterface(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Contracts;
+interface UserRepository {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('App\\Contracts\\UserRepository', $ast);
+
+        self::assertInstanceOf(Stmt\Interface_::class, $result);
+        self::assertSame('UserRepository', $result->name->toString());
+    }
+
+    public function testFindTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Concerns;
+trait HasTimestamps {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('App\\Concerns\\HasTimestamps', $ast);
+
+        self::assertInstanceOf(Stmt\Trait_::class, $result);
+        self::assertSame('HasTimestamps', $result->name->toString());
+    }
+
+    public function testFindEnum(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Enums;
+enum Status: string {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('App\\Enums\\Status', $ast);
+
+        self::assertInstanceOf(Stmt\Enum_::class, $result);
+        self::assertSame('Status', $result->name->toString());
+    }
+
+    public function testReturnsNullWhenNotFound(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Foo {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('Bar', $ast);
+
+        self::assertNull($result);
+    }
+
+    public function testFindsClassInGlobalNamespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+class GlobalClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('GlobalClass', $ast);
+
+        self::assertInstanceOf(Stmt\Class_::class, $result);
+    }
+
+    public function testFindsFirstMatchingClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace First;
+class Duplicate {}
+
+namespace Second;
+class Duplicate {}
+PHP;
+        $ast = self::parse($code);
+        $result = ClassFinder::findInAst('First\\Duplicate', $ast);
+
+        self::assertInstanceOf(Stmt\Class_::class, $result);
+    }
+}

--- a/tests/Utility/ClassFinderTest.php
+++ b/tests/Utility/ClassFinderTest.php
@@ -8,12 +8,14 @@ use Firehed\PhpLsp\Utility\ClassFinder;
 use PhpParser\Node\Stmt;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ClassFinder::class)]
 class ClassFinderTest extends TestCase
 {
+    /**
+     * @return array<Stmt>
+     */
     private static function parse(string $code): array
     {
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
@@ -30,6 +32,7 @@ PHP;
         $result = ClassFinder::findInAst('MyClass', $ast);
 
         self::assertInstanceOf(Stmt\Class_::class, $result);
+        self::assertNotNull($result->name);
         self::assertSame('MyClass', $result->name->toString());
     }
 
@@ -44,6 +47,7 @@ PHP;
         $result = ClassFinder::findInAst('App\\Models\\User', $ast);
 
         self::assertInstanceOf(Stmt\Class_::class, $result);
+        self::assertNotNull($result->name);
         self::assertSame('User', $result->name->toString());
     }
 
@@ -58,6 +62,7 @@ PHP;
         $result = ClassFinder::findInAst('App\\Contracts\\UserRepository', $ast);
 
         self::assertInstanceOf(Stmt\Interface_::class, $result);
+        self::assertNotNull($result->name);
         self::assertSame('UserRepository', $result->name->toString());
     }
 
@@ -72,6 +77,7 @@ PHP;
         $result = ClassFinder::findInAst('App\\Concerns\\HasTimestamps', $ast);
 
         self::assertInstanceOf(Stmt\Trait_::class, $result);
+        self::assertNotNull($result->name);
         self::assertSame('HasTimestamps', $result->name->toString());
     }
 
@@ -86,6 +92,7 @@ PHP;
         $result = ClassFinder::findInAst('App\\Enums\\Status', $ast);
 
         self::assertInstanceOf(Stmt\Enum_::class, $result);
+        self::assertNotNull($result->name);
         self::assertSame('Status', $result->name->toString());
     }
 


### PR DESCRIPTION
## Summary

Fixes #51

- Extract duplicated `findClassInAst()` logic from CompletionHandler, HoverHandler, and SignatureHelpHandler into a new `ClassFinder` utility
- Add `findWithLocator()` method that combines AST search with Composer class location fallback
- Add unit tests for the new utility

## Changes

| File | Lines Removed |
|------|---------------|
| CompletionHandler.php | -65 |
| HoverHandler.php | -102 |
| SignatureHelpHandler.php | -63 |
| **Total** | **-230** |

The ~230 lines of duplicated code are now consolidated into a 110-line utility class.

## Test plan

- [x] All existing tests pass
- [x] PHPStan clean
- [x] New unit tests for ClassFinder cover all class-like types (class, interface, trait, enum)

🤖 Generated with [Claude Code](https://claude.ai/code)