### PR TITLE
Extract shared type resolution utility

### DIFF
--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -15,11 +15,11 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
+use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -172,7 +172,7 @@ final class DefinitionHandler implements HandlerInterface
 
         // Handle parent:: - resolve to actual parent class name
         if ($className === 'parent') {
-            $enclosingClass = $this->findEnclosingClassNode($call);
+            $enclosingClass = ScopeFinder::findEnclosingClassNode($call);
             if ($enclosingClass instanceof Stmt\Class_ && $enclosingClass->extends !== null) {
                 $className = $this->resolveName($enclosingClass->extends);
             } else {
@@ -182,7 +182,7 @@ final class DefinitionHandler implements HandlerInterface
 
         // Handle self:: and static:: - resolve to enclosing class
         if ($className === 'self' || $className === 'static') {
-            $enclosingClassName = $this->findEnclosingClassName($call);
+            $enclosingClassName = ScopeFinder::findEnclosingClassName($call);
             if ($enclosingClassName === null) {
                 return null;
             }
@@ -190,27 +190,6 @@ final class DefinitionHandler implements HandlerInterface
         }
 
         return $this->findMethodDefinition($className, $methodName->toString(), $ast);
-    }
-
-    /**
-     * Find the enclosing class-like node for a given node.
-     */
-    private function findEnclosingClassNode(
-        Node $node,
-    ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
-        $current = $node->getAttribute('parent');
-        while ($current instanceof Node) {
-            if (
-                $current instanceof Stmt\Class_
-                || $current instanceof Stmt\Interface_
-                || $current instanceof Stmt\Trait_
-                || $current instanceof Stmt\Enum_
-            ) {
-                return $current;
-            }
-            $current = $current->getAttribute('parent');
-        }
-        return null;
     }
 
     /**
@@ -232,52 +211,12 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        $className = $this->resolveExpressionClass($call->var, $ast);
+        $className = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
         if ($className === null) {
             return null;
         }
 
         return $this->findMethodDefinition($className, $methodName->toString(), $ast);
-    }
-
-    /**
-     * Resolve the class name of an expression.
-     *
-     * @param array<Stmt> $ast
-     */
-    private function resolveExpressionClass(Node\Expr $expr, array $ast): ?string
-    {
-        // $this refers to the enclosing class
-        if ($expr instanceof Variable && $expr->name === 'this') {
-            return $this->findEnclosingClassName($expr);
-        }
-
-        // Use type resolver for other expressions
-        if ($this->typeResolver !== null) {
-            $scope = ScopeFinder::findEnclosingScope($expr);
-            if ($scope !== null) {
-                return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Find the enclosing class-like name for a node.
-     */
-    private function findEnclosingClassName(Node $node): ?string
-    {
-        $classNode = $this->findEnclosingClassNode($node);
-        if ($classNode === null || $classNode->name === null) {
-            return null;
-        }
-
-        $namespacedName = $classNode->namespacedName;
-        if ($namespacedName instanceof Name) {
-            return $namespacedName->toString();
-        }
-        return $classNode->name->toString();
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -13,8 +13,8 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
-use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -302,7 +302,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = $this->resolveExpressionClass($call->var, $ast);
+        $className = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
         if ($className === null) {
             return null;
         }
@@ -343,7 +343,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = $this->resolveExpressionClass($fetch->var, $ast);
+        $className = ExpressionTypeResolver::resolveExpressionType($fetch->var, $ast, $this->typeResolver);
         if ($className === null) {
             return null;
         }
@@ -410,48 +410,6 @@ final class HoverHandler implements HandlerInterface
 
         // Fall back to reflection
         return $this->getReflectionPropertyHover($className, $propertyName);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function resolveExpressionClass(Node\Expr $expr, array $ast): ?string
-    {
-        // $this refers to the enclosing class
-        if ($expr instanceof Variable && $expr->name === 'this') {
-            return $this->findEnclosingClassName($expr, $ast);
-        }
-
-        // Use type resolver for other expressions
-        if ($this->typeResolver !== null) {
-            $scope = ScopeFinder::findEnclosingScope($expr);
-            if ($scope !== null) {
-                return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findEnclosingClassName(Node $node, array $ast): ?string
-    {
-        // Walk up through parent nodes to find enclosing class
-        $current = $node->getAttribute('parent');
-        while ($current instanceof Node) {
-            if ($current instanceof Stmt\Class_ && $current->name !== null) {
-                // Get the fully qualified name if available
-                $namespacedName = $current->namespacedName;
-                if ($namespacedName instanceof Name) {
-                    return $namespacedName->toString();
-                }
-                return $current->name->toString();
-            }
-            $current = $current->getAttribute('parent');
-        }
-        return null;
     }
 
     /**

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -12,6 +12,7 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
@@ -237,33 +238,12 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        $className = $this->resolveExpressionClass($call->var, $ast);
+        $className = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
         if ($className === null) {
             return null;
         }
 
         return $this->getMethodSignatureForClass($className, $methodName->toString(), $ast, $document);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function resolveExpressionClass(Node\Expr $expr, array $ast): ?string
-    {
-        // $this refers to the enclosing class
-        if ($expr instanceof Variable && $expr->name === 'this') {
-            return $this->findEnclosingClassName($expr, $ast);
-        }
-
-        // Use type resolver for other expressions
-        if ($this->typeResolver !== null) {
-            $scope = ScopeFinder::findEnclosingScope($expr);
-            if ($scope !== null) {
-                return $this->typeResolver->resolveExpressionType($expr, $scope, $ast);
-            }
-        }
-
-        return null;
     }
 
     /**
@@ -289,7 +269,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
         // Handle self/static/parent
         if ($className === 'self' || $className === 'static' || $className === 'parent') {
-            $enclosingClass = $this->findEnclosingClassName($call, $ast);
+            $enclosingClass = ScopeFinder::findEnclosingClassName($call);
             if ($enclosingClass === null) {
                 return null;
             }
@@ -370,25 +350,6 @@ final class SignatureHelpHandler implements HandlerInterface
         $traverser->traverse($ast);
 
         return $finder->found;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findEnclosingClassName(Node $node, array $ast): ?string
-    {
-        $current = $node->getAttribute('parent');
-        while ($current instanceof Node) {
-            if ($current instanceof Stmt\Class_ && $current->name !== null) {
-                $namespacedName = $current->namespacedName;
-                if ($namespacedName instanceof Name) {
-                    return $namespacedName->toString();
-                }
-                return $current->name->toString();
-            }
-            $current = $current->getAttribute('parent');
-        }
-        return null;
     }
 
     /**

--- a/src/Utility/ExpressionTypeResolver.php
+++ b/src/Utility/ExpressionTypeResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+
+/**
+ * Utility for resolving the type of an expression.
+ *
+ * Consolidates the logic for determining what class an expression refers to,
+ * handling $this and delegating to TypeResolver for typed variables.
+ */
+final class ExpressionTypeResolver
+{
+    /**
+     * Resolve the class name of an expression.
+     *
+     * Handles:
+     * - $this → enclosing class name
+     * - Typed variables → delegated to TypeResolver
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function resolveExpressionType(
+        Expr $expr,
+        array $ast,
+        ?TypeResolverInterface $typeResolver,
+    ): ?string {
+        if ($expr instanceof Variable && $expr->name === 'this') {
+            return ScopeFinder::findEnclosingClassName($expr);
+        }
+
+        if ($typeResolver === null) {
+            return null;
+        }
+
+        $scope = ScopeFinder::findEnclosingScope($expr);
+        if ($scope === null) {
+            return null;
+        }
+
+        return $typeResolver->resolveExpressionType($expr, $scope, $ast);
+    }
+}

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Utility;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
 /**
@@ -35,5 +36,48 @@ final class ScopeFinder
             $current = $current->getAttribute('parent');
         }
         return null;
+    }
+
+    /**
+     * Find the enclosing class-like node (class, interface, trait, or enum).
+     *
+     * Walks up the parent chain to find the innermost class-like scope.
+     */
+    public static function findEnclosingClassNode(
+        Node $node,
+    ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if (
+                $current instanceof Stmt\Class_
+                || $current instanceof Stmt\Interface_
+                || $current instanceof Stmt\Trait_
+                || $current instanceof Stmt\Enum_
+            ) {
+                return $current;
+            }
+            $current = $current->getAttribute('parent');
+        }
+        return null;
+    }
+
+    /**
+     * Find the fully qualified name of the enclosing class-like node.
+     *
+     * Returns the FQN if available, otherwise the short name, or null if not
+     * in a class context.
+     */
+    public static function findEnclosingClassName(Node $node): ?string
+    {
+        $classNode = self::findEnclosingClassNode($node);
+        if ($classNode === null || $classNode->name === null) {
+            return null;
+        }
+
+        $namespacedName = $classNode->namespacedName;
+        if ($namespacedName instanceof Name) {
+            return $namespacedName->toString();
+        }
+        return $classNode->name->toString();
     }
 }

--- a/tests/Utility/AstTestHelperTrait.php
+++ b/tests/Utility/AstTestHelperTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\ParserFactory;
+
+trait AstTestHelperTrait
+{
+    /**
+     * @return array<Stmt>
+     */
+    private static function parseWithParents(string $code): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $ast = $parser->parse($code) ?? [];
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->traverse($ast);
+
+        return $ast;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findVariableNode(string $name, array $ast): ?Variable
+    {
+        $visitor = new class ($name) extends \PhpParser\NodeVisitorAbstract {
+            public ?Variable $found = null;
+
+            public function __construct(private readonly string $name)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Variable && $node->name === $this->name) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->found;
+    }
+}

--- a/tests/Utility/ExpressionTypeResolverTest.php
+++ b/tests/Utility/ExpressionTypeResolverTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
+use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExpressionTypeResolver::class)]
+class ExpressionTypeResolverTest extends TestCase
+{
+    /**
+     * @return array<Stmt>
+     */
+    private static function parseWithParents(string $code): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $ast = $parser->parse($code) ?? [];
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->traverse($ast);
+
+        return $ast;
+    }
+
+    private static function findVariableNode(string $name, array $ast): ?Variable
+    {
+        $found = null;
+        $visitor = new class ($name, $found) extends \PhpParser\NodeVisitorAbstract {
+            public ?Variable $found = null;
+
+            public function __construct(
+                private readonly string $name,
+                &$found,
+            ) {
+                $this->found = &$found;
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Variable && $node->name === $this->name) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->found;
+    }
+
+    public function testResolveExpressionTypeReturnsClassNameForThis(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class User {
+    public function getName(): string {
+        $this->name;
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $thisNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($thisNode);
+        $result = ExpressionTypeResolver::resolveExpressionType($thisNode, $ast, null);
+
+        self::assertSame('App\Models\User', $result);
+    }
+
+    public function testResolveExpressionTypeReturnsNullForThisOutsideClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+function globalFunc(): void {
+    $this->foo();
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $thisNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($thisNode);
+        $result = ExpressionTypeResolver::resolveExpressionType($thisNode, $ast, null);
+
+        self::assertNull($result);
+    }
+
+    public function testResolveExpressionTypeDelegatesToTypeResolver(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {
+        $user->getName();
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $userNode = self::findVariableNode('user', $ast);
+
+        self::assertNotNull($userNode);
+
+        $typeResolver = $this->createMock(TypeResolverInterface::class);
+        $typeResolver->expects(self::once())
+            ->method('resolveExpressionType')
+            ->willReturn('App\Models\User');
+
+        $result = ExpressionTypeResolver::resolveExpressionType($userNode, $ast, $typeResolver);
+
+        self::assertSame('App\Models\User', $result);
+    }
+
+    public function testResolveExpressionTypeReturnsNullWithoutTypeResolver(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {
+        $user->getName();
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $userNode = self::findVariableNode('user', $ast);
+
+        self::assertNotNull($userNode);
+        $result = ExpressionTypeResolver::resolveExpressionType($userNode, $ast, null);
+
+        self::assertNull($result);
+    }
+
+    public function testResolveExpressionTypeReturnsNullWhenTypeResolverReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {
+        $unknown->foo();
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('unknown', $ast);
+
+        self::assertNotNull($varNode);
+
+        $typeResolver = $this->createStub(TypeResolverInterface::class);
+        $typeResolver->method('resolveExpressionType')
+            ->willReturn(null);
+
+        $result = ExpressionTypeResolver::resolveExpressionType($varNode, $ast, $typeResolver);
+
+        self::assertNull($result);
+    }
+}

--- a/tests/Utility/ExpressionTypeResolverTest.php
+++ b/tests/Utility/ExpressionTypeResolverTest.php
@@ -35,17 +35,16 @@ class ExpressionTypeResolverTest extends TestCase
         return $ast;
     }
 
+    /**
+     * @param array<Stmt> $ast
+     */
     private static function findVariableNode(string $name, array $ast): ?Variable
     {
-        $found = null;
-        $visitor = new class ($name, $found) extends \PhpParser\NodeVisitorAbstract {
+        $visitor = new class ($name) extends \PhpParser\NodeVisitorAbstract {
             public ?Variable $found = null;
 
-            public function __construct(
-                private readonly string $name,
-                &$found,
-            ) {
-                $this->found = &$found;
+            public function __construct(private readonly string $name)
+            {
             }
 
             public function enterNode(Node $node): ?int
@@ -162,7 +161,7 @@ PHP;
 
         self::assertNotNull($varNode);
 
-        $typeResolver = $this->createStub(TypeResolverInterface::class);
+        $typeResolver = self::createStub(TypeResolverInterface::class);
         $typeResolver->method('resolveExpressionType')
             ->willReturn(null);
 

--- a/tests/Utility/ExpressionTypeResolverTest.php
+++ b/tests/Utility/ExpressionTypeResolverTest.php
@@ -6,63 +6,13 @@ namespace Firehed\PhpLsp\Tests\Utility;
 
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
-use PhpParser\Node;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NameResolver;
-use PhpParser\NodeVisitor\ParentConnectingVisitor;
-use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ExpressionTypeResolver::class)]
 class ExpressionTypeResolverTest extends TestCase
 {
-    /**
-     * @return array<Stmt>
-     */
-    private static function parseWithParents(string $code): array
-    {
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
-        $ast = $parser->parse($code) ?? [];
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new NameResolver());
-        $traverser->addVisitor(new ParentConnectingVisitor());
-        $traverser->traverse($ast);
-
-        return $ast;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private static function findVariableNode(string $name, array $ast): ?Variable
-    {
-        $visitor = new class ($name) extends \PhpParser\NodeVisitorAbstract {
-            public ?Variable $found = null;
-
-            public function __construct(private readonly string $name)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Variable && $node->name === $this->name) {
-                    $this->found = $node;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($visitor);
-        $traverser->traverse($ast);
-
-        return $visitor->found;
-    }
+    use AstTestHelperTrait;
 
     public function testResolveExpressionTypeReturnsClassNameForThis(): void
     {

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -6,62 +6,15 @@ namespace Firehed\PhpLsp\Tests\Utility;
 
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NameResolver;
-use PhpParser\NodeVisitor\ParentConnectingVisitor;
-use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ScopeFinder::class)]
 class ScopeFinderTest extends TestCase
 {
-    /**
-     * @return array<Stmt>
-     */
-    private static function parseWithParents(string $code): array
-    {
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
-        $ast = $parser->parse($code) ?? [];
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new NameResolver());
-        $traverser->addVisitor(new ParentConnectingVisitor());
-        $traverser->traverse($ast);
-
-        return $ast;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private static function findVariableNode(string $name, array $ast): ?Variable
-    {
-        $visitor = new class ($name) extends \PhpParser\NodeVisitorAbstract {
-            public ?Variable $found = null;
-
-            public function __construct(private readonly string $name)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Variable && $node->name === $this->name) {
-                    $this->found = $node;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($visitor);
-        $traverser->traverse($ast);
-
-        return $visitor->found;
-    }
+    use AstTestHelperTrait;
 
     public function testFindEnclosingScopeReturnsMethodForThis(): void
     {

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Tests\Utility;
 
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -49,6 +51,56 @@ PHP;
         $scope = ScopeFinder::findEnclosingScope($varNode);
 
         self::assertNull($scope);
+    }
+
+    public function testFindEnclosingScopeReturnsFunction(): void
+    {
+        $code = <<<'PHP'
+<?php
+function myFunction(): void {
+    $var = 1;
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $scope = ScopeFinder::findEnclosingScope($varNode);
+
+        self::assertInstanceOf(Stmt\Function_::class, $scope);
+        self::assertSame('myFunction', $scope->name->toString());
+    }
+
+    public function testFindEnclosingScopeReturnsClosure(): void
+    {
+        $code = <<<'PHP'
+<?php
+$fn = function () {
+    $var = 1;
+};
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $scope = ScopeFinder::findEnclosingScope($varNode);
+
+        self::assertInstanceOf(Closure::class, $scope);
+    }
+
+    public function testFindEnclosingScopeReturnsArrowFunction(): void
+    {
+        $code = <<<'PHP'
+<?php
+$fn = fn() => $var = 1;
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $scope = ScopeFinder::findEnclosingScope($varNode);
+
+        self::assertInstanceOf(ArrowFunction::class, $scope);
     }
 
     public function testFindEnclosingClassNodeReturnsClass(): void

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Utility\ScopeFinder;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ScopeFinder::class)]
+class ScopeFinderTest extends TestCase
+{
+    /**
+     * @return array<Stmt>
+     */
+    private static function parseWithParents(string $code): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $ast = $parser->parse($code) ?? [];
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        $traverser->traverse($ast);
+
+        return $ast;
+    }
+
+    private static function findVariableNode(string $name, array $ast): ?Variable
+    {
+        $found = null;
+        $visitor = new class ($name, $found) extends \PhpParser\NodeVisitorAbstract {
+            public ?Variable $found = null;
+
+            public function __construct(
+                private readonly string $name,
+                &$found,
+            ) {
+                $this->found = &$found;
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Variable && $node->name === $this->name) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->found;
+    }
+
+    public function testFindEnclosingScopeReturnsMethodForThis(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {
+        $this->foo();
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $thisNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($thisNode);
+        $scope = ScopeFinder::findEnclosingScope($thisNode);
+
+        self::assertInstanceOf(Stmt\ClassMethod::class, $scope);
+        self::assertSame('myMethod', $scope->name->toString());
+    }
+
+    public function testFindEnclosingScopeReturnsNullOutsideFunction(): void
+    {
+        $code = <<<'PHP'
+<?php
+$globalVar = 1;
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('globalVar', $ast);
+
+        self::assertNotNull($varNode);
+        $scope = ScopeFinder::findEnclosingScope($varNode);
+
+        self::assertNull($scope);
+    }
+
+    public function testFindEnclosingClassNodeReturnsClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {
+        $this->foo();
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $thisNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($thisNode);
+        $classNode = ScopeFinder::findEnclosingClassNode($thisNode);
+
+        self::assertInstanceOf(Stmt\Class_::class, $classNode);
+        self::assertNotNull($classNode->name);
+        self::assertSame('MyClass', $classNode->name->toString());
+    }
+
+    public function testFindEnclosingClassNodeReturnsInterface(): void
+    {
+        $code = <<<'PHP'
+<?php
+interface MyInterface {
+    public function myMethod(): void;
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $methodNode = null;
+        $visitor = new class ($methodNode) extends \PhpParser\NodeVisitorAbstract {
+            public ?Stmt\ClassMethod $found = null;
+
+            public function __construct(&$found)
+            {
+                $this->found = &$found;
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\ClassMethod) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        self::assertNotNull($visitor->found);
+        $classNode = ScopeFinder::findEnclosingClassNode($visitor->found);
+
+        self::assertInstanceOf(Stmt\Interface_::class, $classNode);
+    }
+
+    public function testFindEnclosingClassNodeReturnsTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    public function myMethod(): void {
+        $var = 1;
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $classNode = ScopeFinder::findEnclosingClassNode($varNode);
+
+        self::assertInstanceOf(Stmt\Trait_::class, $classNode);
+    }
+
+    public function testFindEnclosingClassNodeReturnsEnum(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status: string {
+    case Active = 'active';
+
+    public function label(): string {
+        $var = 1;
+        return $this->value;
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $classNode = ScopeFinder::findEnclosingClassNode($varNode);
+
+        self::assertInstanceOf(Stmt\Enum_::class, $classNode);
+    }
+
+    public function testFindEnclosingClassNodeReturnsNullOutsideClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+function globalFunc(): void {
+    $var = 1;
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $classNode = ScopeFinder::findEnclosingClassNode($varNode);
+
+        self::assertNull($classNode);
+    }
+
+    public function testFindEnclosingClassNameReturnsShortName(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {
+        $this->foo();
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $thisNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($thisNode);
+        $className = ScopeFinder::findEnclosingClassName($thisNode);
+
+        self::assertSame('MyClass', $className);
+    }
+
+    public function testFindEnclosingClassNameReturnsFqn(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class User {
+    public function getName(): string {
+        $this->name;
+    }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $thisNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($thisNode);
+        $className = ScopeFinder::findEnclosingClassName($thisNode);
+
+        self::assertSame('App\Models\User', $className);
+    }
+
+    public function testFindEnclosingClassNameReturnsNullOutsideClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+function globalFunc(): void {
+    $var = 1;
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $className = ScopeFinder::findEnclosingClassName($varNode);
+
+        self::assertNull($className);
+    }
+
+    public function testFindEnclosingClassNameReturnsNullForAnonymousClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+$obj = new class {
+    public function myMethod(): void {
+        $var = 1;
+    }
+};
+PHP;
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('var', $ast);
+
+        self::assertNotNull($varNode);
+        $className = ScopeFinder::findEnclosingClassName($varNode);
+
+        self::assertNull($className);
+    }
+}

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -34,17 +34,16 @@ class ScopeFinderTest extends TestCase
         return $ast;
     }
 
+    /**
+     * @param array<Stmt> $ast
+     */
     private static function findVariableNode(string $name, array $ast): ?Variable
     {
-        $found = null;
-        $visitor = new class ($name, $found) extends \PhpParser\NodeVisitorAbstract {
+        $visitor = new class ($name) extends \PhpParser\NodeVisitorAbstract {
             public ?Variable $found = null;
 
-            public function __construct(
-                private readonly string $name,
-                &$found,
-            ) {
-                $this->found = &$found;
+            public function __construct(private readonly string $name)
+            {
             }
 
             public function enterNode(Node $node): ?int
@@ -130,14 +129,8 @@ interface MyInterface {
 PHP;
         $ast = self::parseWithParents($code);
 
-        $methodNode = null;
-        $visitor = new class ($methodNode) extends \PhpParser\NodeVisitorAbstract {
+        $visitor = new class () extends \PhpParser\NodeVisitorAbstract {
             public ?Stmt\ClassMethod $found = null;
-
-            public function __construct(&$found)
-            {
-                $this->found = &$found;
-            }
 
             public function enterNode(Node $node): ?int
             {


### PR DESCRIPTION
## Summary

Fixes #97

- Adds `findEnclosingClassNode` and `findEnclosingClassName` methods to `ScopeFinder` utility
- Creates new `ExpressionTypeResolver` utility that consolidates the duplicated `resolveExpressionClass` logic
- Updates HoverHandler, DefinitionHandler, and SignatureHelpHandler to use the shared utilities
- Removes ~150 lines of duplicated code across the handlers

## Benefits

- Single place to fix type resolution bugs
- Consistent behavior across completion, hover, and go-to-definition
- Prerequisite for unified member lookup (#98)

## Test plan

- [x] All existing tests pass
- [x] New tests added for ScopeFinder and ExpressionTypeResolver
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)