### PR TITLE
Jump to definition for class methods

### DIFF
--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -308,61 +308,9 @@ final class DefinitionHandler implements HandlerInterface
      */
     private function findMethodDefinition(string $className, string $methodName, array $ast): ?array
     {
-        // First, try to find the class in the current AST
-        $classNode = ClassFinder::findInAst($className, $ast);
-        $classUri = null;
+        [$classNode, $classUri] = $this->findClassWithUri($className, $ast);
 
-        if ($classNode === null) {
-            // Try to find via SymbolIndex
-            $symbol = $this->symbolIndex->findByFqn($className);
-            if ($symbol === null) {
-                $matches = $this->symbolIndex->findByName($className);
-                $symbol = $matches[0] ?? null;
-            }
-
-            if ($symbol !== null) {
-                $classUri = $symbol->location->uri;
-                // Load and parse the file containing the class
-                $document = $this->documentManager->get($classUri);
-                if ($document === null) {
-                    // Try to load from file system
-                    $filePath = str_starts_with($classUri, 'file://') ? substr($classUri, 7) : $classUri;
-                    $content = @file_get_contents($filePath);
-                    if ($content !== false) {
-                        $document = new TextDocument($classUri, 'php', 0, $content);
-                    }
-                }
-
-                if ($document !== null) {
-                    $classAst = $this->parser->parse($document);
-                    if ($classAst !== null) {
-                        $classNode = ClassFinder::findInAst($className, $classAst);
-                    }
-                }
-            }
-        }
-
-        // Try Composer locator as fallback
-        if ($classNode === null && $this->classLocator !== null) {
-            $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
-            if ($classNode !== null) {
-                $filePath = $this->classLocator->locateClass($className);
-                if ($filePath !== null) {
-                    $classUri = 'file://' . $filePath;
-                }
-            }
-        }
-
-        if ($classNode === null) {
-            return null;
-        }
-
-        // Determine the URI if not already set
-        if ($classUri === null) {
-            $classUri = $this->getClassUri($classNode);
-        }
-
-        if ($classUri === null) {
+        if ($classNode === null || $classUri === null) {
             return null;
         }
 
@@ -453,6 +401,72 @@ final class DefinitionHandler implements HandlerInterface
         }
 
         return null;
+    }
+
+    /**
+     * Find a class node and its URI.
+     *
+     * Searches in order:
+     * 1. Current AST
+     * 2. SymbolIndex (for open files)
+     * 3. Composer autoload (for external dependencies)
+     *
+     * @param array<Stmt> $ast
+     * @return array{
+     *   0: Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null,
+     *   1: string|null,
+     * }
+     */
+    private function findClassWithUri(string $className, array $ast): array
+    {
+        // First, try to find the class in the current AST
+        $classNode = ClassFinder::findInAst($className, $ast);
+        if ($classNode !== null) {
+            $uri = $this->getClassUri($classNode);
+            return [$classNode, $uri];
+        }
+
+        // Try to find via SymbolIndex
+        $symbol = $this->symbolIndex->findByFqn($className);
+        if ($symbol === null) {
+            $matches = $this->symbolIndex->findByName($className);
+            $symbol = $matches[0] ?? null;
+        }
+
+        if ($symbol !== null) {
+            $classUri = $symbol->location->uri;
+            $document = $this->documentManager->get($classUri);
+            if ($document === null) {
+                $filePath = str_starts_with($classUri, 'file://') ? substr($classUri, 7) : $classUri;
+                $content = @file_get_contents($filePath);
+                if ($content !== false) {
+                    $document = new TextDocument($classUri, 'php', 0, $content);
+                }
+            }
+
+            if ($document !== null) {
+                $classAst = $this->parser->parse($document);
+                if ($classAst !== null) {
+                    $classNode = ClassFinder::findInAst($className, $classAst);
+                    if ($classNode !== null) {
+                        return [$classNode, $classUri];
+                    }
+                }
+            }
+        }
+
+        // Try Composer locator as fallback
+        if ($this->classLocator !== null) {
+            $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
+            if ($classNode !== null) {
+                $filePath = $this->classLocator->locateClass($className);
+                if ($filePath !== null) {
+                    return [$classNode, 'file://' . $filePath];
+                }
+            }
+        }
+
+        return [null, null];
     }
 
     private function locateViaComposer(string $className): ?Location

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -127,11 +127,7 @@ final class DefinitionHandler implements HandlerInterface
      */
     private function handleNameDefinition(Name $node): ?array
     {
-        // Use the resolved name if available (handles use statements)
-        $resolvedName = $node->getAttribute('resolvedName');
-        $symbolName = $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $node->toString();
+        $symbolName = $this->resolveName($node);
 
         // Look up in index first (for open files)
         $symbol = $this->symbolIndex->findByFqn($symbolName);
@@ -172,19 +168,13 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        $resolvedName = $class->getAttribute('resolvedName');
-        $className = $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $class->toString();
+        $className = $this->resolveName($class);
 
         // Handle parent:: - resolve to actual parent class name
         if ($className === 'parent') {
             $enclosingClass = $this->findEnclosingClassNode($call);
             if ($enclosingClass instanceof Stmt\Class_ && $enclosingClass->extends !== null) {
-                $parentResolved = $enclosingClass->extends->getAttribute('resolvedName');
-                $className = $parentResolved instanceof Name
-                    ? $parentResolved->toString()
-                    : $enclosingClass->extends->toString();
+                $className = $this->resolveName($enclosingClass->extends);
             } else {
                 return null;
             }
@@ -327,11 +317,7 @@ final class DefinitionHandler implements HandlerInterface
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
-                    $traitResolved = $traitName->getAttribute('resolvedName');
-                    $traitFqn = $traitResolved instanceof Name
-                        ? $traitResolved->toString()
-                        : $traitName->toString();
-                    $traitResult = $this->findMethodDefinition($traitFqn, $methodName, $ast);
+                    $traitResult = $this->findMethodDefinition($this->resolveName($traitName), $methodName, $ast);
                     if ($traitResult !== null) {
                         return $traitResult;
                     }
@@ -341,11 +327,7 @@ final class DefinitionHandler implements HandlerInterface
 
         // Search in parent class
         if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $parentResolved = $classNode->extends->getAttribute('resolvedName');
-            $parentName = $parentResolved instanceof Name
-                ? $parentResolved->toString()
-                : $classNode->extends->toString();
-            $parentResult = $this->findMethodDefinition($parentName, $methodName, $ast);
+            $parentResult = $this->findMethodDefinition($this->resolveName($classNode->extends), $methodName, $ast);
             if ($parentResult !== null) {
                 return $parentResult;
             }
@@ -513,5 +495,16 @@ final class DefinitionHandler implements HandlerInterface
 
         // Fallback: return start of file
         return new Location($uri, 0, 0, 0, 0);
+    }
+
+    /**
+     * Get the fully qualified name from a Name node, using resolvedName if available.
+     */
+    private function resolveName(Name $node): string
+    {
+        $resolved = $node->getAttribute('resolvedName');
+        return $resolved instanceof Name
+            ? $resolved->toString()
+            : $node->toString();
     }
 }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -274,13 +274,16 @@ final class DefinitionHandler implements HandlerInterface
     }
 
     /**
-     * Find the enclosing class name for a node.
+     * Find the enclosing class or trait name for a node.
      */
     private function findEnclosingClassName(Node $node): ?string
     {
         $current = $node->getAttribute('parent');
         while ($current instanceof Node) {
-            if ($current instanceof Stmt\Class_ && $current->name !== null) {
+            if (
+                ($current instanceof Stmt\Class_ || $current instanceof Stmt\Trait_)
+                && $current->name !== null
+            ) {
                 $namespacedName = $current->namespacedName;
                 if ($namespacedName instanceof Name) {
                     return $namespacedName->toString();

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -192,7 +192,7 @@ final class DefinitionHandler implements HandlerInterface
 
         // Handle self:: and static:: - resolve to enclosing class
         if ($className === 'self' || $className === 'static') {
-            $enclosingClassName = $this->findEnclosingClassName($call, $ast);
+            $enclosingClassName = $this->findEnclosingClassName($call);
             if ($enclosingClassName === null) {
                 return null;
             }
@@ -259,7 +259,7 @@ final class DefinitionHandler implements HandlerInterface
     {
         // $this refers to the enclosing class
         if ($expr instanceof Variable && $expr->name === 'this') {
-            return $this->findEnclosingClassName($expr, $ast);
+            return $this->findEnclosingClassName($expr);
         }
 
         // Use type resolver for other expressions
@@ -275,10 +275,8 @@ final class DefinitionHandler implements HandlerInterface
 
     /**
      * Find the enclosing class name for a node.
-     *
-     * @param array<Stmt> $ast
      */
-    private function findEnclosingClassName(Node $node, array $ast): ?string
+    private function findEnclosingClassName(Node $node): ?string
     {
         $current = $node->getAttribute('parent');
         while ($current instanceof Node) {
@@ -326,7 +324,11 @@ final class DefinitionHandler implements HandlerInterface
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
-                    $traitResult = $this->findMethodDefinition($traitName->toString(), $methodName, $ast);
+                    $traitResolved = $traitName->getAttribute('resolvedName');
+                    $traitFqn = $traitResolved instanceof Name
+                        ? $traitResolved->toString()
+                        : $traitName->toString();
+                    $traitResult = $this->findMethodDefinition($traitFqn, $methodName, $ast);
                     if ($traitResult !== null) {
                         return $traitResult;
                     }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -200,15 +200,22 @@ final class DefinitionHandler implements HandlerInterface
     }
 
     /**
-     * Find the enclosing class node for a given node.
+     * Find the enclosing class-like node for a given node.
      *
      * @param array<Stmt> $ast
      */
-    private function findEnclosingClassNode(Node $node, array $ast): ?Stmt\Class_
-    {
+    private function findEnclosingClassNode(
+        Node $node,
+        array $ast,
+    ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
         $current = $node->getAttribute('parent');
         while ($current instanceof Node) {
-            if ($current instanceof Stmt\Class_) {
+            if (
+                $current instanceof Stmt\Class_
+                || $current instanceof Stmt\Interface_
+                || $current instanceof Stmt\Trait_
+                || $current instanceof Stmt\Enum_
+            ) {
                 return $current;
             }
             $current = $current->getAttribute('parent');
@@ -366,16 +373,8 @@ final class DefinitionHandler implements HandlerInterface
             }
         }
 
-        // Search in parent class
-        if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $parentName = $classNode->extends->toString();
-            $parentResult = $this->findMethodDefinition($parentName, $methodName, $ast);
-            if ($parentResult !== null) {
-                return $parentResult;
-            }
-        }
-
-        // Search in traits
+        // PHP method resolution order: class -> traits -> parent
+        // Search in traits first (before parent)
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
@@ -384,6 +383,15 @@ final class DefinitionHandler implements HandlerInterface
                         return $traitResult;
                     }
                 }
+            }
+        }
+
+        // Search in parent class
+        if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
+            $parentName = $classNode->extends->toString();
+            $parentResult = $this->findMethodDefinition($parentName, $methodName, $ast);
+            if ($parentResult !== null) {
+                return $parentResult;
             }
         }
 

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -179,9 +179,12 @@ final class DefinitionHandler implements HandlerInterface
 
         // Handle parent:: - resolve to actual parent class name
         if ($className === 'parent') {
-            $enclosingClass = $this->findEnclosingClassNode($call, $ast);
+            $enclosingClass = $this->findEnclosingClassNode($call);
             if ($enclosingClass instanceof Stmt\Class_ && $enclosingClass->extends !== null) {
-                $className = $enclosingClass->extends->toString();
+                $parentResolved = $enclosingClass->extends->getAttribute('resolvedName');
+                $className = $parentResolved instanceof Name
+                    ? $parentResolved->toString()
+                    : $enclosingClass->extends->toString();
             } else {
                 return null;
             }
@@ -201,12 +204,9 @@ final class DefinitionHandler implements HandlerInterface
 
     /**
      * Find the enclosing class-like node for a given node.
-     *
-     * @param array<Stmt> $ast
      */
     private function findEnclosingClassNode(
         Node $node,
-        array $ast,
     ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
         $current = $node->getAttribute('parent');
         while ($current instanceof Node) {
@@ -336,7 +336,10 @@ final class DefinitionHandler implements HandlerInterface
 
         // Search in parent class
         if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $parentName = $classNode->extends->toString();
+            $parentResolved = $classNode->extends->getAttribute('resolvedName');
+            $parentName = $parentResolved instanceof Name
+                ? $parentResolved->toString()
+                : $classNode->extends->toString();
             $parentResult = $this->findMethodDefinition($parentName, $methodName, $ast);
             if ($parentResult !== null) {
                 return $parentResult;

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -13,7 +13,16 @@ use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
+use Firehed\PhpLsp\Utility\ClassFinder;
+use Firehed\PhpLsp\Utility\ScopeFinder;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
 
 final class DefinitionHandler implements HandlerInterface
 {
@@ -22,6 +31,7 @@ final class DefinitionHandler implements HandlerInterface
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
         private readonly ?ComposerClassLocator $classLocator = null,
+        private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
 
@@ -83,11 +93,40 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        // Extract the symbol name we're looking for
-        if (!$node instanceof Name) {
-            return null;
+        // Check if this is a method name (Identifier) in a method call
+        if ($node instanceof Identifier) {
+            $parent = $node->getAttribute('parent');
+
+            // Static method call: ClassName::method()
+            if ($parent instanceof StaticCall) {
+                return $this->handleStaticMethodDefinition($parent, $ast);
+            }
+
+            // Instance method call: $obj->method()
+            if ($parent instanceof MethodCall) {
+                return $this->handleInstanceMethodDefinition($parent, $ast);
+            }
         }
 
+        // Class/interface/trait/enum reference
+        if ($node instanceof Name) {
+            return $this->handleNameDefinition($node);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function handleNameDefinition(Name $node): ?array
+    {
         // Use the resolved name if available (handles use statements)
         $resolvedName = $node->getAttribute('resolvedName');
         $symbolName = $resolvedName instanceof Name
@@ -107,6 +146,305 @@ final class DefinitionHandler implements HandlerInterface
 
         // Not in index - try to locate via Composer autoload
         return $this->locateViaComposer($symbolName)?->toLspLocation();
+    }
+
+    /**
+     * Handle definition for static method call: ClassName::method()
+     *
+     * @param array<Stmt> $ast
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function handleStaticMethodDefinition(StaticCall $call, array $ast): ?array
+    {
+        $methodName = $call->name;
+        if (!$methodName instanceof Identifier) {
+            return null;
+        }
+
+        $class = $call->class;
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        $resolvedName = $class->getAttribute('resolvedName');
+        $className = $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $class->toString();
+
+        // Handle parent:: - resolve to actual parent class name
+        if ($className === 'parent') {
+            $enclosingClass = $this->findEnclosingClassNode($call, $ast);
+            if ($enclosingClass instanceof Stmt\Class_ && $enclosingClass->extends !== null) {
+                $className = $enclosingClass->extends->toString();
+            } else {
+                return null;
+            }
+        }
+
+        // Handle self:: and static:: - resolve to enclosing class
+        if ($className === 'self' || $className === 'static') {
+            $enclosingClassName = $this->findEnclosingClassName($call, $ast);
+            if ($enclosingClassName === null) {
+                return null;
+            }
+            $className = $enclosingClassName;
+        }
+
+        return $this->findMethodDefinition($className, $methodName->toString(), $ast);
+    }
+
+    /**
+     * Find the enclosing class node for a given node.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function findEnclosingClassNode(Node $node, array $ast): ?Stmt\Class_
+    {
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if ($current instanceof Stmt\Class_) {
+                return $current;
+            }
+            $current = $current->getAttribute('parent');
+        }
+        return null;
+    }
+
+    /**
+     * Handle definition for instance method call: $obj->method()
+     *
+     * @param array<Stmt> $ast
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function handleInstanceMethodDefinition(MethodCall $call, array $ast): ?array
+    {
+        $methodName = $call->name;
+        if (!$methodName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveExpressionClass($call->var, $ast);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->findMethodDefinition($className, $methodName->toString(), $ast);
+    }
+
+    /**
+     * Resolve the class name of an expression.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function resolveExpressionClass(Node\Expr $expr, array $ast): ?string
+    {
+        // $this refers to the enclosing class
+        if ($expr instanceof Variable && $expr->name === 'this') {
+            return $this->findEnclosingClassName($expr, $ast);
+        }
+
+        // Use type resolver for other expressions
+        if ($this->typeResolver !== null) {
+            $scope = ScopeFinder::findEnclosingScope($expr);
+            if ($scope !== null) {
+                return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the enclosing class name for a node.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function findEnclosingClassName(Node $node, array $ast): ?string
+    {
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if ($current instanceof Stmt\Class_ && $current->name !== null) {
+                $namespacedName = $current->namespacedName;
+                if ($namespacedName instanceof Name) {
+                    return $namespacedName->toString();
+                }
+                return $current->name->toString();
+            }
+            $current = $current->getAttribute('parent');
+        }
+        return null;
+    }
+
+    /**
+     * Find the definition of a method in a class.
+     *
+     * @param array<Stmt> $ast
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function findMethodDefinition(string $className, string $methodName, array $ast): ?array
+    {
+        // First, try to find the class in the current AST
+        $classNode = ClassFinder::findInAst($className, $ast);
+        $classUri = null;
+
+        if ($classNode === null) {
+            // Try to find via SymbolIndex
+            $symbol = $this->symbolIndex->findByFqn($className);
+            if ($symbol === null) {
+                $matches = $this->symbolIndex->findByName($className);
+                $symbol = $matches[0] ?? null;
+            }
+
+            if ($symbol !== null) {
+                $classUri = $symbol->location->uri;
+                // Load and parse the file containing the class
+                $document = $this->documentManager->get($classUri);
+                if ($document === null) {
+                    // Try to load from file system
+                    $filePath = str_starts_with($classUri, 'file://') ? substr($classUri, 7) : $classUri;
+                    $content = @file_get_contents($filePath);
+                    if ($content !== false) {
+                        $document = new TextDocument($classUri, 'php', 0, $content);
+                    }
+                }
+
+                if ($document !== null) {
+                    $classAst = $this->parser->parse($document);
+                    if ($classAst !== null) {
+                        $classNode = ClassFinder::findInAst($className, $classAst);
+                    }
+                }
+            }
+        }
+
+        // Try Composer locator as fallback
+        if ($classNode === null && $this->classLocator !== null) {
+            $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
+            if ($classNode !== null) {
+                $filePath = $this->classLocator->locateClass($className);
+                if ($filePath !== null) {
+                    $classUri = 'file://' . $filePath;
+                }
+            }
+        }
+
+        if ($classNode === null) {
+            return null;
+        }
+
+        // Determine the URI if not already set
+        if ($classUri === null) {
+            $classUri = $this->getClassUri($classNode);
+        }
+
+        if ($classUri === null) {
+            return null;
+        }
+
+        // Search for the method in the class
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
+                return $this->createMethodLocationWithUri($stmt, $classUri);
+            }
+        }
+
+        // Search in parent class
+        if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
+            $parentName = $classNode->extends->toString();
+            $parentResult = $this->findMethodDefinition($parentName, $methodName, $ast);
+            if ($parentResult !== null) {
+                return $parentResult;
+            }
+        }
+
+        // Search in traits
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\TraitUse) {
+                foreach ($stmt->traits as $traitName) {
+                    $traitResult = $this->findMethodDefinition($traitName->toString(), $methodName, $ast);
+                    if ($traitResult !== null) {
+                        return $traitResult;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Create a Location for a method definition with a known URI.
+     *
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function createMethodLocationWithUri(Stmt\ClassMethod $method, string $uri): ?array
+    {
+        $startLine = $method->getStartLine();
+        $endLine = $method->getEndLine();
+
+        if ($startLine === -1 || $endLine === -1) {
+            return null;
+        }
+
+        // Convert to 0-based line numbers
+        $location = new Location(
+            $uri,
+            $startLine - 1,
+            0,
+            $endLine - 1,
+            0,
+        );
+
+        return $location->toLspLocation();
+    }
+
+    /**
+     * Get the URI for a class node.
+     */
+    private function getClassUri(Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $classNode): ?string
+    {
+        // First check if this class is in the symbol index
+        $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+        if ($className !== null) {
+            $symbol = $this->symbolIndex->findByFqn($className);
+            if ($symbol !== null) {
+                return $symbol->location->uri;
+            }
+
+            // Try to locate via Composer
+            if ($this->classLocator !== null) {
+                $filePath = $this->classLocator->locateClass($className);
+                if ($filePath !== null) {
+                    return 'file://' . $filePath;
+                }
+            }
+        }
+
+        return null;
     }
 
     private function locateViaComposer(string $className): ?Location

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -264,25 +264,20 @@ final class DefinitionHandler implements HandlerInterface
     }
 
     /**
-     * Find the enclosing class or trait name for a node.
+     * Find the enclosing class-like name for a node.
      */
     private function findEnclosingClassName(Node $node): ?string
     {
-        $current = $node->getAttribute('parent');
-        while ($current instanceof Node) {
-            if (
-                ($current instanceof Stmt\Class_ || $current instanceof Stmt\Trait_)
-                && $current->name !== null
-            ) {
-                $namespacedName = $current->namespacedName;
-                if ($namespacedName instanceof Name) {
-                    return $namespacedName->toString();
-                }
-                return $current->name->toString();
-            }
-            $current = $current->getAttribute('parent');
+        $classNode = $this->findEnclosingClassNode($node);
+        if ($classNode === null || $classNode->name === null) {
+            return null;
         }
-        return null;
+
+        $namespacedName = $classNode->namespacedName;
+        if ($namespacedName instanceof Name) {
+            return $namespacedName->toString();
+        }
+        return $classNode->name->toString();
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -49,7 +49,13 @@ final class Server
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
         $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
-        $this->handlers[] = new DefinitionHandler($this->documentManager, $parser, $symbolIndex, $classLocator);
+        $this->handlers[] = new DefinitionHandler(
+            $this->documentManager,
+            $parser,
+            $symbolIndex,
+            $classLocator,
+            $typeResolver,
+        );
         $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator, $typeResolver);
         $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator, $typeResolver);
         $this->handlers[] = new CompletionHandler(

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -11,6 +11,7 @@ use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -36,6 +37,8 @@ class DefinitionHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->index,
+            classLocator: null,
+            typeResolver: new BasicTypeResolver(),
         );
     }
 
@@ -116,5 +119,345 @@ class DefinitionHandlerTest extends TestCase
         $result = $this->handler->handle($request);
 
         self::assertNull($result);
+    }
+
+    public function testGoToStaticMethodDefinition(): void
+    {
+        // Class with a static method
+        $classCode = <<<'PHP'
+<?php
+class MyClass {
+    public static function myStaticMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
+        $classDoc = $this->documents->get('file:///MyClass.php');
+        self::assertNotNull($classDoc);
+        $ast = $this->parser->parse($classDoc);
+        self::assertNotNull($ast);
+        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
+        foreach ($symbols as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Usage: MyClass::myStaticMethod()
+        $usageCode = '<?php MyClass::myStaticMethod();';
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "myStaticMethod" (character 15 is on the method name)
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 0, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        // Line 2 (0-indexed) is where the method is defined
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testGoToInstanceMethodDefinition(): void
+    {
+        // Class with an instance method
+        $classCode = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
+        $classDoc = $this->documents->get('file:///MyClass.php');
+        self::assertNotNull($classDoc);
+        $ast = $this->parser->parse($classDoc);
+        self::assertNotNull($ast);
+        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
+        foreach ($symbols as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Usage: $obj->myMethod() where $obj is typed
+        $usageCode = <<<'PHP'
+<?php
+function test(MyClass $obj): void {
+    $obj->myMethod();
+}
+PHP;
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "myMethod" on line 2 (0-indexed)
+        // "$obj->myMethod()" - "myMethod" starts at character 10
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 12],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testGoToMethodDefinitionViaAssignment(): void
+    {
+        // Class with an instance method
+        $classCode = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
+        $classDoc = $this->documents->get('file:///MyClass.php');
+        self::assertNotNull($classDoc);
+        $ast = $this->parser->parse($classDoc);
+        self::assertNotNull($ast);
+        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
+        foreach ($symbols as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Usage: $obj = new MyClass(); $obj->myMethod();
+        $usageCode = <<<'PHP'
+<?php
+function test(): void {
+    $obj = new MyClass();
+    $obj->myMethod();
+}
+PHP;
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "myMethod" on line 3 (0-indexed)
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 3, 'character' => 12],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testReturnsNullForMethodOnUnknownType(): void
+    {
+        $usageCode = <<<'PHP'
+<?php
+function test($obj): void {
+    $obj->unknownMethod();
+}
+PHP;
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 12],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertNull($result);
+    }
+
+    public function testGoToInheritedMethodDefinition(): void
+    {
+        // Parent class with method
+        $parentCode = <<<'PHP'
+<?php
+class ParentClass {
+    public function inheritedMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
+        $parentDoc = $this->documents->get('file:///ParentClass.php');
+        self::assertNotNull($parentDoc);
+        $parentAst = $this->parser->parse($parentDoc);
+        self::assertNotNull($parentAst);
+        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Child class that extends parent
+        $childCode = <<<'PHP'
+<?php
+class ChildClass extends ParentClass {
+}
+PHP;
+        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
+        $childDoc = $this->documents->get('file:///ChildClass.php');
+        self::assertNotNull($childDoc);
+        $childAst = $this->parser->parse($childDoc);
+        self::assertNotNull($childAst);
+        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Usage: $child->inheritedMethod()
+        $usageCode = <<<'PHP'
+<?php
+function test(ChildClass $child): void {
+    $child->inheritedMethod();
+}
+PHP;
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "inheritedMethod"
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 14],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        // Should go to ParentClass where the method is actually defined
+        self::assertIsArray($result);
+        self::assertSame('file:///ParentClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testGoToOverriddenMethodDefinition(): void
+    {
+        // Parent class with method
+        $parentCode = <<<'PHP'
+<?php
+class ParentClass {
+    public function overriddenMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
+        $parentDoc = $this->documents->get('file:///ParentClass.php');
+        self::assertNotNull($parentDoc);
+        $parentAst = $this->parser->parse($parentDoc);
+        self::assertNotNull($parentAst);
+        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Child class that overrides the method
+        $childCode = <<<'PHP'
+<?php
+class ChildClass extends ParentClass {
+    public function overriddenMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
+        $childDoc = $this->documents->get('file:///ChildClass.php');
+        self::assertNotNull($childDoc);
+        $childAst = $this->parser->parse($childDoc);
+        self::assertNotNull($childAst);
+        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Usage: $child->overriddenMethod()
+        $usageCode = <<<'PHP'
+<?php
+function test(ChildClass $child): void {
+    $child->overriddenMethod();
+}
+PHP;
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "overriddenMethod"
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 14],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        // Should go to ChildClass where the method is overridden
+        self::assertIsArray($result);
+        self::assertSame('file:///ChildClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testGoToParentMethodDefinition(): void
+    {
+        // Parent class with method
+        $parentCode = <<<'PHP'
+<?php
+class ParentClass {
+    public function doFoo(): void {}
+}
+PHP;
+        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
+        $parentDoc = $this->documents->get('file:///ParentClass.php');
+        self::assertNotNull($parentDoc);
+        $parentAst = $this->parser->parse($parentDoc);
+        self::assertNotNull($parentAst);
+        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Child class that calls parent::doFoo()
+        $childCode = <<<'PHP'
+<?php
+class ChildClass extends ParentClass {
+    public function doFoo(): void {
+        parent::doFoo();
+    }
+}
+PHP;
+        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
+        $childDoc = $this->documents->get('file:///ChildClass.php');
+        self::assertNotNull($childDoc);
+        $childAst = $this->parser->parse($childDoc);
+        self::assertNotNull($childAst);
+        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Request definition at "doFoo" in parent::doFoo() on line 3
+        // "        parent::doFoo();" - doFoo starts at character 16
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///ChildClass.php'],
+                'position' => ['line' => 3, 'character' => 17],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        // Should go to ParentClass, not ChildClass
+        self::assertIsArray($result);
+        self::assertSame('file:///ParentClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
     }
 }

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -460,4 +460,144 @@ PHP;
         self::assertSame('file:///ParentClass.php', $result['uri']);
         self::assertSame(2, $result['range']['start']['line']);
     }
+
+    public function testGoToTraitMethodDefinition(): void
+    {
+        // Trait with method
+        $traitCode = <<<'PHP'
+<?php
+trait MyTrait {
+    public function traitMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///MyTrait.php', 'php', 1, $traitCode);
+        $traitDoc = $this->documents->get('file:///MyTrait.php');
+        self::assertNotNull($traitDoc);
+        $traitAst = $this->parser->parse($traitDoc);
+        self::assertNotNull($traitAst);
+        foreach ((new SymbolExtractor())->extract($traitDoc, $traitAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Class that uses the trait
+        $classCode = <<<'PHP'
+<?php
+class MyClass {
+    use MyTrait;
+}
+PHP;
+        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
+        $classDoc = $this->documents->get('file:///MyClass.php');
+        self::assertNotNull($classDoc);
+        $classAst = $this->parser->parse($classDoc);
+        self::assertNotNull($classAst);
+        foreach ((new SymbolExtractor())->extract($classDoc, $classAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Usage: $obj->traitMethod()
+        $usageCode = <<<'PHP'
+<?php
+function test(MyClass $obj): void {
+    $obj->traitMethod();
+}
+PHP;
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "traitMethod"
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 12],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        // Should go to the trait where the method is defined
+        self::assertIsArray($result);
+        self::assertSame('file:///MyTrait.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testTraitMethodTakesPrecedenceOverParent(): void
+    {
+        // Parent class with method
+        $parentCode = <<<'PHP'
+<?php
+class ParentClass {
+    public function sharedMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
+        $parentDoc = $this->documents->get('file:///ParentClass.php');
+        self::assertNotNull($parentDoc);
+        $parentAst = $this->parser->parse($parentDoc);
+        self::assertNotNull($parentAst);
+        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Trait with same method
+        $traitCode = <<<'PHP'
+<?php
+trait MyTrait {
+    public function sharedMethod(): void {}
+}
+PHP;
+        $this->documents->open('file:///MyTrait.php', 'php', 1, $traitCode);
+        $traitDoc = $this->documents->get('file:///MyTrait.php');
+        self::assertNotNull($traitDoc);
+        $traitAst = $this->parser->parse($traitDoc);
+        self::assertNotNull($traitAst);
+        foreach ((new SymbolExtractor())->extract($traitDoc, $traitAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Child class extends ParentClass and uses MyTrait
+        $childCode = <<<'PHP'
+<?php
+class ChildClass extends ParentClass {
+    use MyTrait;
+}
+PHP;
+        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
+        $childDoc = $this->documents->get('file:///ChildClass.php');
+        self::assertNotNull($childDoc);
+        $childAst = $this->parser->parse($childDoc);
+        self::assertNotNull($childAst);
+        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
+            $this->index->add($symbol);
+        }
+
+        // Usage: $obj->sharedMethod()
+        $usageCode = <<<'PHP'
+<?php
+function test(ChildClass $obj): void {
+    $obj->sharedMethod();
+}
+PHP;
+        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+
+        // Request definition at "sharedMethod"
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 12],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        // Should go to trait (trait takes precedence over parent in PHP)
+        self::assertIsArray($result);
+        self::assertSame('file:///MyTrait.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
 }

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -6,7 +6,6 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
-use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -28,11 +27,6 @@ class DefinitionHandlerTest extends TestCase
         $this->documents = new DocumentManager();
         $this->index = new SymbolIndex();
         $this->parser = new ParserService();
-        $indexer = new DocumentIndexer(
-            $this->parser,
-            new SymbolExtractor(),
-            $this->index,
-        );
         $this->handler = new DefinitionHandler(
             $this->documents,
             $this->parser,


### PR DESCRIPTION
Fixes #65

## Summary
- Extends go to definition to work on method names, not just class names
- Supports static calls (Foo::bar()), instance calls ($foo->bar()), and special keywords (parent::, self::, static::)
- Traverses inheritance chain to find where methods are actually defined (parent classes, traits)
- Correctly handles overridden methods (goes to the implementation matching the called type)

## Test plan
- [x] Foo::bar() - bar goes to static method definition
- [x] $foo->bar() where $foo has known type - bar goes to instance method
- [x] Inherited methods go to parent class definition
- [x] Overridden methods go to child class definition
- [x] parent::foo() goes to parent method, not current class
- [x] All existing tests pass
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.ai/code)