### PR TITLE
Add enum case and built-in method completion

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -531,20 +531,24 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * @return array{label: string, kind: int, detail?: string}
+     * @return array{label: string, kind: int, detail: string}
      */
     private function formatEnumCaseCompletion(Stmt\EnumCase $case): array
     {
-        $item = [
-            'label' => $case->name->toString(),
-            'kind' => self::KIND_ENUM_MEMBER,
-        ];
+        $name = $case->name->toString();
+        $detail = 'case ' . $name;
 
-        if ($case->expr !== null) {
-            $item['detail'] = 'case ' . $case->name->toString();
+        if ($case->expr instanceof Node\Scalar\Int_) {
+            $detail .= ' = ' . $case->expr->value;
+        } elseif ($case->expr instanceof Node\Scalar\String_) {
+            $detail .= " = '" . $case->expr->value . "'";
         }
 
-        return $item;
+        return [
+            'label' => $name,
+            'kind' => self::KIND_ENUM_MEMBER,
+            'detail' => $detail,
+        ];
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -35,6 +35,7 @@ final class CompletionHandler implements HandlerInterface
     private const KIND_CLASS = 7;
     private const KIND_PROPERTY = 10;
     private const KIND_KEYWORD = 14;
+    private const KIND_ENUM_MEMBER = 20;
     private const KIND_CONSTANT = 21;
 
     public function __construct(
@@ -273,6 +274,19 @@ final class CompletionHandler implements HandlerInterface
                         }
                     }
                 }
+
+                // Enum cases
+                if ($stmt instanceof Stmt\EnumCase) {
+                    $name = $stmt->name->toString();
+                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                        $items[] = $this->formatEnumCaseCompletion($stmt);
+                    }
+                }
+            }
+
+            // Add built-in enum methods
+            if ($classNode instanceof Stmt\Enum_) {
+                $items = array_merge($items, $this->getEnumBuiltinMethods($classNode, $prefix));
             }
         }
 
@@ -514,6 +528,63 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $item;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string}
+     */
+    private function formatEnumCaseCompletion(Stmt\EnumCase $case): array
+    {
+        $item = [
+            'label' => $case->name->toString(),
+            'kind' => self::KIND_ENUM_MEMBER,
+        ];
+
+        if ($case->expr !== null) {
+            $item['detail'] = 'case ' . $case->name->toString();
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return list<array{label: string, kind: int, detail: string}>
+     */
+    private function getEnumBuiltinMethods(Stmt\Enum_ $enum, string $prefix): array
+    {
+        $items = [];
+
+        // cases() is available on all enums
+        if ($prefix === '' || str_starts_with('cases', strtolower($prefix))) {
+            $items[] = [
+                'label' => 'cases',
+                'kind' => self::KIND_METHOD,
+                'detail' => 'cases(): array',
+            ];
+        }
+
+        // from() and tryFrom() are only available on backed enums
+        if ($enum->scalarType !== null) {
+            $scalarType = $enum->scalarType->toString();
+
+            if ($prefix === '' || str_starts_with('from', strtolower($prefix))) {
+                $items[] = [
+                    'label' => 'from',
+                    'kind' => self::KIND_METHOD,
+                    'detail' => "from($scalarType \$value): static",
+                ];
+            }
+
+            if ($prefix === '' || str_starts_with('tryfrom', strtolower($prefix))) {
+                $items[] = [
+                    'label' => 'tryFrom',
+                    'kind' => self::KIND_METHOD,
+                    'detail' => "tryFrom($scalarType \$value): ?static",
+                ];
+            }
+        }
+
+        return $items;
     }
 
     /**

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1080,6 +1080,12 @@ PHP;
         self::assertContains('Active', $labels);
         self::assertContains('Inactive', $labels);
         self::assertContains('class', $labels);
+
+        // Check unit enum case detail
+        $activeItems = array_filter($result['items'], fn($item) => $item['label'] === 'Active');
+        self::assertNotEmpty($activeItems);
+        $activeItem = reset($activeItems);
+        self::assertSame('case Active', $activeItem['detail'] ?? '');
     }
 
     public function testEnumBuiltinMethodCompletion(): void
@@ -1159,6 +1165,12 @@ PHP;
         self::assertNotEmpty($fromItems);
         $fromItem = reset($fromItems);
         self::assertStringContainsString('int', $fromItem['detail'] ?? '');
+
+        // Check enum case detail shows backing value
+        $lowItems = array_filter($result['items'], fn($item) => $item['label'] === 'Low');
+        self::assertNotEmpty($lowItems);
+        $lowItem = reset($lowItems);
+        self::assertSame('case Low = 1', $lowItem['detail'] ?? '');
     }
 
     public function testBackedEnumCompletionString(): void
@@ -1204,5 +1216,46 @@ PHP;
         self::assertNotEmpty($fromItems);
         $fromItem = reset($fromItems);
         self::assertStringContainsString('string', $fromItem['detail'] ?? '');
+
+        // Check enum case detail shows backing value
+        $redItems = array_filter($result['items'], fn($item) => $item['label'] === 'Red');
+        self::assertNotEmpty($redItems);
+        $redItem = reset($redItems);
+        self::assertSame("case Red = 'red'", $redItem['detail'] ?? '');
+    }
+
+    public function testBackedEnumMethodPrefixFiltering(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Priority: int
+{
+    case Low = 1;
+    case High = 2;
+}
+
+$p = Priority::f
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 16], // After Priority::f
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('from', $labels);
+        self::assertNotContains('cases', $labels);
+        self::assertNotContains('tryFrom', $labels);
+        self::assertNotContains('Low', $labels);
+        self::assertNotContains('High', $labels);
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1014,4 +1014,195 @@ PHP;
         self::assertIsArray($result);
         self::assertEmpty($result['items']);
     }
+
+    public function testEnumCaseCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status
+{
+    case Active;
+    case Inactive;
+    case Pending;
+}
+
+$status = Status::A
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 19], // After Status::A
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('Active', $labels);
+        self::assertNotContains('Inactive', $labels); // doesn't match prefix
+        self::assertNotContains('Pending', $labels); // doesn't match prefix
+    }
+
+    public function testEnumCaseCompletionNoPrefix(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status
+{
+    case Active;
+    case Inactive;
+}
+
+$status = Status::
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 18], // After Status::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('Active', $labels);
+        self::assertContains('Inactive', $labels);
+        self::assertContains('class', $labels);
+    }
+
+    public function testEnumBuiltinMethodCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status
+{
+    case Active;
+    case Inactive;
+}
+
+$cases = Status::c
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 18], // After Status::c
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('cases', $labels);
+        self::assertContains('class', $labels);
+    }
+
+    public function testBackedEnumCompletionInt(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Priority: int
+{
+    case Low = 1;
+    case Medium = 2;
+    case High = 3;
+}
+
+$p = Priority::
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 15], // After Priority::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Cases
+        self::assertContains('Low', $labels);
+        self::assertContains('Medium', $labels);
+        self::assertContains('High', $labels);
+        // Built-in methods for backed enums
+        self::assertContains('cases', $labels);
+        self::assertContains('from', $labels);
+        self::assertContains('tryFrom', $labels);
+        // Magic constant
+        self::assertContains('class', $labels);
+
+        // Check from() signature shows int type
+        $fromItems = array_filter($result['items'], fn($item) => $item['label'] === 'from');
+        self::assertNotEmpty($fromItems);
+        $fromItem = reset($fromItems);
+        self::assertStringContainsString('int', $fromItem['detail'] ?? '');
+    }
+
+    public function testBackedEnumCompletionString(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Color: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}
+
+$c = Color::
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 12], // After Color::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Cases
+        self::assertContains('Red', $labels);
+        self::assertContains('Green', $labels);
+        self::assertContains('Blue', $labels);
+        // Built-in methods for backed enums
+        self::assertContains('cases', $labels);
+        self::assertContains('from', $labels);
+        self::assertContains('tryFrom', $labels);
+
+        // Check from() signature shows string type
+        $fromItems = array_filter($result['items'], fn($item) => $item['label'] === 'from');
+        self::assertNotEmpty($fromItems);
+        $fromItem = reset($fromItems);
+        self::assertStringContainsString('string', $fromItem['detail'] ?? '');
+    }
 }


### PR DESCRIPTION
## Summary
- Adds completion for enum cases when typing `EnumName::` (fixes #46)
- Adds completion for built-in enum methods: `cases()` for all enums, `from()` and `tryFrom()` for backed enums (fixes #45)
- The `from()`/`tryFrom()` signatures correctly show the backing type (int or string)

## Test plan
- [x] Added tests for unit enum case completion
- [x] Added tests for built-in `cases()` method
- [x] Added tests for int-backed enum with `from()`/`tryFrom()`
- [x] Added tests for string-backed enum with `from()`/`tryFrom()`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)