### PR TITLE
Fix: Completion for parent:: methods

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -137,6 +137,12 @@ final class CompletionHandler implements HandlerInterface
             return $this->getVariableCompletions($prefix, $ast, $line);
         }
 
+        // parent:: completion - methods from parent class
+        if (preg_match('/\bparent::(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            $prefix = $matches[1];
+            return $this->getParentCompletions($prefix, $ast, $line);
+        }
+
         // ClassName:: completion (static) - also match single : for mid-typing
         if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $className = $matches[1];
@@ -234,6 +240,82 @@ final class CompletionHandler implements HandlerInterface
         $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
         if ($className !== null) {
             $items = array_merge($items, $this->getInheritedMemberCompletions($className, $prefix, $items));
+        }
+
+        return $items;
+    }
+
+    /**
+     * Get completions for parent:: - methods from the parent class.
+     *
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getParentCompletions(string $prefix, array $ast, int $line): array
+    {
+        $classNode = $this->findClassAtLine($ast, $line);
+        if ($classNode === null || $classNode->extends === null) {
+            return [];
+        }
+
+        $parentClassName = $classNode->extends->toString();
+
+        // Resolve the parent class name if it's in the same file
+        $parentClassNode = ClassFinder::findWithLocator(
+            $parentClassName,
+            $ast,
+            $this->classLocator,
+            $this->parser,
+        );
+
+        $items = [];
+
+        if ($parentClassNode !== null) {
+            foreach ($parentClassNode->stmts as $stmt) {
+                // Methods (public and protected, both static and non-static)
+                if ($stmt instanceof Stmt\ClassMethod) {
+                    if ($stmt->isPrivate()) {
+                        continue;
+                    }
+                    $name = $stmt->name->toString();
+                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                        $items[] = $this->formatMethodCompletion($stmt);
+                    }
+                }
+            }
+        }
+
+        // Also check via reflection for inherited/built-in classes
+        $items = array_merge($items, $this->getParentReflectionCompletions($parentClassName, $prefix, $items));
+
+        return $items;
+    }
+
+    /**
+     * Get parent class methods via reflection.
+     *
+     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getParentReflectionCompletions(string $className, string $prefix, array $existingItems): array
+    {
+        $reflection = ReflectionHelper::getClass($className);
+        if ($reflection === null) {
+            return [];
+        }
+
+        $existingLabels = array_column($existingItems, 'label');
+        $items = [];
+
+        // Public and protected methods (both static and non-static)
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
+            $name = $method->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
+            }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionMethodCompletion($method);
+            }
         }
 
         return $items;
@@ -484,6 +566,45 @@ final class CompletionHandler implements HandlerInterface
             }
         }
         return null;
+    }
+
+    /**
+     * Find the class containing the given line.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function findClassAtLine(array $ast, int $line): ?Stmt\Class_
+    {
+        $visitor = new class ($line) extends NodeVisitorAbstract {
+            public ?Stmt\Class_ $found = null;
+
+            public function __construct(private readonly int $line)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Class_) {
+                    $startLine = $node->getStartLine();
+                    $endLine = $node->getEndLine();
+
+                    if (
+                        $startLine !== -1 && $endLine !== -1
+                        && $this->line >= $startLine - 1
+                        && $this->line <= $endLine - 1
+                    ) {
+                        $this->found = $node;
+                    }
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->found;
     }
 
     /**

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1523,6 +1523,85 @@ PHP;
         self::assertNotContains('getPassword', $labels);
     }
 
+    public function testParentMethodCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    public function __construct(string $name) {}
+    protected function greet(): string { return 'Hello'; }
+}
+
+class ChildClass extends ParentClass
+{
+    public function __construct(string $name)
+    {
+        parent::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 11, 'character' => 16], // After parent::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('__construct', $labels);
+        self::assertContains('greet', $labels);
+    }
+
+    public function testParentMethodCompletionWithPrefix(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    public function __construct() {}
+    protected function greet(): string { return 'Hello'; }
+    protected function goodbye(): string { return 'Bye'; }
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        parent::gr
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 18], // After parent::gr
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('greet', $labels);
+        self::assertNotContains('goodbye', $labels);
+        self::assertNotContains('__construct', $labels);
+    }
+
     public function testTypedVariableCompletionReturnsEmptyWithoutTypeResolver(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1562,6 +1562,37 @@ PHP;
         self::assertContains('greet', $labels);
     }
 
+    public function testParentMethodCompletionReturnsEmptyWhenNoParent(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    public function test(): void
+    {
+        parent::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 5, 'character' => 16], // After parent::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        self::assertEmpty($result['items']);
+    }
+
     public function testParentMethodCompletionWithPrefix(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
- Adds autocompletion support for parent:: method calls (fixes #77)
- Detects parent:: context and resolves the parent class to suggest its public/protected methods
- Adds findClassAtLine() to correctly identify the enclosing class when multiple classes exist in a file

## Test plan
- [x] Added tests for parent:: completion with and without prefix
- [x] All existing tests pass
- [x] PHPStan clean

Generated with Claude Code