### PR TITLE
Fix: Include private members from traits in MemberFinder

### DIFF
--- a/src/Utility/MemberFinder.php
+++ b/src/Utility/MemberFinder.php
@@ -102,7 +102,7 @@ final class MemberFinder
                             $ast,
                             $classLocator,
                             $parser,
-                            VisibilityFilter::PublicProtected,
+                            VisibilityFilter::All,
                         );
                         if ($traitMethod !== null) {
                             return $traitMethod;
@@ -162,7 +162,7 @@ final class MemberFinder
                             $ast,
                             $classLocator,
                             $parser,
-                            VisibilityFilter::PublicProtected,
+                            VisibilityFilter::All,
                         );
                         if ($traitProperty !== null) {
                             return $traitProperty;

--- a/tests/Utility/MemberFinderTest.php
+++ b/tests/Utility/MemberFinderTest.php
@@ -124,6 +124,24 @@ PHP;
         self::assertSame('traitMethod', $result->name->toString());
     }
 
+    public function testFindMethodIncludesPrivateFromTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    private function privateTraitMethod(): void {}
+}
+class MyClass {
+    use MyTrait;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findMethod('MyClass', 'privateTraitMethod', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('privateTraitMethod', $result->name->toString());
+    }
+
     public function testFindMethodPrefersClassOverTrait(): void
     {
         $code = <<<'PHP'
@@ -281,6 +299,24 @@ PHP;
 
         self::assertNotNull($result);
         self::assertSame('traitProperty', $result->name);
+    }
+
+    public function testFindPropertyIncludesPrivateFromTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    private string $privateTraitProperty;
+}
+class MyClass {
+    use MyTrait;
+}
+PHP;
+        $ast = self::parse($code);
+        $result = MemberFinder::findProperty('MyClass', 'privateTraitProperty', $ast, null, $this->parser);
+
+        self::assertNotNull($result);
+        self::assertSame('privateTraitProperty', $result->name);
     }
 
     public function testFindPropertyIncludesProtectedFromParent(): void


### PR DESCRIPTION
## Summary

- Change trait lookups in `MemberFinder` to use `VisibilityFilter::All` instead of `PublicProtected`
- Traits are copy-pasted into the using class, so private trait members ARE accessible

Fixes #103

## Test plan
- [x] Added tests for private method/property lookup from traits
- [x] All existing tests pass
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.ai/code)