### PR TITLE
Refactor: Unify property iteration with PropertyCollector

### DIFF
--- a/src/Completion/VisibilityFilter.php
+++ b/src/Completion/VisibilityFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Completion;
 
+use Firehed\PhpLsp\Utility\PropertyInfo;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Stmt;
@@ -44,6 +45,15 @@ enum VisibilityFilter
                 | \ReflectionClassConstant::IS_PRIVATE,
             self::PublicOnly => \ReflectionClassConstant::IS_PUBLIC,
             self::PublicProtected => \ReflectionClassConstant::IS_PUBLIC | \ReflectionClassConstant::IS_PROTECTED,
+        };
+    }
+
+    public function allowsProperty(PropertyInfo $property): bool
+    {
+        return match ($this) {
+            self::All => true,
+            self::PublicOnly => $property->isPublic,
+            self::PublicProtected => $property->isPublic || $property->isProtected,
         };
     }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -607,13 +607,13 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatPropertyCompletion(PropertyInfo $property): array
     {
-        $type = $property->type !== null ? TypeFormatter::formatNode($property->type) : 'mixed';
+        $type = $property->type ?? 'mixed';
 
         return self::withDocumentation([
             'label' => $property->name,
             'kind' => self::KIND_PROPERTY,
             'detail' => $type . ' $' . $property->name,
-        ], $property->docComment?->getText());
+        ], $property->docComment);
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -18,6 +18,7 @@ use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\MemberCollector;
+use Firehed\PhpLsp\Utility\PropertyInfo;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
@@ -339,10 +340,9 @@ final class CompletionHandler implements HandlerInterface
         }
 
         if ($includeProperties) {
-            foreach ($members['properties'] as $member) {
-                $name = $member['name'];
-                if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = $this->formatPropertyCompletion($member['node'], $name);
+            foreach ($members['properties'] as $property) {
+                if (self::matchesPrefix($property->name, $prefix)) {
+                    $items[] = $this->formatPropertyCompletion($property);
                 }
             }
         }
@@ -605,15 +605,15 @@ final class CompletionHandler implements HandlerInterface
     /**
      * @return array{label: string, kind: int, detail?: string, documentation?: string}
      */
-    private function formatPropertyCompletion(Stmt\Property $property, string $name): array
+    private function formatPropertyCompletion(PropertyInfo $property): array
     {
         $type = $property->type !== null ? TypeFormatter::formatNode($property->type) : 'mixed';
 
         return self::withDocumentation([
-            'label' => $name,
+            'label' => $property->name,
             'kind' => self::KIND_PROPERTY,
-            'detail' => $type . ' $' . $name,
-        ], $property->getDocComment()?->getText());
+            'detail' => $type . ' $' . $property->name,
+        ], $property->docComment?->getText());
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -444,7 +444,7 @@ final class HoverHandler implements HandlerInterface
         $parts = [];
 
         if ($property->docComment !== null) {
-            $parts[] = DocblockParser::extractDescription($property->docComment->getText());
+            $parts[] = DocblockParser::extractDescription($property->docComment);
         }
 
         $visibility = match (true) {
@@ -455,10 +455,7 @@ final class HoverHandler implements HandlerInterface
         $static = $property->isStatic ? 'static ' : '';
         $readonly = $property->isReadonly ? 'readonly ' : '';
 
-        $type = '';
-        if ($property->type !== null) {
-            $type = TypeFormatter::formatNode($property->type) . ' ';
-        }
+        $type = $property->type !== null ? $property->type . ' ' : '';
 
         $signature = $visibility . $static . $readonly . $type . '$' . $property->name;
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\MemberFinder;
+use Firehed\PhpLsp\Utility\PropertyInfo;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -393,9 +394,9 @@ final class HoverHandler implements HandlerInterface
         array $ast,
         TextDocument $document,
     ): ?string {
-        $propertyNode = MemberFinder::findProperty($className, $propertyName, $ast, $this->classLocator, $this->parser);
-        if ($propertyNode !== null) {
-            return $this->formatPropertyHover($propertyNode, $propertyName);
+        $property = MemberFinder::findProperty($className, $propertyName, $ast, $this->classLocator, $this->parser);
+        if ($property !== null) {
+            return $this->formatPropertyHover($property);
         }
 
         return $this->getReflectionPropertyHover($className, $propertyName);
@@ -438,25 +439,28 @@ final class HoverHandler implements HandlerInterface
         return implode("\n\n", $parts);
     }
 
-    private function formatPropertyHover(Stmt\Property $property, string $propertyName): string
+    private function formatPropertyHover(PropertyInfo $property): string
     {
         $parts = [];
 
-        $docComment = $property->getDocComment();
-        if ($docComment !== null) {
-            $parts[] = DocblockParser::extractDescription($docComment->getText());
+        if ($property->docComment !== null) {
+            $parts[] = DocblockParser::extractDescription($property->docComment->getText());
         }
 
-        $visibility = $this->getPropertyVisibility($property);
-        $static = $property->isStatic() ? 'static ' : '';
-        $readonly = $property->isReadonly() ? 'readonly ' : '';
+        $visibility = match (true) {
+            $property->isPrivate => 'private ',
+            $property->isProtected => 'protected ',
+            default => 'public ',
+        };
+        $static = $property->isStatic ? 'static ' : '';
+        $readonly = $property->isReadonly ? 'readonly ' : '';
 
         $type = '';
         if ($property->type !== null) {
             $type = TypeFormatter::formatNode($property->type) . ' ';
         }
 
-        $signature = $visibility . $static . $readonly . $type . '$' . $propertyName;
+        $signature = $visibility . $static . $readonly . $type . '$' . $property->name;
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
 
@@ -469,17 +473,6 @@ final class HoverHandler implements HandlerInterface
             return 'private ';
         }
         if ($method->isProtected()) {
-            return 'protected ';
-        }
-        return 'public ';
-    }
-
-    private function getPropertyVisibility(Stmt\Property $property): string
-    {
-        if ($property->isPrivate()) {
-            return 'private ';
-        }
-        if ($property->isProtected()) {
             return 'protected ';
         }
         return 'public ';

--- a/src/Utility/MemberCollector.php
+++ b/src/Utility/MemberCollector.php
@@ -15,7 +15,7 @@ final class MemberCollector
      *
      * @return array{
      *   methods: list<array{name: string, node: Stmt\ClassMethod}>,
-     *   properties: list<array{name: string, node: Stmt\Property}>,
+     *   properties: list<PropertyInfo>,
      *   constants: list<array{name: string, node: Stmt\ClassConst}>,
      *   enumCases: list<array{name: string, node: Stmt\EnumCase}>,
      * }
@@ -35,7 +35,6 @@ final class MemberCollector
         }
 
         $methods = [];
-        $properties = [];
         $constants = [];
         $enumCases = [];
 
@@ -46,17 +45,9 @@ final class MemberCollector
                 }
             }
 
-            if ($stmt instanceof Stmt\Property) {
-                if (self::matchesFilters($stmt, $visibility, $memberFilter)) {
-                    foreach ($stmt->props as $prop) {
-                        $properties[] = ['name' => $prop->name->toString(), 'node' => $stmt];
-                    }
-                }
-            }
-
             if ($stmt instanceof Stmt\ClassConst) {
                 if ($memberFilter !== MemberFilter::Instance) {
-                    if (self::matchesVisibility($stmt, $visibility)) {
+                    if (self::matchesMethodVisibility($stmt, $visibility)) {
                         foreach ($stmt->consts as $const) {
                             $constants[] = ['name' => $const->name->toString(), 'node' => $stmt];
                         }
@@ -71,6 +62,12 @@ final class MemberCollector
             }
         }
 
+        $properties = self::filterProperties(
+            PropertyCollector::collect($classNode),
+            $visibility,
+            $memberFilter,
+        );
+
         return [
             'methods' => $methods,
             'properties' => $properties,
@@ -80,19 +77,19 @@ final class MemberCollector
     }
 
     private static function matchesFilters(
-        Stmt\ClassMethod|Stmt\Property $stmt,
+        Stmt\ClassMethod $stmt,
         VisibilityFilter $visibility,
         MemberFilter $memberFilter,
     ): bool {
-        if (!self::matchesVisibility($stmt, $visibility)) {
+        if (!self::matchesMethodVisibility($stmt, $visibility)) {
             return false;
         }
 
         return $memberFilter->matches($stmt->isStatic());
     }
 
-    private static function matchesVisibility(
-        Stmt\ClassMethod|Stmt\Property|Stmt\ClassConst $stmt,
+    private static function matchesMethodVisibility(
+        Stmt\ClassMethod|Stmt\ClassConst $stmt,
         VisibilityFilter $visibility,
     ): bool {
         return match ($visibility) {
@@ -100,5 +97,21 @@ final class MemberCollector
             VisibilityFilter::PublicOnly => $stmt->isPublic(),
             VisibilityFilter::PublicProtected => $stmt->isPublic() || $stmt->isProtected(),
         };
+    }
+
+    /**
+     * @param list<PropertyInfo> $properties
+     * @return list<PropertyInfo>
+     */
+    private static function filterProperties(
+        array $properties,
+        VisibilityFilter $visibility,
+        MemberFilter $memberFilter,
+    ): array {
+        return array_values(array_filter(
+            $properties,
+            static fn(PropertyInfo $p) =>
+                $visibility->allowsProperty($p) && $memberFilter->matches($p->isStatic),
+        ));
     }
 }

--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -46,7 +46,7 @@ final class MemberFinder
         array $ast,
         ?ComposerClassLocator $classLocator,
         ParserService $parser,
-    ): ?Stmt\Property {
+    ): ?PropertyInfo {
         $classNode = ClassFinder::findWithLocator($className, $ast, $classLocator, $parser);
         if ($classNode === null) {
             return null;
@@ -125,17 +125,13 @@ final class MemberFinder
         ?ComposerClassLocator $classLocator,
         ParserService $parser,
         bool $excludePrivate,
-    ): ?Stmt\Property {
-        foreach ($classNode->stmts as $stmt) {
-            if ($stmt instanceof Stmt\Property) {
-                if ($excludePrivate && $stmt->isPrivate()) {
+    ): ?PropertyInfo {
+        foreach (PropertyCollector::collect($classNode) as $property) {
+            if ($property->name === $propertyName) {
+                if ($excludePrivate && $property->isPrivate) {
                     continue;
                 }
-                foreach ($stmt->props as $prop) {
-                    if ($prop->name->toString() === $propertyName) {
-                        return $stmt;
-                    }
-                }
+                return $property;
             }
         }
 

--- a/src/Utility/PropertyCollector.php
+++ b/src/Utility/PropertyCollector.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use PhpParser\Modifiers;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
+
+final class PropertyCollector
+{
+    /**
+     * Collect all properties from a class node, including promoted properties.
+     *
+     * @return list<PropertyInfo>
+     */
+    public static function collect(
+        Stmt\Class_|Stmt\Enum_|Stmt\Interface_|Stmt\Trait_|null $classNode,
+    ): array {
+        if ($classNode === null) {
+            return [];
+        }
+
+        $properties = [];
+
+        foreach ($classNode->stmts as $stmt) {
+            if ($stmt instanceof Stmt\Property) {
+                foreach ($stmt->props as $prop) {
+                    $properties[] = new PropertyInfo(
+                        name: $prop->name->toString(),
+                        type: $stmt->type,
+                        docComment: $stmt->getDocComment(),
+                        startLine: $stmt->getStartLine(),
+                        endLine: $stmt->getEndLine(),
+                        isStatic: $stmt->isStatic(),
+                        isReadonly: $stmt->isReadonly(),
+                        isPublic: $stmt->isPublic(),
+                        isProtected: $stmt->isProtected(),
+                        isPrivate: $stmt->isPrivate(),
+                    );
+                }
+            }
+
+            if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toLowerString() === '__construct') {
+                foreach ($stmt->params as $param) {
+                    if (!self::isPromotedProperty($param)) {
+                        continue;
+                    }
+                    if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                        continue;
+                    }
+
+                    $properties[] = new PropertyInfo(
+                        name: $param->var->name,
+                        type: $param->type,
+                        docComment: $param->getDocComment(),
+                        startLine: $param->getStartLine(),
+                        endLine: $param->getEndLine(),
+                        isStatic: false,
+                        isReadonly: ($param->flags & Modifiers::READONLY) !== 0,
+                        isPublic: ($param->flags & Modifiers::PUBLIC) !== 0,
+                        isProtected: ($param->flags & Modifiers::PROTECTED) !== 0,
+                        isPrivate: ($param->flags & Modifiers::PRIVATE) !== 0,
+                    );
+                }
+            }
+        }
+
+        return $properties;
+    }
+
+    private static function isPromotedProperty(Param $param): bool
+    {
+        return ($param->flags & Modifiers::VISIBILITY_MASK) !== 0;
+    }
+}

--- a/src/Utility/PropertyCollector.php
+++ b/src/Utility/PropertyCollector.php
@@ -30,8 +30,8 @@ final class PropertyCollector
                 foreach ($stmt->props as $prop) {
                     $properties[] = new PropertyInfo(
                         name: $prop->name->toString(),
-                        type: $stmt->type,
-                        docComment: $stmt->getDocComment(),
+                        type: TypeFormatter::formatNode($stmt->type),
+                        docComment: $stmt->getDocComment()?->getText(),
                         startLine: $stmt->getStartLine(),
                         endLine: $stmt->getEndLine(),
                         isStatic: $stmt->isStatic(),
@@ -54,8 +54,8 @@ final class PropertyCollector
 
                     $properties[] = new PropertyInfo(
                         name: $param->var->name,
-                        type: $param->type,
-                        docComment: $param->getDocComment(),
+                        type: TypeFormatter::formatNode($param->type),
+                        docComment: $param->getDocComment()?->getText(),
                         startLine: $param->getStartLine(),
                         endLine: $param->getEndLine(),
                         isStatic: false,

--- a/src/Utility/PropertyInfo.php
+++ b/src/Utility/PropertyInfo.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Utility;
 
-use PhpParser\Comment\Doc;
-use PhpParser\Node;
-
 final class PropertyInfo
 {
     public function __construct(
         public readonly string $name,
-        public readonly ?Node $type,
-        public readonly ?Doc $docComment,
+        public readonly ?string $type,
+        public readonly ?string $docComment,
         public readonly int $startLine,
         public readonly int $endLine,
         public readonly bool $isStatic,

--- a/src/Utility/PropertyInfo.php
+++ b/src/Utility/PropertyInfo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+
+final class PropertyInfo
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly ?Node $type,
+        public readonly ?Doc $docComment,
+        public readonly int $startLine,
+        public readonly int $endLine,
+        public readonly bool $isStatic,
+        public readonly bool $isReadonly,
+        public readonly bool $isPublic,
+        public readonly bool $isProtected,
+        public readonly bool $isPrivate,
+    ) {
+    }
+}

--- a/tests/Utility/MemberFinderTest.php
+++ b/tests/Utility/MemberFinderTest.php
@@ -158,8 +158,7 @@ PHP;
         $result = MemberFinder::findProperty('MyClass', 'myProperty', $ast, null, $this->parser);
 
         self::assertNotNull($result);
-        self::assertCount(1, $result->props);
-        self::assertSame('myProperty', $result->props[0]->name->toString());
+        self::assertSame('myProperty', $result->name);
     }
 
     public function testFindPropertyReturnsNullWhenNotFound(): void
@@ -189,7 +188,7 @@ PHP;
         $result = MemberFinder::findProperty('ChildClass', 'parentProperty', $ast, null, $this->parser);
 
         self::assertNotNull($result);
-        self::assertSame('parentProperty', $result->props[0]->name->toString());
+        self::assertSame('parentProperty', $result->name);
     }
 
     public function testFindPropertyExcludesPrivateFromParent(): void
@@ -263,7 +262,7 @@ PHP;
         $result = MemberFinder::findProperty('MyClass', 'privateProperty', $ast, null, $this->parser);
 
         self::assertNotNull($result);
-        self::assertSame('privateProperty', $result->props[0]->name->toString());
+        self::assertSame('privateProperty', $result->name);
     }
 
     public function testFindPropertyInTrait(): void
@@ -281,7 +280,7 @@ PHP;
         $result = MemberFinder::findProperty('MyClass', 'traitProperty', $ast, null, $this->parser);
 
         self::assertNotNull($result);
-        self::assertSame('traitProperty', $result->props[0]->name->toString());
+        self::assertSame('traitProperty', $result->name);
     }
 
     public function testFindPropertyIncludesProtectedFromParent(): void
@@ -297,7 +296,7 @@ PHP;
         $result = MemberFinder::findProperty('ChildClass', 'protectedProperty', $ast, null, $this->parser);
 
         self::assertNotNull($result);
-        self::assertSame('protectedProperty', $result->props[0]->name->toString());
+        self::assertSame('protectedProperty', $result->name);
     }
 
     public function testFindMethodInInterface(): void
@@ -346,7 +345,7 @@ PHP;
         $result = MemberFinder::findProperty('ChildClass', 'grandparentProperty', $ast, null, $this->parser);
 
         self::assertNotNull($result);
-        self::assertSame('grandparentProperty', $result->props[0]->name->toString());
+        self::assertSame('grandparentProperty', $result->name);
     }
 
     public function testFindMethodInEnum(): void

--- a/tests/Utility/PropertyCollectorTest.php
+++ b/tests/Utility/PropertyCollectorTest.php
@@ -125,7 +125,7 @@ PHP;
         self::assertNotContains('lastName', $names);
     }
 
-    public function testPropertyInfoContainsTypeNode(): void
+    public function testPropertyInfoContainsType(): void
     {
         $code = <<<'PHP'
 <?php
@@ -137,7 +137,7 @@ PHP;
         $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
-        self::assertNotNull($properties[0]->type);
+        self::assertSame('string', $properties[0]->type);
     }
 
     public function testPropertyInfoContainsLineNumbers(): void
@@ -228,7 +228,7 @@ PHP;
 
         self::assertCount(1, $properties);
         self::assertNotNull($properties[0]->docComment);
-        self::assertStringContainsString('display name', $properties[0]->docComment->getText());
+        self::assertStringContainsString('display name', $properties[0]->docComment);
     }
 
     public function testPromotedPropertyDocComment(): void
@@ -247,7 +247,7 @@ PHP;
 
         self::assertCount(1, $properties);
         self::assertNotNull($properties[0]->docComment);
-        self::assertStringContainsString('display name', $properties[0]->docComment->getText());
+        self::assertStringContainsString('display name', $properties[0]->docComment);
     }
 
     public function testReturnsEmptyForInterface(): void

--- a/tests/Utility/PropertyCollectorTest.php
+++ b/tests/Utility/PropertyCollectorTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Utility;
 
 use Firehed\PhpLsp\Utility\PropertyCollector;
 use Firehed\PhpLsp\Utility\PropertyInfo;
+use PhpParser\Node\Stmt;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -21,6 +22,23 @@ final class PropertyCollectorTest extends TestCase
         $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
     }
 
+    /**
+     * @return Stmt\Class_|Stmt\Interface_|Stmt\Enum_|Stmt\Trait_
+     */
+    private function getClassNode(string $code): Stmt\Class_|Stmt\Interface_|Stmt\Enum_|Stmt\Trait_
+    {
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+        $node = $ast[0];
+        self::assertTrue(
+            $node instanceof Stmt\Class_
+            || $node instanceof Stmt\Interface_
+            || $node instanceof Stmt\Enum_
+            || $node instanceof Stmt\Trait_,
+        );
+        return $node;
+    }
+
     public function testCollectsRegularProperty(): void
     {
         $code = <<<'PHP'
@@ -30,10 +48,7 @@ class User
     private string $name;
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
         self::assertSame('name', $properties[0]->name);
@@ -53,10 +68,7 @@ class User
     ) {}
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(2, $properties);
 
@@ -78,10 +90,7 @@ class User
     ) {}
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(2, $properties);
         $names = array_map(fn(PropertyInfo $p) => $p->name, $properties);
@@ -106,10 +115,7 @@ class User
     }
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(2, $properties);
         $names = array_map(fn(PropertyInfo $p) => $p->name, $properties);
@@ -128,10 +134,7 @@ class User
     private string $name;
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
         self::assertNotNull($properties[0]->type);
@@ -146,10 +149,7 @@ class User
     private string $name;
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
         self::assertSame(4, $properties[0]->startLine);
@@ -168,10 +168,7 @@ class User
     ) {}
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(3, $properties);
 
@@ -194,10 +191,7 @@ class Counter
     private static int $count = 0;
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
         self::assertTrue($properties[0]->isStatic);
@@ -214,10 +208,7 @@ class User
     ) {}
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
         self::assertTrue($properties[0]->isReadonly);
@@ -233,10 +224,7 @@ class User
     private string $name;
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
         self::assertNotNull($properties[0]->docComment);
@@ -255,10 +243,7 @@ class User
     ) {}
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(1, $properties);
         self::assertNotNull($properties[0]->docComment);
@@ -274,10 +259,7 @@ interface UserInterface
     public function getName(): string;
 }
 PHP;
-        $ast = $this->parser->parse($code);
-        self::assertNotNull($ast);
-
-        $properties = PropertyCollector::collect($ast[0]);
+        $properties = PropertyCollector::collect($this->getClassNode($code));
 
         self::assertCount(0, $properties);
     }

--- a/tests/Utility/PropertyCollectorTest.php
+++ b/tests/Utility/PropertyCollectorTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Utility\PropertyCollector;
+use Firehed\PhpLsp\Utility\PropertyInfo;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PropertyCollector::class)]
+#[CoversClass(PropertyInfo::class)]
+final class PropertyCollectorTest extends TestCase
+{
+    private \PhpParser\Parser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+    }
+
+    public function testCollectsRegularProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    private string $name;
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(1, $properties);
+        self::assertSame('name', $properties[0]->name);
+        self::assertTrue($properties[0]->isPrivate);
+        self::assertFalse($properties[0]->isStatic);
+    }
+
+    public function testCollectsPromotedProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        private string $name,
+        private int $age,
+    ) {}
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(2, $properties);
+
+        $names = array_map(fn(PropertyInfo $p) => $p->name, $properties);
+        self::assertContains('name', $names);
+        self::assertContains('age', $names);
+    }
+
+    public function testCollectsMixedRegularAndPromotedProperties(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public string $email;
+
+    public function __construct(
+        private string $name,
+    ) {}
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(2, $properties);
+        $names = array_map(fn(PropertyInfo $p) => $p->name, $properties);
+        self::assertContains('email', $names);
+        self::assertContains('name', $names);
+    }
+
+    public function testExcludesNonPromotedConstructorParams(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    private string $fullName;
+
+    public function __construct(
+        string $firstName,
+        string $lastName,
+        private int $age,
+    ) {
+        $this->fullName = $firstName . ' ' . $lastName;
+    }
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(2, $properties);
+        $names = array_map(fn(PropertyInfo $p) => $p->name, $properties);
+        self::assertContains('fullName', $names);
+        self::assertContains('age', $names);
+        self::assertNotContains('firstName', $names);
+        self::assertNotContains('lastName', $names);
+    }
+
+    public function testPropertyInfoContainsTypeNode(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    private string $name;
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(1, $properties);
+        self::assertNotNull($properties[0]->type);
+    }
+
+    public function testPropertyInfoContainsLineNumbers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    private string $name;
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(1, $properties);
+        self::assertSame(4, $properties[0]->startLine);
+    }
+
+    public function testPromotedPropertyHasCorrectVisibility(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        public string $publicName,
+        protected string $protectedName,
+        private string $privateName,
+    ) {}
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(3, $properties);
+
+        $byName = [];
+        foreach ($properties as $prop) {
+            $byName[$prop->name] = $prop;
+        }
+
+        self::assertTrue($byName['publicName']->isPublic);
+        self::assertTrue($byName['protectedName']->isProtected);
+        self::assertTrue($byName['privateName']->isPrivate);
+    }
+
+    public function testStaticProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Counter
+{
+    private static int $count = 0;
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(1, $properties);
+        self::assertTrue($properties[0]->isStatic);
+    }
+
+    public function testReadonlyProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        public readonly string $name,
+    ) {}
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(1, $properties);
+        self::assertTrue($properties[0]->isReadonly);
+    }
+
+    public function testDocCommentExtraction(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    /** The user's display name */
+    private string $name;
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(1, $properties);
+        self::assertNotNull($properties[0]->docComment);
+        self::assertStringContainsString('display name', $properties[0]->docComment->getText());
+    }
+
+    public function testPromotedPropertyDocComment(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function __construct(
+        /** The user's display name */
+        private string $name,
+    ) {}
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(1, $properties);
+        self::assertNotNull($properties[0]->docComment);
+        self::assertStringContainsString('display name', $properties[0]->docComment->getText());
+    }
+
+    public function testReturnsEmptyForInterface(): void
+    {
+        $code = <<<'PHP'
+<?php
+interface UserInterface
+{
+    public function getName(): string;
+}
+PHP;
+        $ast = $this->parser->parse($code);
+        self::assertNotNull($ast);
+
+        $properties = PropertyCollector::collect($ast[0]);
+
+        self::assertCount(0, $properties);
+    }
+
+    public function testReturnsEmptyForNull(): void
+    {
+        $properties = PropertyCollector::collect(null);
+
+        self::assertCount(0, $properties);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PropertyInfo` value object for normalized property data
- Add `PropertyCollector` to collect all properties from a class, including promoted properties
- Update `MemberCollector` to use `PropertyCollector` for property iteration
- Update `MemberFinder::findProperty` to return `PropertyInfo`
- Update `CompletionHandler` and `HoverHandler` to use `PropertyInfo`

This unifies property handling across the codebase. Promoted properties now work automatically for completion and hover.

Fixes #92
Closes #94

## Test plan
- [x] All existing tests pass
- [x] PHPStan clean
- [x] New tests for PropertyCollector covering regular and promoted properties

🤖 Generated with [Claude Code](https://claude.ai/code)