### PR TITLE
Extract shared member lookup utility

### DIFF
--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -13,6 +13,7 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\MemberFinder;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
@@ -383,13 +384,11 @@ final class HoverHandler implements HandlerInterface
         array $ast,
         TextDocument $document,
     ): ?string {
-        // Try to find in AST first (current file or via Composer)
-        $methodNode = $this->findMethodInClass($className, $methodName, $ast);
+        $methodNode = MemberFinder::findMethod($className, $methodName, $ast, $this->classLocator, $this->parser);
         if ($methodNode !== null) {
             return $this->formatMethodHover($methodNode);
         }
 
-        // Fall back to reflection for built-in or autoloaded classes
         return $this->getReflectionMethodHover($className, $methodName);
     }
 
@@ -402,92 +401,12 @@ final class HoverHandler implements HandlerInterface
         array $ast,
         TextDocument $document,
     ): ?string {
-        // Try to find in AST first
-        $propertyNode = $this->findPropertyInClass($className, $propertyName, $ast);
+        $propertyNode = MemberFinder::findProperty($className, $propertyName, $ast, $this->classLocator, $this->parser);
         if ($propertyNode !== null) {
             return $this->formatPropertyHover($propertyNode, $propertyName);
         }
 
-        // Fall back to reflection
         return $this->getReflectionPropertyHover($className, $propertyName);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findMethodInClass(
-        string $className,
-        string $methodName,
-        array $ast,
-    ): ?Stmt\ClassMethod {
-        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
-        if ($classNode === null) {
-            return null;
-        }
-
-        foreach ($classNode->stmts as $stmt) {
-            if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
-                return $stmt;
-            }
-        }
-
-        // Check parent class (only non-private members are inherited)
-        $parentName = $this->getParentClassName($classNode);
-        if ($parentName !== null) {
-            $parentMethod = $this->findMethodInClass($parentName, $methodName, $ast);
-            if ($parentMethod !== null && !$parentMethod->isPrivate()) {
-                return $parentMethod;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findPropertyInClass(
-        string $className,
-        string $propertyName,
-        array $ast,
-    ): ?Stmt\Property {
-        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
-        if ($classNode === null) {
-            return null;
-        }
-
-        foreach ($classNode->stmts as $stmt) {
-            if ($stmt instanceof Stmt\Property) {
-                foreach ($stmt->props as $prop) {
-                    if ($prop->name->toString() === $propertyName) {
-                        return $stmt;
-                    }
-                }
-            }
-        }
-
-        // Check parent class (only non-private members are inherited)
-        $parentName = $this->getParentClassName($classNode);
-        if ($parentName !== null) {
-            $parentProperty = $this->findPropertyInClass($parentName, $propertyName, $ast);
-            if ($parentProperty !== null && !$parentProperty->isPrivate()) {
-                return $parentProperty;
-            }
-        }
-
-        return null;
-    }
-
-    private function getParentClassName(
-        Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $classNode,
-    ): ?string {
-        if (!$classNode instanceof Stmt\Class_ || $classNode->extends === null) {
-            return null;
-        }
-        $resolvedName = $classNode->extends->getAttribute('resolvedName');
-        return $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $classNode->extends->toString();
     }
 
     private function formatMethodHover(Stmt\ClassMethod $method): string

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -10,8 +10,8 @@ use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
-use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\MemberFinder;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -308,13 +308,11 @@ final class SignatureHelpHandler implements HandlerInterface
         array $ast,
         TextDocument $document,
     ): ?array {
-        // Try to find in AST first
-        $methodNode = $this->findMethodInClass($className, $methodName, $ast, $document);
+        $methodNode = MemberFinder::findMethod($className, $methodName, $ast, $this->classLocator, $this->parser);
         if ($methodNode !== null) {
             return $this->formatMethodNodeSignature($methodNode);
         }
 
-        // Fall back to reflection
         $classReflection = ReflectionHelper::getClass($className);
         if ($classReflection === null || !$classReflection->hasMethod($methodName)) {
             return null;
@@ -350,29 +348,6 @@ final class SignatureHelpHandler implements HandlerInterface
         $traverser->traverse($ast);
 
         return $finder->found;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findMethodInClass(
-        string $className,
-        string $methodName,
-        array $ast,
-        TextDocument $document,
-    ): ?Stmt\ClassMethod {
-        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
-        if ($classNode === null) {
-            return null;
-        }
-
-        foreach ($classNode->stmts as $stmt) {
-            if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
-                return $stmt;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Parser\ParserService;
+use PhpParser\Node\Stmt;
+
+final class MemberFinder
+{
+    /**
+     * Find a method by name in a class, traversing the inheritance hierarchy.
+     *
+     * Searches in PHP method resolution order: class -> traits -> parent.
+     * Private methods are not inherited from parent classes.
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function findMethod(
+        string $className,
+        string $methodName,
+        array $ast,
+        ?ComposerClassLocator $classLocator,
+        ParserService $parser,
+    ): ?Stmt\ClassMethod {
+        $classNode = ClassFinder::findWithLocator($className, $ast, $classLocator, $parser);
+        if ($classNode === null) {
+            return null;
+        }
+
+        return self::findMethodInClassNode($classNode, $methodName, $ast, $classLocator, $parser, false);
+    }
+
+    /**
+     * Find a property by name in a class, traversing the inheritance hierarchy.
+     *
+     * Private properties are not inherited from parent classes.
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function findProperty(
+        string $className,
+        string $propertyName,
+        array $ast,
+        ?ComposerClassLocator $classLocator,
+        ParserService $parser,
+    ): ?Stmt\Property {
+        $classNode = ClassFinder::findWithLocator($className, $ast, $classLocator, $parser);
+        if ($classNode === null) {
+            return null;
+        }
+
+        return self::findPropertyInClassNode($classNode, $propertyName, $ast, $classLocator, $parser, false);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findMethodInClassNode(
+        Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $classNode,
+        string $methodName,
+        array $ast,
+        ?ComposerClassLocator $classLocator,
+        ParserService $parser,
+        bool $excludePrivate,
+    ): ?Stmt\ClassMethod {
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
+                if ($excludePrivate && $stmt->isPrivate()) {
+                    continue;
+                }
+                return $stmt;
+            }
+        }
+
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\TraitUse) {
+                foreach ($stmt->traits as $traitName) {
+                    $traitClassName = $traitName->toString();
+                    $traitNode = ClassFinder::findWithLocator($traitClassName, $ast, $classLocator, $parser);
+                    if ($traitNode !== null) {
+                        $traitMethod = self::findMethodInClassNode(
+                            $traitNode,
+                            $methodName,
+                            $ast,
+                            $classLocator,
+                            $parser,
+                            true,
+                        );
+                        if ($traitMethod !== null) {
+                            return $traitMethod;
+                        }
+                    }
+                }
+            }
+        }
+
+        $parentName = self::getParentClassName($classNode);
+        if ($parentName !== null) {
+            $parentNode = ClassFinder::findWithLocator($parentName, $ast, $classLocator, $parser);
+            if ($parentNode !== null) {
+                return self::findMethodInClassNode(
+                    $parentNode,
+                    $methodName,
+                    $ast,
+                    $classLocator,
+                    $parser,
+                    true,
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findPropertyInClassNode(
+        Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $classNode,
+        string $propertyName,
+        array $ast,
+        ?ComposerClassLocator $classLocator,
+        ParserService $parser,
+        bool $excludePrivate,
+    ): ?Stmt\Property {
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\Property) {
+                if ($excludePrivate && $stmt->isPrivate()) {
+                    continue;
+                }
+                foreach ($stmt->props as $prop) {
+                    if ($prop->name->toString() === $propertyName) {
+                        return $stmt;
+                    }
+                }
+            }
+        }
+
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\TraitUse) {
+                foreach ($stmt->traits as $traitName) {
+                    $traitClassName = $traitName->toString();
+                    $traitNode = ClassFinder::findWithLocator($traitClassName, $ast, $classLocator, $parser);
+                    if ($traitNode !== null) {
+                        $traitProperty = self::findPropertyInClassNode(
+                            $traitNode,
+                            $propertyName,
+                            $ast,
+                            $classLocator,
+                            $parser,
+                            true,
+                        );
+                        if ($traitProperty !== null) {
+                            return $traitProperty;
+                        }
+                    }
+                }
+            }
+        }
+
+        $parentName = self::getParentClassName($classNode);
+        if ($parentName !== null) {
+            $parentNode = ClassFinder::findWithLocator($parentName, $ast, $classLocator, $parser);
+            if ($parentNode !== null) {
+                return self::findPropertyInClassNode(
+                    $parentNode,
+                    $propertyName,
+                    $ast,
+                    $classLocator,
+                    $parser,
+                    true,
+                );
+            }
+        }
+
+        return null;
+    }
+
+    private static function getParentClassName(
+        Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $classNode,
+    ): ?string {
+        if (!$classNode instanceof Stmt\Class_ || $classNode->extends === null) {
+            return null;
+        }
+        return $classNode->extends->toString();
+    }
+}

--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
 final class MemberFinder
@@ -78,7 +79,7 @@ final class MemberFinder
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
-                    $traitClassName = $traitName->toString();
+                    $traitClassName = self::resolveName($traitName);
                     $traitNode = ClassFinder::findWithLocator($traitClassName, $ast, $classLocator, $parser);
                     if ($traitNode !== null) {
                         $traitMethod = self::findMethodInClassNode(
@@ -142,7 +143,7 @@ final class MemberFinder
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
-                    $traitClassName = $traitName->toString();
+                    $traitClassName = self::resolveName($traitName);
                     $traitNode = ClassFinder::findWithLocator($traitClassName, $ast, $classLocator, $parser);
                     if ($traitNode !== null) {
                         $traitProperty = self::findPropertyInClassNode(
@@ -185,6 +186,14 @@ final class MemberFinder
         if (!$classNode instanceof Stmt\Class_ || $classNode->extends === null) {
             return null;
         }
-        return $classNode->extends->toString();
+        return self::resolveName($classNode->extends);
+    }
+
+    private static function resolveName(Name $name): string
+    {
+        $resolvedName = $name->getAttribute('resolvedName');
+        return $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $name->toString();
     }
 }

--- a/tests/Utility/MemberFinderTest.php
+++ b/tests/Utility/MemberFinderTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Utility\MemberFinder;
+use PhpParser\Node\Stmt;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MemberFinder::class)]
+class MemberFinderTest extends TestCase
+{
+    private ParserService $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new ParserService();
+    }
+
+    /**
+     * @return array<Stmt>
+     */
+    private static function parse(string $code): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        return $parser->parse($code) ?? [];
+    }
+
+    public function testFindMethodInClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {}
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('MyClass', 'myMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('myMethod', $result->name->toString());
+    }
+
+    public function testFindMethodReturnsNullWhenNotFound(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function otherMethod(): void {}
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('MyClass', 'notFound', $ast, null, $this->parser);
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodInParentClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass {
+    public function parentMethod(): void {}
+}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('ChildClass', 'parentMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('parentMethod', $result->name->toString());
+    }
+
+    public function testFindMethodExcludesPrivateFromParent(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass {
+    private function privateMethod(): void {}
+}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('ChildClass', 'privateMethod', $ast, null, $this->parser);
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodIncludesProtectedFromParent(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass {
+    protected function protectedMethod(): void {}
+}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('ChildClass', 'protectedMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('protectedMethod', $result->name->toString());
+    }
+
+    public function testFindMethodInTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    public function traitMethod(): void {}
+}
+class MyClass {
+    use MyTrait;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('MyClass', 'traitMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('traitMethod', $result->name->toString());
+    }
+
+    public function testFindMethodPrefersClassOverTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    public function overriddenMethod(): string { return 'trait'; }
+}
+class MyClass {
+    use MyTrait;
+    public function overriddenMethod(): string { return 'class'; }
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('MyClass', 'overriddenMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        // The class method should be found (has return type that differs)
+        self::assertSame('overriddenMethod', $result->name->toString());
+        // Should be from the class, not trait - class method is on line 8
+        self::assertGreaterThan(6, $result->getStartLine());
+    }
+
+    public function testFindPropertyInClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public string $myProperty;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('MyClass', 'myProperty', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertCount(1, $result->props);
+        self::assertSame('myProperty', $result->props[0]->name->toString());
+    }
+
+    public function testFindPropertyReturnsNullWhenNotFound(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public string $otherProperty;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('MyClass', 'notFound', $ast, null, $this->parser);
+
+        self::assertNull($result);
+    }
+
+    public function testFindPropertyInParentClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass {
+    public string $parentProperty;
+}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('ChildClass', 'parentProperty', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('parentProperty', $result->props[0]->name->toString());
+    }
+
+    public function testFindPropertyExcludesPrivateFromParent(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass {
+    private string $privateProperty;
+}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('ChildClass', 'privateProperty', $ast, null, $this->parser);
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodReturnsNullWhenClassNotFound(): void
+    {
+        $code = <<<'PHP'
+<?php
+class SomeClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('NonExistent', 'method', $ast, null, $this->parser);
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodInNamespacedClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class User {
+    public function getName(): string {}
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('App\\Models\\User', 'getName', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('getName', $result->name->toString());
+    }
+}

--- a/tests/Utility/MemberFinderTest.php
+++ b/tests/Utility/MemberFinderTest.php
@@ -235,4 +235,117 @@ PHP;
         self::assertNotNull($result);
         self::assertSame('getName', $result->name->toString());
     }
+
+    public function testFindPrivateMethodInSameClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    private function privateMethod(): void {}
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('MyClass', 'privateMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('privateMethod', $result->name->toString());
+    }
+
+    public function testFindPrivatePropertyInSameClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    private string $privateProperty;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('MyClass', 'privateProperty', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('privateProperty', $result->props[0]->name->toString());
+    }
+
+    public function testFindPropertyInTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    public string $traitProperty;
+}
+class MyClass {
+    use MyTrait;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('MyClass', 'traitProperty', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('traitProperty', $result->props[0]->name->toString());
+    }
+
+    public function testFindPropertyIncludesProtectedFromParent(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass {
+    protected string $protectedProperty;
+}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('ChildClass', 'protectedProperty', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('protectedProperty', $result->props[0]->name->toString());
+    }
+
+    public function testFindMethodInInterface(): void
+    {
+        $code = <<<'PHP'
+<?php
+interface MyInterface {
+    public function interfaceMethod(): void;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('MyInterface', 'interfaceMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('interfaceMethod', $result->name->toString());
+    }
+
+    public function testFindMethodInGrandparent(): void
+    {
+        $code = <<<'PHP'
+<?php
+class GrandparentClass {
+    public function grandparentMethod(): void {}
+}
+class ParentClass extends GrandparentClass {}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('ChildClass', 'grandparentMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('grandparentMethod', $result->name->toString());
+    }
+
+    public function testFindPropertyInGrandparent(): void
+    {
+        $code = <<<'PHP'
+<?php
+class GrandparentClass {
+    public string $grandparentProperty;
+}
+class ParentClass extends GrandparentClass {}
+class ChildClass extends ParentClass {}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('ChildClass', 'grandparentProperty', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('grandparentProperty', $result->props[0]->name->toString());
+    }
 }

--- a/tests/Utility/MemberFinderTest.php
+++ b/tests/Utility/MemberFinderTest.php
@@ -348,4 +348,27 @@ PHP;
         self::assertNotNull($result);
         self::assertSame('grandparentProperty', $result->props[0]->name->toString());
     }
+
+    public function testFindMethodInEnum(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status: string {
+    case Active = 'active';
+    case Inactive = 'inactive';
+
+    public function label(): string {
+        return match($this) {
+            self::Active => 'Active',
+            self::Inactive => 'Inactive',
+        };
+    }
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('Status', 'label', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('label', $result->name->toString());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `MemberFinder` utility that consolidates member lookup logic
- Properly traverses inheritance hierarchy: class -> traits -> parent
- Respects PHP visibility rules (private members not inherited from parents)
- Uses resolved names for parent class and trait lookup

Fixes #98

## Changes

- `MemberFinder::findMethod()` - find a method by name in a class hierarchy
- `MemberFinder::findProperty()` - find a property by name in a class hierarchy
- Refactored HoverHandler to use MemberFinder (removed ~80 lines)
- Refactored SignatureHelpHandler to use MemberFinder (removed ~25 lines, also fixed missing inheritance lookup)

## Notes

DefinitionHandler still uses its own `findMethodDefinition` because it has unique requirements (needs to track URI via SymbolIndex for creating Locations). The core iteration pattern is shared, but the class-finding strategy differs.

## Test plan

- [x] All existing tests pass
- [x] New MemberFinder tests cover: method/property lookup, inheritance, trait lookup, private exclusion, namespaced classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)