### PR TITLE
Consolidate Name resolution to ScopeFinder::resolveName

### DIFF
--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -127,7 +127,7 @@ final class DefinitionHandler implements HandlerInterface
      */
     private function handleNameDefinition(Name $node): ?array
     {
-        $symbolName = $this->resolveName($node);
+        $symbolName = ScopeFinder::resolveName($node);
 
         // Look up in index first (for open files)
         $symbol = $this->symbolIndex->findByFqn($symbolName);
@@ -168,13 +168,13 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        $className = $this->resolveName($class);
+        $className = ScopeFinder::resolveName($class);
 
         // Handle parent:: - resolve to actual parent class name
         if ($className === 'parent') {
             $enclosingClass = ScopeFinder::findEnclosingClassNode($call);
             if ($enclosingClass instanceof Stmt\Class_ && $enclosingClass->extends !== null) {
-                $className = $this->resolveName($enclosingClass->extends);
+                $className = ScopeFinder::resolveName($enclosingClass->extends);
             } else {
                 return null;
             }
@@ -251,7 +251,7 @@ final class DefinitionHandler implements HandlerInterface
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
-                    $traitResult = $this->findMethodDefinition($this->resolveName($traitName), $methodName, $ast);
+                    $traitResult = $this->findMethodDefinition(ScopeFinder::resolveName($traitName), $methodName, $ast);
                     if ($traitResult !== null) {
                         return $traitResult;
                     }
@@ -261,7 +261,8 @@ final class DefinitionHandler implements HandlerInterface
 
         // Search in parent class
         if ($classNode instanceof Stmt\Class_ && $classNode->extends !== null) {
-            $parentResult = $this->findMethodDefinition($this->resolveName($classNode->extends), $methodName, $ast);
+            $parentName = ScopeFinder::resolveName($classNode->extends);
+            $parentResult = $this->findMethodDefinition($parentName, $methodName, $ast);
             if ($parentResult !== null) {
                 return $parentResult;
             }
@@ -429,16 +430,5 @@ final class DefinitionHandler implements HandlerInterface
 
         // Fallback: return start of file
         return new Location($uri, 0, 0, 0, 0);
-    }
-
-    /**
-     * Get the fully qualified name from a Name node, using resolvedName if available.
-     */
-    private function resolveName(Name $node): string
-    {
-        $resolved = $node->getAttribute('resolvedName');
-        return $resolved instanceof Name
-            ? $resolved->toString()
-            : $node->toString();
     }
 }

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -16,6 +16,7 @@ use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\MemberFinder;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
+use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -171,10 +172,7 @@ final class HoverHandler implements HandlerInterface
      */
     private function getClassHover(Name $node, array $ast, TextDocument $document): ?string
     {
-        $resolvedName = $node->getAttribute('resolvedName');
-        $className = $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $node->toString();
+        $className = ScopeFinder::resolveName($node);
 
         $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
 
@@ -326,10 +324,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $resolvedName = $class->getAttribute('resolvedName');
-        $className = $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $class->toString();
+        $className = ScopeFinder::resolveName($class);
 
         return $this->getMethodHoverForClass($className, $methodName->toString(), $ast, $document);
     }
@@ -367,10 +362,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $resolvedName = $class->getAttribute('resolvedName');
-        $className = $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $class->toString();
+        $className = ScopeFinder::resolveName($class);
 
         return $this->getPropertyHoverForClass($className, $propertyName->toString(), $ast, $document);
     }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -262,10 +262,7 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        $resolvedName = $class->getAttribute('resolvedName');
-        $className = $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $class->toString();
+        $className = ScopeFinder::resolveName($class);
 
         // Handle self/static/parent
         if ($className === 'self' || $className === 'static' || $className === 'parent') {
@@ -290,10 +287,7 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        $resolvedName = $class->getAttribute('resolvedName');
-        $className = $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $class->toString();
+        $className = ScopeFinder::resolveName($class);
 
         return $this->getMethodSignatureForClass($className, '__construct', $ast, $document);
     }

--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -6,7 +6,6 @@ namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
 final class MemberFinder
@@ -79,7 +78,7 @@ final class MemberFinder
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
-                    $traitClassName = self::resolveName($traitName);
+                    $traitClassName = ScopeFinder::resolveName($traitName);
                     $traitNode = ClassFinder::findWithLocator($traitClassName, $ast, $classLocator, $parser);
                     if ($traitNode !== null) {
                         $traitMethod = self::findMethodInClassNode(
@@ -143,7 +142,7 @@ final class MemberFinder
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\TraitUse) {
                 foreach ($stmt->traits as $traitName) {
-                    $traitClassName = self::resolveName($traitName);
+                    $traitClassName = ScopeFinder::resolveName($traitName);
                     $traitNode = ClassFinder::findWithLocator($traitClassName, $ast, $classLocator, $parser);
                     if ($traitNode !== null) {
                         $traitProperty = self::findPropertyInClassNode(
@@ -186,14 +185,6 @@ final class MemberFinder
         if (!$classNode instanceof Stmt\Class_ || $classNode->extends === null) {
             return null;
         }
-        return self::resolveName($classNode->extends);
-    }
-
-    private static function resolveName(Name $name): string
-    {
-        $resolvedName = $name->getAttribute('resolvedName');
-        return $resolvedName instanceof Name
-            ? $resolvedName->toString()
-            : $name->toString();
+        return ScopeFinder::resolveName($classNode->extends);
     }
 }

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -62,6 +62,20 @@ final class ScopeFinder
     }
 
     /**
+     * Resolve a Name node to its fully qualified name.
+     *
+     * Uses the resolved name attribute if available (from NameResolver),
+     * otherwise falls back to the raw name.
+     */
+    public static function resolveName(Name $name): string
+    {
+        $resolvedName = $name->getAttribute('resolvedName');
+        return $resolvedName instanceof Name
+            ? $resolvedName->toString()
+            : $name->toString();
+    }
+
+    /**
      * Find the fully qualified name of the enclosing class-like node.
      *
      * Returns the FQN if available, otherwise the short name, or null if not

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -290,4 +290,33 @@ PHP;
 
         self::assertNull($className);
     }
+
+    public function testResolveNameReturnsRawNameWhenNoResolvedAttribute(): void
+    {
+        $code = '<?php class Foo extends Bar {}';
+        $ast = self::parseWithParents($code);
+        $class = $ast[0];
+        self::assertInstanceOf(Stmt\Class_::class, $class);
+        self::assertNotNull($class->extends);
+
+        self::assertSame('Bar', ScopeFinder::resolveName($class->extends));
+    }
+
+    public function testResolveNameUsesResolvedNameWhenAvailable(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App;
+use Other\Bar;
+class Foo extends Bar {}
+PHP;
+        $ast = self::parseWithParents($code);
+        $namespace = $ast[0];
+        self::assertInstanceOf(Stmt\Namespace_::class, $namespace);
+        $class = $namespace->stmts[1];
+        self::assertInstanceOf(Stmt\Class_::class, $class);
+        self::assertNotNull($class->extends);
+
+        self::assertSame('Other\Bar', ScopeFinder::resolveName($class->extends));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `ScopeFinder::resolveName(Name $name)` utility method for resolving `Name` nodes to their FQN
- Removes duplicate `resolveName` implementations from `MemberFinder` and `DefinitionHandler`
- Replaces inline `resolvedName` attribute handling in `HoverHandler` and `SignatureHelpHandler`

Net result: -10 lines, single source of truth for name resolution.

## Test plan
- [x] Added unit tests for `ScopeFinder::resolveName`
- [x] All 321 existing tests pass
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)