### PR TITLE
Completion: Support constructor property promotion

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -18,9 +18,11 @@ use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -260,6 +262,24 @@ final class CompletionHandler implements HandlerInterface
                 if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
                     $items[] = $this->formatMethodCompletion($stmt);
                 }
+
+                // Check for promoted properties in constructor
+                if ($stmt->name->toLowerString() === '__construct') {
+                    foreach ($stmt->params as $param) {
+                        if (!$this->isPromotedProperty($param) || !$param->var instanceof Variable) {
+                            continue;
+                        }
+                        $name = $param->var->name;
+                        if (!is_string($name)) {
+                            continue;
+                        }
+                        $matchesPrefix = $prefix === ''
+                            || str_starts_with(strtolower($name), strtolower($prefix));
+                        if ($matchesPrefix) {
+                            $items[] = $this->formatPromotedPropertyCompletion($param);
+                        }
+                    }
+                }
             }
 
             // Properties
@@ -411,6 +431,27 @@ final class CompletionHandler implements HandlerInterface
                     $name = $stmt->name->toString();
                     if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
                         $items[] = $this->formatMethodCompletion($stmt);
+                    }
+                }
+
+                // Check for public promoted properties in constructor
+                if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toLowerString() === '__construct') {
+                    foreach ($stmt->params as $param) {
+                        $isPublicPromoted = $this->isPromotedProperty($param)
+                            && ($param->flags & Modifiers::PUBLIC) !== 0
+                            && $param->var instanceof Variable;
+                        if (!$isPublicPromoted) {
+                            continue;
+                        }
+                        $name = $param->var->name;
+                        if (!is_string($name)) {
+                            continue;
+                        }
+                        $matchesPrefix = $prefix === ''
+                            || str_starts_with(strtolower($name), strtolower($prefix));
+                        if ($matchesPrefix) {
+                            $items[] = $this->formatPromotedPropertyCompletion($param);
+                        }
                     }
                 }
 
@@ -784,6 +825,37 @@ final class CompletionHandler implements HandlerInterface
         ];
 
         $docComment = $property->getDocComment();
+        if ($docComment !== null) {
+            $doc = DocblockParser::extractDescription($docComment->getText());
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+
+        return $item;
+    }
+
+    private function isPromotedProperty(Param $param): bool
+    {
+        return ($param->flags & Modifiers::VISIBILITY_MASK) !== 0;
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail: string, documentation?: string}
+     */
+    private function formatPromotedPropertyCompletion(Param $param): array
+    {
+        assert($param->var instanceof Variable);
+        $name = is_string($param->var->name) ? $param->var->name : '';
+        $type = $param->type !== null ? TypeFormatter::formatNode($param->type) : 'mixed';
+
+        $item = [
+            'label' => $name,
+            'kind' => self::KIND_PROPERTY,
+            'detail' => $type . ' $' . $name,
+        ];
+
+        $docComment = $param->getDocComment();
         if ($docComment !== null) {
             $doc = DocblockParser::extractDescription($docComment->getText());
             if ($doc !== '') {

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2381,4 +2381,568 @@ PHP;
         self::assertNotContains('PHP_VERSION', $labels);
         self::assertNotContains('PHP_INT_MAX', $labels);
     }
+
+    // ==================== Constructor Property Promotion Tests ====================
+
+    public function testThisCompletionIncludesPromotedProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string $name,
+        private int $age,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('name', $labels);
+        self::assertContains('age', $labels);
+        self::assertContains('greet', $labels);
+    }
+
+    public function testThisCompletionIncludesMixedPromotedAndRegularProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    private string $email;
+
+    public function __construct(
+        private string $name,
+        private int $age,
+    ) {
+        $this->email = 'test@example.com';
+    }
+
+    public function info(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Regular property
+        self::assertContains('email', $labels);
+        // Promoted properties
+        self::assertContains('name', $labels);
+        self::assertContains('age', $labels);
+    }
+
+    public function testThisCompletionWithPrefixFiltersPromotedProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string $name,
+        private string $nickname,
+        private int $age,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->na
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 11, 'character' => 17],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('name', $labels);
+        self::assertContains('nickname', $labels);
+        self::assertNotContains('age', $labels);
+    }
+
+    public function testThisCompletionIncludesAllVisibilityPromotedProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        public string $publicName,
+        protected string $protectedName,
+        private string $privateName,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 11, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('publicName', $labels);
+        self::assertContains('protectedName', $labels);
+        self::assertContains('privateName', $labels);
+    }
+
+    public function testThisCompletionIncludesReadonlyPromotedProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly int $age,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('name', $labels);
+        self::assertContains('age', $labels);
+    }
+
+    public function testPromotedPropertyCompletionShowsTypeInDetail(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string $name,
+        private int $age,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $items = $result['items'];
+
+        $nameItem = null;
+        $ageItem = null;
+        foreach ($items as $item) {
+            if ($item['label'] === 'name') {
+                $nameItem = $item;
+            }
+            if ($item['label'] === 'age') {
+                $ageItem = $item;
+            }
+        }
+
+        self::assertNotNull($nameItem, 'name property should be in completions');
+        self::assertNotNull($ageItem, 'age property should be in completions');
+        self::assertStringContainsString('string', $nameItem['detail'] ?? '');
+        self::assertStringContainsString('int', $ageItem['detail'] ?? '');
+    }
+
+    public function testExternalAccessShowsOnlyPublicPromotedProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        public string $publicName,
+        protected string $protectedName,
+        private string $privateName,
+    ) {}
+}
+
+function foo(User $user): void
+{
+    $user->
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            null,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 11],
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Public promoted property should be included
+        self::assertContains('publicName', $labels);
+        // Protected and private promoted properties should be excluded
+        self::assertNotContains('protectedName', $labels);
+        self::assertNotContains('privateName', $labels);
+    }
+
+    public function testStaticContextExcludesPromotedProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public const STATUS_ACTIVE = 'active';
+
+    public function __construct(
+        private string $name,
+        private int $age,
+    ) {}
+
+    public function greet(): void
+    {
+        self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 14],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Constant should be included
+        self::assertContains('STATUS_ACTIVE', $labels);
+        // Promoted properties should NOT be in static context
+        self::assertNotContains('name', $labels);
+        self::assertNotContains('age', $labels);
+    }
+
+    public function testPromotedPropertiesNotDuplicatedWithRegularProperties(): void
+    {
+        // Edge case: someone might define both a promoted property and a regular property
+        // with the same name (invalid PHP, but we should handle gracefully)
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string $name,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Count occurrences of 'name' - should only appear once
+        $nameCount = array_count_values($labels)['name'] ?? 0;
+        self::assertSame(1, $nameCount, 'Promoted property should appear exactly once');
+    }
+
+    public function testPromotedPropertyWithDefaultValue(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string $name = 'Anonymous',
+        private int $age = 0,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('name', $labels);
+        self::assertContains('age', $labels);
+    }
+
+    public function testNonPromotedConstructorParametersNotIncludedAsProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    private string $fullName;
+
+    public function __construct(
+        string $firstName,
+        string $lastName,
+        private int $age,
+    ) {
+        $this->fullName = $firstName . ' ' . $lastName;
+    }
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Regular property should be included
+        self::assertContains('fullName', $labels);
+        // Promoted property should be included
+        self::assertContains('age', $labels);
+        // Non-promoted parameters should NOT be included as properties
+        self::assertNotContains('firstName', $labels);
+        self::assertNotContains('lastName', $labels);
+    }
+
+    public function testPromotedPropertyWithNullableType(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private ?string $nickname,
+        private ?int $age = null,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('nickname', $labels);
+        self::assertContains('age', $labels);
+
+        // Check type info includes nullable marker
+        $items = $result['items'];
+        $nicknameItem = null;
+        foreach ($items as $item) {
+            if ($item['label'] === 'nickname') {
+                $nicknameItem = $item;
+                break;
+            }
+        }
+        self::assertNotNull($nicknameItem);
+        self::assertStringContainsString('?string', $nicknameItem['detail'] ?? '');
+    }
+
+    public function testPromotedPropertyWithUnionType(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string|int $id,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('id', $labels);
+
+        // Check type info includes union type
+        $items = $result['items'];
+        $idItem = null;
+        foreach ($items as $item) {
+            if ($item['label'] === 'id') {
+                $idItem = $item;
+                break;
+            }
+        }
+        self::assertNotNull($idItem);
+        $detail = $idItem['detail'] ?? '';
+        self::assertTrue(
+            str_contains($detail, 'string|int') || str_contains($detail, 'int|string'),
+            "Expected detail to contain 'string|int' or 'int|string', got: $detail"
+        );
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2945,4 +2945,104 @@ PHP;
             "Expected detail to contain 'string|int' or 'int|string', got: $detail"
         );
     }
+
+    public function testPromotedPropertyWithIntersectionType(): void
+    {
+        $code = <<<'PHP'
+<?php
+interface Foo {}
+interface Bar {}
+
+class User
+{
+    public function __construct(
+        private Foo&Bar $service,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('service', $labels);
+
+        $items = $result['items'];
+        $serviceItem = null;
+        foreach ($items as $item) {
+            if ($item['label'] === 'service') {
+                $serviceItem = $item;
+                break;
+            }
+        }
+        self::assertNotNull($serviceItem);
+        $detail = $serviceItem['detail'] ?? '';
+        self::assertTrue(
+            str_contains($detail, 'Foo&Bar') || str_contains($detail, 'Bar&Foo'),
+            "Expected detail to contain intersection type, got: $detail"
+        );
+    }
+
+    public function testPromotedPropertyDocblockExtraction(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        /** The user's display name. */
+        private string $name,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $items = $result['items'];
+
+        $nameItem = null;
+        foreach ($items as $item) {
+            if ($item['label'] === 'name') {
+                $nameItem = $item;
+                break;
+            }
+        }
+        self::assertNotNull($nameItem, 'name property should be in completions');
+        self::assertArrayHasKey('documentation', $nameItem);
+        $doc = $nameItem['documentation'] ?? '';
+        self::assertStringContainsString('display name', $doc);
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -3045,4 +3045,113 @@ PHP;
         $doc = $nameItem['documentation'] ?? '';
         self::assertStringContainsString('display name', $doc);
     }
+
+    public function testPromotedPropertyCompletionInsideConstructorBody(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string $name,
+        private int $age,
+    ) {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('name', $labels);
+        self::assertContains('age', $labels);
+    }
+
+    public function testPromotedPropertyWithAttribute(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        #[\SensitiveParameter]
+        private string $password,
+    ) {}
+
+    public function greet(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('password', $labels);
+    }
+
+    public function testPromotedPropertyWithVariadicNonPromotedParam(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TaggedItem
+{
+    public function __construct(
+        private string $name,
+        string ...$tags,
+    ) {}
+
+    public function info(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Promoted property should be included
+        self::assertContains('name', $labels);
+        // Variadic non-promoted param should NOT be a property
+        self::assertNotContains('tags', $labels);
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2474,13 +2474,13 @@ class User
 {
     public function __construct(
         private string $name,
-        private string $nickname,
+        private string $number,
         private int $age,
     ) {}
 
     public function greet(): void
     {
-        $this->na
+        $this->n
     }
 }
 PHP;
@@ -2492,7 +2492,7 @@ PHP;
             'method' => 'textDocument/completion',
             'params' => [
                 'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 11, 'character' => 17],
+                'position' => ['line' => 11, 'character' => 16],
             ],
         ]);
 
@@ -2501,7 +2501,7 @@ PHP;
         self::assertIsArray($result);
         $labels = array_column($result['items'], 'label');
         self::assertContains('name', $labels);
-        self::assertContains('nickname', $labels);
+        self::assertContains('number', $labels);
         self::assertNotContains('age', $labels);
     }
 


### PR DESCRIPTION
## Summary
- Add support for constructor property promotion in `$this->` completions
- Add support for public promoted properties in external access (`$obj->`) completions
- Scan constructor parameters with visibility flags and treat them as properties

Fixes #92

## Test plan
- [x] Basic `$this->` completion includes promoted properties
- [x] Mixed promoted and regular properties both appear
- [x] Prefix filtering works for promoted properties
- [x] All visibility levels (public/protected/private) appear in `$this->` context
- [x] Only public promoted properties appear in external access
- [x] Static context (`self::`) excludes promoted properties
- [x] Type info shown in detail (nullable, union, intersection)
- [x] Docblock extraction works
- [x] Non-promoted constructor params not included as properties
- [x] Readonly modifier works
- [x] Attributes on promoted properties work
- [x] Completion inside constructor body works
- [x] Variadic non-promoted params excluded

🤖 Generated with [Claude Code](https://claude.ai/code)