### PR TITLE
Hover: Support inherited methods and properties

### DIFF
--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -475,11 +475,8 @@ final class HoverHandler implements HandlerInterface
         }
 
         // Check parent class (only non-private members are inherited)
-        if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $resolvedName = $classNode->extends->getAttribute('resolvedName');
-            $parentName = $resolvedName instanceof Name
-                ? $resolvedName->toString()
-                : $classNode->extends->toString();
+        $parentName = $this->getParentClassName($classNode);
+        if ($parentName !== null) {
             $parentMethod = $this->findMethodInClass($parentName, $methodName, $ast, $document);
             if ($parentMethod !== null && !$parentMethod->isPrivate()) {
                 return $parentMethod;
@@ -514,11 +511,8 @@ final class HoverHandler implements HandlerInterface
         }
 
         // Check parent class (only non-private members are inherited)
-        if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $resolvedName = $classNode->extends->getAttribute('resolvedName');
-            $parentName = $resolvedName instanceof Name
-                ? $resolvedName->toString()
-                : $classNode->extends->toString();
+        $parentName = $this->getParentClassName($classNode);
+        if ($parentName !== null) {
             $parentProperty = $this->findPropertyInClass($parentName, $propertyName, $ast, $document);
             if ($parentProperty !== null && !$parentProperty->isPrivate()) {
                 return $parentProperty;
@@ -526,6 +520,18 @@ final class HoverHandler implements HandlerInterface
         }
 
         return null;
+    }
+
+    private function getParentClassName(
+        Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $classNode,
+    ): ?string {
+        if (!$classNode instanceof Stmt\Class_ || $classNode->extends === null) {
+            return null;
+        }
+        $resolvedName = $classNode->extends->getAttribute('resolvedName');
+        return $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $classNode->extends->toString();
     }
 
     private function formatMethodHover(Stmt\ClassMethod $method): string

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -474,6 +474,12 @@ final class HoverHandler implements HandlerInterface
             }
         }
 
+        // Check parent class
+        if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
+            $parentName = $classNode->extends->toString();
+            return $this->findMethodInClass($parentName, $methodName, $ast, $document);
+        }
+
         return null;
     }
 
@@ -499,6 +505,12 @@ final class HoverHandler implements HandlerInterface
                     }
                 }
             }
+        }
+
+        // Check parent class
+        if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
+            $parentName = $classNode->extends->toString();
+            return $this->findPropertyInClass($parentName, $propertyName, $ast, $document);
         }
 
         return null;

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -474,10 +474,16 @@ final class HoverHandler implements HandlerInterface
             }
         }
 
-        // Check parent class
+        // Check parent class (only non-private members are inherited)
         if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $parentName = $classNode->extends->toString();
-            return $this->findMethodInClass($parentName, $methodName, $ast, $document);
+            $resolvedName = $classNode->extends->getAttribute('resolvedName');
+            $parentName = $resolvedName instanceof Name
+                ? $resolvedName->toString()
+                : $classNode->extends->toString();
+            $parentMethod = $this->findMethodInClass($parentName, $methodName, $ast, $document);
+            if ($parentMethod !== null && !$parentMethod->isPrivate()) {
+                return $parentMethod;
+            }
         }
 
         return null;
@@ -507,10 +513,16 @@ final class HoverHandler implements HandlerInterface
             }
         }
 
-        // Check parent class
+        // Check parent class (only non-private members are inherited)
         if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $parentName = $classNode->extends->toString();
-            return $this->findPropertyInClass($parentName, $propertyName, $ast, $document);
+            $resolvedName = $classNode->extends->getAttribute('resolvedName');
+            $parentName = $resolvedName instanceof Name
+                ? $resolvedName->toString()
+                : $classNode->extends->toString();
+            $parentProperty = $this->findPropertyInClass($parentName, $propertyName, $ast, $document);
+            if ($parentProperty !== null && !$parentProperty->isPrivate()) {
+                return $parentProperty;
+            }
         }
 
         return null;

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -384,7 +384,7 @@ final class HoverHandler implements HandlerInterface
         TextDocument $document,
     ): ?string {
         // Try to find in AST first (current file or via Composer)
-        $methodNode = $this->findMethodInClass($className, $methodName, $ast, $document);
+        $methodNode = $this->findMethodInClass($className, $methodName, $ast);
         if ($methodNode !== null) {
             return $this->formatMethodHover($methodNode);
         }
@@ -403,7 +403,7 @@ final class HoverHandler implements HandlerInterface
         TextDocument $document,
     ): ?string {
         // Try to find in AST first
-        $propertyNode = $this->findPropertyInClass($className, $propertyName, $ast, $document);
+        $propertyNode = $this->findPropertyInClass($className, $propertyName, $ast);
         if ($propertyNode !== null) {
             return $this->formatPropertyHover($propertyNode, $propertyName);
         }
@@ -461,7 +461,6 @@ final class HoverHandler implements HandlerInterface
         string $className,
         string $methodName,
         array $ast,
-        TextDocument $document,
     ): ?Stmt\ClassMethod {
         $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
@@ -477,7 +476,7 @@ final class HoverHandler implements HandlerInterface
         // Check parent class (only non-private members are inherited)
         $parentName = $this->getParentClassName($classNode);
         if ($parentName !== null) {
-            $parentMethod = $this->findMethodInClass($parentName, $methodName, $ast, $document);
+            $parentMethod = $this->findMethodInClass($parentName, $methodName, $ast);
             if ($parentMethod !== null && !$parentMethod->isPrivate()) {
                 return $parentMethod;
             }
@@ -493,7 +492,6 @@ final class HoverHandler implements HandlerInterface
         string $className,
         string $propertyName,
         array $ast,
-        TextDocument $document,
     ): ?Stmt\Property {
         $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
         if ($classNode === null) {
@@ -513,7 +511,7 @@ final class HoverHandler implements HandlerInterface
         // Check parent class (only non-private members are inherited)
         $parentName = $this->getParentClassName($classNode);
         if ($parentName !== null) {
-            $parentProperty = $this->findPropertyInClass($parentName, $propertyName, $ast, $document);
+            $parentProperty = $this->findPropertyInClass($parentName, $propertyName, $ast);
             if ($parentProperty !== null && !$parentProperty->isPrivate()) {
                 return $parentProperty;
             }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -584,4 +584,125 @@ PHP;
         self::assertStringContainsString('parentMethod', $result['contents']);
         self::assertStringContainsString('Namespaced parent method', $result['contents']);
     }
+
+    public function testHoverOnInheritedMethodAcrossNamespaces(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace Base;
+
+class ParentClass
+{
+    /**
+     * Method from Base namespace.
+     */
+    public function baseMethod(): void {}
+}
+
+namespace App;
+
+use Base\ParentClass;
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->baseMethod();
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 20, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('baseMethod', $result['contents']);
+        self::assertStringContainsString('Method from Base namespace', $result['contents']);
+    }
+
+    public function testHoverOnPrivateInheritedMethodReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    /**
+     * Private parent method.
+     */
+    private function privateMethod(): void {}
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->privateMethod();
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 13, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        // Private methods are not inherited, so hover should return null
+        self::assertNull($result);
+    }
+
+    public function testHoverOnPrivateInheritedPropertyReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    /**
+     * Private parent property.
+     */
+    private string $privateProperty;
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->privateProperty;
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 13, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        // Private properties are not inherited, so hover should return null
+        self::assertNull($result);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -543,4 +543,45 @@ PHP;
         self::assertStringContainsString('$grandparentProperty', $result['contents']);
         self::assertStringContainsString('Grandparent property docs', $result['contents']);
     }
+
+    public function testHoverOnInheritedMethodWithNamespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App;
+
+class ParentClass
+{
+    /**
+     * Namespaced parent method.
+     */
+    public function parentMethod(): void {}
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->parentMethod();
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('parentMethod', $result['contents']);
+        self::assertStringContainsString('Namespaced parent method', $result['contents']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -619,7 +619,7 @@ PHP;
             'method' => 'textDocument/hover',
             'params' => [
                 'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 20, 'character' => 16],
+                'position' => ['line' => 19, 'character' => 16],
             ],
         ]);
 

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -379,4 +379,82 @@ PHP;
         self::assertStringContainsString('greet', $result['contents']);
         self::assertStringContainsString('Greets a person', $result['contents']);
     }
+
+    public function testHoverOnInheritedMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    /**
+     * Parent method docs.
+     */
+    public function parentMethod(): void {}
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->parentMethod();
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 13, 'character' => 16], // On "parentMethod"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('parentMethod', $result['contents']);
+        self::assertStringContainsString('Parent method docs', $result['contents']);
+    }
+
+    public function testHoverOnInheritedProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    /**
+     * Parent property docs.
+     */
+    protected string $parentProperty;
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->parentProperty;
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 13, 'character' => 16], // On "parentProperty"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$parentProperty', $result['contents']);
+        self::assertStringContainsString('Parent property docs', $result['contents']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -705,4 +705,94 @@ PHP;
         // Private properties are not inherited, so hover should return null
         self::assertNull($result);
     }
+
+    public function testHoverOnOverriddenMethodShowsChildVersion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    /**
+     * Parent implementation.
+     */
+    public function sharedMethod(): void {}
+}
+
+class ChildClass extends ParentClass
+{
+    /**
+     * Child implementation.
+     */
+    public function sharedMethod(): void {}
+
+    public function test(): void
+    {
+        $this->sharedMethod();
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 18, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('sharedMethod', $result['contents']);
+        self::assertStringContainsString('Child implementation', $result['contents']);
+        self::assertStringNotContainsString('Parent implementation', $result['contents']);
+    }
+
+    public function testHoverOnOverriddenPropertyShowsChildVersion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    /**
+     * Parent property.
+     */
+    protected string $sharedProperty;
+}
+
+class ChildClass extends ParentClass
+{
+    /**
+     * Child property.
+     */
+    protected string $sharedProperty;
+
+    public function test(): void
+    {
+        $this->sharedProperty;
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 18, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$sharedProperty', $result['contents']);
+        self::assertStringContainsString('Child property', $result['contents']);
+        self::assertStringNotContainsString('Parent property', $result['contents']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -457,4 +457,90 @@ PHP;
         self::assertStringContainsString('$parentProperty', $result['contents']);
         self::assertStringContainsString('Parent property docs', $result['contents']);
     }
+
+    public function testHoverOnMultiLevelInheritedMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+class GrandparentClass
+{
+    /**
+     * Grandparent method docs.
+     */
+    public function grandparentMethod(): void {}
+}
+
+class ParentClass extends GrandparentClass
+{
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->grandparentMethod();
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 17, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('grandparentMethod', $result['contents']);
+        self::assertStringContainsString('Grandparent method docs', $result['contents']);
+    }
+
+    public function testHoverOnMultiLevelInheritedProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class GrandparentClass
+{
+    /**
+     * Grandparent property docs.
+     */
+    protected string $grandparentProperty;
+}
+
+class ParentClass extends GrandparentClass
+{
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        $this->grandparentProperty;
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 17, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$grandparentProperty', $result['contents']);
+        self::assertStringContainsString('Grandparent property docs', $result['contents']);
+    }
 }


### PR DESCRIPTION
## Summary
- Traverse inheritance hierarchy when looking up methods and properties for hover
- When a method/property isn't found in the immediate class, recursively check parent classes via extends

Closes #7

## Test plan
- [x] Added testHoverOnInheritedMethod - verifies hover on $this->parentMethod() shows parent class method info
- [x] Added testHoverOnInheritedProperty - verifies hover on $this->parentProperty shows parent class property info
- [x] Added testHoverOnMultiLevelInheritedMethod - verifies recursion through grandparent classes
- [x] Added testHoverOnMultiLevelInheritedProperty - verifies property lookup through grandparent classes
- [x] Added testHoverOnInheritedMethodWithNamespace - verifies name resolution works in namespaced code
- [x] All existing tests pass

Generated with Claude Code