### PR TITLE
Refactor: Unify member completion paths

### DIFF
--- a/src/Completion/MemberFilter.php
+++ b/src/Completion/MemberFilter.php
@@ -9,4 +9,13 @@ enum MemberFilter
     case Instance;
     case Static;
     case Both;
+
+    public function matches(bool $isStatic): bool
+    {
+        return match ($this) {
+            self::Instance => !$isStatic,
+            self::Static => $isStatic,
+            self::Both => true,
+        };
+    }
 }

--- a/src/Completion/MemberFilter.php
+++ b/src/Completion/MemberFilter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+enum MemberFilter
+{
+    case Instance;
+    case Static;
+    case Both;
+}

--- a/src/Completion/VisibilityFilter.php
+++ b/src/Completion/VisibilityFilter.php
@@ -9,4 +9,37 @@ enum VisibilityFilter
     case All;
     case PublicOnly;
     case PublicProtected;
+
+    public function getMethodFlags(): int
+    {
+        return match ($this) {
+            self::All => \ReflectionMethod::IS_PUBLIC
+                | \ReflectionMethod::IS_PROTECTED
+                | \ReflectionMethod::IS_PRIVATE,
+            self::PublicOnly => \ReflectionMethod::IS_PUBLIC,
+            self::PublicProtected => \ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED,
+        };
+    }
+
+    public function getPropertyFlags(): int
+    {
+        return match ($this) {
+            self::All => \ReflectionProperty::IS_PUBLIC
+                | \ReflectionProperty::IS_PROTECTED
+                | \ReflectionProperty::IS_PRIVATE,
+            self::PublicOnly => \ReflectionProperty::IS_PUBLIC,
+            self::PublicProtected => \ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED,
+        };
+    }
+
+    public function getConstantFlags(): int
+    {
+        return match ($this) {
+            self::All => \ReflectionClassConstant::IS_PUBLIC
+                | \ReflectionClassConstant::IS_PROTECTED
+                | \ReflectionClassConstant::IS_PRIVATE,
+            self::PublicOnly => \ReflectionClassConstant::IS_PUBLIC,
+            self::PublicProtected => \ReflectionClassConstant::IS_PUBLIC | \ReflectionClassConstant::IS_PROTECTED,
+        };
+    }
 }

--- a/src/Completion/VisibilityFilter.php
+++ b/src/Completion/VisibilityFilter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+enum VisibilityFilter
+{
+    case All;
+    case PublicOnly;
+    case PublicProtected;
+}

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -185,7 +185,7 @@ final class CompletionHandler implements HandlerInterface
         // Must check before general type hint context since both patterns overlap
         if (preg_match('/(?:public|private|protected)\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
-            $items = $this->getClassMemberKeywordCompletions($prefix);
+            $items = $this->filterKeywords(self::KEYWORDS_AFTER_VISIBILITY, $prefix);
             $items = array_merge($items, $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Property));
             return $this->deduplicateCompletions($items);
         }
@@ -219,7 +219,7 @@ final class CompletionHandler implements HandlerInterface
         if ($this->isInClassBody($textBeforeCursor)) {
             if (preg_match('/(?:^|[\s{;])(\w+)$/', $textBeforeCursor, $matches) === 1) {
                 $prefix = $matches[1];
-                return $this->getClassBodyKeywordCompletions($prefix);
+                return $this->filterKeywords(self::KEYWORDS_CLASS_BODY, $prefix);
             }
             return [];
         }
@@ -227,7 +227,7 @@ final class CompletionHandler implements HandlerInterface
         // Function/class/keyword completion (at start of expression or after operators)
         if (preg_match('/(?:^|[(\s=,!&|])(\w+)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
-            $items = $this->getKeywordCompletions($prefix);
+            $items = $this->filterKeywords(self::KEYWORDS_ALL, $prefix);
             $items = array_merge($items, $this->getFunctionCompletions($prefix, $ast));
             $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
             $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
@@ -279,6 +279,7 @@ final class CompletionHandler implements HandlerInterface
         VisibilityFilter $visibility,
         MemberFilter $memberFilter,
         string $prefix,
+        bool $includeProperties = true,
         bool $includeConstants = false,
         bool $includeEnumCases = false,
     ): array {
@@ -300,10 +301,12 @@ final class CompletionHandler implements HandlerInterface
             }
         }
 
-        foreach ($members['properties'] as $member) {
-            $name = $member['name'];
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatPropertyCompletion($member['node'], $name);
+        if ($includeProperties) {
+            foreach ($members['properties'] as $member) {
+                $name = $member['name'];
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatPropertyCompletion($member['node'], $name);
+                }
             }
         }
 
@@ -353,6 +356,7 @@ final class CompletionHandler implements HandlerInterface
                 $memberFilter,
                 $items,
                 $includeConstants,
+                $includeProperties,
             ),
         );
 
@@ -476,39 +480,14 @@ final class CompletionHandler implements HandlerInterface
             $resolvedName = $classNode->extends->getAttribute('resolvedName')->toString();
         }
 
-        $parentNode = ClassFinder::findWithLocator(
+        return $this->getMemberCompletions(
             $resolvedName,
             $ast,
-            $this->classLocator,
-            $this->parser,
+            VisibilityFilter::PublicProtected,
+            MemberFilter::Both,
+            $prefix,
+            includeProperties: false,
         );
-
-        $items = [];
-
-        $members = MemberCollector::collect($parentNode, VisibilityFilter::PublicProtected, MemberFilter::Both);
-
-        foreach ($members['methods'] as $member) {
-            $name = $member['name'];
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatMethodCompletion($member['node']);
-            }
-        }
-
-        // Add inherited methods via reflection (parent:: only supports methods)
-        $items = array_merge(
-            $items,
-            $this->getReflectionMemberCompletions(
-                $resolvedName,
-                $prefix,
-                VisibilityFilter::PublicProtected,
-                MemberFilter::Both,
-                $items,
-                includeConstants: false,
-                includeProperties: false,
-            ),
-        );
-
-        return $items;
     }
 
     /**
@@ -539,20 +518,6 @@ final class CompletionHandler implements HandlerInterface
             return [];
         }
 
-        return $this->getInstanceMemberCompletions($className, $prefix, $ast);
-    }
-
-    /**
-     * Get instance (non-static) member completions for a class.
-     *
-     * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
-     */
-    private function getInstanceMemberCompletions(
-        string $className,
-        string $prefix,
-        array $ast,
-    ): array {
         return $this->getMemberCompletions(
             $className,
             $ast,
@@ -1133,28 +1098,35 @@ final class CompletionHandler implements HandlerInterface
         return $this->deduplicateCompletions($items);
     }
 
+    private const KEYWORDS_ALL = [
+        // Control flow
+        'if', 'else', 'elseif', 'switch', 'case', 'default',
+        'while', 'do', 'for', 'foreach', 'break', 'continue',
+        'return', 'throw', 'try', 'catch', 'finally',
+        // Declarations
+        'function', 'class', 'interface', 'trait', 'enum', 'namespace', 'use',
+        'extends', 'implements', 'const', 'public', 'protected', 'private',
+        'static', 'final', 'abstract', 'readonly',
+        // Operators and other
+        'new', 'instanceof', 'clone', 'yield', 'match',
+        'echo', 'print', 'include', 'include_once', 'require', 'require_once',
+        'global', 'unset', 'isset', 'empty', 'list', 'fn',
+    ];
+
+    private const KEYWORDS_CLASS_BODY = [
+        'public', 'private', 'protected',
+        'static', 'final', 'abstract', 'readonly',
+        'const', 'function', 'use',
+    ];
+
+    private const KEYWORDS_AFTER_VISIBILITY = ['function', 'static', 'readonly', 'const'];
+
     /**
-     * Get PHP keyword completions.
-     *
+     * @param list<string> $keywords
      * @return list<array{label: string, kind: int}>
      */
-    private function getKeywordCompletions(string $prefix): array
+    private function filterKeywords(array $keywords, string $prefix): array
     {
-        $keywords = [
-            // Control flow
-            'if', 'else', 'elseif', 'switch', 'case', 'default',
-            'while', 'do', 'for', 'foreach', 'break', 'continue',
-            'return', 'throw', 'try', 'catch', 'finally',
-            // Declarations
-            'function', 'class', 'interface', 'trait', 'enum', 'namespace', 'use',
-            'extends', 'implements', 'const', 'public', 'protected', 'private',
-            'static', 'final', 'abstract', 'readonly',
-            // Operators and other
-            'new', 'instanceof', 'clone', 'yield', 'match',
-            'echo', 'print', 'include', 'include_once', 'require', 'require_once',
-            'global', 'unset', 'isset', 'empty', 'list', 'fn',
-        ];
-
         $items = [];
         $prefixLower = strtolower($prefix);
 
@@ -1220,58 +1192,6 @@ final class CompletionHandler implements HandlerInterface
 
         // depth === 1 means we're directly inside the class body (not in a method)
         return $depth === 1;
-    }
-
-    /**
-     * Get keywords valid at class body level.
-     *
-     * @return list<array{label: string, kind: int}>
-     */
-    private function getClassBodyKeywordCompletions(string $prefix): array
-    {
-        $keywords = [
-            'public', 'private', 'protected',
-            'static', 'final', 'abstract', 'readonly',
-            'const', 'function', 'use',
-        ];
-
-        $items = [];
-        $prefixLower = strtolower($prefix);
-
-        foreach ($keywords as $keyword) {
-            if ($prefix === '' || str_starts_with($keyword, $prefixLower)) {
-                $items[] = [
-                    'label' => $keyword,
-                    'kind' => self::KIND_KEYWORD,
-                ];
-            }
-        }
-
-        return $items;
-    }
-
-    /**
-     * Get keywords valid after a visibility modifier.
-     *
-     * @return list<array{label: string, kind: int}>
-     */
-    private function getClassMemberKeywordCompletions(string $prefix): array
-    {
-        $keywords = ['function', 'static', 'readonly', 'const'];
-
-        $items = [];
-        $prefixLower = strtolower($prefix);
-
-        foreach ($keywords as $keyword) {
-            if ($prefix === '' || str_starts_with($keyword, $prefixLower)) {
-                $items[] = [
-                    'label' => $keyword,
-                    'kind' => self::KIND_KEYWORD,
-                ];
-            }
-        }
-
-        return $items;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -443,12 +443,7 @@ final class CompletionHandler implements HandlerInterface
         };
 
         foreach ($reflection->getMethods($methodFlags) as $method) {
-            $matchesStatic = match ($memberFilter) {
-                MemberFilter::Instance => !$method->isStatic(),
-                MemberFilter::Static => $method->isStatic(),
-                MemberFilter::Both => true,
-            };
-            if (!$matchesStatic) {
+            if (!$memberFilter->matches($method->isStatic())) {
                 continue;
             }
             $name = $method->getName();
@@ -471,12 +466,7 @@ final class CompletionHandler implements HandlerInterface
             };
 
             foreach ($reflection->getProperties($propertyFlags) as $prop) {
-                $matchesStatic = match ($memberFilter) {
-                    MemberFilter::Instance => !$prop->isStatic(),
-                    MemberFilter::Static => $prop->isStatic(),
-                    MemberFilter::Both => true,
-                };
-                if (!$matchesStatic) {
+                if (!$memberFilter->matches($prop->isStatic())) {
                     continue;
                 }
                 $name = $prop->getName();

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Completion\ContextDetector;
+use Firehed\PhpLsp\Completion\MemberFilter;
 use Firehed\PhpLsp\Completion\TypeHintContext;
+use Firehed\PhpLsp\Completion\VisibilityFilter;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
@@ -16,6 +18,7 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\MemberCollector;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
@@ -245,38 +248,208 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getThisMemberCompletions(string $prefix, array $ast): array
     {
-        // Find the enclosing class
         $classNode = $this->findFirstClass($ast);
         if ($classNode === null) {
             return [];
         }
 
+        $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+        if ($className === null) {
+            return [];
+        }
+
+        return $this->getMemberCompletions(
+            $className,
+            $ast,
+            VisibilityFilter::All,
+            MemberFilter::Instance,
+            $prefix,
+        );
+    }
+
+    /**
+     * Unified method to collect member completions with visibility and static/instance filters.
+     *
+     * @param array<Stmt> $ast
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getMemberCompletions(
+        string $className,
+        array $ast,
+        VisibilityFilter $visibility,
+        MemberFilter $memberFilter,
+        string $prefix,
+        bool $includeConstants = false,
+        bool $includeEnumCases = false,
+    ): array {
         $items = [];
 
-        foreach ($classNode->stmts as $stmt) {
-            // Methods
-            if ($stmt instanceof Stmt\ClassMethod) {
-                $name = $stmt->name->toString();
+        $classNode = ClassFinder::findWithLocator(
+            $className,
+            $ast,
+            $this->classLocator,
+            $this->parser,
+        );
+
+        $collector = new MemberCollector();
+        $members = $collector->collect($className, $ast, $visibility, $memberFilter);
+
+        foreach ($members['methods'] as $member) {
+            $name = $member['name'];
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatMethodCompletion($member['node']);
+            }
+        }
+
+        foreach ($members['properties'] as $member) {
+            $name = $member['name'];
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatPropertyCompletion($member['node'], $name);
+            }
+        }
+
+        if ($includeConstants) {
+            foreach ($members['constants'] as $member) {
+                $name = $member['name'];
                 if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                    $items[] = $this->formatMethodCompletion($stmt);
+                    $items[] = $this->formatConstantCompletion($member['node'], $name);
                 }
             }
 
-            // Properties
-            if ($stmt instanceof Stmt\Property) {
-                foreach ($stmt->props as $prop) {
-                    $name = $prop->name->toString();
-                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                        $items[] = $this->formatPropertyCompletion($stmt, $name);
-                    }
+            // ::class magic constant is always available for static access
+            if (
+                $memberFilter === MemberFilter::Static || $memberFilter === MemberFilter::Both
+            ) {
+                if ($prefix === '' || str_starts_with('class', strtolower($prefix))) {
+                    $items[] = [
+                        'label' => 'class',
+                        'kind' => self::KIND_CONSTANT,
+                        'detail' => 'string (fully qualified class name)',
+                    ];
                 }
             }
         }
 
-        // Also include inherited members via reflection if class exists
-        $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
-        if ($className !== null) {
-            $items = array_merge($items, $this->getInheritedMemberCompletions($className, $prefix, $items));
+        if ($includeEnumCases) {
+            foreach ($members['enumCases'] as $member) {
+                $name = $member['name'];
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatEnumCaseCompletion($member['node']);
+                }
+            }
+
+            // Enum built-in methods
+            if ($classNode instanceof Stmt\Enum_) {
+                $items = array_merge($items, $this->getEnumBuiltinMethods($classNode, $prefix));
+            }
+        }
+
+        // Add inherited members via reflection
+        $items = array_merge(
+            $items,
+            $this->getReflectionMemberCompletions(
+                $className,
+                $prefix,
+                $visibility,
+                $memberFilter,
+                $items,
+                $includeConstants,
+            ),
+        );
+
+        return $items;
+    }
+
+    /**
+     * Get members via reflection for inherited/built-in classes.
+     *
+     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
+     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     */
+    private function getReflectionMemberCompletions(
+        string $className,
+        string $prefix,
+        VisibilityFilter $visibility,
+        MemberFilter $memberFilter,
+        array $existingItems,
+        bool $includeConstants = false,
+    ): array {
+        $reflection = ReflectionHelper::getClass($className);
+        if ($reflection === null) {
+            return [];
+        }
+
+        $existingLabels = array_column($existingItems, 'label');
+        $items = [];
+
+        $allMethods = ReflectionMethod::IS_PUBLIC
+            | ReflectionMethod::IS_PROTECTED
+            | ReflectionMethod::IS_PRIVATE;
+        $methodFlags = match ($visibility) {
+            VisibilityFilter::All => $allMethods,
+            VisibilityFilter::PublicOnly => ReflectionMethod::IS_PUBLIC,
+            VisibilityFilter::PublicProtected => ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED,
+        };
+
+        foreach ($reflection->getMethods($methodFlags) as $method) {
+            $matchesStatic = match ($memberFilter) {
+                MemberFilter::Instance => !$method->isStatic(),
+                MemberFilter::Static => $method->isStatic(),
+                MemberFilter::Both => true,
+            };
+            if (!$matchesStatic) {
+                continue;
+            }
+            $name = $method->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
+            }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionMethodCompletion($method);
+            }
+        }
+
+        $allProps = ReflectionProperty::IS_PUBLIC
+            | ReflectionProperty::IS_PROTECTED
+            | ReflectionProperty::IS_PRIVATE;
+        $propertyFlags = match ($visibility) {
+            VisibilityFilter::All => $allProps,
+            VisibilityFilter::PublicOnly => ReflectionProperty::IS_PUBLIC,
+            VisibilityFilter::PublicProtected => ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED,
+        };
+
+        foreach ($reflection->getProperties($propertyFlags) as $prop) {
+            $matchesStatic = match ($memberFilter) {
+                MemberFilter::Instance => !$prop->isStatic(),
+                MemberFilter::Static => $prop->isStatic(),
+                MemberFilter::Both => true,
+            };
+            if (!$matchesStatic) {
+                continue;
+            }
+            $name = $prop->getName();
+            if (in_array($name, $existingLabels, true)) {
+                continue;
+            }
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatReflectionPropertyCompletion($prop);
+            }
+        }
+
+        if ($includeConstants) {
+            foreach ($reflection->getReflectionConstants() as $const) {
+                $name = $const->getName();
+                if (in_array($name, $existingLabels, true)) {
+                    continue;
+                }
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = [
+                        'label' => $name,
+                        'kind' => self::KIND_CONSTANT,
+                        'detail' => 'const ' . $name,
+                    ];
+                }
+            }
         }
 
         return $items;
@@ -296,46 +469,51 @@ final class CompletionHandler implements HandlerInterface
         }
 
         $parentClassName = $classNode->extends->toString();
-
-        // Resolve the parent class name if it's in the same file
-        $parentClassNode = ClassFinder::findWithLocator(
-            $parentClassName,
-            $ast,
-            $this->classLocator,
-            $this->parser,
-        );
+        $resolvedName = $parentClassName;
+        if ($classNode->extends->getAttribute('resolvedName') instanceof Name) {
+            $resolvedName = $classNode->extends->getAttribute('resolvedName')->toString();
+        }
 
         $items = [];
 
-        if ($parentClassNode !== null) {
-            foreach ($parentClassNode->stmts as $stmt) {
-                // Methods (public and protected, both static and non-static)
-                if ($stmt instanceof Stmt\ClassMethod) {
-                    if ($stmt->isPrivate()) {
-                        continue;
-                    }
-                    $name = $stmt->name->toString();
-                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                        $items[] = $this->formatMethodCompletion($stmt);
-                    }
-                }
+        $collector = new MemberCollector();
+        $members = $collector->collect($resolvedName, $ast, VisibilityFilter::PublicProtected, MemberFilter::Both);
+
+        foreach ($members['methods'] as $member) {
+            $name = $member['name'];
+            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                $items[] = $this->formatMethodCompletion($member['node']);
             }
         }
 
-        // Also check via reflection for inherited/built-in classes
-        $items = array_merge($items, $this->getParentReflectionCompletions($parentClassName, $prefix, $items));
+        // Add inherited methods via reflection
+        $items = array_merge(
+            $items,
+            $this->getReflectionMethodCompletions(
+                $resolvedName,
+                $prefix,
+                VisibilityFilter::PublicProtected,
+                MemberFilter::Both,
+                $items,
+            ),
+        );
 
         return $items;
     }
 
     /**
-     * Get parent class methods via reflection.
+     * Get methods via reflection (for parent:: which only needs methods, not properties).
      *
      * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
      * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
      */
-    private function getParentReflectionCompletions(string $className, string $prefix, array $existingItems): array
-    {
+    private function getReflectionMethodCompletions(
+        string $className,
+        string $prefix,
+        VisibilityFilter $visibility,
+        MemberFilter $memberFilter,
+        array $existingItems,
+    ): array {
         $reflection = ReflectionHelper::getClass($className);
         if ($reflection === null) {
             return [];
@@ -344,8 +522,24 @@ final class CompletionHandler implements HandlerInterface
         $existingLabels = array_column($existingItems, 'label');
         $items = [];
 
-        // Public and protected methods (both static and non-static)
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
+        $allMethods = ReflectionMethod::IS_PUBLIC
+            | ReflectionMethod::IS_PROTECTED
+            | ReflectionMethod::IS_PRIVATE;
+        $methodFlags = match ($visibility) {
+            VisibilityFilter::All => $allMethods,
+            VisibilityFilter::PublicOnly => ReflectionMethod::IS_PUBLIC,
+            VisibilityFilter::PublicProtected => ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED,
+        };
+
+        foreach ($reflection->getMethods($methodFlags) as $method) {
+            $matchesStatic = match ($memberFilter) {
+                MemberFilter::Instance => !$method->isStatic(),
+                MemberFilter::Static => $method->isStatic(),
+                MemberFilter::Both => true,
+            };
+            if (!$matchesStatic) {
+                continue;
+            }
             $name = $method->getName();
             if (in_array($name, $existingLabels, true)) {
                 continue;
@@ -400,83 +594,13 @@ final class CompletionHandler implements HandlerInterface
         string $prefix,
         array $ast,
     ): array {
-        $items = [];
-
-        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
-
-        if ($classNode !== null) {
-            foreach ($classNode->stmts as $stmt) {
-                // Public methods (non-static)
-                if ($stmt instanceof Stmt\ClassMethod && !$stmt->isStatic() && $stmt->isPublic()) {
-                    $name = $stmt->name->toString();
-                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                        $items[] = $this->formatMethodCompletion($stmt);
-                    }
-                }
-
-                // Public properties (non-static)
-                if ($stmt instanceof Stmt\Property && !$stmt->isStatic() && $stmt->isPublic()) {
-                    foreach ($stmt->props as $prop) {
-                        $name = $prop->name->toString();
-                        if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                            $items[] = $this->formatPropertyCompletion($stmt, $name);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Add public members from reflection (for inherited/built-in classes)
-        $items = array_merge($items, $this->getReflectionInstanceCompletions($className, $prefix, $items));
-
-        return $items;
-    }
-
-    /**
-     * Get public instance members via reflection.
-     *
-     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
-     */
-    private function getReflectionInstanceCompletions(string $className, string $prefix, array $existingItems): array
-    {
-        $reflection = ReflectionHelper::getClass($className);
-        if ($reflection === null) {
-            return [];
-        }
-
-        $existingLabels = array_column($existingItems, 'label');
-        $items = [];
-
-        // Public non-static methods
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            if ($method->isStatic()) {
-                continue;
-            }
-            $name = $method->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatReflectionMethodCompletion($method);
-            }
-        }
-
-        // Public non-static properties
-        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $prop) {
-            if ($prop->isStatic()) {
-                continue;
-            }
-            $name = $prop->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatReflectionPropertyCompletion($prop);
-            }
-        }
-
-        return $items;
+        return $this->getMemberCompletions(
+            $className,
+            $ast,
+            VisibilityFilter::PublicOnly,
+            MemberFilter::Instance,
+            $prefix,
+        );
     }
 
     /**
@@ -485,71 +609,18 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getStaticCompletions(string $className, string $prefix, array $ast, TextDocument $document): array
     {
-        $items = [];
-
         // Resolve short name to FQCN using imports
         $resolvedClassName = $this->resolveClassName($className, $ast);
 
-        $classNode = ClassFinder::findWithLocator($resolvedClassName, $ast, $this->classLocator, $this->parser);
-
-        if ($classNode !== null) {
-            foreach ($classNode->stmts as $stmt) {
-                // Static methods
-                if ($stmt instanceof Stmt\ClassMethod && $stmt->isStatic()) {
-                    $name = $stmt->name->toString();
-                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                        $items[] = $this->formatMethodCompletion($stmt);
-                    }
-                }
-
-                // Static properties
-                if ($stmt instanceof Stmt\Property && $stmt->isStatic()) {
-                    foreach ($stmt->props as $prop) {
-                        $name = $prop->name->toString();
-                        if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                            $items[] = $this->formatPropertyCompletion($stmt, $name);
-                        }
-                    }
-                }
-
-                // Constants
-                if ($stmt instanceof Stmt\ClassConst) {
-                    foreach ($stmt->consts as $const) {
-                        $name = $const->name->toString();
-                        if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                            $items[] = $this->formatConstantCompletion($stmt, $name);
-                        }
-                    }
-                }
-
-                // Enum cases
-                if ($stmt instanceof Stmt\EnumCase) {
-                    $name = $stmt->name->toString();
-                    if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                        $items[] = $this->formatEnumCaseCompletion($stmt);
-                    }
-                }
-            }
-
-            // Add built-in enum methods
-            if ($classNode instanceof Stmt\Enum_) {
-                $items = array_merge($items, $this->getEnumBuiltinMethods($classNode, $prefix));
-            }
-        }
-
-        // Also try reflection for inherited/built-in
-        $items = array_merge($items, $this->getReflectionStaticCompletions($resolvedClassName, $prefix, $items));
-
-        // Always offer ::class magic constant
-        if ($prefix === '' || str_starts_with('class', strtolower($prefix))) {
-            $items[] = [
-                'label' => 'class',
-                'kind' => self::KIND_CONSTANT,
-                'detail' => 'string (fully qualified class name)',
-            ];
-        }
-
-        return $items;
+        return $this->getMemberCompletions(
+            $resolvedClassName,
+            $ast,
+            VisibilityFilter::All,
+            MemberFilter::Static,
+            $prefix,
+            includeConstants: true,
+            includeEnumCases: true,
+        );
     }
 
     /**
@@ -642,92 +713,6 @@ final class CompletionHandler implements HandlerInterface
         $traverser->traverse($ast);
 
         return $visitor->found;
-    }
-
-    /**
-     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
-     */
-    private function getInheritedMemberCompletions(string $className, string $prefix, array $existingItems): array
-    {
-        $reflection = ReflectionHelper::getClass($className);
-        if ($reflection === null) {
-            return [];
-        }
-
-        $existingLabels = array_column($existingItems, 'label');
-        $items = [];
-
-        // Methods from parent classes
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $method) {
-            $name = $method->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatReflectionMethodCompletion($method);
-            }
-        }
-
-        // Properties from parent classes
-        $flags = ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED;
-        foreach ($reflection->getProperties($flags) as $prop) {
-            $name = $prop->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatReflectionPropertyCompletion($prop);
-            }
-        }
-
-        return $items;
-    }
-
-    /**
-     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
-     */
-    private function getReflectionStaticCompletions(string $className, string $prefix, array $existingItems): array
-    {
-        $reflection = ReflectionHelper::getClass($className);
-        if ($reflection === null) {
-            return [];
-        }
-
-        $existingLabels = array_column($existingItems, 'label');
-        $items = [];
-
-        // Static methods
-        foreach ($reflection->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC) as $method) {
-            if (!$method->isStatic()) {
-                continue;
-            }
-            $name = $method->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatReflectionMethodCompletion($method);
-            }
-        }
-
-        // Constants
-        foreach ($reflection->getReflectionConstants() as $const) {
-            $name = $const->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = [
-                    'label' => $name,
-                    'kind' => self::KIND_CONSTANT,
-                    'detail' => 'const ' . $name,
-                ];
-            }
-        }
-
-        return $items;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -9,7 +9,6 @@ use Firehed\PhpLsp\Completion\MemberFilter;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Completion\VisibilityFilter;
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
@@ -159,7 +158,7 @@ final class CompletionHandler implements HandlerInterface
         $lineText = $document->getLine($line);
         $textBeforeCursor = substr($lineText, 0, $character);
 
-        $items = $this->getCompletionItems($textBeforeCursor, $ast, $document, $line);
+        $items = $this->getCompletionItems($textBeforeCursor, $ast, $line);
 
         return [
             'isIncomplete' => false,
@@ -171,7 +170,7 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
      */
-    private function getCompletionItems(string $textBeforeCursor, array $ast, TextDocument $document, int $line): array
+    private function getCompletionItems(string $textBeforeCursor, array $ast, int $line): array
     {
         // $this-> completion
         if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches) === 1) {
@@ -202,7 +201,7 @@ final class CompletionHandler implements HandlerInterface
                     return [];
                 }
                 $prefix = $matches[1];
-                return $this->getStaticCompletions($className, $prefix, $ast, $document);
+                return $this->getStaticCompletions($className, $prefix, $ast);
             }
             return [];
         }
@@ -217,7 +216,7 @@ final class CompletionHandler implements HandlerInterface
         if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $className = $matches[1];
             $prefix = $matches[2];
-            return $this->getStaticCompletions($className, $prefix, $ast, $document);
+            return $this->getStaticCompletions($className, $prefix, $ast);
         }
 
         // new ClassName completion - suggest imported classes and indexed instantiable types
@@ -579,7 +578,7 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
      */
-    private function getStaticCompletions(string $className, string $prefix, array $ast, TextDocument $document): array
+    private function getStaticCompletions(string $className, string $prefix, array $ast): array
     {
         // Resolve short name to FQCN using imports
         $resolvedClassName = $this->resolveClassName($className, $ast);

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -81,7 +81,7 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return \Generator<Stmt>
      */
-    private function iterateTopLevelStatements(array $ast): \Generator
+    private static function iterateTopLevelStatements(array $ast): \Generator
     {
         foreach ($ast as $stmt) {
             if ($stmt instanceof Stmt\Namespace_) {
@@ -433,16 +433,7 @@ final class CompletionHandler implements HandlerInterface
         $existingLabels = array_column($existingItems, 'label');
         $items = [];
 
-        $allMethods = ReflectionMethod::IS_PUBLIC
-            | ReflectionMethod::IS_PROTECTED
-            | ReflectionMethod::IS_PRIVATE;
-        $methodFlags = match ($visibility) {
-            VisibilityFilter::All => $allMethods,
-            VisibilityFilter::PublicOnly => ReflectionMethod::IS_PUBLIC,
-            VisibilityFilter::PublicProtected => ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED,
-        };
-
-        foreach ($reflection->getMethods($methodFlags) as $method) {
+        foreach ($reflection->getMethods($visibility->getMethodFlags()) as $method) {
             if (!$memberFilter->matches($method->isStatic())) {
                 continue;
             }
@@ -456,16 +447,7 @@ final class CompletionHandler implements HandlerInterface
         }
 
         if ($includeProperties) {
-            $allProps = ReflectionProperty::IS_PUBLIC
-                | ReflectionProperty::IS_PROTECTED
-                | ReflectionProperty::IS_PRIVATE;
-            $propertyFlags = match ($visibility) {
-                VisibilityFilter::All => $allProps,
-                VisibilityFilter::PublicOnly => ReflectionProperty::IS_PUBLIC,
-                VisibilityFilter::PublicProtected => ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED,
-            };
-
-            foreach ($reflection->getProperties($propertyFlags) as $prop) {
+            foreach ($reflection->getProperties($visibility->getPropertyFlags()) as $prop) {
                 if (!$memberFilter->matches($prop->isStatic())) {
                     continue;
                 }
@@ -480,7 +462,7 @@ final class CompletionHandler implements HandlerInterface
         }
 
         if ($includeConstants) {
-            foreach ($reflection->getReflectionConstants() as $const) {
+            foreach ($reflection->getReflectionConstants($visibility->getConstantFlags()) as $const) {
                 $name = $const->getName();
                 if (in_array($name, $existingLabels, true)) {
                     continue;
@@ -622,7 +604,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function findFirstClass(array $ast): ?Stmt\Class_
     {
-        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
+        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
             if ($stmt instanceof Stmt\Class_) {
                 return $stmt;
             }
@@ -869,7 +851,7 @@ final class CompletionHandler implements HandlerInterface
     {
         $imports = [];
 
-        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
+        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
             $this->extractImportsFromUse($stmt, $imports);
         }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -76,6 +76,23 @@ final class CompletionHandler implements HandlerInterface
         return $item;
     }
 
+    /**
+     * Iterate top-level statements, flattening namespace contents.
+     *
+     * @param array<Stmt> $ast
+     * @return \Generator<Stmt>
+     */
+    private function iterateTopLevelStatements(array $ast): \Generator
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                yield from $stmt->stmts;
+            } else {
+                yield $stmt;
+            }
+        }
+    }
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
@@ -616,14 +633,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function findFirstClass(array $ast): ?Stmt\Class_
     {
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                foreach ($stmt->stmts as $nsStmt) {
-                    if ($nsStmt instanceof Stmt\Class_) {
-                        return $nsStmt;
-                    }
-                }
-            }
+        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
             if ($stmt instanceof Stmt\Class_) {
                 return $stmt;
             }
@@ -848,19 +858,10 @@ final class CompletionHandler implements HandlerInterface
      */
     private function resolveClassName(string $shortName, array $ast): string
     {
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                foreach ($stmt->stmts as $nsStmt) {
-                    $resolved = $this->checkUseStatement($nsStmt, $shortName);
-                    if ($resolved !== null) {
-                        return $resolved;
-                    }
-                }
-            } else {
-                $resolved = $this->checkUseStatement($stmt, $shortName);
-                if ($resolved !== null) {
-                    return $resolved;
-                }
+        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
+            $resolved = $this->checkUseStatement($stmt, $shortName);
+            if ($resolved !== null) {
+                return $resolved;
             }
         }
 
@@ -918,14 +919,8 @@ final class CompletionHandler implements HandlerInterface
     {
         $imports = [];
 
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                foreach ($stmt->stmts as $nsStmt) {
-                    $this->extractImportsFromUse($nsStmt, $imports);
-                }
-            } else {
-                $this->extractImportsFromUse($stmt, $imports);
-            }
+        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
+            $this->extractImportsFromUse($stmt, $imports);
         }
 
         return $imports;

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -345,7 +345,7 @@ final class CompletionHandler implements HandlerInterface
         foreach ($members['methods'] as $member) {
             $name = $member['name'];
             if (self::matchesPrefix($name, $prefix)) {
-                $items[] = $this->formatMethodCompletion($member['node']);
+                $items[] = $this->formatCallableCompletion($member['node'], self::KIND_METHOD);
             }
         }
 
@@ -608,7 +608,7 @@ final class CompletionHandler implements HandlerInterface
             if ($stmt instanceof Stmt\Function_) {
                 $name = $stmt->name->toString();
                 if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = $this->formatFunctionCompletion($stmt);
+                    $items[] = $this->formatCallableCompletion($stmt, self::KIND_FUNCTION, 'function ');
                 }
             }
         }
@@ -669,14 +669,6 @@ final class CompletionHandler implements HandlerInterface
         $traverser->traverse($ast);
 
         return $visitor->found;
-    }
-
-    /**
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
-     */
-    private function formatMethodCompletion(Stmt\ClassMethod $method): array
-    {
-        return $this->formatCallableCompletion($method, self::KIND_METHOD);
     }
 
     /**
@@ -764,14 +756,6 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $items;
-    }
-
-    /**
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
-     */
-    private function formatFunctionCompletion(Stmt\Function_ $func): array
-    {
-        return $this->formatCallableCompletion($func, self::KIND_FUNCTION, 'function ');
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -45,6 +45,11 @@ final class CompletionHandler implements HandlerInterface
     // Matches property type continuations: "private ?", "public int|", "protected Foo&"
     private const PROPERTY_TYPE_PATTERN = '/(?:public|private|protected)\s+(?:readonly\s+)?(?:\w+\s*)?[?|&]\s*(\w*)$/';
 
+    private static function matchesPrefix(string $name, string $prefix): bool
+    {
+        return $prefix === '' || str_starts_with(strtolower($name), strtolower($prefix));
+    }
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
@@ -296,7 +301,7 @@ final class CompletionHandler implements HandlerInterface
 
         foreach ($members['methods'] as $member) {
             $name = $member['name'];
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+            if (self::matchesPrefix($name, $prefix)) {
                 $items[] = $this->formatMethodCompletion($member['node']);
             }
         }
@@ -304,7 +309,7 @@ final class CompletionHandler implements HandlerInterface
         if ($includeProperties) {
             foreach ($members['properties'] as $member) {
                 $name = $member['name'];
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                if (self::matchesPrefix($name, $prefix)) {
                     $items[] = $this->formatPropertyCompletion($member['node'], $name);
                 }
             }
@@ -313,7 +318,7 @@ final class CompletionHandler implements HandlerInterface
         if ($includeConstants) {
             foreach ($members['constants'] as $member) {
                 $name = $member['name'];
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                if (self::matchesPrefix($name, $prefix)) {
                     $items[] = $this->formatConstantCompletion($member['node'], $name);
                 }
             }
@@ -322,7 +327,7 @@ final class CompletionHandler implements HandlerInterface
             if (
                 $memberFilter === MemberFilter::Static || $memberFilter === MemberFilter::Both
             ) {
-                if ($prefix === '' || str_starts_with('class', strtolower($prefix))) {
+                if (self::matchesPrefix('class', $prefix)) {
                     $items[] = [
                         'label' => 'class',
                         'kind' => self::KIND_CONSTANT,
@@ -335,7 +340,7 @@ final class CompletionHandler implements HandlerInterface
         if ($includeEnumCases) {
             foreach ($members['enumCases'] as $member) {
                 $name = $member['name'];
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                if (self::matchesPrefix($name, $prefix)) {
                     $items[] = $this->formatEnumCaseCompletion($member['node']);
                 }
             }
@@ -408,7 +413,7 @@ final class CompletionHandler implements HandlerInterface
             if (in_array($name, $existingLabels, true)) {
                 continue;
             }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+            if (self::matchesPrefix($name, $prefix)) {
                 $items[] = $this->formatReflectionMethodCompletion($method);
             }
         }
@@ -436,7 +441,7 @@ final class CompletionHandler implements HandlerInterface
                 if (in_array($name, $existingLabels, true)) {
                     continue;
                 }
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                if (self::matchesPrefix($name, $prefix)) {
                     $items[] = $this->formatReflectionPropertyCompletion($prop);
                 }
             }
@@ -448,7 +453,7 @@ final class CompletionHandler implements HandlerInterface
                 if (in_array($name, $existingLabels, true)) {
                     continue;
                 }
-                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                if (self::matchesPrefix($name, $prefix)) {
                     $items[] = [
                         'label' => $name,
                         'kind' => self::KIND_CONSTANT,
@@ -559,7 +564,7 @@ final class CompletionHandler implements HandlerInterface
         foreach ($ast as $stmt) {
             if ($stmt instanceof Stmt\Function_) {
                 $name = $stmt->name->toString();
-                if (str_starts_with(strtolower($name), strtolower($prefix))) {
+                if (self::matchesPrefix($name, $prefix)) {
                     $items[] = $this->formatFunctionCompletion($stmt);
                 }
             }
@@ -568,7 +573,7 @@ final class CompletionHandler implements HandlerInterface
         // Built-in functions
         $definedFunctions = get_defined_functions();
         foreach ($definedFunctions['internal'] as $name) {
-            if (str_starts_with(strtolower($name), strtolower($prefix))) {
+            if (self::matchesPrefix($name, $prefix)) {
                 $items[] = [
                     'label' => $name,
                     'kind' => self::KIND_FUNCTION,
@@ -722,7 +727,7 @@ final class CompletionHandler implements HandlerInterface
         $items = [];
 
         // cases() is available on all enums
-        if ($prefix === '' || str_starts_with('cases', strtolower($prefix))) {
+        if (self::matchesPrefix('cases', $prefix)) {
             $items[] = [
                 'label' => 'cases',
                 'kind' => self::KIND_METHOD,
@@ -734,7 +739,7 @@ final class CompletionHandler implements HandlerInterface
         if ($enum->scalarType !== null) {
             $scalarType = $enum->scalarType->toString();
 
-            if ($prefix === '' || str_starts_with('from', strtolower($prefix))) {
+            if (self::matchesPrefix('from', $prefix)) {
                 $items[] = [
                     'label' => 'from',
                     'kind' => self::KIND_METHOD,
@@ -742,7 +747,7 @@ final class CompletionHandler implements HandlerInterface
                 ];
             }
 
-            if ($prefix === '' || str_starts_with('tryfrom', strtolower($prefix))) {
+            if (self::matchesPrefix('tryFrom', $prefix)) {
                 $items[] = [
                     'label' => 'tryFrom',
                     'kind' => self::KIND_METHOD,
@@ -924,7 +929,7 @@ final class CompletionHandler implements HandlerInterface
         $imports = $this->getImports($ast);
 
         foreach ($imports as $shortName => $fqcn) {
-            if ($prefix === '' || str_starts_with(strtolower($shortName), strtolower($prefix))) {
+            if (self::matchesPrefix($shortName, $prefix)) {
                 $items[] = [
                     'label' => $shortName,
                     'kind' => self::KIND_CLASS,
@@ -1055,7 +1060,7 @@ final class CompletionHandler implements HandlerInterface
         };
 
         foreach ($builtinTypes as $type) {
-            if ($prefix === '' || str_starts_with($type, strtolower($prefix))) {
+            if (self::matchesPrefix($type, $prefix)) {
                 $items[] = [
                     'label' => $type,
                     'kind' => self::KIND_KEYWORD,
@@ -1192,10 +1197,9 @@ final class CompletionHandler implements HandlerInterface
 
         // Build completion items
         $items = [];
-        $prefixLower = strtolower($prefix);
 
         // Add $this if we're in a method
-        if ($inMethod && ($prefix === '' || str_starts_with('this', $prefixLower))) {
+        if ($inMethod && self::matchesPrefix('this', $prefix)) {
             $className = $this->typeResolver?->resolveVariableType('this', $enclosingScope, $cursorLine, $ast);
             $items[] = [
                 'label' => '$this',
@@ -1205,7 +1209,7 @@ final class CompletionHandler implements HandlerInterface
         }
 
         foreach ($variables as $name => $basicType) {
-            if ($prefix === '' || str_starts_with(strtolower($name), $prefixLower)) {
+            if (self::matchesPrefix($name, $prefix)) {
                 // Use type resolver if available, fall back to basic type
                 $resolvedType = $this->typeResolver?->resolveVariableType($name, $enclosingScope, $cursorLine, $ast);
                 $items[] = [

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -831,31 +831,8 @@ final class CompletionHandler implements HandlerInterface
      */
     private function resolveClassName(string $shortName, array $ast): string
     {
-        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
-            $resolved = $this->checkUseStatement($stmt, $shortName);
-            if ($resolved !== null) {
-                return $resolved;
-            }
-        }
-
-        // Not found in imports, return as-is (might be FQCN or in same namespace)
-        return $shortName;
-    }
-
-    private function checkUseStatement(Stmt $stmt, string $shortName): ?string
-    {
-        if (!$stmt instanceof Stmt\Use_) {
-            return null;
-        }
-
-        foreach ($stmt->uses as $use) {
-            $alias = $use->alias?->toString() ?? $use->name->getLast();
-            if ($alias === $shortName) {
-                return $use->name->toString();
-            }
-        }
-
-        return null;
+        $imports = $this->getImports($ast);
+        return $imports[$shortName] ?? $shortName;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -1218,7 +1218,7 @@ final class CompletionHandler implements HandlerInterface
         // Collect parameters
         foreach ($scope->params as $param) {
             if ($param->var instanceof Variable && is_string($param->var->name)) {
-                $variables[$param->var->name] = $this->formatParamType($param->type);
+                $variables[$param->var->name] = TypeFormatter::formatNode($param->type) ?? 'mixed';
             }
         }
 
@@ -1293,26 +1293,5 @@ final class CompletionHandler implements HandlerInterface
         $traverser->traverse($stmts);
 
         return $collector->variables;
-    }
-
-    private function formatParamType(?Node $type): string
-    {
-        if ($type === null) {
-            return 'mixed';
-        }
-        if ($type instanceof Node\Identifier) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\Name) {
-            return $type->toString();
-        }
-        if ($type instanceof Node\NullableType) {
-            return '?' . $this->formatParamType($type->type);
-        }
-        if ($type instanceof Node\UnionType) {
-            $types = array_map(fn($t) => $this->formatParamType($t), $type->types);
-            return implode('|', $types);
-        }
-        return 'mixed';
     }
 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -291,8 +291,7 @@ final class CompletionHandler implements HandlerInterface
             $this->parser,
         );
 
-        $collector = new MemberCollector();
-        $members = $collector->collect($className, $ast, $visibility, $memberFilter);
+        $members = MemberCollector::collect($classNode, $visibility, $memberFilter);
 
         foreach ($members['methods'] as $member) {
             $name = $member['name'];
@@ -373,6 +372,7 @@ final class CompletionHandler implements HandlerInterface
         MemberFilter $memberFilter,
         array $existingItems,
         bool $includeConstants = false,
+        bool $includeProperties = true,
     ): array {
         $reflection = ReflectionHelper::getClass($className);
         if ($reflection === null) {
@@ -409,30 +409,32 @@ final class CompletionHandler implements HandlerInterface
             }
         }
 
-        $allProps = ReflectionProperty::IS_PUBLIC
-            | ReflectionProperty::IS_PROTECTED
-            | ReflectionProperty::IS_PRIVATE;
-        $propertyFlags = match ($visibility) {
-            VisibilityFilter::All => $allProps,
-            VisibilityFilter::PublicOnly => ReflectionProperty::IS_PUBLIC,
-            VisibilityFilter::PublicProtected => ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED,
-        };
-
-        foreach ($reflection->getProperties($propertyFlags) as $prop) {
-            $matchesStatic = match ($memberFilter) {
-                MemberFilter::Instance => !$prop->isStatic(),
-                MemberFilter::Static => $prop->isStatic(),
-                MemberFilter::Both => true,
+        if ($includeProperties) {
+            $allProps = ReflectionProperty::IS_PUBLIC
+                | ReflectionProperty::IS_PROTECTED
+                | ReflectionProperty::IS_PRIVATE;
+            $propertyFlags = match ($visibility) {
+                VisibilityFilter::All => $allProps,
+                VisibilityFilter::PublicOnly => ReflectionProperty::IS_PUBLIC,
+                VisibilityFilter::PublicProtected => ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED,
             };
-            if (!$matchesStatic) {
-                continue;
-            }
-            $name = $prop->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatReflectionPropertyCompletion($prop);
+
+            foreach ($reflection->getProperties($propertyFlags) as $prop) {
+                $matchesStatic = match ($memberFilter) {
+                    MemberFilter::Instance => !$prop->isStatic(),
+                    MemberFilter::Static => $prop->isStatic(),
+                    MemberFilter::Both => true,
+                };
+                if (!$matchesStatic) {
+                    continue;
+                }
+                $name = $prop->getName();
+                if (in_array($name, $existingLabels, true)) {
+                    continue;
+                }
+                if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
+                    $items[] = $this->formatReflectionPropertyCompletion($prop);
+                }
             }
         }
 
@@ -474,10 +476,16 @@ final class CompletionHandler implements HandlerInterface
             $resolvedName = $classNode->extends->getAttribute('resolvedName')->toString();
         }
 
+        $parentNode = ClassFinder::findWithLocator(
+            $resolvedName,
+            $ast,
+            $this->classLocator,
+            $this->parser,
+        );
+
         $items = [];
 
-        $collector = new MemberCollector();
-        $members = $collector->collect($resolvedName, $ast, VisibilityFilter::PublicProtected, MemberFilter::Both);
+        $members = MemberCollector::collect($parentNode, VisibilityFilter::PublicProtected, MemberFilter::Both);
 
         foreach ($members['methods'] as $member) {
             $name = $member['name'];
@@ -486,68 +494,19 @@ final class CompletionHandler implements HandlerInterface
             }
         }
 
-        // Add inherited methods via reflection
+        // Add inherited methods via reflection (parent:: only supports methods)
         $items = array_merge(
             $items,
-            $this->getReflectionMethodCompletions(
+            $this->getReflectionMemberCompletions(
                 $resolvedName,
                 $prefix,
                 VisibilityFilter::PublicProtected,
                 MemberFilter::Both,
                 $items,
+                includeConstants: false,
+                includeProperties: false,
             ),
         );
-
-        return $items;
-    }
-
-    /**
-     * Get methods via reflection (for parent:: which only needs methods, not properties).
-     *
-     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
-     */
-    private function getReflectionMethodCompletions(
-        string $className,
-        string $prefix,
-        VisibilityFilter $visibility,
-        MemberFilter $memberFilter,
-        array $existingItems,
-    ): array {
-        $reflection = ReflectionHelper::getClass($className);
-        if ($reflection === null) {
-            return [];
-        }
-
-        $existingLabels = array_column($existingItems, 'label');
-        $items = [];
-
-        $allMethods = ReflectionMethod::IS_PUBLIC
-            | ReflectionMethod::IS_PROTECTED
-            | ReflectionMethod::IS_PRIVATE;
-        $methodFlags = match ($visibility) {
-            VisibilityFilter::All => $allMethods,
-            VisibilityFilter::PublicOnly => ReflectionMethod::IS_PUBLIC,
-            VisibilityFilter::PublicProtected => ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED,
-        };
-
-        foreach ($reflection->getMethods($methodFlags) as $method) {
-            $matchesStatic = match ($memberFilter) {
-                MemberFilter::Instance => !$method->isStatic(),
-                MemberFilter::Static => $method->isStatic(),
-                MemberFilter::Both => true,
-            };
-            if (!$matchesStatic) {
-                continue;
-            }
-            $name = $method->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if ($prefix === '' || str_starts_with(strtolower($name), strtolower($prefix))) {
-                $items[] = $this->formatReflectionMethodCompletion($method);
-            }
-        }
 
         return $items;
     }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -644,39 +644,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatMethodCompletion(Stmt\ClassMethod $method): array
     {
-        $params = [];
-        foreach ($method->params as $param) {
-            $paramStr = '';
-            if ($param->type !== null) {
-                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
-            }
-            $var = $param->var;
-            if ($var instanceof Variable && is_string($var->name)) {
-                $paramStr .= '$' . $var->name;
-            }
-            $params[] = $paramStr;
-        }
-
-        $detail = $method->name->toString() . '(' . implode(', ', $params) . ')';
-        if ($method->returnType !== null) {
-            $detail .= ': ' . TypeFormatter::formatNode($method->returnType);
-        }
-
-        $item = [
-            'label' => $method->name->toString(),
-            'kind' => self::KIND_METHOD,
-            'detail' => $detail,
-        ];
-
-        $docComment = $method->getDocComment();
-        if ($docComment !== null) {
-            $doc = DocblockParser::extractDescription($docComment->getText());
-            if ($doc !== '') {
-                $item['documentation'] = $doc;
-            }
-        }
-
-        return $item;
+        return $this->formatCallableCompletion($method, self::KIND_METHOD);
     }
 
     /**
@@ -791,8 +759,19 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatFunctionCompletion(Stmt\Function_ $func): array
     {
+        return $this->formatCallableCompletion($func, self::KIND_FUNCTION, 'function ');
+    }
+
+    /**
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private function formatCallableCompletion(
+        Stmt\ClassMethod|Stmt\Function_ $callable,
+        int $kind,
+        string $detailPrefix = '',
+    ): array {
         $params = [];
-        foreach ($func->params as $param) {
+        foreach ($callable->params as $param) {
             $paramStr = '';
             if ($param->type !== null) {
                 $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
@@ -804,18 +783,18 @@ final class CompletionHandler implements HandlerInterface
             $params[] = $paramStr;
         }
 
-        $detail = 'function ' . $func->name->toString() . '(' . implode(', ', $params) . ')';
-        if ($func->returnType !== null) {
-            $detail .= ': ' . TypeFormatter::formatNode($func->returnType);
+        $detail = $detailPrefix . $callable->name->toString() . '(' . implode(', ', $params) . ')';
+        if ($callable->returnType !== null) {
+            $detail .= ': ' . TypeFormatter::formatNode($callable->returnType);
         }
 
         $item = [
-            'label' => $func->name->toString(),
-            'kind' => self::KIND_FUNCTION,
+            'label' => $callable->name->toString(),
+            'kind' => $kind,
             'detail' => $detail,
         ];
 
-        $docComment = $func->getDocComment();
+        $docComment = $callable->getDocComment();
         if ($docComment !== null) {
             $doc = DocblockParser::extractDescription($docComment->getText());
             if ($doc !== '') {

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -50,6 +50,32 @@ final class CompletionHandler implements HandlerInterface
         return $prefix === '' || str_starts_with(strtolower($name), strtolower($prefix));
     }
 
+    public static function nodeContainsLine(Node $node, int $line): bool
+    {
+        $startLine = $node->getStartLine();
+        $endLine = $node->getEndLine();
+
+        return $startLine !== -1
+            && $endLine !== -1
+            && $line >= $startLine - 1
+            && $line <= $endLine - 1;
+    }
+
+    /**
+     * @param array{label: string, kind: int, detail?: string, documentation?: string} $item
+     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     */
+    private static function withDocumentation(array $item, string|false|null $docText): array
+    {
+        if ($docText !== null && $docText !== false && $docText !== '') {
+            $doc = DocblockParser::extractDescription($docText);
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+        return $item;
+    }
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
@@ -621,17 +647,8 @@ final class CompletionHandler implements HandlerInterface
 
             public function enterNode(Node $node): ?int
             {
-                if ($node instanceof Stmt\Class_) {
-                    $startLine = $node->getStartLine();
-                    $endLine = $node->getEndLine();
-
-                    if (
-                        $startLine !== -1 && $endLine !== -1
-                        && $this->line >= $startLine - 1
-                        && $this->line <= $endLine - 1
-                    ) {
-                        $this->found = $node;
-                    }
+                if ($node instanceof Stmt\Class_ && CompletionHandler::nodeContainsLine($node, $this->line)) {
+                    $this->found = $node;
                 }
                 return null;
             }
@@ -659,21 +676,11 @@ final class CompletionHandler implements HandlerInterface
     {
         $type = $property->type !== null ? TypeFormatter::formatNode($property->type) : 'mixed';
 
-        $item = [
+        return self::withDocumentation([
             'label' => $name,
             'kind' => self::KIND_PROPERTY,
             'detail' => $type . ' $' . $name,
-        ];
-
-        $docComment = $property->getDocComment();
-        if ($docComment !== null) {
-            $doc = DocblockParser::extractDescription($docComment->getText());
-            if ($doc !== '') {
-                $item['documentation'] = $doc;
-            }
-        }
-
-        return $item;
+        ], $property->getDocComment()?->getText());
     }
 
     /**
@@ -681,21 +688,11 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatConstantCompletion(Stmt\ClassConst $const, string $name): array
     {
-        $item = [
+        return self::withDocumentation([
             'label' => $name,
             'kind' => self::KIND_CONSTANT,
             'detail' => 'const ' . $name,
-        ];
-
-        $docComment = $const->getDocComment();
-        if ($docComment !== null) {
-            $doc = DocblockParser::extractDescription($docComment->getText());
-            if ($doc !== '') {
-                $item['documentation'] = $doc;
-            }
-        }
-
-        return $item;
+        ], $const->getDocComment()?->getText());
     }
 
     /**
@@ -793,21 +790,11 @@ final class CompletionHandler implements HandlerInterface
             $detail .= ': ' . TypeFormatter::formatNode($callable->returnType);
         }
 
-        $item = [
+        return self::withDocumentation([
             'label' => $callable->name->toString(),
             'kind' => $kind,
             'detail' => $detail,
-        ];
-
-        $docComment = $callable->getDocComment();
-        if ($docComment !== null) {
-            $doc = DocblockParser::extractDescription($docComment->getText());
-            if ($doc !== '') {
-                $item['documentation'] = $doc;
-            }
-        }
-
-        return $item;
+        ], $callable->getDocComment()?->getText());
     }
 
     /**
@@ -832,21 +819,11 @@ final class CompletionHandler implements HandlerInterface
             $detail .= ': ' . TypeFormatter::formatReflection($returnType);
         }
 
-        $item = [
+        return self::withDocumentation([
             'label' => $method->getName(),
             'kind' => self::KIND_METHOD,
             'detail' => $detail,
-        ];
-
-        $docComment = $method->getDocComment();
-        if ($docComment !== false) {
-            $doc = DocblockParser::extractDescription($docComment);
-            if ($doc !== '') {
-                $item['documentation'] = $doc;
-            }
-        }
-
-        return $item;
+        ], $method->getDocComment());
     }
 
     /**
@@ -857,21 +834,11 @@ final class CompletionHandler implements HandlerInterface
         $type = $prop->getType();
         $typeStr = $type !== null ? TypeFormatter::formatReflection($type) : 'mixed';
 
-        $item = [
+        return self::withDocumentation([
             'label' => $prop->getName(),
             'kind' => self::KIND_PROPERTY,
             'detail' => $typeStr . ' $' . $prop->getName(),
-        ];
-
-        $docComment = $prop->getDocComment();
-        if ($docComment !== false) {
-            $doc = DocblockParser::extractDescription($docComment);
-            if ($doc !== '') {
-                $item['documentation'] = $doc;
-            }
-        }
-
-        return $item;
+        ], $prop->getDocComment());
     }
 
     /**
@@ -1251,23 +1218,13 @@ final class CompletionHandler implements HandlerInterface
             public function enterNode(Node $node): ?int
             {
                 if (
-                    $node instanceof Stmt\Function_
-                    || $node instanceof Stmt\ClassMethod
-                    || $node instanceof Node\Expr\Closure
-                    || $node instanceof Node\Expr\ArrowFunction
+                    ($node instanceof Stmt\Function_
+                        || $node instanceof Stmt\ClassMethod
+                        || $node instanceof Node\Expr\Closure
+                        || $node instanceof Node\Expr\ArrowFunction)
+                    && CompletionHandler::nodeContainsLine($node, $this->cursorLine)
                 ) {
-                    $startLine = $node->getStartLine();
-                    $endLine = $node->getEndLine();
-
-                    // Check if cursor is within this scope (1-based lines from parser)
-                    if (
-                        $startLine !== -1 && $endLine !== -1
-                        && $this->cursorLine >= $startLine - 1
-                        && $this->cursorLine <= $endLine - 1
-                    ) {
-                        // Keep the innermost (last found) scope
-                        $this->found = $node;
-                    }
+                    $this->found = $node;
                 }
                 return null;
             }

--- a/src/Utility/MemberCollector.php
+++ b/src/Utility/MemberCollector.php
@@ -88,11 +88,7 @@ final class MemberCollector
             return false;
         }
 
-        return match ($memberFilter) {
-            MemberFilter::Instance => !$stmt->isStatic(),
-            MemberFilter::Static => $stmt->isStatic(),
-            MemberFilter::Both => true,
-        };
+        return $memberFilter->matches($stmt->isStatic());
     }
 
     private static function matchesVisibility(

--- a/src/Utility/MemberCollector.php
+++ b/src/Utility/MemberCollector.php
@@ -13,7 +13,6 @@ final class MemberCollector
     /**
      * Collect class members filtered by visibility and static/instance.
      *
-     * @param array<Stmt> $ast
      * @return array{
      *   methods: list<array{name: string, node: Stmt\ClassMethod}>,
      *   properties: list<array{name: string, node: Stmt\Property}>,
@@ -21,13 +20,11 @@ final class MemberCollector
      *   enumCases: list<array{name: string, node: Stmt\EnumCase}>,
      * }
      */
-    public function collect(
-        string $className,
-        array $ast,
+    public static function collect(
+        Stmt\Class_|Stmt\Enum_|Stmt\Interface_|Stmt\Trait_|null $classNode,
         VisibilityFilter $visibility,
         MemberFilter $memberFilter,
     ): array {
-        $classNode = $this->findClass($className, $ast);
         if ($classNode === null) {
             return [
                 'methods' => [],
@@ -44,13 +41,13 @@ final class MemberCollector
 
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\ClassMethod) {
-                if ($this->matchesFilters($stmt, $visibility, $memberFilter)) {
+                if (self::matchesFilters($stmt, $visibility, $memberFilter)) {
                     $methods[] = ['name' => $stmt->name->toString(), 'node' => $stmt];
                 }
             }
 
             if ($stmt instanceof Stmt\Property) {
-                if ($this->matchesFilters($stmt, $visibility, $memberFilter)) {
+                if (self::matchesFilters($stmt, $visibility, $memberFilter)) {
                     foreach ($stmt->props as $prop) {
                         $properties[] = ['name' => $prop->name->toString(), 'node' => $stmt];
                     }
@@ -58,10 +55,8 @@ final class MemberCollector
             }
 
             if ($stmt instanceof Stmt\ClassConst) {
-                if (
-                    $memberFilter === MemberFilter::Static || $memberFilter === MemberFilter::Both
-                ) {
-                    if ($this->matchesVisibility($stmt, $visibility)) {
+                if ($memberFilter !== MemberFilter::Instance) {
+                    if (self::matchesVisibility($stmt, $visibility)) {
                         foreach ($stmt->consts as $const) {
                             $constants[] = ['name' => $const->name->toString(), 'node' => $stmt];
                         }
@@ -70,9 +65,7 @@ final class MemberCollector
             }
 
             if ($stmt instanceof Stmt\EnumCase) {
-                if (
-                    $memberFilter === MemberFilter::Static || $memberFilter === MemberFilter::Both
-                ) {
+                if ($memberFilter !== MemberFilter::Instance) {
                     $enumCases[] = ['name' => $stmt->name->toString(), 'node' => $stmt];
                 }
             }
@@ -86,46 +79,12 @@ final class MemberCollector
         ];
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findClass(string $className, array $ast): Stmt\Class_|Stmt\Enum_|null
-    {
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                foreach ($stmt->stmts as $nsStmt) {
-                    $result = $this->checkClassNode($nsStmt, $className);
-                    if ($result !== null) {
-                        return $result;
-                    }
-                }
-            } else {
-                $result = $this->checkClassNode($stmt, $className);
-                if ($result !== null) {
-                    return $result;
-                }
-            }
-        }
-        return null;
-    }
-
-    private function checkClassNode(Stmt $stmt, string $className): Stmt\Class_|Stmt\Enum_|null
-    {
-        if ($stmt instanceof Stmt\Class_ || $stmt instanceof Stmt\Enum_) {
-            $fqcn = $stmt->namespacedName?->toString() ?? $stmt->name?->toString();
-            if ($fqcn === $className) {
-                return $stmt;
-            }
-        }
-        return null;
-    }
-
-    private function matchesFilters(
+    private static function matchesFilters(
         Stmt\ClassMethod|Stmt\Property $stmt,
         VisibilityFilter $visibility,
         MemberFilter $memberFilter,
     ): bool {
-        if (!$this->matchesVisibility($stmt, $visibility)) {
+        if (!self::matchesVisibility($stmt, $visibility)) {
             return false;
         }
 
@@ -136,7 +95,7 @@ final class MemberCollector
         };
     }
 
-    private function matchesVisibility(
+    private static function matchesVisibility(
         Stmt\ClassMethod|Stmt\Property|Stmt\ClassConst $stmt,
         VisibilityFilter $visibility,
     ): bool {

--- a/src/Utility/MemberCollector.php
+++ b/src/Utility/MemberCollector.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\Completion\MemberFilter;
+use Firehed\PhpLsp\Completion\VisibilityFilter;
+use PhpParser\Node\Stmt;
+
+final class MemberCollector
+{
+    /**
+     * Collect class members filtered by visibility and static/instance.
+     *
+     * @param array<Stmt> $ast
+     * @return array{
+     *   methods: list<array{name: string, node: Stmt\ClassMethod}>,
+     *   properties: list<array{name: string, node: Stmt\Property}>,
+     *   constants: list<array{name: string, node: Stmt\ClassConst}>,
+     *   enumCases: list<array{name: string, node: Stmt\EnumCase}>,
+     * }
+     */
+    public function collect(
+        string $className,
+        array $ast,
+        VisibilityFilter $visibility,
+        MemberFilter $memberFilter,
+    ): array {
+        $classNode = $this->findClass($className, $ast);
+        if ($classNode === null) {
+            return [
+                'methods' => [],
+                'properties' => [],
+                'constants' => [],
+                'enumCases' => [],
+            ];
+        }
+
+        $methods = [];
+        $properties = [];
+        $constants = [];
+        $enumCases = [];
+
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\ClassMethod) {
+                if ($this->matchesFilters($stmt, $visibility, $memberFilter)) {
+                    $methods[] = ['name' => $stmt->name->toString(), 'node' => $stmt];
+                }
+            }
+
+            if ($stmt instanceof Stmt\Property) {
+                if ($this->matchesFilters($stmt, $visibility, $memberFilter)) {
+                    foreach ($stmt->props as $prop) {
+                        $properties[] = ['name' => $prop->name->toString(), 'node' => $stmt];
+                    }
+                }
+            }
+
+            if ($stmt instanceof Stmt\ClassConst) {
+                if (
+                    $memberFilter === MemberFilter::Static || $memberFilter === MemberFilter::Both
+                ) {
+                    if ($this->matchesVisibility($stmt, $visibility)) {
+                        foreach ($stmt->consts as $const) {
+                            $constants[] = ['name' => $const->name->toString(), 'node' => $stmt];
+                        }
+                    }
+                }
+            }
+
+            if ($stmt instanceof Stmt\EnumCase) {
+                if (
+                    $memberFilter === MemberFilter::Static || $memberFilter === MemberFilter::Both
+                ) {
+                    $enumCases[] = ['name' => $stmt->name->toString(), 'node' => $stmt];
+                }
+            }
+        }
+
+        return [
+            'methods' => $methods,
+            'properties' => $properties,
+            'constants' => $constants,
+            'enumCases' => $enumCases,
+        ];
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findClass(string $className, array $ast): Stmt\Class_|Stmt\Enum_|null
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                foreach ($stmt->stmts as $nsStmt) {
+                    $result = $this->checkClassNode($nsStmt, $className);
+                    if ($result !== null) {
+                        return $result;
+                    }
+                }
+            } else {
+                $result = $this->checkClassNode($stmt, $className);
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+        }
+        return null;
+    }
+
+    private function checkClassNode(Stmt $stmt, string $className): Stmt\Class_|Stmt\Enum_|null
+    {
+        if ($stmt instanceof Stmt\Class_ || $stmt instanceof Stmt\Enum_) {
+            $fqcn = $stmt->namespacedName?->toString() ?? $stmt->name?->toString();
+            if ($fqcn === $className) {
+                return $stmt;
+            }
+        }
+        return null;
+    }
+
+    private function matchesFilters(
+        Stmt\ClassMethod|Stmt\Property $stmt,
+        VisibilityFilter $visibility,
+        MemberFilter $memberFilter,
+    ): bool {
+        if (!$this->matchesVisibility($stmt, $visibility)) {
+            return false;
+        }
+
+        return match ($memberFilter) {
+            MemberFilter::Instance => !$stmt->isStatic(),
+            MemberFilter::Static => $stmt->isStatic(),
+            MemberFilter::Both => true,
+        };
+    }
+
+    private function matchesVisibility(
+        Stmt\ClassMethod|Stmt\Property|Stmt\ClassConst $stmt,
+        VisibilityFilter $visibility,
+    ): bool {
+        return match ($visibility) {
+            VisibilityFilter::All => true,
+            VisibilityFilter::PublicOnly => $stmt->isPublic(),
+            VisibilityFilter::PublicProtected => $stmt->isPublic() || $stmt->isProtected(),
+        };
+    }
+}

--- a/tests/Completion/MemberFilterTest.php
+++ b/tests/Completion/MemberFilterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Completion;
+
+use Firehed\PhpLsp\Completion\MemberFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MemberFilter::class)]
+class MemberFilterTest extends TestCase
+{
+    /**
+     * @return array<string, array{MemberFilter, bool, bool}>
+     * @codeCoverageIgnore
+     */
+    public static function matchesProvider(): array
+    {
+        return [
+            'Instance matches non-static' => [MemberFilter::Instance, false, true],
+            'Instance rejects static' => [MemberFilter::Instance, true, false],
+            'Static matches static' => [MemberFilter::Static, true, true],
+            'Static rejects non-static' => [MemberFilter::Static, false, false],
+            'Both matches static' => [MemberFilter::Both, true, true],
+            'Both matches non-static' => [MemberFilter::Both, false, true],
+        ];
+    }
+
+    #[DataProvider('matchesProvider')]
+    public function testMatches(MemberFilter $filter, bool $isStatic, bool $expected): void
+    {
+        self::assertSame($expected, $filter->matches($isStatic));
+    }
+}

--- a/tests/Completion/VisibilityFilterTest.php
+++ b/tests/Completion/VisibilityFilterTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Completion;
+
+use Firehed\PhpLsp\Completion\VisibilityFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClassConstant;
+use ReflectionMethod;
+use ReflectionProperty;
+
+#[CoversClass(VisibilityFilter::class)]
+class VisibilityFilterTest extends TestCase
+{
+    /**
+     * @return array<string, array{VisibilityFilter, int}>
+     * @codeCoverageIgnore
+     */
+    public static function methodFlagsProvider(): array
+    {
+        return [
+            'All' => [
+                VisibilityFilter::All,
+                ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED | ReflectionMethod::IS_PRIVATE,
+            ],
+            'PublicOnly' => [
+                VisibilityFilter::PublicOnly,
+                ReflectionMethod::IS_PUBLIC,
+            ],
+            'PublicProtected' => [
+                VisibilityFilter::PublicProtected,
+                ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED,
+            ],
+        ];
+    }
+
+    #[DataProvider('methodFlagsProvider')]
+    public function testGetMethodFlags(VisibilityFilter $filter, int $expected): void
+    {
+        self::assertSame($expected, $filter->getMethodFlags());
+    }
+
+    /**
+     * @return array<string, array{VisibilityFilter, int}>
+     * @codeCoverageIgnore
+     */
+    public static function propertyFlagsProvider(): array
+    {
+        return [
+            'All' => [
+                VisibilityFilter::All,
+                ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_PRIVATE,
+            ],
+            'PublicOnly' => [
+                VisibilityFilter::PublicOnly,
+                ReflectionProperty::IS_PUBLIC,
+            ],
+            'PublicProtected' => [
+                VisibilityFilter::PublicProtected,
+                ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED,
+            ],
+        ];
+    }
+
+    #[DataProvider('propertyFlagsProvider')]
+    public function testGetPropertyFlags(VisibilityFilter $filter, int $expected): void
+    {
+        self::assertSame($expected, $filter->getPropertyFlags());
+    }
+
+    /**
+     * @return array<string, array{VisibilityFilter, int}>
+     * @codeCoverageIgnore
+     */
+    public static function constantFlagsProvider(): array
+    {
+        return [
+            'All' => [
+                VisibilityFilter::All,
+                ReflectionClassConstant::IS_PUBLIC
+                    | ReflectionClassConstant::IS_PROTECTED
+                    | ReflectionClassConstant::IS_PRIVATE,
+            ],
+            'PublicOnly' => [
+                VisibilityFilter::PublicOnly,
+                ReflectionClassConstant::IS_PUBLIC,
+            ],
+            'PublicProtected' => [
+                VisibilityFilter::PublicProtected,
+                ReflectionClassConstant::IS_PUBLIC | ReflectionClassConstant::IS_PROTECTED,
+            ],
+        ];
+    }
+
+    #[DataProvider('constantFlagsProvider')]
+    public function testGetConstantFlags(VisibilityFilter $filter, int $expected): void
+    {
+        self::assertSame($expected, $filter->getConstantFlags());
+    }
+}

--- a/tests/Utility/MemberCollectorTest.php
+++ b/tests/Utility/MemberCollectorTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Completion\MemberFilter;
+use Firehed\PhpLsp\Completion\VisibilityFilter;
+use Firehed\PhpLsp\Utility\MemberCollector;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MemberCollector::class)]
+class MemberCollectorTest extends TestCase
+{
+    use AstTestHelperTrait;
+
+    public function testCollectsAllInstanceMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public string $name;
+    protected int $age;
+    private string $password;
+
+    public function getName(): string { return $this->name; }
+    protected function getAge(): int { return $this->age; }
+    private function getPassword(): string { return $this->password; }
+
+    public static string $count;
+    public static function getCount(): int { return 0; }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('User', $ast, VisibilityFilter::All, MemberFilter::Instance);
+
+        $methodNames = array_column($members['methods'], 'name');
+        $propertyNames = array_column($members['properties'], 'name');
+
+        // Should include all instance members
+        self::assertContains('getName', $methodNames);
+        self::assertContains('getAge', $methodNames);
+        self::assertContains('getPassword', $methodNames);
+        self::assertContains('name', $propertyNames);
+        self::assertContains('age', $propertyNames);
+        self::assertContains('password', $propertyNames);
+
+        // Should exclude static members
+        self::assertNotContains('getCount', $methodNames);
+        self::assertNotContains('count', $propertyNames);
+    }
+
+    public function testCollectsPublicOnlyMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public string $name;
+    protected int $age;
+    private string $password;
+
+    public function getName(): string { return $this->name; }
+    protected function getAge(): int { return $this->age; }
+    private function getPassword(): string { return $this->password; }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('User', $ast, VisibilityFilter::PublicOnly, MemberFilter::Instance);
+
+        $methodNames = array_column($members['methods'], 'name');
+        $propertyNames = array_column($members['properties'], 'name');
+
+        // Should include only public
+        self::assertContains('getName', $methodNames);
+        self::assertContains('name', $propertyNames);
+
+        // Should exclude protected and private
+        self::assertNotContains('getAge', $methodNames);
+        self::assertNotContains('getPassword', $methodNames);
+        self::assertNotContains('age', $propertyNames);
+        self::assertNotContains('password', $propertyNames);
+    }
+
+    public function testCollectsPublicProtectedMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public string $name;
+    protected int $age;
+    private string $password;
+
+    public function getName(): string { return $this->name; }
+    protected function getAge(): int { return $this->age; }
+    private function getPassword(): string { return $this->password; }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('User', $ast, VisibilityFilter::PublicProtected, MemberFilter::Instance);
+
+        $methodNames = array_column($members['methods'], 'name');
+        $propertyNames = array_column($members['properties'], 'name');
+
+        // Should include public and protected
+        self::assertContains('getName', $methodNames);
+        self::assertContains('getAge', $methodNames);
+        self::assertContains('name', $propertyNames);
+        self::assertContains('age', $propertyNames);
+
+        // Should exclude private
+        self::assertNotContains('getPassword', $methodNames);
+        self::assertNotContains('password', $propertyNames);
+    }
+
+    public function testCollectsStaticMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Counter
+{
+    public static int $count = 0;
+    private static string $internalState;
+
+    public static function increment(): void { self::$count++; }
+    private static function reset(): void { self::$count = 0; }
+
+    public int $instanceProp;
+    public function instanceMethod(): void {}
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('Counter', $ast, VisibilityFilter::All, MemberFilter::Static);
+
+        $methodNames = array_column($members['methods'], 'name');
+        $propertyNames = array_column($members['properties'], 'name');
+
+        // Should include all static members
+        self::assertContains('increment', $methodNames);
+        self::assertContains('reset', $methodNames);
+        self::assertContains('count', $propertyNames);
+        self::assertContains('internalState', $propertyNames);
+
+        // Should exclude instance members
+        self::assertNotContains('instanceMethod', $methodNames);
+        self::assertNotContains('instanceProp', $propertyNames);
+    }
+
+    public function testCollectsBothStaticAndInstanceMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Mixed
+{
+    public string $instanceProp;
+    public static int $staticProp;
+
+    public function instanceMethod(): void {}
+    public static function staticMethod(): void {}
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('Mixed', $ast, VisibilityFilter::All, MemberFilter::Both);
+
+        $methodNames = array_column($members['methods'], 'name');
+        $propertyNames = array_column($members['properties'], 'name');
+
+        // Should include both
+        self::assertContains('instanceMethod', $methodNames);
+        self::assertContains('staticMethod', $methodNames);
+        self::assertContains('instanceProp', $propertyNames);
+        self::assertContains('staticProp', $propertyNames);
+    }
+
+    public function testCollectsConstants(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Config
+{
+    public const VERSION = '1.0';
+    private const SECRET = 'abc';
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('Config', $ast, VisibilityFilter::All, MemberFilter::Static);
+
+        $constantNames = array_column($members['constants'], 'name');
+
+        self::assertContains('VERSION', $constantNames);
+        self::assertContains('SECRET', $constantNames);
+    }
+
+    public function testCollectsEnumCases(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status
+{
+    case Active;
+    case Inactive;
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('Status', $ast, VisibilityFilter::All, MemberFilter::Static);
+
+        $caseNames = array_column($members['enumCases'], 'name');
+
+        self::assertContains('Active', $caseNames);
+        self::assertContains('Inactive', $caseNames);
+    }
+
+    public function testReturnsEmptyForUnknownClass(): void
+    {
+        $code = '<?php class Foo {}';
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('UnknownClass', $ast, VisibilityFilter::All, MemberFilter::Instance);
+
+        self::assertEmpty($members['methods']);
+        self::assertEmpty($members['properties']);
+        self::assertEmpty($members['constants']);
+        self::assertEmpty($members['enumCases']);
+    }
+
+    public function testCollectsNamespacedClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class User
+{
+    public string $name;
+    public function getName(): string { return $this->name; }
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $collector = new MemberCollector();
+        $members = $collector->collect('App\\Models\\User', $ast, VisibilityFilter::All, MemberFilter::Instance);
+
+        $methodNames = array_column($members['methods'], 'name');
+        $propertyNames = array_column($members['properties'], 'name');
+
+        self::assertContains('getName', $methodNames);
+        self::assertContains('name', $propertyNames);
+    }
+}

--- a/tests/Utility/MemberCollectorTest.php
+++ b/tests/Utility/MemberCollectorTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Utility;
 use Firehed\PhpLsp\Completion\MemberFilter;
 use Firehed\PhpLsp\Completion\VisibilityFilter;
 use Firehed\PhpLsp\Utility\MemberCollector;
+use PhpParser\Node\Stmt;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -33,15 +34,12 @@ class User
     public static function getCount(): int { return 0; }
 }
 PHP;
-        $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('User', $ast, VisibilityFilter::All, MemberFilter::Instance);
+        $classNode = self::findClassInCode($code, 'User');
+        $members = MemberCollector::collect($classNode, VisibilityFilter::All, MemberFilter::Instance);
 
         $methodNames = array_column($members['methods'], 'name');
         $propertyNames = array_column($members['properties'], 'name');
 
-        // Should include all instance members
         self::assertContains('getName', $methodNames);
         self::assertContains('getAge', $methodNames);
         self::assertContains('getPassword', $methodNames);
@@ -49,7 +47,6 @@ PHP;
         self::assertContains('age', $propertyNames);
         self::assertContains('password', $propertyNames);
 
-        // Should exclude static members
         self::assertNotContains('getCount', $methodNames);
         self::assertNotContains('count', $propertyNames);
     }
@@ -69,19 +66,15 @@ class User
     private function getPassword(): string { return $this->password; }
 }
 PHP;
-        $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('User', $ast, VisibilityFilter::PublicOnly, MemberFilter::Instance);
+        $classNode = self::findClassInCode($code, 'User');
+        $members = MemberCollector::collect($classNode, VisibilityFilter::PublicOnly, MemberFilter::Instance);
 
         $methodNames = array_column($members['methods'], 'name');
         $propertyNames = array_column($members['properties'], 'name');
 
-        // Should include only public
         self::assertContains('getName', $methodNames);
         self::assertContains('name', $propertyNames);
 
-        // Should exclude protected and private
         self::assertNotContains('getAge', $methodNames);
         self::assertNotContains('getPassword', $methodNames);
         self::assertNotContains('age', $propertyNames);
@@ -103,21 +96,17 @@ class User
     private function getPassword(): string { return $this->password; }
 }
 PHP;
-        $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('User', $ast, VisibilityFilter::PublicProtected, MemberFilter::Instance);
+        $classNode = self::findClassInCode($code, 'User');
+        $members = MemberCollector::collect($classNode, VisibilityFilter::PublicProtected, MemberFilter::Instance);
 
         $methodNames = array_column($members['methods'], 'name');
         $propertyNames = array_column($members['properties'], 'name');
 
-        // Should include public and protected
         self::assertContains('getName', $methodNames);
         self::assertContains('getAge', $methodNames);
         self::assertContains('name', $propertyNames);
         self::assertContains('age', $propertyNames);
 
-        // Should exclude private
         self::assertNotContains('getPassword', $methodNames);
         self::assertNotContains('password', $propertyNames);
     }
@@ -138,51 +127,19 @@ class Counter
     public function instanceMethod(): void {}
 }
 PHP;
-        $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('Counter', $ast, VisibilityFilter::All, MemberFilter::Static);
+        $classNode = self::findClassInCode($code, 'Counter');
+        $members = MemberCollector::collect($classNode, VisibilityFilter::All, MemberFilter::Static);
 
         $methodNames = array_column($members['methods'], 'name');
         $propertyNames = array_column($members['properties'], 'name');
 
-        // Should include all static members
         self::assertContains('increment', $methodNames);
         self::assertContains('reset', $methodNames);
         self::assertContains('count', $propertyNames);
         self::assertContains('internalState', $propertyNames);
 
-        // Should exclude instance members
         self::assertNotContains('instanceMethod', $methodNames);
         self::assertNotContains('instanceProp', $propertyNames);
-    }
-
-    public function testCollectsBothStaticAndInstanceMembers(): void
-    {
-        $code = <<<'PHP'
-<?php
-class Mixed
-{
-    public string $instanceProp;
-    public static int $staticProp;
-
-    public function instanceMethod(): void {}
-    public static function staticMethod(): void {}
-}
-PHP;
-        $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('Mixed', $ast, VisibilityFilter::All, MemberFilter::Both);
-
-        $methodNames = array_column($members['methods'], 'name');
-        $propertyNames = array_column($members['properties'], 'name');
-
-        // Should include both
-        self::assertContains('instanceMethod', $methodNames);
-        self::assertContains('staticMethod', $methodNames);
-        self::assertContains('instanceProp', $propertyNames);
-        self::assertContains('staticProp', $propertyNames);
     }
 
     public function testCollectsConstants(): void
@@ -195,10 +152,8 @@ class Config
     private const SECRET = 'abc';
 }
 PHP;
-        $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('Config', $ast, VisibilityFilter::All, MemberFilter::Static);
+        $classNode = self::findClassInCode($code, 'Config');
+        $members = MemberCollector::collect($classNode, VisibilityFilter::All, MemberFilter::Static);
 
         $constantNames = array_column($members['constants'], 'name');
 
@@ -217,9 +172,8 @@ enum Status
 }
 PHP;
         $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('Status', $ast, VisibilityFilter::All, MemberFilter::Static);
+        $enumNode = self::findEnumInAst($ast, 'Status');
+        $members = MemberCollector::collect($enumNode, VisibilityFilter::All, MemberFilter::Static);
 
         $caseNames = array_column($members['enumCases'], 'name');
 
@@ -227,13 +181,9 @@ PHP;
         self::assertContains('Inactive', $caseNames);
     }
 
-    public function testReturnsEmptyForUnknownClass(): void
+    public function testReturnsEmptyForNullNode(): void
     {
-        $code = '<?php class Foo {}';
-        $ast = self::parseWithParents($code);
-
-        $collector = new MemberCollector();
-        $members = $collector->collect('UnknownClass', $ast, VisibilityFilter::All, MemberFilter::Instance);
+        $members = MemberCollector::collect(null, VisibilityFilter::All, MemberFilter::Instance);
 
         self::assertEmpty($members['methods']);
         self::assertEmpty($members['properties']);
@@ -241,27 +191,27 @@ PHP;
         self::assertEmpty($members['enumCases']);
     }
 
-    public function testCollectsNamespacedClass(): void
+    private static function findClassInCode(string $code, string $className): ?Stmt\Class_
     {
-        $code = <<<'PHP'
-<?php
-namespace App\Models;
-
-class User
-{
-    public string $name;
-    public function getName(): string { return $this->name; }
-}
-PHP;
         $ast = self::parseWithParents($code);
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Class_ && $stmt->name?->toString() === $className) {
+                return $stmt;
+            }
+        }
+        return null;
+    }
 
-        $collector = new MemberCollector();
-        $members = $collector->collect('App\\Models\\User', $ast, VisibilityFilter::All, MemberFilter::Instance);
-
-        $methodNames = array_column($members['methods'], 'name');
-        $propertyNames = array_column($members['properties'], 'name');
-
-        self::assertContains('getName', $methodNames);
-        self::assertContains('name', $propertyNames);
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findEnumInAst(array $ast, string $enumName): ?Stmt\Enum_
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Enum_ && $stmt->name?->toString() === $enumName) {
+                return $stmt;
+            }
+        }
+        return null;
     }
 }

--- a/tests/Utility/MemberCollectorTest.php
+++ b/tests/Utility/MemberCollectorTest.php
@@ -142,6 +142,31 @@ PHP;
         self::assertNotContains('instanceProp', $propertyNames);
     }
 
+    public function testCollectsBothStaticAndInstanceMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Mixed
+{
+    public static int $staticProp = 0;
+    public int $instanceProp;
+
+    public static function staticMethod(): void {}
+    public function instanceMethod(): void {}
+}
+PHP;
+        $classNode = self::findClassInCode($code, 'Mixed');
+        $members = MemberCollector::collect($classNode, VisibilityFilter::All, MemberFilter::Both);
+
+        $methodNames = array_column($members['methods'], 'name');
+        $propertyNames = array_column($members['properties'], 'name');
+
+        self::assertContains('staticMethod', $methodNames);
+        self::assertContains('instanceMethod', $methodNames);
+        self::assertContains('staticProp', $propertyNames);
+        self::assertContains('instanceProp', $propertyNames);
+    }
+
     public function testCollectsConstants(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
Fixes #96

Unifies the four member completion paths (`$this->`, `$var->`, `ClassName::`, `parent::`) into a single `getMemberCompletions()` method with configurable visibility and static/instance filters.

### Changes:
- Add `VisibilityFilter` enum (All, PublicOnly, PublicProtected)
- Add `MemberFilter` enum (Instance, Static, Both)
- Add `MemberCollector` utility that collects class members with filtering
- Refactor `CompletionHandler` to use unified `getMemberCompletions()`

### Extracted helpers:
- `matchesPrefix()` - case-insensitive prefix matching (was duplicated 15+ times)
- `nodeContainsLine()` - AST line-range checking (was duplicated in 2 visitors)
- `withDocumentation()` - docblock extraction (was duplicated in 5 format methods)
- `filterKeywords()` - keyword completion with prefix filtering (was 3 separate methods)
- `formatCallableCompletion()` - shared method/function formatting (was 2 separate methods)
- `iterateTopLevelStatements()` - namespace-aware statement iteration (was duplicated in 3 methods)

### Net impact:
- **CompletionHandler: -201 lines** (353 insertions, 554 deletions)
- +217 lines of new tests for MemberCollector
- +108 lines for MemberCollector utility
- +24 lines for enum definitions

## Test plan
- [x] All existing completion tests pass (99 tests)
- [x] Full test suite passes (303 tests)
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)