### PR TITLE
Centralize visibility filtering logic

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -311,7 +311,8 @@ final class CompletionHandler implements HandlerInterface
 
         if ($parentClassNode !== null) {
             foreach ($parentClassNode->stmts as $stmt) {
-                if ($stmt instanceof Stmt\ClassMethod
+                if (
+                    $stmt instanceof Stmt\ClassMethod
                     && VisibilityFilter::isMethodAccessible($stmt, AccessContext::Subclass)
                 ) {
                     $name = $stmt->name->toString();
@@ -406,7 +407,8 @@ final class CompletionHandler implements HandlerInterface
 
         if ($classNode !== null) {
             foreach ($classNode->stmts as $stmt) {
-                if ($stmt instanceof Stmt\ClassMethod
+                if (
+                    $stmt instanceof Stmt\ClassMethod
                     && !$stmt->isStatic()
                     && VisibilityFilter::isMethodAccessible($stmt, AccessContext::External)
                 ) {
@@ -416,7 +418,8 @@ final class CompletionHandler implements HandlerInterface
                     }
                 }
 
-                if ($stmt instanceof Stmt\Property
+                if (
+                    $stmt instanceof Stmt\Property
                     && !$stmt->isStatic()
                     && VisibilityFilter::isPropertyAccessible($stmt, AccessContext::External)
                 ) {

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -345,8 +345,10 @@ final class CompletionHandler implements HandlerInterface
         $existingLabels = array_column($existingItems, 'label');
         $items = [];
 
-        // Public and protected methods (both static and non-static)
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
+        foreach ($reflection->getMethods() as $method) {
+            if (!VisibilityFilter::isReflectionMethodAccessible($method, AccessContext::Subclass)) {
+                continue;
+            }
             $name = $method->getName();
             if (in_array($name, $existingLabels, true)) {
                 continue;
@@ -455,9 +457,11 @@ final class CompletionHandler implements HandlerInterface
         $existingLabels = array_column($existingItems, 'label');
         $items = [];
 
-        // Public non-static methods
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+        foreach ($reflection->getMethods() as $method) {
             if ($method->isStatic()) {
+                continue;
+            }
+            if (!VisibilityFilter::isReflectionMethodAccessible($method, AccessContext::External)) {
                 continue;
             }
             $name = $method->getName();
@@ -469,9 +473,11 @@ final class CompletionHandler implements HandlerInterface
             }
         }
 
-        // Public non-static properties
-        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $prop) {
+        foreach ($reflection->getProperties() as $prop) {
             if ($prop->isStatic()) {
+                continue;
+            }
+            if (!VisibilityFilter::isReflectionPropertyAccessible($prop, AccessContext::External)) {
                 continue;
             }
             $name = $prop->getName();

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -14,10 +14,12 @@ use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
+use Firehed\PhpLsp\Utility\AccessContext;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
+use Firehed\PhpLsp\Utility\VisibilityFilter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
@@ -309,11 +311,9 @@ final class CompletionHandler implements HandlerInterface
 
         if ($parentClassNode !== null) {
             foreach ($parentClassNode->stmts as $stmt) {
-                // Methods (public and protected, both static and non-static)
-                if ($stmt instanceof Stmt\ClassMethod) {
-                    if ($stmt->isPrivate()) {
-                        continue;
-                    }
+                if ($stmt instanceof Stmt\ClassMethod
+                    && VisibilityFilter::isMethodAccessible($stmt, AccessContext::Subclass)
+                ) {
                     $name = $stmt->name->toString();
                     if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
                         $items[] = $this->formatMethodCompletion($stmt);
@@ -406,16 +406,20 @@ final class CompletionHandler implements HandlerInterface
 
         if ($classNode !== null) {
             foreach ($classNode->stmts as $stmt) {
-                // Public methods (non-static)
-                if ($stmt instanceof Stmt\ClassMethod && !$stmt->isStatic() && $stmt->isPublic()) {
+                if ($stmt instanceof Stmt\ClassMethod
+                    && !$stmt->isStatic()
+                    && VisibilityFilter::isMethodAccessible($stmt, AccessContext::External)
+                ) {
                     $name = $stmt->name->toString();
                     if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
                         $items[] = $this->formatMethodCompletion($stmt);
                     }
                 }
 
-                // Public properties (non-static)
-                if ($stmt instanceof Stmt\Property && !$stmt->isStatic() && $stmt->isPublic()) {
+                if ($stmt instanceof Stmt\Property
+                    && !$stmt->isStatic()
+                    && VisibilityFilter::isPropertyAccessible($stmt, AccessContext::External)
+                ) {
                     foreach ($stmt->props as $prop) {
                         $name = $prop->name->toString();
                         if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {

--- a/src/Utility/AccessContext.php
+++ b/src/Utility/AccessContext.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+enum AccessContext
+{
+    case SameClass;
+    case Subclass;
+    case External;
+}

--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -67,10 +67,9 @@ final class MemberFinder
         ParserService $parser,
         bool $excludePrivate,
     ): ?Stmt\ClassMethod {
-        $context = $excludePrivate ? AccessContext::Subclass : AccessContext::SameClass;
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
-                if (!VisibilityFilter::isMethodAccessible($stmt, $context)) {
+                if ($excludePrivate && $stmt->isPrivate()) {
                     continue;
                 }
                 return $stmt;
@@ -128,10 +127,9 @@ final class MemberFinder
         ParserService $parser,
         bool $excludePrivate,
     ): ?Stmt\Property {
-        $context = $excludePrivate ? AccessContext::Subclass : AccessContext::SameClass;
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\Property) {
-                if (!VisibilityFilter::isPropertyAccessible($stmt, $context)) {
+                if ($excludePrivate && $stmt->isPrivate()) {
                     continue;
                 }
                 foreach ($stmt->props as $prop) {

--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -67,9 +67,10 @@ final class MemberFinder
         ParserService $parser,
         bool $excludePrivate,
     ): ?Stmt\ClassMethod {
+        $context = $excludePrivate ? AccessContext::Subclass : AccessContext::SameClass;
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
-                if ($excludePrivate && $stmt->isPrivate()) {
+                if (!VisibilityFilter::isMethodAccessible($stmt, $context)) {
                     continue;
                 }
                 return $stmt;
@@ -127,9 +128,10 @@ final class MemberFinder
         ParserService $parser,
         bool $excludePrivate,
     ): ?Stmt\Property {
+        $context = $excludePrivate ? AccessContext::Subclass : AccessContext::SameClass;
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\Property) {
-                if ($excludePrivate && $stmt->isPrivate()) {
+                if (!VisibilityFilter::isPropertyAccessible($stmt, $context)) {
                     continue;
                 }
                 foreach ($stmt->props as $prop) {

--- a/src/Utility/VisibilityFilter.php
+++ b/src/Utility/VisibilityFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use PhpParser\Node\Stmt;
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class VisibilityFilter
+{
+    public static function isMethodAccessible(Stmt\ClassMethod $method, AccessContext $context): bool
+    {
+        return match ($context) {
+            AccessContext::SameClass => true,
+            AccessContext::Subclass => !$method->isPrivate(),
+            AccessContext::External => $method->isPublic(),
+        };
+    }
+
+    public static function isPropertyAccessible(Stmt\Property $property, AccessContext $context): bool
+    {
+        return match ($context) {
+            AccessContext::SameClass => true,
+            AccessContext::Subclass => !$property->isPrivate(),
+            AccessContext::External => $property->isPublic(),
+        };
+    }
+
+    public static function isReflectionMethodAccessible(ReflectionMethod $method, AccessContext $context): bool
+    {
+        return match ($context) {
+            AccessContext::SameClass => true,
+            AccessContext::Subclass => !$method->isPrivate(),
+            AccessContext::External => $method->isPublic(),
+        };
+    }
+
+    public static function isReflectionPropertyAccessible(ReflectionProperty $property, AccessContext $context): bool
+    {
+        return match ($context) {
+            AccessContext::SameClass => true,
+            AccessContext::Subclass => !$property->isPrivate(),
+            AccessContext::External => $property->isPublic(),
+        };
+    }
+}

--- a/tests/Utility/TestFixtureClass.php
+++ b/tests/Utility/TestFixtureClass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+class TestFixtureClass
+{
+    public string $publicProperty = '';
+    protected string $protectedProperty = '';
+    private string $privateProperty = '';
+
+    public function publicMethod(): void
+    {
+    }
+
+    protected function protectedMethod(): void
+    {
+    }
+
+    private function privateMethod(): void
+    {
+    }
+}

--- a/tests/Utility/TestFixtureClass.php
+++ b/tests/Utility/TestFixtureClass.php
@@ -21,4 +21,10 @@ class TestFixtureClass
     private function privateMethod(): void
     {
     }
+
+    public function usePrivateMembers(): string
+    {
+        $this->privateMethod();
+        return $this->privateProperty;
+    }
 }

--- a/tests/Utility/VisibilityFilterTest.php
+++ b/tests/Utility/VisibilityFilterTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Utility\AccessContext;
+use Firehed\PhpLsp\Utility\VisibilityFilter;
+use PhpParser\ParserFactory;
+use PhpParser\Node\Stmt;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+#[CoversClass(VisibilityFilter::class)]
+class VisibilityFilterTest extends TestCase
+{
+    /**
+     * @return array<string, array{AccessContext, int, bool}>
+     */
+    public static function methodVisibilityProvider(): array
+    {
+        return [
+            'SameClass sees public' => [AccessContext::SameClass, Stmt\Class_::MODIFIER_PUBLIC, true],
+            'SameClass sees protected' => [AccessContext::SameClass, Stmt\Class_::MODIFIER_PROTECTED, true],
+            'SameClass sees private' => [AccessContext::SameClass, Stmt\Class_::MODIFIER_PRIVATE, true],
+            'Subclass sees public' => [AccessContext::Subclass, Stmt\Class_::MODIFIER_PUBLIC, true],
+            'Subclass sees protected' => [AccessContext::Subclass, Stmt\Class_::MODIFIER_PROTECTED, true],
+            'Subclass does not see private' => [AccessContext::Subclass, Stmt\Class_::MODIFIER_PRIVATE, false],
+            'External sees public' => [AccessContext::External, Stmt\Class_::MODIFIER_PUBLIC, true],
+            'External does not see protected' => [AccessContext::External, Stmt\Class_::MODIFIER_PROTECTED, false],
+            'External does not see private' => [AccessContext::External, Stmt\Class_::MODIFIER_PRIVATE, false],
+        ];
+    }
+
+    #[DataProvider('methodVisibilityProvider')]
+    public function testIsMethodAccessible(AccessContext $context, int $modifier, bool $expected): void
+    {
+        $code = <<<PHP
+<?php
+class MyClass {
+    {$this->modifierKeyword($modifier)} function myMethod() {}
+}
+PHP;
+        $ast = $this->parse($code);
+        $classNode = $ast[0];
+        assert($classNode instanceof Stmt\Class_);
+        $method = $classNode->stmts[0];
+        assert($method instanceof Stmt\ClassMethod);
+
+        self::assertSame($expected, VisibilityFilter::isMethodAccessible($method, $context));
+    }
+
+    #[DataProvider('methodVisibilityProvider')]
+    public function testIsPropertyAccessible(AccessContext $context, int $modifier, bool $expected): void
+    {
+        $code = <<<PHP
+<?php
+class MyClass {
+    {$this->modifierKeyword($modifier)} \$myProperty;
+}
+PHP;
+        $ast = $this->parse($code);
+        $classNode = $ast[0];
+        assert($classNode instanceof Stmt\Class_);
+        $property = $classNode->stmts[0];
+        assert($property instanceof Stmt\Property);
+
+        self::assertSame($expected, VisibilityFilter::isPropertyAccessible($property, $context));
+    }
+
+    public function testIsReflectionMethodAccessibleSameClass(): void
+    {
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'publicMethod');
+        self::assertTrue(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::SameClass));
+
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'protectedMethod');
+        self::assertTrue(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::SameClass));
+
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'privateMethod');
+        self::assertTrue(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::SameClass));
+    }
+
+    public function testIsReflectionMethodAccessibleSubclass(): void
+    {
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'publicMethod');
+        self::assertTrue(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::Subclass));
+
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'protectedMethod');
+        self::assertTrue(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::Subclass));
+
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'privateMethod');
+        self::assertFalse(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::Subclass));
+    }
+
+    public function testIsReflectionMethodAccessibleExternal(): void
+    {
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'publicMethod');
+        self::assertTrue(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::External));
+
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'protectedMethod');
+        self::assertFalse(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::External));
+
+        $reflection = new ReflectionMethod(TestFixtureClass::class, 'privateMethod');
+        self::assertFalse(VisibilityFilter::isReflectionMethodAccessible($reflection, AccessContext::External));
+    }
+
+    public function testIsReflectionPropertyAccessibleSameClass(): void
+    {
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'publicProperty');
+        self::assertTrue(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::SameClass));
+
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'protectedProperty');
+        self::assertTrue(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::SameClass));
+
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'privateProperty');
+        self::assertTrue(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::SameClass));
+    }
+
+    public function testIsReflectionPropertyAccessibleSubclass(): void
+    {
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'publicProperty');
+        self::assertTrue(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::Subclass));
+
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'protectedProperty');
+        self::assertTrue(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::Subclass));
+
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'privateProperty');
+        self::assertFalse(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::Subclass));
+    }
+
+    public function testIsReflectionPropertyAccessibleExternal(): void
+    {
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'publicProperty');
+        self::assertTrue(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::External));
+
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'protectedProperty');
+        self::assertFalse(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::External));
+
+        $reflection = new ReflectionProperty(TestFixtureClass::class, 'privateProperty');
+        self::assertFalse(VisibilityFilter::isReflectionPropertyAccessible($reflection, AccessContext::External));
+    }
+
+    private function modifierKeyword(int $modifier): string
+    {
+        return match ($modifier) {
+            Stmt\Class_::MODIFIER_PUBLIC => 'public',
+            Stmt\Class_::MODIFIER_PROTECTED => 'protected',
+            Stmt\Class_::MODIFIER_PRIVATE => 'private',
+            default => throw new \InvalidArgumentException("Unexpected modifier: $modifier"),
+        };
+    }
+
+    /**
+     * @return array<Stmt>
+     */
+    private function parse(string $code): array
+    {
+        $parserFactory = new ParserFactory();
+        $parser = $parserFactory->createForNewestSupportedVersion();
+        $result = $parser->parse($code);
+        assert($result !== null);
+        return $result;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `AccessContext` enum with `SameClass`, `Subclass`, and `External` values
- Adds `VisibilityFilter` utility with methods to check member accessibility based on context
- Updates `CompletionHandler` to use the centralized visibility logic

This centralizes visibility rules into a shared utility that:
- Takes the access context (same class, subclass, external)
- Filters members based on PHP visibility rules
- Provides consistent handling across completion features

Note: `MemberFinder` continues to use simple `isPrivate()` checks since its concern is inheritance visibility (excluding private members when traversing hierarchy), not access control.

Closes #99

## Test plan

- [x] All existing tests pass
- [x] New unit tests for `VisibilityFilter` cover all visibility/context combinations
- [x] PHPStan and PHPCS pass

🤖 Generated with [Claude Code](https://claude.ai/code)