### PR TITLE
Upgrade PHPUnit to 12.5.22 to fix security advisory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^12.5.22",
         "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

- Upgrades PHPUnit from ^11.0 to ^12.5.22
- Fixes security advisory PKSA-5jz8-6tcw-pbk4 (argument injection via newline in PHP INI values)
- Advisory affects all PHPUnit versions <= 12.5.21

## Test plan

- [x] All tests pass locally
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)