### PR TITLE
Set up PHPCS with PSR-12 standard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    name: PHPCS
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPCS
+        run: composer phpcs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 /.phpunit.cache/
+/phpcs.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,11 @@
 ## Quick Start
 
 ```bash
-composer check # PHPStan + tests (run before commits)
+composer check # PHPStan + tests + PHPCS (run before commits)
 composer phpunit -- --filter X # Run specific tests
 composer phpstan -- --error-format=raw --no-progress # run phpstan
 composer phpstan -- --error-format=raw --no-progress path/to/analyze # run phpstan on a specific path
+composer phpcs # run code style checks (PSR-12)
 ```
 
 ## Project Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ composer check # PHPStan + tests + PHPCS (run before commits)
 composer phpunit -- --filter X # Run specific tests
 composer phpstan -- --error-format=raw --no-progress # run phpstan
 composer phpstan -- --error-format=raw --no-progress path/to/analyze # run phpstan on a specific path
-composer phpcs # run code style checks (PSR-12)
+composer phpcs -- -q --report=emacs # run code style checks (PSR-12)
 ```
 
 ## Project Structure

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,13 @@
         }
     },
     "scripts": {
+        "phpcs": "phpcs",
         "phpunit": "phpunit",
         "phpstan": "phpstan analyze",
         "check": [
             "@phpstan",
-            "@phpunit"
+            "@phpunit",
+            "@phpcs"
         ]
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^11.0",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="php-lsp">
+    <description>Coding standard for php-lsp</description>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <rule ref="PSR12"/>
+
+    <file>bin/</file>
+    <file>src/</file>
+    <file>tests/</file>
+</ruleset>

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -52,7 +52,10 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * @return array{isIncomplete: bool, items: list<array{label: string, kind?: int, detail?: string, documentation?: string}>}|null
+     * @return array{
+     *   isIncomplete: bool,
+     *   items: list<array{label: string, kind?: int, detail?: string, documentation?: string}>,
+     * }|null
      */
     public function handle(Message $message): ?array
     {
@@ -137,7 +140,8 @@ final class CompletionHandler implements HandlerInterface
         if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches)) {
             $prefix = $matches[1];
             $items = $this->getImportedClassCompletions($prefix, $ast);
-            $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [SymbolKind::Class_, SymbolKind::Enum_]));
+            $indexedItems = $this->getIndexedClassCompletions($prefix, [SymbolKind::Class_, SymbolKind::Enum_]);
+            $items = array_merge($items, $indexedItems);
             return $this->deduplicateCompletions($items);
         }
 
@@ -366,7 +370,8 @@ final class CompletionHandler implements HandlerInterface
         }
 
         // Properties from parent classes
-        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED) as $prop) {
+        $flags = ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED;
+        foreach ($reflection->getProperties($flags) as $prop) {
             $name = $prop->getName();
             if (in_array($name, $existingLabels, true)) {
                 continue;
@@ -999,8 +1004,10 @@ final class CompletionHandler implements HandlerInterface
      *
      * @param array<Stmt> $ast
      */
-    private function findEnclosingScope(array $ast, int $cursorLine): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null
-    {
+    private function findEnclosingScope(
+        array $ast,
+        int $cursorLine,
+    ): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null {
         $found = null;
 
         $visitor = new class ($cursorLine, $found) extends NodeVisitorAbstract {
@@ -1054,8 +1061,9 @@ final class CompletionHandler implements HandlerInterface
      *
      * @return array<string, string> Variable name => type
      */
-    private function collectScopeVariables(Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction $scope): array
-    {
+    private function collectScopeVariables(
+        Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction $scope,
+    ): array {
         $variables = [];
 
         // Collect parameters

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -1019,7 +1019,8 @@ final class CompletionHandler implements HandlerInterface
 
             public function enterNode(Node $node): ?int
             {
-                if ($node instanceof Stmt\Function_
+                if (
+                    $node instanceof Stmt\Function_
                     || $node instanceof Stmt\ClassMethod
                     || $node instanceof Node\Expr\Closure
                     || $node instanceof Node\Expr\ArrowFunction
@@ -1028,7 +1029,8 @@ final class CompletionHandler implements HandlerInterface
                     $endLine = $node->getEndLine();
 
                     // Check if cursor is within this scope (1-based lines from parser)
-                    if ($startLine !== -1 && $endLine !== -1
+                    if (
+                        $startLine !== -1 && $endLine !== -1
                         && $this->cursorLine >= $startLine - 1
                         && $this->cursorLine <= $endLine - 1
                     ) {
@@ -1090,7 +1092,8 @@ final class CompletionHandler implements HandlerInterface
             public function enterNode(Node $node): ?int
             {
                 // Skip nested function scopes
-                if ($node instanceof Stmt\Function_
+                if (
+                    $node instanceof Stmt\Function_
                     || $node instanceof Stmt\ClassMethod
                     || $node instanceof Node\Expr\Closure
                     || $node instanceof Node\Expr\ArrowFunction

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -31,7 +31,13 @@ final class DefinitionHandler implements HandlerInterface
     }
 
     /**
-     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}|null
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
      */
     public function handle(Message $message): ?array
     {

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -374,8 +374,12 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function getMethodHoverForClass(string $className, string $methodName, array $ast, TextDocument $document): ?string
-    {
+    private function getMethodHoverForClass(
+        string $className,
+        string $methodName,
+        array $ast,
+        TextDocument $document,
+    ): ?string {
         // Try to find in AST first (current file or via Composer)
         $methodNode = $this->findMethodInClass($className, $methodName, $ast, $document);
         if ($methodNode !== null) {
@@ -389,8 +393,12 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function getPropertyHoverForClass(string $className, string $propertyName, array $ast, TextDocument $document): ?string
-    {
+    private function getPropertyHoverForClass(
+        string $className,
+        string $propertyName,
+        array $ast,
+        TextDocument $document,
+    ): ?string {
         // Try to find in AST first
         $propertyNode = $this->findPropertyInClass($className, $propertyName, $ast, $document);
         if ($propertyNode !== null) {
@@ -439,8 +447,12 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function findMethodInClass(string $className, string $methodName, array $ast, TextDocument $document): ?Stmt\ClassMethod
-    {
+    private function findMethodInClass(
+        string $className,
+        string $methodName,
+        array $ast,
+        TextDocument $document,
+    ): ?Stmt\ClassMethod {
         $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
             return null;
@@ -458,8 +470,12 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function findPropertyInClass(string $className, string $propertyName, array $ast, TextDocument $document): ?Stmt\Property
-    {
+    private function findPropertyInClass(
+        string $className,
+        string $propertyName,
+        array $ast,
+        TextDocument $document,
+    ): ?Stmt\Property {
         $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
             return null;
@@ -503,7 +519,8 @@ final class HoverHandler implements HandlerInterface
             $params[] = $paramStr;
         }
 
-        $signature = $visibility . $static . 'function ' . $method->name->toString() . '(' . implode(', ', $params) . ')';
+        $signature = $visibility . $static . 'function ' . $method->name->toString()
+            . '(' . implode(', ', $params) . ')';
 
         if ($method->returnType !== null) {
             $signature .= ': ' . TypeFormatter::formatNode($method->returnType);

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -121,7 +121,8 @@ final class SignatureHelpHandler implements HandlerInterface
 
             public function enterNode(Node $node): ?int
             {
-                if (!$node instanceof FuncCall
+                if (
+                    !$node instanceof FuncCall
                     && !$node instanceof MethodCall
                     && !$node instanceof StaticCall
                     && !$node instanceof New_

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -45,7 +45,15 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{signatures: list<array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}>, activeSignature: int, activeParameter: int}|null
+     * @return array{
+     *   signatures: list<array{
+     *     label: string,
+     *     documentation?: string,
+     *     parameters?: list<array{label: string, documentation?: string}>,
+     *   }>,
+     *   activeSignature: int,
+     *   activeParameter: int,
+     * }|null
      */
     public function handle(Message $message): ?array
     {
@@ -167,7 +175,11 @@ final class SignatureHelpHandler implements HandlerInterface
     /**
      * @param FuncCall|MethodCall|StaticCall|New_ $call
      * @param array<Stmt> $ast
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}|null
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }|null
      */
     private function getSignature(Node $call, array $ast, TextDocument $document): ?array
     {
@@ -189,7 +201,11 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}|null
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }|null
      */
     private function getFunctionSignature(FuncCall $call, array $ast): ?array
     {
@@ -217,7 +233,11 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}|null
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }|null
      */
     private function getMethodSignature(MethodCall $call, array $ast, TextDocument $document): ?array
     {
@@ -242,7 +262,11 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}|null
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }|null
      */
     private function getStaticMethodSignature(StaticCall $call, array $ast, TextDocument $document): ?array
     {
@@ -275,7 +299,11 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}|null
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }|null
      */
     private function getConstructorSignature(New_ $call, array $ast, TextDocument $document): ?array
     {
@@ -294,10 +322,18 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}|null
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }|null
      */
-    private function getMethodSignatureForClass(string $className, string $methodName, array $ast, TextDocument $document): ?array
-    {
+    private function getMethodSignatureForClass(
+        string $className,
+        string $methodName,
+        array $ast,
+        TextDocument $document,
+    ): ?array {
         // Try to find in AST first
         $methodNode = $this->findMethodInClass($className, $methodName, $ast, $document);
         if ($methodNode !== null) {
@@ -364,8 +400,12 @@ final class SignatureHelpHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function findMethodInClass(string $className, string $methodName, array $ast, TextDocument $document): ?Stmt\ClassMethod
-    {
+    private function findMethodInClass(
+        string $className,
+        string $methodName,
+        array $ast,
+        TextDocument $document,
+    ): ?Stmt\ClassMethod {
         $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
             return null;
@@ -381,7 +421,11 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }
      */
     private function formatFunctionNodeSignature(Stmt\Function_ $func): array
     {
@@ -420,7 +464,11 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }
      */
     private function formatMethodNodeSignature(Stmt\ClassMethod $method): array
     {
@@ -459,7 +507,11 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{label: string, documentation?: string, parameters?: list<array{label: string, documentation?: string}>}
+     * @return array{
+     *   label: string,
+     *   documentation?: string,
+     *   parameters?: list<array{label: string, documentation?: string}>,
+     * }
      */
     private function formatReflectionSignature(ReflectionFunctionAbstract $func): array
     {

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -30,6 +30,14 @@ use ReflectionFunctionAbstract;
 use ReflectionMethod;
 use ReflectionParameter;
 
+/**
+ * @phpstan-type ParameterInfo array{label: string, documentation?: string}
+ * @phpstan-type SignatureInfo array{
+ *   label: string,
+ *   documentation?: string,
+ *   parameters?: list<ParameterInfo>,
+ * }
+ */
 final class SignatureHelpHandler implements HandlerInterface
 {
     public function __construct(
@@ -45,15 +53,7 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{
-     *   signatures: list<array{
-     *     label: string,
-     *     documentation?: string,
-     *     parameters?: list<array{label: string, documentation?: string}>,
-     *   }>,
-     *   activeSignature: int,
-     *   activeParameter: int,
-     * }|null
+     * @return array{signatures: list<SignatureInfo>, activeSignature: int, activeParameter: int}|null
      */
     public function handle(Message $message): ?array
     {
@@ -175,11 +175,7 @@ final class SignatureHelpHandler implements HandlerInterface
     /**
      * @param FuncCall|MethodCall|StaticCall|New_ $call
      * @param array<Stmt> $ast
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }|null
+     * @return SignatureInfo|null
      */
     private function getSignature(Node $call, array $ast, TextDocument $document): ?array
     {
@@ -201,11 +197,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }|null
+     * @return SignatureInfo|null
      */
     private function getFunctionSignature(FuncCall $call, array $ast): ?array
     {
@@ -233,11 +225,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }|null
+     * @return SignatureInfo|null
      */
     private function getMethodSignature(MethodCall $call, array $ast, TextDocument $document): ?array
     {
@@ -262,11 +250,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }|null
+     * @return SignatureInfo|null
      */
     private function getStaticMethodSignature(StaticCall $call, array $ast, TextDocument $document): ?array
     {
@@ -299,11 +283,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }|null
+     * @return SignatureInfo|null
      */
     private function getConstructorSignature(New_ $call, array $ast, TextDocument $document): ?array
     {
@@ -322,11 +302,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }|null
+     * @return SignatureInfo|null
      */
     private function getMethodSignatureForClass(
         string $className,
@@ -421,11 +397,7 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }
+     * @return SignatureInfo
      */
     private function formatFunctionNodeSignature(Stmt\Function_ $func): array
     {
@@ -464,11 +436,7 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }
+     * @return SignatureInfo
      */
     private function formatMethodNodeSignature(Stmt\ClassMethod $method): array
     {
@@ -507,11 +475,7 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @return array{
-     *   label: string,
-     *   documentation?: string,
-     *   parameters?: list<array{label: string, documentation?: string}>,
-     * }
+     * @return SignatureInfo
      */
     private function formatReflectionSignature(ReflectionFunctionAbstract $func): array
     {

--- a/src/Index/Location.php
+++ b/src/Index/Location.php
@@ -16,7 +16,13 @@ final readonly class Location
     }
 
     /**
-     * @return array{uri: string, range: array{start: array{line: int, character: int}, end: array{line: int, character: int}}}
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }
      */
     public function toLspLocation(): array
     {

--- a/src/Index/SymbolExtractor.php
+++ b/src/Index/SymbolExtractor.php
@@ -100,7 +100,8 @@ final class SymbolExtractor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node): null
     {
-        if ($node instanceof Stmt\Class_
+        if (
+            $node instanceof Stmt\Class_
             || $node instanceof Stmt\Interface_
             || $node instanceof Stmt\Trait_
             || $node instanceof Stmt\Enum_

--- a/src/Server.php
+++ b/src/Server.php
@@ -52,7 +52,13 @@ final class Server
         $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
         $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator);
         $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator);
-        $this->handlers[] = new CompletionHandler($this->documentManager, $parser, $symbolIndex, $classLocator, $typeResolver);
+        $this->handlers[] = new CompletionHandler(
+            $this->documentManager,
+            $parser,
+            $symbolIndex,
+            $classLocator,
+            $typeResolver,
+        );
     }
 
     public function run(): int

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -103,7 +103,8 @@ final class BasicTypeResolver implements TypeResolverInterface
     ): ?string {
         // Check parameters first
         foreach ($scope->params as $param) {
-            if ($param->var instanceof Expr\Variable
+            if (
+                $param->var instanceof Expr\Variable
                 && is_string($param->var->name)
                 && $param->var->name === $variableName
             ) {
@@ -158,7 +159,8 @@ final class BasicTypeResolver implements TypeResolverInterface
             public function enterNode(Node $node): ?int
             {
                 // Skip nested scopes
-                if ($node instanceof Stmt\Function_
+                if (
+                    $node instanceof Stmt\Function_
                     || $node instanceof Stmt\ClassMethod
                     || $node instanceof Expr\Closure
                     || $node instanceof Expr\ArrowFunction
@@ -169,7 +171,8 @@ final class BasicTypeResolver implements TypeResolverInterface
                 // Look for assignments
                 if ($node instanceof Expr\Assign) {
                     $nodeLine = $node->getStartLine() - 1; // Convert to 0-based
-                    if ($nodeLine <= $this->line
+                    if (
+                        $nodeLine <= $this->line
                         && $node->var instanceof Expr\Variable
                         && is_string($node->var->name)
                         && $node->var->name === $this->variableName

--- a/src/Utility/ClassFinder.php
+++ b/src/Utility/ClassFinder.php
@@ -21,8 +21,10 @@ final class ClassFinder
      *
      * @param array<Stmt> $ast
      */
-    public static function findInAst(string $className, array $ast): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null
-    {
+    public static function findInAst(
+        string $className,
+        array $ast,
+    ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
         $finder = new class ($className) extends NodeVisitorAbstract {
             public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
             private string $namespace = '';

--- a/src/Utility/ClassFinder.php
+++ b/src/Utility/ClassFinder.php
@@ -38,7 +38,8 @@ final class ClassFinder
                     return null;
                 }
 
-                if ($node instanceof Stmt\Class_
+                if (
+                    $node instanceof Stmt\Class_
                     || $node instanceof Stmt\Interface_
                     || $node instanceof Stmt\Trait_
                     || $node instanceof Stmt\Enum_

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -20,7 +20,8 @@ class ServerTest extends TestCase
 {
     public function testFullLifecycle(): void
     {
-        $initializeJson = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1234,"capabilities":{}}}';
+        $initializeJson = '{"jsonrpc":"2.0","id":1,"method":"initialize",'
+            . '"params":{"processId":1234,"capabilities":{}}}';
         $initializedJson = '{"jsonrpc":"2.0","method":"initialized"}';
         $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
         $exitJson = '{"jsonrpc":"2.0","method":"exit"}';

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -347,7 +347,8 @@ PHP;
 
             public function enterNode(\PhpParser\Node $node): ?int
             {
-                if ($node instanceof Expr\Variable
+                if (
+                    $node instanceof Expr\Variable
                     && $node->name === 'this'
                     && $this->found === null
                 ) {


### PR DESCRIPTION
## Summary
- Add PHPCS with PSR-12 coding standard configuration
- Create separate lint workflow for CI
- Fix all existing violations (control structure spacing, line length)

Closes #57

## Test plan
- [x] `composer check` passes
- [x] `composer phpcs` runs without errors
- [x] Lint workflow runs successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)