### PR TITLE
Arch Phase 1: Create domain model types

### DIFF
--- a/src/Domain/ClassInfo.php
+++ b/src/Domain/ClassInfo.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Metadata about a class, interface, trait, or enum.
+ */
+final readonly class ClassInfo
+{
+    /**
+     * @param array<string, MethodInfo> $methods Keyed by method name
+     * @param array<string, PropertyInfo> $properties Keyed by property name
+     * @param array<string, ConstantInfo> $constants Keyed by constant name
+     * @param array<string, EnumCaseInfo> $enumCases Keyed by case name
+     */
+    public function __construct(
+        public ClassName $name,
+        public ClassKind $kind,
+        public bool $isAbstract,
+        public bool $isFinal,
+        public bool $isReadonly,
+        public ?ClassName $parent,
+        public array $methods,
+        public array $properties,
+        public array $constants,
+        public array $enumCases,
+        public ?string $docblock,
+        public ?string $file,
+        public ?int $line,
+    ) {
+    }
+}

--- a/src/Domain/ClassKind.php
+++ b/src/Domain/ClassKind.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Kind of class-like declaration.
+ */
+enum ClassKind
+{
+    case Class_;
+    case Interface_;
+    case Trait_;
+    case Enum_;
+}

--- a/src/Domain/ClassName.php
+++ b/src/Domain/ClassName.php
@@ -34,6 +34,6 @@ final readonly class ClassName
 
     public function equals(self $other): bool
     {
-        return $this->fqn === $other->fqn;
+        return strcasecmp($this->fqn, $other->fqn) === 0;
     }
 }

--- a/src/Domain/ClassName.php
+++ b/src/Domain/ClassName.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Type-safe wrapper for fully-qualified class names.
+ */
+final readonly class ClassName
+{
+    public function __construct(
+        public string $fqn,
+    ) {
+    }
+
+    public function shortName(): string
+    {
+        $lastSeparator = strrpos($this->fqn, '\\');
+        if ($lastSeparator === false) {
+            return $this->fqn;
+        }
+        return substr($this->fqn, $lastSeparator + 1);
+    }
+
+    public function namespace(): ?string
+    {
+        $lastSeparator = strrpos($this->fqn, '\\');
+        if ($lastSeparator === false) {
+            return null;
+        }
+        return substr($this->fqn, 0, $lastSeparator);
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->fqn === $other->fqn;
+    }
+}

--- a/src/Domain/ConstantInfo.php
+++ b/src/Domain/ConstantInfo.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Metadata about a class constant.
+ */
+final readonly class ConstantInfo
+{
+    public function __construct(
+        public ConstantName $name,
+        public Visibility $visibility,
+        public bool $isFinal,
+        public ?string $type,
+        public ?string $docblock,
+        public ?string $file,
+        public ?int $line,
+        public ClassName $declaringClass,
+    ) {
+    }
+}

--- a/src/Domain/ConstantName.php
+++ b/src/Domain/ConstantName.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Type-safe wrapper for class constant names.
+ */
+final readonly class ConstantName
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Domain/EnumCaseInfo.php
+++ b/src/Domain/EnumCaseInfo.php
@@ -10,7 +10,7 @@ namespace Firehed\PhpLsp\Domain;
 final readonly class EnumCaseInfo
 {
     public function __construct(
-        public string $name,
+        public EnumCaseName $name,
         public ?string $docblock,
         public ?string $file,
         public ?int $line,

--- a/src/Domain/EnumCaseInfo.php
+++ b/src/Domain/EnumCaseInfo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Metadata about an enum case.
+ */
+final readonly class EnumCaseInfo
+{
+    public function __construct(
+        public string $name,
+        public ?string $docblock,
+        public ?string $file,
+        public ?int $line,
+        public ClassName $declaringClass,
+    ) {
+    }
+}

--- a/src/Domain/EnumCaseName.php
+++ b/src/Domain/EnumCaseName.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Type-safe wrapper for enum case names.
+ */
+final readonly class EnumCaseName
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Domain/MethodInfo.php
+++ b/src/Domain/MethodInfo.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Metadata about a class method.
+ */
+final readonly class MethodInfo
+{
+    /**
+     * @param list<ParameterInfo> $parameters
+     */
+    public function __construct(
+        public MethodName $name,
+        public Visibility $visibility,
+        public bool $isStatic,
+        public bool $isAbstract,
+        public bool $isFinal,
+        public array $parameters,
+        public ?string $returnType,
+        public ?string $docblock,
+        public ?string $file,
+        public ?int $line,
+        public ClassName $declaringClass,
+    ) {
+    }
+}

--- a/src/Domain/MethodName.php
+++ b/src/Domain/MethodName.php
@@ -13,4 +13,9 @@ final readonly class MethodName
         public string $name,
     ) {
     }
+
+    public function equals(self $other): bool
+    {
+        return strcasecmp($this->name, $other->name) === 0;
+    }
 }

--- a/src/Domain/MethodName.php
+++ b/src/Domain/MethodName.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Type-safe wrapper for method names.
+ */
+final readonly class MethodName
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Metadata about a method or function parameter.
+ */
+final readonly class ParameterInfo
+{
+    public function __construct(
+        public string $name,
+        public ?string $type,
+        public bool $hasDefault,
+        public bool $isVariadic,
+        public bool $isPassedByReference,
+    ) {
+    }
+}

--- a/src/Domain/PropertyInfo.php
+++ b/src/Domain/PropertyInfo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Metadata about a class property.
+ */
+final readonly class PropertyInfo
+{
+    public function __construct(
+        public PropertyName $name,
+        public Visibility $visibility,
+        public bool $isStatic,
+        public bool $isReadonly,
+        public bool $isPromoted,
+        public ?string $type,
+        public ?string $docblock,
+        public ?string $file,
+        public ?int $line,
+        public ClassName $declaringClass,
+    ) {
+    }
+}

--- a/src/Domain/PropertyName.php
+++ b/src/Domain/PropertyName.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Type-safe wrapper for property names.
+ */
+final readonly class PropertyName
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Domain/Visibility.php
+++ b/src/Domain/Visibility.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Member visibility level.
+ */
+enum Visibility: int
+{
+    case Private = 0;
+    case Protected = 1;
+    case Public = 2;
+
+    public function isAccessibleFrom(self $minimumRequired): bool
+    {
+        return $this->value >= $minimumRequired->value;
+    }
+}

--- a/tests/Domain/ClassInfoTest.php
+++ b/tests/Domain/ClassInfoTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClassInfo::class)]
+class ClassInfoTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $class = new ClassInfo(
+            name: new ClassName('App\\MyClass'),
+            kind: ClassKind::Class_,
+            isAbstract: false,
+            isFinal: true,
+            isReadonly: true,
+            parent: new ClassName('App\\BaseClass'),
+            methods: [],
+            properties: [],
+            constants: [],
+            enumCases: [],
+            docblock: '/** My class */',
+            file: '/path/to/file.php',
+            line: 3,
+        );
+
+        self::assertSame('App\\MyClass', $class->name->fqn);
+        self::assertSame(ClassKind::Class_, $class->kind);
+        self::assertFalse($class->isAbstract);
+        self::assertTrue($class->isFinal);
+        self::assertTrue($class->isReadonly);
+        self::assertSame('App\\BaseClass', $class->parent?->fqn);
+        self::assertSame([], $class->methods);
+        self::assertSame([], $class->properties);
+        self::assertSame([], $class->constants);
+        self::assertSame([], $class->enumCases);
+        self::assertSame('/** My class */', $class->docblock);
+        self::assertSame('/path/to/file.php', $class->file);
+        self::assertSame(3, $class->line);
+    }
+
+    public function testConstructionWithNullParent(): void
+    {
+        $class = new ClassInfo(
+            name: new ClassName('App\\MyInterface'),
+            kind: ClassKind::Interface_,
+            isAbstract: false,
+            isFinal: false,
+            isReadonly: false,
+            parent: null,
+            methods: [],
+            properties: [],
+            constants: [],
+            enumCases: [],
+            docblock: null,
+            file: null,
+            line: null,
+        );
+
+        self::assertNull($class->parent);
+        self::assertNull($class->docblock);
+        self::assertNull($class->file);
+        self::assertNull($class->line);
+    }
+}

--- a/tests/Domain/ClassNameTest.php
+++ b/tests/Domain/ClassNameTest.php
@@ -48,4 +48,11 @@ class ClassNameTest extends TestCase
         $b = new ClassName('Foo\\Baz');
         self::assertFalse($a->equals($b));
     }
+
+    public function testEqualsCaseInsensitive(): void
+    {
+        $a = new ClassName('Foo\\Bar');
+        $b = new ClassName('FOO\\BAR');
+        self::assertTrue($a->equals($b));
+    }
 }

--- a/tests/Domain/ClassNameTest.php
+++ b/tests/Domain/ClassNameTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClassName::class)]
+class ClassNameTest extends TestCase
+{
+    public function testShortNameWithNamespace(): void
+    {
+        $cn = new ClassName('Vendor\\Package\\MyClass');
+        self::assertSame('MyClass', $cn->shortName());
+    }
+
+    public function testShortNameWithoutNamespace(): void
+    {
+        $cn = new ClassName('MyClass');
+        self::assertSame('MyClass', $cn->shortName());
+    }
+
+    public function testNamespaceWithNamespace(): void
+    {
+        $cn = new ClassName('Vendor\\Package\\MyClass');
+        self::assertSame('Vendor\\Package', $cn->namespace());
+    }
+
+    public function testNamespaceWithoutNamespace(): void
+    {
+        $cn = new ClassName('MyClass');
+        self::assertNull($cn->namespace());
+    }
+
+    public function testEqualsTrue(): void
+    {
+        $a = new ClassName('Foo\\Bar');
+        $b = new ClassName('Foo\\Bar');
+        self::assertTrue($a->equals($b));
+    }
+
+    public function testEqualsFalse(): void
+    {
+        $a = new ClassName('Foo\\Bar');
+        $b = new ClassName('Foo\\Baz');
+        self::assertFalse($a->equals($b));
+    }
+}

--- a/tests/Domain/ConstantInfoTest.php
+++ b/tests/Domain/ConstantInfoTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConstantInfo::class)]
+class ConstantInfoTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $constant = new ConstantInfo(
+            name: new ConstantName('MAX_SIZE'),
+            visibility: Visibility::Public,
+            isFinal: true,
+            type: 'int',
+            docblock: '/** Maximum size */',
+            file: '/path/to/file.php',
+            line: 5,
+            declaringClass: new ClassName('App\\MyClass'),
+        );
+
+        self::assertSame('MAX_SIZE', $constant->name->name);
+        self::assertSame(Visibility::Public, $constant->visibility);
+        self::assertTrue($constant->isFinal);
+        self::assertSame('int', $constant->type);
+        self::assertSame('/** Maximum size */', $constant->docblock);
+        self::assertSame('/path/to/file.php', $constant->file);
+        self::assertSame(5, $constant->line);
+        self::assertSame('App\\MyClass', $constant->declaringClass->fqn);
+    }
+}

--- a/tests/Domain/ConstantNameTest.php
+++ b/tests/Domain/ConstantNameTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConstantName::class)]
+class ConstantNameTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $name = new ConstantName('MY_CONST');
+        self::assertSame('MY_CONST', $name->name);
+    }
+}

--- a/tests/Domain/EnumCaseInfoTest.php
+++ b/tests/Domain/EnumCaseInfoTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EnumCaseInfo::class)]
+class EnumCaseInfoTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $case = new EnumCaseInfo(
+            name: 'Active',
+            docblock: null,
+            file: '/path/to/file.php',
+            line: 8,
+            declaringClass: new ClassName('App\\Status'),
+        );
+
+        self::assertSame('Active', $case->name);
+        self::assertNull($case->docblock);
+        self::assertSame('/path/to/file.php', $case->file);
+        self::assertSame(8, $case->line);
+        self::assertSame('App\\Status', $case->declaringClass->fqn);
+    }
+}

--- a/tests/Domain/EnumCaseInfoTest.php
+++ b/tests/Domain/EnumCaseInfoTest.php
@@ -13,14 +13,14 @@ class EnumCaseInfoTest extends TestCase
     public function testConstruction(): void
     {
         $case = new EnumCaseInfo(
-            name: 'Active',
+            name: new EnumCaseName('Active'),
             docblock: null,
             file: '/path/to/file.php',
             line: 8,
             declaringClass: new ClassName('App\\Status'),
         );
 
-        self::assertSame('Active', $case->name);
+        self::assertSame('Active', $case->name->name);
         self::assertNull($case->docblock);
         self::assertSame('/path/to/file.php', $case->file);
         self::assertSame(8, $case->line);

--- a/tests/Domain/EnumCaseNameTest.php
+++ b/tests/Domain/EnumCaseNameTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EnumCaseName::class)]
+class EnumCaseNameTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $name = new EnumCaseName('Active');
+        self::assertSame('Active', $name->name);
+    }
+}

--- a/tests/Domain/MethodInfoTest.php
+++ b/tests/Domain/MethodInfoTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MethodInfo::class)]
+class MethodInfoTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('doSomething'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: true,
+            parameters: [],
+            returnType: 'void',
+            docblock: null,
+            file: '/path/to/file.php',
+            line: 42,
+            declaringClass: new ClassName('App\\MyClass'),
+        );
+
+        self::assertSame('doSomething', $method->name->name);
+        self::assertSame(Visibility::Public, $method->visibility);
+        self::assertFalse($method->isStatic);
+        self::assertFalse($method->isAbstract);
+        self::assertTrue($method->isFinal);
+        self::assertSame([], $method->parameters);
+        self::assertSame('void', $method->returnType);
+        self::assertNull($method->docblock);
+        self::assertSame('/path/to/file.php', $method->file);
+        self::assertSame(42, $method->line);
+        self::assertSame('App\\MyClass', $method->declaringClass->fqn);
+    }
+}

--- a/tests/Domain/MethodNameTest.php
+++ b/tests/Domain/MethodNameTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MethodName::class)]
+class MethodNameTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $name = new MethodName('doSomething');
+        self::assertSame('doSomething', $name->name);
+    }
+}

--- a/tests/Domain/MethodNameTest.php
+++ b/tests/Domain/MethodNameTest.php
@@ -15,4 +15,25 @@ class MethodNameTest extends TestCase
         $name = new MethodName('doSomething');
         self::assertSame('doSomething', $name->name);
     }
+
+    public function testEqualsTrue(): void
+    {
+        $a = new MethodName('doSomething');
+        $b = new MethodName('doSomething');
+        self::assertTrue($a->equals($b));
+    }
+
+    public function testEqualsFalse(): void
+    {
+        $a = new MethodName('doSomething');
+        $b = new MethodName('doOther');
+        self::assertFalse($a->equals($b));
+    }
+
+    public function testEqualsCaseInsensitive(): void
+    {
+        $a = new MethodName('doSomething');
+        $b = new MethodName('DOSOMETHING');
+        self::assertTrue($a->equals($b));
+    }
 }

--- a/tests/Domain/ParameterInfoTest.php
+++ b/tests/Domain/ParameterInfoTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ParameterInfo::class)]
+class ParameterInfoTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $param = new ParameterInfo(
+            name: 'value',
+            type: 'string',
+            hasDefault: true,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('value', $param->name);
+        self::assertSame('string', $param->type);
+        self::assertTrue($param->hasDefault);
+        self::assertFalse($param->isVariadic);
+        self::assertFalse($param->isPassedByReference);
+    }
+
+    public function testConstructionWithNullType(): void
+    {
+        $param = new ParameterInfo(
+            name: 'args',
+            type: null,
+            hasDefault: false,
+            isVariadic: true,
+            isPassedByReference: false,
+        );
+
+        self::assertNull($param->type);
+        self::assertTrue($param->isVariadic);
+    }
+}

--- a/tests/Domain/PropertyInfoTest.php
+++ b/tests/Domain/PropertyInfoTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PropertyInfo::class)]
+class PropertyInfoTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $property = new PropertyInfo(
+            name: new PropertyName('value'),
+            visibility: Visibility::Private,
+            isStatic: false,
+            isReadonly: true,
+            isPromoted: true,
+            type: 'string',
+            docblock: null,
+            file: '/path/to/file.php',
+            line: 10,
+            declaringClass: new ClassName('App\\MyClass'),
+        );
+
+        self::assertSame('value', $property->name->name);
+        self::assertSame(Visibility::Private, $property->visibility);
+        self::assertFalse($property->isStatic);
+        self::assertTrue($property->isReadonly);
+        self::assertTrue($property->isPromoted);
+        self::assertSame('string', $property->type);
+        self::assertNull($property->docblock);
+        self::assertSame('/path/to/file.php', $property->file);
+        self::assertSame(10, $property->line);
+        self::assertSame('App\\MyClass', $property->declaringClass->fqn);
+    }
+}

--- a/tests/Domain/PropertyNameTest.php
+++ b/tests/Domain/PropertyNameTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PropertyName::class)]
+class PropertyNameTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $name = new PropertyName('myProperty');
+        self::assertSame('myProperty', $name->name);
+    }
+}

--- a/tests/Domain/VisibilityTest.php
+++ b/tests/Domain/VisibilityTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Visibility::class)]
+class VisibilityTest extends TestCase
+{
+    /**
+     * @return array<string, array{Visibility, Visibility, bool}>
+     */
+    public static function accessibilityProvider(): array
+    {
+        return [
+            'public from public' => [Visibility::Public, Visibility::Public, true],
+            'public from protected' => [Visibility::Public, Visibility::Protected, true],
+            'public from private' => [Visibility::Public, Visibility::Private, true],
+            'protected from public' => [Visibility::Protected, Visibility::Public, false],
+            'protected from protected' => [Visibility::Protected, Visibility::Protected, true],
+            'protected from private' => [Visibility::Protected, Visibility::Private, true],
+            'private from public' => [Visibility::Private, Visibility::Public, false],
+            'private from protected' => [Visibility::Private, Visibility::Protected, false],
+            'private from private' => [Visibility::Private, Visibility::Private, true],
+        ];
+    }
+
+    #[DataProvider('accessibilityProvider')]
+    public function testIsAccessibleFrom(
+        Visibility $member,
+        Visibility $required,
+        bool $expected,
+    ): void {
+        self::assertSame($expected, $member->isAccessibleFrom($required));
+    }
+}


### PR DESCRIPTION
## Summary

- Add type-safe identifier wrappers: `ClassName`, `MethodName`, `PropertyName`, `ConstantName`
- Add `Visibility` enum with `isAccessibleFrom()` for access checking
- Add `ClassKind` enum for class/interface/trait/enum discrimination
- Add Info types: `ClassInfo`, `MethodInfo`, `PropertyInfo`, `ConstantInfo`, `ParameterInfo`, `EnumCaseInfo`

All types are `final readonly` with constructor promotion, placed in `src/Domain/`.

## Test plan

- [x] Unit tests for all types (100% coverage)
- [x] PHPStan clean at max level
- [x] `composer check` passes

Closes #117

🤖 Generated with [Claude Code](https://claude.ai/code)