### PR TITLE
Add visibility-aware filtering for static completions

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -9,7 +9,7 @@ This document tracks the current state of code completion in php-lsp.
 | `$this->` member access | `$this->` or `$this->prefix` | Methods and properties from current class + inherited via reflection | ✅ Working |
 | Typed variable member access | `$user->` | Public methods and properties when type is known (parameter types, `new` expressions) | ✅ Working |
 | Variable completions | `$log` | Local variables, parameters, `$this` in methods | ✅ Working |
-| Static access | `ClassName::` | Static methods, constants, static properties | ✅ Working |
+| Static access | `ClassName::` | Static methods, constants, static properties (visibility-aware) | ✅ Working |
 | `new` expression | `new ` | Classes from composer classmap | ✅ Working |
 | Function calls | identifier at expression start | Built-in PHP functions + file-local functions | ✅ Working |
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -201,7 +201,7 @@ final class CompletionHandler implements HandlerInterface
                     return [];
                 }
                 $prefix = $matches[1];
-                return $this->getStaticCompletions($className, $prefix, $ast);
+                return $this->getStaticCompletions($className, $prefix, $ast, $line);
             }
             return [];
         }
@@ -216,7 +216,7 @@ final class CompletionHandler implements HandlerInterface
         if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $className = $matches[1];
             $prefix = $matches[2];
-            return $this->getStaticCompletions($className, $prefix, $ast);
+            return $this->getStaticCompletions($className, $prefix, $ast, $line);
         }
 
         // new ClassName completion - suggest imported classes and indexed instantiable types
@@ -550,20 +550,87 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
      */
-    private function getStaticCompletions(string $className, string $prefix, array $ast): array
+    private function getStaticCompletions(string $className, string $prefix, array $ast, int $line): array
     {
         // Resolve short name to FQCN using imports
         $resolvedClassName = $this->resolveClassName($className, $ast);
 
+        $visibility = $this->determineVisibilityForClass($resolvedClassName, $ast, $line);
+
         return $this->getMemberCompletions(
             $resolvedClassName,
             $ast,
-            VisibilityFilter::All,
+            $visibility,
             MemberFilter::Static,
             $prefix,
             includeConstants: true,
             includeEnumCases: true,
         );
+    }
+
+    /**
+     * Determine the appropriate visibility filter based on the relationship
+     * between the enclosing class and the target class.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function determineVisibilityForClass(string $targetClassName, array $ast, int $line): VisibilityFilter
+    {
+        $enclosingClass = $this->findClassAtLine($ast, $line);
+        if ($enclosingClass === null) {
+            return VisibilityFilter::PublicOnly;
+        }
+
+        $enclosingClassName = $enclosingClass->namespacedName?->toString()
+            ?? $enclosingClass->name?->toString();
+
+        if ($enclosingClassName === null) {
+            return VisibilityFilter::PublicOnly;
+        }
+
+        // Same class - can access all members
+        if ($enclosingClassName === $targetClassName) {
+            return VisibilityFilter::All;
+        }
+
+        // Check if enclosing class extends target class (AST first, then reflection)
+        if ($this->isSubclassOf($enclosingClass, $targetClassName)) {
+            return VisibilityFilter::PublicProtected;
+        }
+
+        return VisibilityFilter::PublicOnly;
+    }
+
+    private function isSubclassOf(Stmt\Class_ $childClass, string $parentClass): bool
+    {
+        // Check extends clause in AST
+        if ($childClass->extends !== null) {
+            $resolvedName = $childClass->extends->getAttribute('resolvedName');
+            $extendsName = $resolvedName instanceof Name
+                ? $resolvedName->toString()
+                : $childClass->extends->toString();
+            if ($extendsName === $parentClass) {
+                return true;
+            }
+        }
+
+        // Try reflection for deeper inheritance
+        $childClassName = $childClass->namespacedName?->toString()
+            ?? $childClass->name?->toString();
+        if ($childClassName === null) {
+            return false;
+        }
+
+        if (class_exists($childClassName, false) && class_exists($parentClass, false)) {
+            return is_subclass_of($childClassName, $parentClass);
+        }
+
+        $childReflection = ReflectionHelper::getClass($childClassName);
+        if ($childReflection === null) {
+            return false;
+        }
+
+        return $childReflection->isSubclassOf($parentClass);
     }
 
     /**

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -316,6 +316,129 @@ PHP;
         self::assertContains('ROLE_ADMIN', $labels);
     }
 
+    public function testStaticCompletionShowsOnlyPublicForExternalClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Target
+{
+    public static function publicMethod(): void {}
+    protected static function protectedMethod(): void {}
+    private static function privateMethod(): void {}
+    public const PUBLIC_CONST = 'pub';
+    protected const PROTECTED_CONST = 'prot';
+    private const PRIVATE_CONST = 'priv';
+}
+
+class Other
+{
+    public function test(): void
+    {
+        Target::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 16], // Target::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('publicMethod', $labels);
+        self::assertContains('PUBLIC_CONST', $labels);
+        self::assertNotContains('protectedMethod', $labels);
+        self::assertNotContains('privateMethod', $labels);
+        self::assertNotContains('PROTECTED_CONST', $labels);
+        self::assertNotContains('PRIVATE_CONST', $labels);
+    }
+
+    public function testStaticCompletionShowsAllForSameClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    public static function publicMethod(): void {}
+    protected static function protectedMethod(): void {}
+    private static function privateMethod(): void {}
+
+    public function test(): void
+    {
+        self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 14], // self::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('publicMethod', $labels);
+        self::assertContains('protectedMethod', $labels);
+        self::assertContains('privateMethod', $labels);
+    }
+
+    public function testStaticCompletionShowsPublicProtectedForSubclass(): void
+    {
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    public static function publicMethod(): void {}
+    protected static function protectedMethod(): void {}
+    private static function privateMethod(): void {}
+}
+
+class ChildClass extends ParentClass
+{
+    public function test(): void
+    {
+        ParentClass::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 21], // ParentClass::
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('publicMethod', $labels);
+        self::assertContains('protectedMethod', $labels);
+        self::assertNotContains('privateMethod', $labels);
+    }
+
     public function testFunctionCompletion(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
Fixes #106

`ClassName::` completions now respect visibility based on the relationship between the cursor location and the target class:

- **Same class** (`self::` or `MyClass::` inside MyClass): shows all members
- **Subclass** (`ParentClass::` inside ChildClass): shows public and protected
- **External** (`OtherClass::` from unrelated code): shows only public

**Depends on #105** - merge that first.

## Test plan
- [x] 3 new test cases covering same-class, subclass, and external access
- [x] All existing tests pass (322 tests)
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)