### PR TITLE
Fix self:: completion for class constants

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -141,7 +141,7 @@ final class CompletionHandler implements HandlerInterface
         if (preg_match('/\b(?:self|static)::(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $classNode = $this->findFirstClass($ast);
             if ($classNode !== null) {
-                $className = $classNode->name?->toString() ?? '';
+                $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString() ?? '';
                 $prefix = $matches[1];
                 return $this->getStaticCompletions($className, $prefix, $ast, $document);
             }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -137,6 +137,17 @@ final class CompletionHandler implements HandlerInterface
             return $this->getVariableCompletions($prefix, $ast, $line);
         }
 
+        // self::, parent::, static:: completion - resolve to enclosing class
+        if (preg_match('/\b(self|parent|static)::(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            $classNode = $this->findFirstClass($ast);
+            if ($classNode !== null) {
+                $className = $classNode->name?->toString() ?? '';
+                $prefix = $matches[2];
+                return $this->getStaticCompletions($className, $prefix, $ast, $document);
+            }
+            return [];
+        }
+
         // ClassName:: completion (static) - also match single : for mid-typing
         if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $className = $matches[1];

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -141,7 +141,11 @@ final class CompletionHandler implements HandlerInterface
         if (preg_match('/\b(?:self|static)::(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $classNode = $this->findFirstClass($ast);
             if ($classNode !== null) {
-                $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString() ?? '';
+                $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+                if ($className === null) {
+                    // Anonymous class - no completions available
+                    return [];
+                }
                 $prefix = $matches[1];
                 return $this->getStaticCompletions($className, $prefix, $ast, $document);
             }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -139,7 +139,7 @@ final class CompletionHandler implements HandlerInterface
 
         // self:: and static:: completion - resolve to enclosing class
         if (preg_match('/\b(?:self|static)::(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $classNode = $this->findFirstClass($ast);
+            $classNode = $this->findClassAtLine($ast, $line);
             if ($classNode !== null) {
                 $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
                 if ($className === null) {

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1560,6 +1560,45 @@ PHP;
         self::assertContains('class', $labels);
     }
 
+    public function testSelfConstantCompletionNamespaced(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class Foo
+{
+    public const FOO = 'foo';
+    public const BAR = 'bar';
+
+    public function thing(): string
+    {
+        return self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 21], // After self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('FOO', $labels);
+        self::assertContains('BAR', $labels);
+        self::assertContains('class', $labels);
+    }
+
     public function testParentMethodCompletion(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1636,6 +1636,43 @@ PHP;
         self::assertContains('class', $labels);
     }
 
+    public function testSelfConstantCompletionWithPrefix(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Foo
+{
+    public const FOO = 'foo';
+    public const BAR = 'bar';
+
+    public function thing(): string
+    {
+        return self::FO
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 23], // After self::FO
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('FOO', $labels);
+        self::assertNotContains('BAR', $labels);
+        self::assertNotContains('class', $labels);
+    }
+
     public function testParentMethodCompletion(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1817,6 +1817,34 @@ PHP;
         self::assertNotContains('instanceProp', $labels);
     }
 
+    public function testSelfCompletionOutsideClassReturnsEmpty(): void
+    {
+        $code = <<<'PHP'
+<?php
+function foo(): void
+{
+    self::
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 10], // After self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        self::assertEmpty($result['items']);
+    }
+
     public function testParentMethodCompletion(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1599,6 +1599,43 @@ PHP;
         self::assertContains('class', $labels);
     }
 
+    public function testStaticConstantCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Foo
+{
+    public const FOO = 'foo';
+    public const BAR = 'bar';
+
+    public function thing(): string
+    {
+        return static::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 23], // After static::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('FOO', $labels);
+        self::assertContains('BAR', $labels);
+        self::assertContains('class', $labels);
+    }
+
     public function testParentMethodCompletion(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1673,6 +1673,38 @@ PHP;
         self::assertNotContains('class', $labels);
     }
 
+    public function testSelfCompletionInAnonymousClassReturnsEmpty(): void
+    {
+        $code = <<<'PHP'
+<?php
+$obj = new class {
+    public const FOO = 'foo';
+
+    public function thing(): string
+    {
+        return self::
+    }
+};
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 6, 'character' => 21], // After self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        self::assertEmpty($result['items']);
+    }
+
     public function testParentMethodCompletion(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1705,6 +1705,118 @@ PHP;
         self::assertEmpty($result['items']);
     }
 
+    public function testSelfCompletionInMultiClassFile(): void
+    {
+        $code = <<<'PHP'
+<?php
+class First
+{
+    public const FIRST_CONST = 1;
+}
+
+class Second
+{
+    public const SECOND_CONST = 2;
+
+    public function thing(): int
+    {
+        return self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 21], // After self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('SECOND_CONST', $labels);
+        self::assertNotContains('FIRST_CONST', $labels);
+    }
+
+    public function testSelfStaticMethodCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Foo
+{
+    public static function staticMethod(): void {}
+    public function instanceMethod(): void {}
+
+    public function thing(): void
+    {
+        self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 14], // After self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('staticMethod', $labels);
+        self::assertNotContains('instanceMethod', $labels);
+    }
+
+    public function testSelfStaticPropertyCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Foo
+{
+    public static string $staticProp = 'static';
+    public string $instanceProp = 'instance';
+
+    public function thing(): void
+    {
+        self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 14], // After self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('staticProp', $labels);
+        self::assertNotContains('instanceProp', $labels);
+    }
+
     public function testParentMethodCompletion(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1523,6 +1523,43 @@ PHP;
         self::assertNotContains('getPassword', $labels);
     }
 
+    public function testSelfConstantCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Foo
+{
+    public const FOO = 'foo';
+    public const BAR = 'bar';
+
+    public function thing(): string
+    {
+        return self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 8, 'character' => 21], // After self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('FOO', $labels);
+        self::assertContains('BAR', $labels);
+        self::assertContains('class', $labels);
+    }
+
     public function testTypedVariableCompletionReturnsEmptyWithoutTypeResolver(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
- Adds completion support for `self::` and `static::` keywords
- Resolves these to the enclosing class and returns constants, static methods, and static properties

Fixes #76

## Test plan
- [x] Added test for `self::` constant completion
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)