### PR TITLE
Wire TypeResolverInterface into HoverHandler and SignatureHelpHandler

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,12 +1,15 @@
 {
   "permissions": {
     "allow": [
-      "Bash(composer analyze:*)",
       "Bash(composer check:*)",
       "Bash(composer install:*)",
+      "Bash(composer phpstan:*)",
+      "Bash(composer phpunit:*)",
       "Bash(composer require:*)",
       "Bash(composer test:*)",
       "Bash(gh issue view*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
       "WebSearch"
     ]
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,15 +1,12 @@
 {
   "permissions": {
     "allow": [
+      "Bash(composer analyze:*)",
       "Bash(composer check:*)",
       "Bash(composer install:*)",
-      "Bash(composer phpstan:*)",
-      "Bash(composer phpunit:*)",
       "Bash(composer require:*)",
       "Bash(composer test:*)",
       "Bash(gh issue view*)",
-      "Bash(gh pr diff:*)",
-      "Bash(gh pr view:*)",
       "WebSearch"
     ]
   }

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
@@ -37,6 +38,7 @@ final class HoverHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ?ComposerClassLocator $classLocator,
+        private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
 
@@ -419,7 +421,38 @@ final class HoverHandler implements HandlerInterface
             return $this->findEnclosingClassName($expr, $ast);
         }
 
-        // For other expressions, we'd need type inference - skip for now
+        // Use type resolver for other expressions
+        if ($this->typeResolver !== null) {
+            $scope = $this->findEnclosingScope($expr, $ast);
+            if ($scope !== null) {
+                return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the enclosing function/method/closure for a node.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function findEnclosingScope(
+        Node $node,
+        array $ast,
+    ): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null {
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if (
+                $current instanceof Stmt\Function_
+                || $current instanceof Stmt\ClassMethod
+                || $current instanceof Node\Expr\Closure
+                || $current instanceof Node\Expr\ArrowFunction
+            ) {
+                return $current;
+            }
+            $current = $current->getAttribute('parent');
+        }
         return null;
     }
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
+use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -423,36 +424,12 @@ final class HoverHandler implements HandlerInterface
 
         // Use type resolver for other expressions
         if ($this->typeResolver !== null) {
-            $scope = $this->findEnclosingScope($expr, $ast);
+            $scope = ScopeFinder::findEnclosingScope($expr, $ast);
             if ($scope !== null) {
                 return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
             }
         }
 
-        return null;
-    }
-
-    /**
-     * Find the enclosing function/method/closure for a node.
-     *
-     * @param array<Stmt> $ast
-     */
-    private function findEnclosingScope(
-        Node $node,
-        array $ast,
-    ): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null {
-        $current = $node->getAttribute('parent');
-        while ($current instanceof Node) {
-            if (
-                $current instanceof Stmt\Function_
-                || $current instanceof Stmt\ClassMethod
-                || $current instanceof Node\Expr\Closure
-                || $current instanceof Node\Expr\ArrowFunction
-            ) {
-                return $current;
-            }
-            $current = $current->getAttribute('parent');
-        }
         return null;
     }
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -424,7 +424,7 @@ final class HoverHandler implements HandlerInterface
 
         // Use type resolver for other expressions
         if ($this->typeResolver !== null) {
-            $scope = ScopeFinder::findEnclosingScope($expr, $ast);
+            $scope = ScopeFinder::findEnclosingScope($expr);
             if ($scope !== null) {
                 return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
             }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -257,7 +257,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
         // Use type resolver for other expressions
         if ($this->typeResolver !== null) {
-            $scope = ScopeFinder::findEnclosingScope($expr, $ast);
+            $scope = ScopeFinder::findEnclosingScope($expr);
             if ($scope !== null) {
                 return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
             }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
@@ -44,6 +45,7 @@ final class SignatureHelpHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ?ComposerClassLocator $classLocator,
+        private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
 
@@ -234,18 +236,57 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        // Only support $this for now
-        $var = $call->var;
-        if (!$var instanceof Variable || $var->name !== 'this') {
-            return null;
-        }
-
-        $className = $this->findEnclosingClassName($call, $ast);
+        $className = $this->resolveExpressionClass($call->var, $ast);
         if ($className === null) {
             return null;
         }
 
         return $this->getMethodSignatureForClass($className, $methodName->toString(), $ast, $document);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveExpressionClass(Node\Expr $expr, array $ast): ?string
+    {
+        // $this refers to the enclosing class
+        if ($expr instanceof Variable && $expr->name === 'this') {
+            return $this->findEnclosingClassName($expr, $ast);
+        }
+
+        // Use type resolver for other expressions
+        if ($this->typeResolver !== null) {
+            $scope = $this->findEnclosingScope($expr, $ast);
+            if ($scope !== null) {
+                return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the enclosing function/method/closure for a node.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function findEnclosingScope(
+        Node $node,
+        array $ast,
+    ): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null {
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if (
+                $current instanceof Stmt\Function_
+                || $current instanceof Stmt\ClassMethod
+                || $current instanceof Node\Expr\Closure
+                || $current instanceof Node\Expr\ArrowFunction
+            ) {
+                return $current;
+            }
+            $current = $current->getAttribute('parent');
+        }
+        return null;
     }
 
     /**

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -13,6 +13,7 @@ use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
+use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -256,36 +257,12 @@ final class SignatureHelpHandler implements HandlerInterface
 
         // Use type resolver for other expressions
         if ($this->typeResolver !== null) {
-            $scope = $this->findEnclosingScope($expr, $ast);
+            $scope = ScopeFinder::findEnclosingScope($expr, $ast);
             if ($scope !== null) {
                 return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
             }
         }
 
-        return null;
-    }
-
-    /**
-     * Find the enclosing function/method/closure for a node.
-     *
-     * @param array<Stmt> $ast
-     */
-    private function findEnclosingScope(
-        Node $node,
-        array $ast,
-    ): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null {
-        $current = $node->getAttribute('parent');
-        while ($current instanceof Node) {
-            if (
-                $current instanceof Stmt\Function_
-                || $current instanceof Stmt\ClassMethod
-                || $current instanceof Node\Expr\Closure
-                || $current instanceof Node\Expr\ArrowFunction
-            ) {
-                return $current;
-            }
-            $current = $current->getAttribute('parent');
-        }
         return null;
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -50,8 +50,8 @@ final class Server
         $this->handlers[] = $this->lifecycleHandler;
         $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
         $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
-        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator);
-        $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator);
+        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator, $typeResolver);
+        $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator, $typeResolver);
         $this->handlers[] = new CompletionHandler(
             $this->documentManager,
             $parser,

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -18,12 +18,9 @@ final class ScopeFinder
      * Find the enclosing function/method/closure for a node.
      *
      * Walks up the parent chain to find the innermost scope.
-     *
-     * @param array<Stmt> $ast Unused, kept for API consistency
      */
     public static function findEnclosingScope(
         Node $node,
-        array $ast,
     ): Stmt\Function_|Stmt\ClassMethod|Closure|ArrowFunction|null {
         $current = $node->getAttribute('parent');
         while ($current instanceof Node) {

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt;
+
+/**
+ * Utility for finding enclosing scopes in an AST.
+ */
+final class ScopeFinder
+{
+    /**
+     * Find the enclosing function/method/closure for a node.
+     *
+     * Walks up the parent chain to find the innermost scope.
+     *
+     * @param array<Stmt> $ast Unused, kept for API consistency
+     */
+    public static function findEnclosingScope(
+        Node $node,
+        array $ast,
+    ): Stmt\Function_|Stmt\ClassMethod|Closure|ArrowFunction|null {
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if (
+                $current instanceof Stmt\Function_
+                || $current instanceof Stmt\ClassMethod
+                || $current instanceof Closure
+                || $current instanceof ArrowFunction
+            ) {
+                return $current;
+            }
+            $current = $current->getAttribute('parent');
+        }
+        return null;
+    }
+}

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Handler\HoverHandler;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -283,5 +284,99 @@ PHP;
         self::assertIsArray($result);
         self::assertStringContainsString('abs', $result['contents']);
         self::assertStringContainsString('Returns the absolute value', $result['contents']);
+    }
+
+    public function testHoverOnTypedVariableMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Adds two numbers.
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+
+function useCalculator(Calculator $calc): void
+{
+    $calc->add(1, 2);
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        // Create handler with type resolver
+        $handlerWithResolver = new HoverHandler(
+            $this->documents,
+            $this->parser,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 12], // On "add"
+            ],
+        ]);
+
+        $result = $handlerWithResolver->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('add', $result['contents']);
+        self::assertStringContainsString('Adds two numbers', $result['contents']);
+    }
+
+    public function testHoverOnAssignedVariableMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Greeter
+{
+    /**
+     * Greets a person.
+     */
+    public function greet(string $name): string
+    {
+        return "Hello, $name!";
+    }
+}
+
+function test(): void
+{
+    $greeter = new Greeter();
+    $greeter->greet("World");
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handlerWithResolver = new HoverHandler(
+            $this->documents,
+            $this->parser,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 15], // On "greet"
+            ],
+        ]);
+
+        $result = $handlerWithResolver->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('greet', $result['contents']);
+        self::assertStringContainsString('Greets a person', $result['contents']);
     }
 }

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -243,5 +244,99 @@ PHP;
         $result = $this->handler->handle($request);
 
         self::assertNull($result);
+    }
+
+    public function testSignatureHelpOnTypedVariableMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Multiplies two numbers.
+     */
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+}
+
+function useCalculator(Calculator $calc): void
+{
+    $calc->multiply(2, 3);
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        // Create handler with type resolver
+        $handlerWithResolver = new SignatureHelpHandler(
+            $this->documents,
+            $this->parser,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/signatureHelp',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 21], // Inside multiply(|2, 3)
+            ],
+        ]);
+
+        $result = $handlerWithResolver->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('multiply', $result['signatures'][0]['label']);
+        self::assertStringContainsString('Multiplies two numbers', $result['signatures'][0]['documentation'] ?? '');
+    }
+
+    public function testSignatureHelpOnAssignedVariableMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Greeter
+{
+    /**
+     * Greets a person by name.
+     */
+    public function greet(string $name, string $greeting = 'Hello'): string
+    {
+        return "$greeting, $name!";
+    }
+}
+
+function test(): void
+{
+    $greeter = new Greeter();
+    $greeter->greet("World");
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handlerWithResolver = new SignatureHelpHandler(
+            $this->documents,
+            $this->parser,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/signatureHelp',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 21], // Inside greet(|"World")
+            ],
+        ]);
+
+        $result = $handlerWithResolver->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('greet', $result['signatures'][0]['label']);
+        self::assertStringContainsString('Greets a person', $result['signatures'][0]['documentation'] ?? '');
     }
 }


### PR DESCRIPTION
## Summary

- Add `TypeResolverInterface` as optional constructor parameter to `HoverHandler` and `SignatureHelpHandler`
- Update `Server.php` to pass the `BasicTypeResolver` instance to both handlers
- Use the resolver to determine variable types when hovering over or getting signature help for method calls on typed variables

This enables hover and signature help for method calls on variables with known types (parameter types and `new ClassName()` assignments), not just `$this`.

Closes #53

## Test plan

- [x] New tests added for `HoverHandler` with typed variable method calls
- [x] New tests added for `SignatureHelpHandler` with typed variable method calls
- [x] All existing tests pass
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)