### PR TITLE
Refactor: Extract ReflectionHelper utility

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -15,6 +15,7 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
@@ -22,8 +23,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use ReflectionClass;
-use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -347,39 +346,34 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getInheritedMemberCompletions(string $className, string $prefix, array $existingItems): array
     {
+        $reflection = ReflectionHelper::getClass($className);
+        if ($reflection === null) {
+            return [];
+        }
+
         $existingLabels = array_column($existingItems, 'label');
         $items = [];
 
-        try {
-            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
-                return [];
+        // Methods from parent classes
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
+            $name = $method->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
             }
-
-            $reflection = new ReflectionClass($className);
-
-            // Methods from parent classes
-            foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
-                $name = $method->getName();
-                if (in_array($name, $existingLabels, true)) {
-                    continue;
-                }
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                    $items[] = $this->formatReflectionMethodCompletion($method);
-                }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionMethodCompletion($method);
             }
+        }
 
-            // Properties from parent classes
-            foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED) as $prop) {
-                $name = $prop->getName();
-                if (in_array($name, $existingLabels, true)) {
-                    continue;
-                }
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                    $items[] = $this->formatReflectionPropertyCompletion($prop);
-                }
+        // Properties from parent classes
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED) as $prop) {
+            $name = $prop->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
             }
-        } catch (ReflectionException) {
-            // Class not autoloadable
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionPropertyCompletion($prop);
+            }
         }
 
         return $items;
@@ -391,46 +385,41 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getReflectionStaticCompletions(string $className, string $prefix, array $existingItems): array
     {
+        $reflection = ReflectionHelper::getClass($className);
+        if ($reflection === null) {
+            return [];
+        }
+
         $existingLabels = array_column($existingItems, 'label');
         $items = [];
 
-        try {
-            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
-                return [];
+        // Static methods
+        foreach ($reflection->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC) as $method) {
+            if (!$method->isStatic()) {
+                continue;
             }
-
-            $reflection = new ReflectionClass($className);
-
-            // Static methods
-            foreach ($reflection->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC) as $method) {
-                if (!$method->isStatic()) {
-                    continue;
-                }
-                $name = $method->getName();
-                if (in_array($name, $existingLabels, true)) {
-                    continue;
-                }
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                    $items[] = $this->formatReflectionMethodCompletion($method);
-                }
+            $name = $method->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
             }
-
-            // Constants
-            foreach ($reflection->getReflectionConstants() as $const) {
-                $name = $const->getName();
-                if (in_array($name, $existingLabels, true)) {
-                    continue;
-                }
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                    $items[] = [
-                        'label' => $name,
-                        'kind' => self::KIND_CONSTANT,
-                        'detail' => 'const ' . $name,
-                    ];
-                }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionMethodCompletion($method);
             }
-        } catch (ReflectionException) {
-            // Class not autoloadable
+        }
+
+        // Constants
+        foreach ($reflection->getReflectionConstants() as $const) {
+            $name = $const->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
+            }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = [
+                    'label' => $name,
+                    'kind' => self::KIND_CONSTANT,
+                    'detail' => 'const ' . $name,
+                ];
+            }
         }
 
         return $items;

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -12,6 +12,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -25,7 +26,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;
 use ReflectionMethod;
@@ -573,36 +573,22 @@ final class HoverHandler implements HandlerInterface
 
     private function getReflectionMethodHover(string $className, string $methodName): ?string
     {
-        try {
-            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
-                return null;
-            }
-            $classReflection = new ReflectionClass($className);
-            if (!$classReflection->hasMethod($methodName)) {
-                return null;
-            }
-            $reflection = $classReflection->getMethod($methodName);
-            return $this->formatReflectionMethod($reflection);
-        } catch (ReflectionException) {
+        $classReflection = ReflectionHelper::getClass($className);
+        if ($classReflection === null || !$classReflection->hasMethod($methodName)) {
             return null;
         }
+        $reflection = $classReflection->getMethod($methodName);
+        return $this->formatReflectionMethod($reflection);
     }
 
     private function getReflectionPropertyHover(string $className, string $propertyName): ?string
     {
-        try {
-            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
-                return null;
-            }
-            $classReflection = new ReflectionClass($className);
-            if (!$classReflection->hasProperty($propertyName)) {
-                return null;
-            }
-            $reflection = $classReflection->getProperty($propertyName);
-            return $this->formatReflectionProperty($reflection);
-        } catch (ReflectionException) {
+        $classReflection = ReflectionHelper::getClass($className);
+        if ($classReflection === null || !$classReflection->hasProperty($propertyName)) {
             return null;
         }
+        $reflection = $classReflection->getProperty($propertyName);
+        return $this->formatReflectionProperty($reflection);
     }
 
     private function formatReflectionFunction(ReflectionFunction $func): string

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -11,6 +11,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -23,7 +24,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;
 use ReflectionFunctionAbstract;
@@ -304,19 +304,12 @@ final class SignatureHelpHandler implements HandlerInterface
         }
 
         // Fall back to reflection
-        try {
-            if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
-                return null;
-            }
-            $classReflection = new ReflectionClass($className);
-            if (!$classReflection->hasMethod($methodName)) {
-                return null;
-            }
-            $reflection = $classReflection->getMethod($methodName);
-            return $this->formatReflectionSignature($reflection);
-        } catch (ReflectionException) {
+        $classReflection = ReflectionHelper::getClass($className);
+        if ($classReflection === null || !$classReflection->hasMethod($methodName)) {
             return null;
         }
+        $reflection = $classReflection->getMethod($methodName);
+        return $this->formatReflectionSignature($reflection);
     }
 
     /**

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -9,8 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use ReflectionClass;
-use ReflectionException;
+use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use ReflectionNamedType;
 
@@ -196,44 +195,30 @@ final class BasicTypeResolver implements TypeResolverInterface
 
     private function getMethodReturnType(string $className, string $methodName): ?string
     {
-        if (!class_exists($className) && !interface_exists($className)) {
+        $reflection = ReflectionHelper::getClass($className);
+        if ($reflection === null || !$reflection->hasMethod($methodName)) {
             return null;
         }
-        try {
-            $reflection = new ReflectionClass($className);
-            if (!$reflection->hasMethod($methodName)) {
-                return null;
-            }
-            $method = $reflection->getMethod($methodName);
-            $returnType = $method->getReturnType();
-            if (!$returnType instanceof ReflectionNamedType) {
-                return null;
-            }
-            return $returnType->getName();
-        } catch (ReflectionException) {
+        $method = $reflection->getMethod($methodName);
+        $returnType = $method->getReturnType();
+        if (!$returnType instanceof ReflectionNamedType) {
             return null;
         }
+        return $returnType->getName();
     }
 
     private function getPropertyType(string $className, string $propertyName): ?string
     {
-        if (!class_exists($className) && !interface_exists($className)) {
+        $reflection = ReflectionHelper::getClass($className);
+        if ($reflection === null || !$reflection->hasProperty($propertyName)) {
             return null;
         }
-        try {
-            $reflection = new ReflectionClass($className);
-            if (!$reflection->hasProperty($propertyName)) {
-                return null;
-            }
-            $property = $reflection->getProperty($propertyName);
-            $type = $property->getType();
-            if (!$type instanceof ReflectionNamedType) {
-                return null;
-            }
-            return $type->getName();
-        } catch (ReflectionException) {
+        $property = $reflection->getProperty($propertyName);
+        $type = $property->getType();
+        if (!$type instanceof ReflectionNamedType) {
             return null;
         }
+        return $type->getName();
     }
 
     /**

--- a/src/Utility/ReflectionHelper.php
+++ b/src/Utility/ReflectionHelper.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use ReflectionClass;
+
+final class ReflectionHelper
+{
+    /**
+     * Get a ReflectionClass for a class, interface, or trait if it exists.
+     *
+     * @template T of object
+     * @param class-string<T>|string $className
+     * @return ($className is class-string<T> ? ReflectionClass<T> : ReflectionClass<object>|null)
+     */
+    public static function getClass(string $className): ?ReflectionClass
+    {
+        if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+            return null;
+        }
+        return new ReflectionClass($className);
+    }
+}

--- a/tests/Fixtures/SampleTrait.php
+++ b/tests/Fixtures/SampleTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Fixtures;
+
+/** @phpstan-ignore trait.unused */
+trait SampleTrait
+{
+}

--- a/tests/Utility/ReflectionHelperTest.php
+++ b/tests/Utility/ReflectionHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Tests\Fixtures\SampleTrait;
+use Firehed\PhpLsp\Utility\ReflectionHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+#[CoversClass(ReflectionHelper::class)]
+class ReflectionHelperTest extends TestCase
+{
+    public function testGetClassReturnsReflectionForExistingClass(): void
+    {
+        $result = ReflectionHelper::getClass(\stdClass::class);
+
+        self::assertInstanceOf(ReflectionClass::class, $result);
+        self::assertSame('stdClass', $result->getName());
+    }
+
+    public function testGetClassReturnsReflectionForExistingInterface(): void
+    {
+        $result = ReflectionHelper::getClass(\Iterator::class);
+
+        self::assertInstanceOf(ReflectionClass::class, $result);
+        self::assertSame('Iterator', $result->getName());
+        self::assertTrue($result->isInterface());
+    }
+
+    public function testGetClassReturnsReflectionForExistingTrait(): void
+    {
+        $result = ReflectionHelper::getClass(SampleTrait::class);
+
+        self::assertInstanceOf(ReflectionClass::class, $result);
+        self::assertSame(SampleTrait::class, $result->getName());
+        self::assertTrue($result->isTrait());
+    }
+
+    public function testGetClassReturnsNullForNonExistentClass(): void
+    {
+        $result = ReflectionHelper::getClass('NonExistent\\Class\\Name');
+
+        self::assertNull($result);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the repeated pattern of checking class/interface/trait existence before creating a `ReflectionClass` into a reusable `ReflectionHelper::getClass()` utility.

- Add `src/Utility/ReflectionHelper.php` with `getClass()` method
- Update `CompletionHandler` to use the helper (2 occurrences)
- Update `HoverHandler` to use the helper (2 occurrences)
- Update `SignatureHelpHandler` to use the helper (1 occurrence)
- Update `BasicTypeResolver` to use the helper (2 occurrences)

Also slightly improves `BasicTypeResolver` by adding `trait_exists` to its checks (previously only checked `class_exists` and `interface_exists`).

Closes #52

🤖 Generated with [Claude Code](https://claude.ai/code)