### PR TITLE
CI: set up PHPStan strict rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.0",
         "squizlabs/php_codesniffer": "^4.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+
 parameters:
     level: max
     paths:

--- a/src/Completion/ContextDetector.php
+++ b/src/Completion/ContextDetector.php
@@ -146,7 +146,7 @@ final class ContextDetector
      */
     private static function checkUnfinishedContext(array $tokens): bool
     {
-        if (empty($tokens)) {
+        if ($tokens === []) {
             return true;
         }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -119,33 +119,33 @@ final class CompletionHandler implements HandlerInterface
     private function getCompletionItems(string $textBeforeCursor, array $ast, TextDocument $document, int $line): array
     {
         // $this-> completion
-        if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             return $this->getThisMemberCompletions($prefix, $ast);
         }
 
         // $variable-> completion (typed variables, not $this)
-        if (preg_match('/\$(\w+)->(\w*)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/\$(\w+)->(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $variableName = $matches[1];
             $prefix = $matches[2];
             return $this->getTypedVariableMemberCompletions($variableName, $prefix, $ast, $line);
         }
 
         // Variable completion ($var)
-        if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             return $this->getVariableCompletions($prefix, $ast, $line);
         }
 
         // ClassName:: completion (static) - also match single : for mid-typing
-        if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $className = $matches[1];
             $prefix = $matches[2];
             return $this->getStaticCompletions($className, $prefix, $ast, $document);
         }
 
         // new ClassName completion - suggest imported classes and indexed instantiable types
-        if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             $items = $this->getImportedClassCompletions($prefix, $ast);
             $indexedItems = $this->getIndexedClassCompletions($prefix, [SymbolKind::Class_, SymbolKind::Enum_]);
@@ -155,7 +155,7 @@ final class CompletionHandler implements HandlerInterface
 
         // After visibility keyword - suggest function, static, readonly, const, or types
         // Must check before general type hint context since both patterns overlap
-        if (preg_match('/(?:public|private|protected)\s+(\w*)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/(?:public|private|protected)\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             $items = $this->getClassMemberKeywordCompletions($prefix);
             $items = array_merge($items, $this->getTypeHintCompletions($prefix, $ast));
@@ -164,14 +164,14 @@ final class CompletionHandler implements HandlerInterface
 
         // Type hint context - after : (return type), in parameters, union/intersection types
         // Matches: "): str", "(str", ", str", "?str", "|str", "&str"
-        if (preg_match('/[(:,?|&]\s*(\w*)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/[(:,?|&]\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             return $this->getTypeHintCompletions($prefix, $ast);
         }
 
         // Class body context - only class-level keywords, no functions
         if ($this->isInClassBody($textBeforeCursor)) {
-            if (preg_match('/(?:^|[\s{;])(\w+)$/', $textBeforeCursor, $matches)) {
+            if (preg_match('/(?:^|[\s{;])(\w+)$/', $textBeforeCursor, $matches) === 1) {
                 $prefix = $matches[1];
                 return $this->getClassBodyKeywordCompletions($prefix);
             }
@@ -179,7 +179,7 @@ final class CompletionHandler implements HandlerInterface
         }
 
         // Function/class/keyword completion (at start of expression or after operators)
-        if (preg_match('/(?:^|[(\s=,!&|])(\w+)$/', $textBeforeCursor, $matches)) {
+        if (preg_match('/(?:^|[(\s=,!&|])(\w+)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             $items = $this->getKeywordCompletions($prefix);
             $items = array_merge($items, $this->getFunctionCompletions($prefix, $ast));
@@ -1063,16 +1063,20 @@ final class CompletionHandler implements HandlerInterface
     {
         // Count braces to detect if we're inside a class body
         // This is a heuristic - look for class/interface/trait/enum followed by unbalanced {
-        if (!preg_match('/(?:class|interface|trait|enum)\s+\w+/', $textBeforeCursor)) {
+        if (preg_match('/(?:class|interface|trait|enum)\s+\w+/', $textBeforeCursor) !== 1) {
             return false;
         }
 
         // Count brace depth after the class declaration
+        $classPos = strrpos($textBeforeCursor, 'class ');
+        $interfacePos = strrpos($textBeforeCursor, 'interface ');
+        $traitPos = strrpos($textBeforeCursor, 'trait ');
+        $enumPos = strrpos($textBeforeCursor, 'enum ');
         $lastClassPos = max(
-            strrpos($textBeforeCursor, 'class ') ?: 0,
-            strrpos($textBeforeCursor, 'interface ') ?: 0,
-            strrpos($textBeforeCursor, 'trait ') ?: 0,
-            strrpos($textBeforeCursor, 'enum ') ?: 0,
+            $classPos !== false ? $classPos : 0,
+            $interfacePos !== false ? $interfacePos : 0,
+            $traitPos !== false ? $traitPos : 0,
+            $enumPos !== false ? $enumPos : 0,
         );
 
         $afterClass = substr($textBeforeCursor, $lastClassPos);

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -76,7 +76,7 @@ final class SymbolIndex
                     $this->byName[$symbol->name] ?? [],
                     fn(Symbol $s) => $s->fullyQualifiedName !== $fqn,
                 ));
-                if (empty($this->byName[$symbol->name])) {
+                if ($this->byName[$symbol->name] === []) {
                     unset($this->byName[$symbol->name]);
                 }
             }

--- a/src/Server.php
+++ b/src/Server.php
@@ -37,7 +37,8 @@ final class Server
         ?string $projectRoot = null,
     ) {
         // Use provided root, or fall back to cwd
-        $projectRoot ??= getcwd() ?: null;
+        $cwd = getcwd();
+        $projectRoot ??= $cwd !== false ? $cwd : null;
 
         $this->documentManager = new DocumentManager();
         $parser = new ParserService();

--- a/tests/Protocol/ResponseMessageTest.php
+++ b/tests/Protocol/ResponseMessageTest.php
@@ -91,25 +91,23 @@ class ResponseMessageTest extends TestCase
     }
 
     #[DataProvider('errorCodesProvider')]
-    public function testStandardErrorCodes(int $code, string $expectedMessage): void
+    public function testStandardErrorCodes(int $code, ResponseError $error): void
     {
-        $error = ResponseError::$expectedMessage();
-        assert($error instanceof ResponseError);
-
         self::assertSame($code, $error->code);
     }
 
     /**
-     * @return array<string, array{int, string}>
+     * @return array<string, array{int, ResponseError}>
+     * @codeCoverageIgnore
      */
     public static function errorCodesProvider(): array
     {
         return [
-            'parseError' => [-32700, 'parseError'],
-            'invalidRequest' => [-32600, 'invalidRequest'],
-            'methodNotFound' => [-32601, 'methodNotFound'],
-            'invalidParams' => [-32602, 'invalidParams'],
-            'internalError' => [-32603, 'internalError'],
+            'parseError' => [-32700, ResponseError::parseError()],
+            'invalidRequest' => [-32600, ResponseError::invalidRequest()],
+            'methodNotFound' => [-32601, ResponseError::methodNotFound()],
+            'invalidParams' => [-32602, ResponseError::invalidParams()],
+            'internalError' => [-32603, ResponseError::internalError()],
         ];
     }
 


### PR DESCRIPTION
## Summary
- Adds `phpstan/phpstan-strict-rules` to catch issues like unused parameters, loose comparisons, and variable method calls
- Fixes all 18 violations found by the strict rules:
  - Replace `empty()` with strict array comparisons
  - Add explicit `=== 1` checks for `preg_match` conditions
  - Replace short ternaries with explicit false checks
  - Refactor test to avoid variable static method calls

Closes #69

## Test plan
- [x] `composer check` passes

🤖 Generated with [Claude Code](https://claude.ai/code)