### PR TITLE
Move AST visibility filtering to VisibilityFilter

### DIFF
--- a/src/Completion/VisibilityFilter.php
+++ b/src/Completion/VisibilityFilter.php
@@ -57,6 +57,24 @@ enum VisibilityFilter
         };
     }
 
+    public function allowsMethod(Stmt\ClassMethod $method): bool
+    {
+        return match ($this) {
+            self::All => true,
+            self::PublicOnly => $method->isPublic(),
+            self::PublicProtected => $method->isPublic() || $method->isProtected(),
+        };
+    }
+
+    public function allowsConstant(Stmt\ClassConst $const): bool
+    {
+        return match ($this) {
+            self::All => true,
+            self::PublicOnly => $const->isPublic(),
+            self::PublicProtected => $const->isPublic() || $const->isProtected(),
+        };
+    }
+
     /**
      * Determine visibility filter based on the relationship between an
      * enclosing class and a target class being accessed.

--- a/src/Utility/MemberCollector.php
+++ b/src/Utility/MemberCollector.php
@@ -46,11 +46,9 @@ final class MemberCollector
             }
 
             if ($stmt instanceof Stmt\ClassConst) {
-                if ($memberFilter !== MemberFilter::Instance) {
-                    if (self::matchesMethodVisibility($stmt, $visibility)) {
-                        foreach ($stmt->consts as $const) {
-                            $constants[] = ['name' => $const->name->toString(), 'node' => $stmt];
-                        }
+                if ($memberFilter !== MemberFilter::Instance && $visibility->allowsConstant($stmt)) {
+                    foreach ($stmt->consts as $const) {
+                        $constants[] = ['name' => $const->name->toString(), 'node' => $stmt];
                     }
                 }
             }
@@ -81,22 +79,7 @@ final class MemberCollector
         VisibilityFilter $visibility,
         MemberFilter $memberFilter,
     ): bool {
-        if (!self::matchesMethodVisibility($stmt, $visibility)) {
-            return false;
-        }
-
-        return $memberFilter->matches($stmt->isStatic());
-    }
-
-    private static function matchesMethodVisibility(
-        Stmt\ClassMethod|Stmt\ClassConst $stmt,
-        VisibilityFilter $visibility,
-    ): bool {
-        return match ($visibility) {
-            VisibilityFilter::All => true,
-            VisibilityFilter::PublicOnly => $stmt->isPublic(),
-            VisibilityFilter::PublicProtected => $stmt->isPublic() || $stmt->isProtected(),
-        };
+        return $visibility->allowsMethod($stmt) && $memberFilter->matches($stmt->isStatic());
     }
 
     /**

--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Utility;
 
+use Firehed\PhpLsp\Completion\VisibilityFilter;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use PhpParser\Node\Stmt;
@@ -30,7 +31,14 @@ final class MemberFinder
             return null;
         }
 
-        return self::findMethodInClassNode($classNode, $methodName, $ast, $classLocator, $parser, false);
+        return self::findMethodInClassNode(
+            $classNode,
+            $methodName,
+            $ast,
+            $classLocator,
+            $parser,
+            VisibilityFilter::All,
+        );
     }
 
     /**
@@ -52,7 +60,14 @@ final class MemberFinder
             return null;
         }
 
-        return self::findPropertyInClassNode($classNode, $propertyName, $ast, $classLocator, $parser, false);
+        return self::findPropertyInClassNode(
+            $classNode,
+            $propertyName,
+            $ast,
+            $classLocator,
+            $parser,
+            VisibilityFilter::All,
+        );
     }
 
     /**
@@ -64,11 +79,11 @@ final class MemberFinder
         array $ast,
         ?ComposerClassLocator $classLocator,
         ParserService $parser,
-        bool $excludePrivate,
+        VisibilityFilter $visibility,
     ): ?Stmt\ClassMethod {
         foreach ($classNode->stmts as $stmt) {
             if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
-                if ($excludePrivate && $stmt->isPrivate()) {
+                if (!$visibility->allowsMethod($stmt)) {
                     continue;
                 }
                 return $stmt;
@@ -87,7 +102,7 @@ final class MemberFinder
                             $ast,
                             $classLocator,
                             $parser,
-                            true,
+                            VisibilityFilter::PublicProtected,
                         );
                         if ($traitMethod !== null) {
                             return $traitMethod;
@@ -107,7 +122,7 @@ final class MemberFinder
                     $ast,
                     $classLocator,
                     $parser,
-                    true,
+                    VisibilityFilter::PublicProtected,
                 );
             }
         }
@@ -124,11 +139,11 @@ final class MemberFinder
         array $ast,
         ?ComposerClassLocator $classLocator,
         ParserService $parser,
-        bool $excludePrivate,
+        VisibilityFilter $visibility,
     ): ?PropertyInfo {
         foreach (PropertyCollector::collect($classNode) as $property) {
             if ($property->name === $propertyName) {
-                if ($excludePrivate && $property->isPrivate) {
+                if (!$visibility->allowsProperty($property)) {
                     continue;
                 }
                 return $property;
@@ -147,7 +162,7 @@ final class MemberFinder
                             $ast,
                             $classLocator,
                             $parser,
-                            true,
+                            VisibilityFilter::PublicProtected,
                         );
                         if ($traitProperty !== null) {
                             return $traitProperty;
@@ -167,7 +182,7 @@ final class MemberFinder
                     $ast,
                     $classLocator,
                     $parser,
-                    true,
+                    VisibilityFilter::PublicProtected,
                 );
             }
         }

--- a/tests/Completion/VisibilityFilterTest.php
+++ b/tests/Completion/VisibilityFilterTest.php
@@ -105,6 +105,60 @@ class VisibilityFilterTest extends TestCase
         self::assertSame($expected, $filter->getConstantFlags());
     }
 
+    /**
+     * @return array<string, array{VisibilityFilter, string, bool}>
+     * @codeCoverageIgnore
+     */
+    public static function allowsMethodProvider(): array
+    {
+        return [
+            'All allows public' => [VisibilityFilter::All, 'public', true],
+            'All allows protected' => [VisibilityFilter::All, 'protected', true],
+            'All allows private' => [VisibilityFilter::All, 'private', true],
+            'PublicOnly allows public' => [VisibilityFilter::PublicOnly, 'public', true],
+            'PublicOnly denies protected' => [VisibilityFilter::PublicOnly, 'protected', false],
+            'PublicOnly denies private' => [VisibilityFilter::PublicOnly, 'private', false],
+            'PublicProtected allows public' => [VisibilityFilter::PublicProtected, 'public', true],
+            'PublicProtected allows protected' => [VisibilityFilter::PublicProtected, 'protected', true],
+            'PublicProtected denies private' => [VisibilityFilter::PublicProtected, 'private', false],
+        ];
+    }
+
+    #[DataProvider('allowsMethodProvider')]
+    public function testAllowsMethod(VisibilityFilter $filter, string $visibility, bool $expected): void
+    {
+        $method = $this->parseMethod("<?php class Foo { {$visibility} function bar() {} }");
+        self::assertNotNull($method);
+        self::assertSame($expected, $filter->allowsMethod($method));
+    }
+
+    /**
+     * @return array<string, array{VisibilityFilter, string, bool}>
+     * @codeCoverageIgnore
+     */
+    public static function allowsConstantProvider(): array
+    {
+        return [
+            'All allows public' => [VisibilityFilter::All, 'public', true],
+            'All allows protected' => [VisibilityFilter::All, 'protected', true],
+            'All allows private' => [VisibilityFilter::All, 'private', true],
+            'PublicOnly allows public' => [VisibilityFilter::PublicOnly, 'public', true],
+            'PublicOnly denies protected' => [VisibilityFilter::PublicOnly, 'protected', false],
+            'PublicOnly denies private' => [VisibilityFilter::PublicOnly, 'private', false],
+            'PublicProtected allows public' => [VisibilityFilter::PublicProtected, 'public', true],
+            'PublicProtected allows protected' => [VisibilityFilter::PublicProtected, 'protected', true],
+            'PublicProtected denies private' => [VisibilityFilter::PublicProtected, 'private', false],
+        ];
+    }
+
+    #[DataProvider('allowsConstantProvider')]
+    public function testAllowsConstant(VisibilityFilter $filter, string $visibility, bool $expected): void
+    {
+        $const = $this->parseConstant("<?php class Foo { {$visibility} const BAR = 1; }");
+        self::assertNotNull($const);
+        self::assertSame($expected, $filter->allowsConstant($const));
+    }
+
     public function testForClassAccessReturnsPublicOnlyWhenNoEnclosingClass(): void
     {
         self::assertSame(VisibilityFilter::PublicOnly, VisibilityFilter::forClassAccess(null, 'Target'));
@@ -142,6 +196,36 @@ class VisibilityFilterTest extends TestCase
         foreach ($ast as $stmt) {
             if ($stmt instanceof Stmt\Class_ && $stmt->name?->toString() === $className) {
                 return $stmt;
+            }
+        }
+        return null;
+    }
+
+    private function parseMethod(string $code): ?Stmt\ClassMethod
+    {
+        $ast = self::parseWithParents($code);
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Class_) {
+                foreach ($stmt->stmts as $member) {
+                    if ($member instanceof Stmt\ClassMethod) {
+                        return $member;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private function parseConstant(string $code): ?Stmt\ClassConst
+    {
+        $ast = self::parseWithParents($code);
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Class_) {
+                foreach ($stmt->stmts as $member) {
+                    if ($member instanceof Stmt\ClassConst) {
+                        return $member;
+                    }
+                }
             }
         }
         return null;


### PR DESCRIPTION
## Summary

- Add `allowsMethod(ClassMethod)` and `allowsConstant(ClassConst)` to `VisibilityFilter`
- Update `MemberCollector` to use these methods
- Remove duplicate `matchesMethodVisibility` from `MemberCollector`
- Update `MemberFinder` to use `VisibilityFilter` instead of `bool $excludePrivate`

This centralizes all visibility filtering logic in `VisibilityFilter`.

## Test plan
- [x] All existing tests pass
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.ai/code)