### PR TITLE
Completion: Support method/property completion on typed variables

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -7,16 +7,21 @@ This document tracks the current state of code completion in php-lsp.
 | Context | Trigger | What's Suggested | Status |
 |---------|---------|------------------|--------|
 | `$this->` member access | `$this->` or `$this->prefix` | Methods and properties from current class + inherited via reflection | ✅ Working |
+| Typed variable member access | `$user->` | Public methods and properties when type is known (parameter types, `new` expressions) | ✅ Working |
+| Variable completions | `$log` | Local variables, parameters, `$this` in methods | ✅ Working |
 | Static access | `ClassName::` | Static methods, constants, static properties | ✅ Working |
 | `new` expression | `new ` | Classes from composer classmap | ✅ Working |
 | Function calls | identifier at expression start | Built-in PHP functions + file-local functions | ✅ Working |
+
+## Limitations
+
+- **Union types**: For parameters typed as `User|Admin`, no completions are suggested. Only single-type parameters are supported.
+- **Visibility**: Typed variable completions only show public members. Use `$this->` for protected/private access within the class.
 
 ## Not Yet Supported
 
 | Context | Example | Notes |
 |---------|---------|-------|
-| Variable completions | `$log` → `$logger` | No local variable or parameter suggestions |
-| Member access on variables | `$logger->` | Only `$this->` works, not arbitrary typed variables |
 | Keywords | `fore` → `foreach` | No language keyword suggestions |
 | Array keys | `$config['` | No key suggestions from array shapes |
 | Docblock tags | `@par` → `@param` | No PHPDoc completion |
@@ -29,6 +34,8 @@ This document tracks the current state of code completion in php-lsp.
 CompletionHandler
 └── Regex-based context detection in getCompletionItems()
     ├── $this-> member completions
+    ├── $variable-> typed variable completions (via TypeResolverInterface)
+    ├── $var variable completions
     ├── ClassName:: static completions
     ├── new ClassName completions
     └── Function name completions

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -128,7 +128,7 @@ final class CompletionHandler implements HandlerInterface
         if (preg_match('/\$(\w+)->(\w*)$/', $textBeforeCursor, $matches)) {
             $variableName = $matches[1];
             $prefix = $matches[2];
-            return $this->getTypedVariableMemberCompletions($variableName, $prefix, $ast, $document, $line);
+            return $this->getTypedVariableMemberCompletions($variableName, $prefix, $ast, $line);
         }
 
         // Variable completion ($var)
@@ -249,7 +249,6 @@ final class CompletionHandler implements HandlerInterface
         string $variableName,
         string $prefix,
         array $ast,
-        TextDocument $document,
         int $line,
     ): array {
         if ($this->typeResolver === null) {
@@ -268,7 +267,7 @@ final class CompletionHandler implements HandlerInterface
             return [];
         }
 
-        return $this->getInstanceMemberCompletions($className, $prefix, $ast, $document);
+        return $this->getInstanceMemberCompletions($className, $prefix, $ast);
     }
 
     /**
@@ -281,7 +280,6 @@ final class CompletionHandler implements HandlerInterface
         string $className,
         string $prefix,
         array $ast,
-        TextDocument $document,
     ): array {
         $items = [];
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -124,6 +124,13 @@ final class CompletionHandler implements HandlerInterface
             return $this->getThisMemberCompletions($prefix, $ast);
         }
 
+        // $variable-> completion (typed variables, not $this)
+        if (preg_match('/\$(\w+)->(\w*)$/', $textBeforeCursor, $matches)) {
+            $variableName = $matches[1];
+            $prefix = $matches[2];
+            return $this->getTypedVariableMemberCompletions($variableName, $prefix, $ast, $document, $line);
+        }
+
         // Variable completion ($var)
         if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches)) {
             $prefix = $matches[1];
@@ -227,6 +234,129 @@ final class CompletionHandler implements HandlerInterface
         $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
         if ($className !== null) {
             $items = array_merge($items, $this->getInheritedMemberCompletions($className, $prefix, $items));
+        }
+
+        return $items;
+    }
+
+    /**
+     * Get completions for a typed variable: $user-> where $user has a known type.
+     *
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getTypedVariableMemberCompletions(
+        string $variableName,
+        string $prefix,
+        array $ast,
+        TextDocument $document,
+        int $line,
+    ): array {
+        if ($this->typeResolver === null) {
+            return [];
+        }
+
+        // Find the enclosing scope
+        $scope = $this->findEnclosingScope($ast, $line);
+        if ($scope === null) {
+            return [];
+        }
+
+        // Resolve the variable's type
+        $className = $this->typeResolver->resolveVariableType($variableName, $scope, $line, $ast);
+        if ($className === null) {
+            return [];
+        }
+
+        return $this->getInstanceMemberCompletions($className, $prefix, $ast, $document);
+    }
+
+    /**
+     * Get instance (non-static) member completions for a class.
+     *
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getInstanceMemberCompletions(
+        string $className,
+        string $prefix,
+        array $ast,
+        TextDocument $document,
+    ): array {
+        $items = [];
+
+        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
+
+        if ($classNode !== null) {
+            foreach ($classNode->stmts as $stmt) {
+                // Public methods (non-static)
+                if ($stmt instanceof Stmt\ClassMethod && !$stmt->isStatic() && $stmt->isPublic()) {
+                    $name = $stmt->name->toString();
+                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                        $items[] = $this->formatMethodCompletion($stmt);
+                    }
+                }
+
+                // Public properties (non-static)
+                if ($stmt instanceof Stmt\Property && !$stmt->isStatic() && $stmt->isPublic()) {
+                    foreach ($stmt->props as $prop) {
+                        $name = $prop->name->toString();
+                        if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                            $items[] = $this->formatPropertyCompletion($stmt, $name);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add public members from reflection (for inherited/built-in classes)
+        $items = array_merge($items, $this->getReflectionInstanceCompletions($className, $prefix, $items));
+
+        return $items;
+    }
+
+    /**
+     * Get public instance members via reflection.
+     *
+     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getReflectionInstanceCompletions(string $className, string $prefix, array $existingItems): array
+    {
+        $reflection = ReflectionHelper::getClass($className);
+        if ($reflection === null) {
+            return [];
+        }
+
+        $existingLabels = array_column($existingItems, 'label');
+        $items = [];
+
+        // Public non-static methods
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isStatic()) {
+                continue;
+            }
+            $name = $method->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
+            }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionMethodCompletion($method);
+            }
+        }
+
+        // Public non-static properties
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $prop) {
+            if ($prop->isStatic()) {
+                continue;
+            }
+            $name = $prop->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
+            }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionPropertyCompletion($prop);
+            }
         }
 
         return $items;

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1429,4 +1429,77 @@ PHP;
         self::assertIsArray($result);
         self::assertEmpty($result['items']);
     }
+
+    public function testTypedVariableCompletionIncludesInheritedMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+function foo(ArrayObject $obj): void
+{
+    $obj->
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 10], // After $obj->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // ArrayObject methods from reflection
+        self::assertContains('append', $labels);
+        self::assertContains('count', $labels);
+        self::assertContains('getIterator', $labels);
+    }
+
+    public function testTypedVariableCompletionReturnsEmptyWithoutTypeResolver(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function getName(): string { return ''; }
+}
+
+function foo(User $user): void
+{
+    $user->
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        // Handler without type resolver (uses default from setUp)
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 11], // After $user->
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        // Without type resolver, no completions for typed variables
+        self::assertEmpty($result['items']);
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -12,6 +12,7 @@ use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -1257,5 +1258,175 @@ PHP;
         self::assertNotContains('tryFrom', $labels);
         self::assertNotContains('Low', $labels);
         self::assertNotContains('High', $labels);
+    }
+
+    public function testTypedVariableCompletionFromParameter(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public string $name;
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): void { $this->name = $name; }
+}
+
+function processUser(User $user): void
+{
+    $user->
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 11, 'character' => 11], // After $user->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('name', $labels);
+        self::assertContains('getName', $labels);
+        self::assertContains('setName', $labels);
+    }
+
+    public function testTypedVariableCompletionFromNewExpression(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Logger
+{
+    public function info(string $message): void {}
+    public function error(string $message): void {}
+}
+
+function foo(): void
+{
+    $logger = new Logger();
+    $logger->
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 13], // After $logger->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('info', $labels);
+        self::assertContains('error', $labels);
+    }
+
+    public function testTypedVariableCompletionWithPrefix(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function getName(): string { return ''; }
+    public function getEmail(): string { return ''; }
+    public function setName(string $name): void {}
+}
+
+function processUser(User $user): void
+{
+    $user->get
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 14], // After $user->get
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getName', $labels);
+        self::assertContains('getEmail', $labels);
+        self::assertNotContains('setName', $labels);
+    }
+
+    public function testTypedVariableCompletionReturnsEmptyWhenTypeUnknown(): void
+    {
+        $code = <<<'PHP'
+<?php
+function foo(): void
+{
+    $unknown->
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 14], // After $unknown->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1469,6 +1469,60 @@ PHP;
         self::assertContains('getIterator', $labels);
     }
 
+    public function testTypedVariableCompletionExcludesNonPublicMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public string $name;
+    protected string $email;
+    private string $password;
+
+    public function getName(): string { return $this->name; }
+    protected function getEmail(): string { return $this->email; }
+    private function getPassword(): string { return $this->password; }
+}
+
+function foo(User $user): void
+{
+    $user->
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 11], // After $user->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Public members should be included
+        self::assertContains('name', $labels);
+        self::assertContains('getName', $labels);
+        // Protected and private members should be excluded
+        self::assertNotContains('email', $labels);
+        self::assertNotContains('password', $labels);
+        self::assertNotContains('getEmail', $labels);
+        self::assertNotContains('getPassword', $labels);
+    }
+
     public function testTypedVariableCompletionReturnsEmptyWithoutTypeResolver(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1292,7 +1292,7 @@ PHP;
             'method' => 'textDocument/completion',
             'params' => [
                 'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 11, 'character' => 11], // After $user->
+                'position' => ['line' => 10, 'character' => 11], // After $user->
             ],
         ]);
 


### PR DESCRIPTION
## Summary
- Add `$variable->` completion when the variable has a known type
- Supports parameter type hints (`function foo(User $user) { $user-> }`)
- Supports `new` expression assignments (`$user = new User(); $user->`)
- Shows public methods and properties from AST or reflection

Closes #14

## Test plan
- [x] Tests for parameter type completion
- [x] Tests for `new` expression completion  
- [x] Tests for prefix filtering
- [x] Tests for unknown type (returns empty)
- [x] Full test suite passes
- [x] PHPStan passes

🤖 Generated with [Claude Code](https://claude.ai/code)