### PR TITLE
Arch Phase 3: Create MemberResolver with inheritance

### DIFF
--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -157,7 +157,7 @@ final class MemberResolver
             if (!$methodInfo->name->equals($method)) {
                 continue;
             }
-            if ($this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass, false)) {
+            if ($this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass)) {
                 return $methodInfo;
             }
         }
@@ -200,7 +200,7 @@ final class MemberResolver
 
         if (array_key_exists($property->name, $classInfo->properties)) {
             $propInfo = $classInfo->properties[$property->name];
-            if ($this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass, false)) {
+            if ($this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass)) {
                 return $propInfo;
             }
         }
@@ -243,7 +243,7 @@ final class MemberResolver
 
         if (array_key_exists($constant->name, $classInfo->constants)) {
             $constInfo = $classInfo->constants[$constant->name];
-            if ($this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass, false)) {
+            if ($this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass)) {
                 return $constInfo;
             }
         }
@@ -261,7 +261,20 @@ final class MemberResolver
         if ($classInfo->parent !== null) {
             $parentInfo = $this->classes->get($classInfo->parent);
             if ($parentInfo !== null) {
-                return $this->findConstantInHierarchy($parentInfo, $constant, $minVisibility, $seen, false);
+                $result = $this->findConstantInHierarchy($parentInfo, $constant, $minVisibility, $seen, false);
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+        }
+
+        foreach ($classInfo->interfaces as $interfaceName) {
+            $interfaceInfo = $this->classes->get($interfaceName);
+            if ($interfaceInfo !== null) {
+                $result = $this->findConstantInHierarchy($interfaceInfo, $constant, $minVisibility, $seen, false);
+                if ($result !== null) {
+                    return $result;
+                }
             }
         }
 
@@ -294,7 +307,7 @@ final class MemberResolver
             if ($static !== null && $methodInfo->isStatic !== $static) {
                 continue;
             }
-            if (!$this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass, false)) {
+            if (!$this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass)) {
                 continue;
             }
             $methods[$key] = $methodInfo;
@@ -340,7 +353,7 @@ final class MemberResolver
             if ($static !== null && $propInfo->isStatic !== $static) {
                 continue;
             }
-            if (!$this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass, false)) {
+            if (!$this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass)) {
                 continue;
             }
             $properties[$key] = $propInfo;
@@ -382,7 +395,7 @@ final class MemberResolver
             if (array_key_exists($key, $constants)) {
                 continue;
             }
-            if (!$this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass, false)) {
+            if (!$this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass)) {
                 continue;
             }
             $constants[$key] = $constInfo;
@@ -401,20 +414,26 @@ final class MemberResolver
                 $this->collectConstants($parentInfo, $minVisibility, $constants, $seen, false);
             }
         }
+
+        foreach ($classInfo->interfaces as $interfaceName) {
+            $interfaceInfo = $this->classes->get($interfaceName);
+            if ($interfaceInfo !== null) {
+                $this->collectConstants($interfaceInfo, $minVisibility, $constants, $seen, false);
+            }
+        }
     }
 
     private function isAccessible(
         Visibility $memberVisibility,
         Visibility $minVisibility,
         bool $isOriginClass,
-        bool $isTrait,
     ): bool {
         if (!$memberVisibility->isAccessibleFrom($minVisibility)) {
             return false;
         }
 
         if ($memberVisibility === Visibility::Private) {
-            return $isOriginClass || $isTrait;
+            return $isOriginClass;
         }
 
         return true;

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantInfo;
 use Firehed\PhpLsp\Domain\ConstantName;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\EnumCaseName;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyInfo;
@@ -65,6 +66,12 @@ final class MemberResolver
 
         $seen = [];
         return $this->findConstantInHierarchy($classInfo, $constant, $minVisibility, $seen, true);
+    }
+
+    public function findEnumCase(ClassName $class, EnumCaseName $case): ?EnumCaseInfo
+    {
+        $classInfo = $this->classes->get($class);
+        return $classInfo?->enumCases[$case->name] ?? null;
     }
 
     /**

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Repository;
+
+use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\ConstantInfo;
+use Firehed\PhpLsp\Domain\ConstantName;
+use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
+
+/**
+ * Resolves class members with inheritance traversal.
+ */
+final class MemberResolver
+{
+    public function __construct(
+        private readonly ClassRepository $classes,
+    ) {
+    }
+
+    public function findMethod(
+        ClassName $class,
+        MethodName $method,
+        Visibility $minVisibility,
+    ): ?MethodInfo {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return null;
+        }
+
+        $seen = [];
+        return $this->findMethodInHierarchy($classInfo, $method, $minVisibility, $seen, true);
+    }
+
+    public function findProperty(
+        ClassName $class,
+        PropertyName $property,
+        Visibility $minVisibility,
+    ): ?PropertyInfo {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return null;
+        }
+
+        $seen = [];
+        return $this->findPropertyInHierarchy($classInfo, $property, $minVisibility, $seen, true);
+    }
+
+    public function findConstant(
+        ClassName $class,
+        ConstantName $constant,
+        Visibility $minVisibility,
+    ): ?ConstantInfo {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return null;
+        }
+
+        $seen = [];
+        return $this->findConstantInHierarchy($classInfo, $constant, $minVisibility, $seen, true);
+    }
+
+    /**
+     * @return list<MethodInfo>
+     */
+    public function getMethods(
+        ClassName $class,
+        Visibility $minVisibility,
+        ?bool $static = null,
+    ): array {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return [];
+        }
+
+        $methods = [];
+        $seen = [];
+        $this->collectMethods($classInfo, $minVisibility, $static, $methods, $seen, true);
+
+        return array_values($methods);
+    }
+
+    /**
+     * @return list<PropertyInfo>
+     */
+    public function getProperties(
+        ClassName $class,
+        Visibility $minVisibility,
+        ?bool $static = null,
+    ): array {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return [];
+        }
+
+        $properties = [];
+        $seen = [];
+        $this->collectProperties($classInfo, $minVisibility, $static, $properties, $seen, true);
+
+        return array_values($properties);
+    }
+
+    /**
+     * @return list<ConstantInfo>
+     */
+    public function getConstants(ClassName $class, Visibility $minVisibility): array
+    {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return [];
+        }
+
+        $constants = [];
+        $seen = [];
+        $this->collectConstants($classInfo, $minVisibility, $constants, $seen, true);
+
+        return array_values($constants);
+    }
+
+    /**
+     * @return list<EnumCaseInfo>
+     */
+    public function getEnumCases(ClassName $class): array
+    {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return [];
+        }
+
+        return array_values($classInfo->enumCases);
+    }
+
+    /**
+     * @param array<string, true> $seen
+     */
+    private function findMethodInHierarchy(
+        ClassInfo $classInfo,
+        MethodName $method,
+        Visibility $minVisibility,
+        array &$seen,
+        bool $isOriginClass,
+    ): ?MethodInfo {
+        $fqn = $classInfo->name->fqn;
+        if (array_key_exists($fqn, $seen)) {
+            return null;
+        }
+        $seen[$fqn] = true;
+
+        foreach ($classInfo->methods as $methodInfo) {
+            if (!$methodInfo->name->equals($method)) {
+                continue;
+            }
+            if ($this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass, false)) {
+                return $methodInfo;
+            }
+        }
+
+        foreach ($classInfo->traits as $traitName) {
+            $traitInfo = $this->classes->get($traitName);
+            if ($traitInfo !== null) {
+                $result = $this->findMethodInHierarchy($traitInfo, $method, $minVisibility, $seen, true);
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+        }
+
+        if ($classInfo->parent !== null) {
+            $parentInfo = $this->classes->get($classInfo->parent);
+            if ($parentInfo !== null) {
+                return $this->findMethodInHierarchy($parentInfo, $method, $minVisibility, $seen, false);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, true> $seen
+     */
+    private function findPropertyInHierarchy(
+        ClassInfo $classInfo,
+        PropertyName $property,
+        Visibility $minVisibility,
+        array &$seen,
+        bool $isOriginClass,
+    ): ?PropertyInfo {
+        $fqn = $classInfo->name->fqn;
+        if (array_key_exists($fqn, $seen)) {
+            return null;
+        }
+        $seen[$fqn] = true;
+
+        if (array_key_exists($property->name, $classInfo->properties)) {
+            $propInfo = $classInfo->properties[$property->name];
+            if ($this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass, false)) {
+                return $propInfo;
+            }
+        }
+
+        foreach ($classInfo->traits as $traitName) {
+            $traitInfo = $this->classes->get($traitName);
+            if ($traitInfo !== null) {
+                $result = $this->findPropertyInHierarchy($traitInfo, $property, $minVisibility, $seen, true);
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+        }
+
+        if ($classInfo->parent !== null) {
+            $parentInfo = $this->classes->get($classInfo->parent);
+            if ($parentInfo !== null) {
+                return $this->findPropertyInHierarchy($parentInfo, $property, $minVisibility, $seen, false);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, true> $seen
+     */
+    private function findConstantInHierarchy(
+        ClassInfo $classInfo,
+        ConstantName $constant,
+        Visibility $minVisibility,
+        array &$seen,
+        bool $isOriginClass,
+    ): ?ConstantInfo {
+        $fqn = $classInfo->name->fqn;
+        if (array_key_exists($fqn, $seen)) {
+            return null;
+        }
+        $seen[$fqn] = true;
+
+        if (array_key_exists($constant->name, $classInfo->constants)) {
+            $constInfo = $classInfo->constants[$constant->name];
+            if ($this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass, false)) {
+                return $constInfo;
+            }
+        }
+
+        foreach ($classInfo->traits as $traitName) {
+            $traitInfo = $this->classes->get($traitName);
+            if ($traitInfo !== null) {
+                $result = $this->findConstantInHierarchy($traitInfo, $constant, $minVisibility, $seen, true);
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+        }
+
+        if ($classInfo->parent !== null) {
+            $parentInfo = $this->classes->get($classInfo->parent);
+            if ($parentInfo !== null) {
+                return $this->findConstantInHierarchy($parentInfo, $constant, $minVisibility, $seen, false);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, MethodInfo> $methods
+     * @param array<string, true> $seen
+     */
+    private function collectMethods(
+        ClassInfo $classInfo,
+        Visibility $minVisibility,
+        ?bool $static,
+        array &$methods,
+        array &$seen,
+        bool $isOriginClass,
+    ): void {
+        $fqn = $classInfo->name->fqn;
+        if (array_key_exists($fqn, $seen)) {
+            return;
+        }
+        $seen[$fqn] = true;
+
+        foreach ($classInfo->methods as $methodInfo) {
+            $key = strtolower($methodInfo->name->name);
+            if (array_key_exists($key, $methods)) {
+                continue;
+            }
+            if ($static !== null && $methodInfo->isStatic !== $static) {
+                continue;
+            }
+            if (!$this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass, false)) {
+                continue;
+            }
+            $methods[$key] = $methodInfo;
+        }
+
+        foreach ($classInfo->traits as $traitName) {
+            $traitInfo = $this->classes->get($traitName);
+            if ($traitInfo !== null) {
+                $this->collectMethods($traitInfo, $minVisibility, $static, $methods, $seen, true);
+            }
+        }
+
+        if ($classInfo->parent !== null) {
+            $parentInfo = $this->classes->get($classInfo->parent);
+            if ($parentInfo !== null) {
+                $this->collectMethods($parentInfo, $minVisibility, $static, $methods, $seen, false);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, PropertyInfo> $properties
+     * @param array<string, true> $seen
+     */
+    private function collectProperties(
+        ClassInfo $classInfo,
+        Visibility $minVisibility,
+        ?bool $static,
+        array &$properties,
+        array &$seen,
+        bool $isOriginClass,
+    ): void {
+        $fqn = $classInfo->name->fqn;
+        if (array_key_exists($fqn, $seen)) {
+            return;
+        }
+        $seen[$fqn] = true;
+
+        foreach ($classInfo->properties as $key => $propInfo) {
+            if (array_key_exists($key, $properties)) {
+                continue;
+            }
+            if ($static !== null && $propInfo->isStatic !== $static) {
+                continue;
+            }
+            if (!$this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass, false)) {
+                continue;
+            }
+            $properties[$key] = $propInfo;
+        }
+
+        foreach ($classInfo->traits as $traitName) {
+            $traitInfo = $this->classes->get($traitName);
+            if ($traitInfo !== null) {
+                $this->collectProperties($traitInfo, $minVisibility, $static, $properties, $seen, true);
+            }
+        }
+
+        if ($classInfo->parent !== null) {
+            $parentInfo = $this->classes->get($classInfo->parent);
+            if ($parentInfo !== null) {
+                $this->collectProperties($parentInfo, $minVisibility, $static, $properties, $seen, false);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, ConstantInfo> $constants
+     * @param array<string, true> $seen
+     */
+    private function collectConstants(
+        ClassInfo $classInfo,
+        Visibility $minVisibility,
+        array &$constants,
+        array &$seen,
+        bool $isOriginClass,
+    ): void {
+        $fqn = $classInfo->name->fqn;
+        if (array_key_exists($fqn, $seen)) {
+            return;
+        }
+        $seen[$fqn] = true;
+
+        foreach ($classInfo->constants as $key => $constInfo) {
+            if (array_key_exists($key, $constants)) {
+                continue;
+            }
+            if (!$this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass, false)) {
+                continue;
+            }
+            $constants[$key] = $constInfo;
+        }
+
+        foreach ($classInfo->traits as $traitName) {
+            $traitInfo = $this->classes->get($traitName);
+            if ($traitInfo !== null) {
+                $this->collectConstants($traitInfo, $minVisibility, $constants, $seen, true);
+            }
+        }
+
+        if ($classInfo->parent !== null) {
+            $parentInfo = $this->classes->get($classInfo->parent);
+            if ($parentInfo !== null) {
+                $this->collectConstants($parentInfo, $minVisibility, $constants, $seen, false);
+            }
+        }
+    }
+
+    private function isAccessible(
+        Visibility $memberVisibility,
+        Visibility $minVisibility,
+        bool $isOriginClass,
+        bool $isTrait,
+    ): bool {
+        if (!$memberVisibility->isAccessibleFrom($minVisibility)) {
+            return false;
+        }
+
+        if ($memberVisibility === Visibility::Private) {
+            return $isOriginClass || $isTrait;
+        }
+
+        return true;
+    }
+}

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -72,6 +72,21 @@ final class MemberResolverTest extends TestCase
         self::assertNull($result);
     }
 
+    public function testFindEnumCaseReturnsNullForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findEnumCase(
+            new ClassName(self::fakeClass()),
+            new EnumCaseName('Foo'),
+        );
+
+        self::assertNull($result);
+    }
+
     public function testGetMethodsReturnsEmptyForUnknownClass(): void
     {
         $repo = self::createStub(ClassRepository::class);
@@ -718,6 +733,42 @@ final class MemberResolverTest extends TestCase
         self::assertCount(2, $result);
         self::assertContains($case1, $result);
         self::assertContains($case2, $result);
+    }
+
+    public function testFindEnumCaseReturnsCase(): void
+    {
+        $enumName = new ClassName(self::fakeClass());
+        $case1 = $this->createEnumCaseInfo('Case1', $enumName);
+        $case2 = $this->createEnumCaseInfo('Case2', $enumName);
+
+        $enumInfo = $this->createClassInfo($enumName, kind: ClassKind::Enum_, enumCases: [
+            'Case1' => $case1,
+            'Case2' => $case2,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($enumInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findEnumCase($enumName, new EnumCaseName('Case2'));
+
+        self::assertSame($case2, $result);
+    }
+
+    public function testFindEnumCaseReturnsNullWhenNotFound(): void
+    {
+        $enumName = new ClassName(self::fakeClass());
+        $enumInfo = $this->createClassInfo($enumName, kind: ClassKind::Enum_);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($enumInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findEnumCase($enumName, new EnumCaseName('NonExistent'));
+
+        self::assertNull($result);
     }
 
     public function testDiamondInheritanceNoDuplicates(): void

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -400,6 +400,105 @@ final class MemberResolverTest extends TestCase
         self::assertSame($childMethod, $result);
     }
 
+    public function testFindMethodFromGrandparent(): void
+    {
+        $grandparentName = new ClassName(self::fakeClass());
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $grandparentMethod = $this->createMethodInfo('deepMethod', Visibility::Public, $grandparentName);
+
+        $grandparentInfo = $this->createClassInfo(
+            $grandparentName,
+            methods: ['deepMethod' => $grandparentMethod],
+        );
+        $parentInfo = $this->createClassInfo($parentName, parent: $grandparentName);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $grandparentName->fqn => $grandparentInfo,
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($childName, new MethodName('deepMethod'), Visibility::Public);
+
+        self::assertSame($grandparentMethod, $result);
+    }
+
+    public function testFindConstantFromInterface(): void
+    {
+        $interfaceName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+
+        $interfaceConst = $this->createConstantInfo('INTERFACE_CONST', Visibility::Public, $interfaceName);
+
+        $interfaceInfo = $this->createClassInfo(
+            $interfaceName,
+            kind: ClassKind::Interface_,
+            constants: ['INTERFACE_CONST' => $interfaceConst],
+        );
+        $classInfo = $this->createClassInfo($className, interfaces: [$interfaceName]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $interfaceName->fqn => $interfaceInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant($className, new ConstantName('INTERFACE_CONST'), Visibility::Public);
+
+        self::assertSame($interfaceConst, $result);
+    }
+
+    public function testGetConstantsIncludesInterfaceConstants(): void
+    {
+        $interfaceName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+
+        $classConst = $this->createConstantInfo('CLASS_CONST', Visibility::Public, $className);
+        $interfaceConst = $this->createConstantInfo('INTERFACE_CONST', Visibility::Public, $interfaceName);
+
+        $interfaceInfo = $this->createClassInfo(
+            $interfaceName,
+            kind: ClassKind::Interface_,
+            constants: ['INTERFACE_CONST' => $interfaceConst],
+        );
+        $classInfo = $this->createClassInfo(
+            $className,
+            constants: ['CLASS_CONST' => $classConst],
+            interfaces: [$interfaceName],
+        );
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $interfaceName->fqn => $interfaceInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($className, Visibility::Public);
+
+        self::assertCount(2, $result);
+        self::assertContains($classConst, $result);
+        self::assertContains($interfaceConst, $result);
+    }
+
     /**
      * @return class-string
      */
@@ -415,6 +514,7 @@ final class MemberResolverTest extends TestCase
      * @param array<string, ConstantInfo> $constants
      * @param array<string, EnumCaseInfo> $enumCases
      * @param list<ClassName> $traits
+     * @param list<ClassName> $interfaces
      */
     private function createClassInfo(
         ClassName $name,
@@ -425,6 +525,7 @@ final class MemberResolverTest extends TestCase
         array $constants = [],
         array $enumCases = [],
         array $traits = [],
+        array $interfaces = [],
     ): ClassInfo {
         return new ClassInfo(
             name: $name,
@@ -433,7 +534,7 @@ final class MemberResolverTest extends TestCase
             isFinal: false,
             isReadonly: false,
             parent: $parent,
-            interfaces: [],
+            interfaces: $interfaces,
             traits: $traits,
             methods: $methods,
             properties: $properties,

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -40,6 +40,86 @@ final class MemberResolverTest extends TestCase
         self::assertNull($result);
     }
 
+    public function testFindPropertyReturnsNullForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findProperty(
+            new ClassName(self::fakeClass()),
+            new PropertyName('foo'),
+            Visibility::Public,
+        );
+
+        self::assertNull($result);
+    }
+
+    public function testFindConstantReturnsNullForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant(
+            new ClassName(self::fakeClass()),
+            new ConstantName('FOO'),
+            Visibility::Public,
+        );
+
+        self::assertNull($result);
+    }
+
+    public function testGetMethodsReturnsEmptyForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getMethods(new ClassName(self::fakeClass()), Visibility::Public);
+
+        self::assertSame([], $result);
+    }
+
+    public function testGetPropertiesReturnsEmptyForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getProperties(new ClassName(self::fakeClass()), Visibility::Public);
+
+        self::assertSame([], $result);
+    }
+
+    public function testGetConstantsReturnsEmptyForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants(new ClassName(self::fakeClass()), Visibility::Public);
+
+        self::assertSame([], $result);
+    }
+
+    public function testGetEnumCasesReturnsEmptyForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getEnumCases(new ClassName(self::fakeClass()));
+
+        self::assertSame([], $result);
+    }
+
     public function testFindMethodReturnsMethodFromClass(): void
     {
         $className = new ClassName(self::fakeClass());
@@ -252,6 +332,21 @@ final class MemberResolverTest extends TestCase
         self::assertSame($propInfo, $result);
     }
 
+    public function testFindPropertyReturnsNullWhenNotFound(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $classInfo = $this->createClassInfo($className);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findProperty($className, new PropertyName('nonexistent'), Visibility::Public);
+
+        self::assertNull($result);
+    }
+
     public function testFindConstantReturnsConstantFromClass(): void
     {
         $className = new ClassName(self::fakeClass());
@@ -320,6 +415,21 @@ final class MemberResolverTest extends TestCase
         $result = $resolver->findConstant($className, new ConstantName('TRAIT_CONST'), Visibility::Public);
 
         self::assertSame($constInfo, $result);
+    }
+
+    public function testFindConstantReturnsNullWhenNotFound(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $classInfo = $this->createClassInfo($className);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant($className, new ConstantName('NONEXISTENT'), Visibility::Public);
+
+        self::assertNull($result);
     }
 
     public function testGetMethodsReturnsAllAccessibleMethods(): void
@@ -446,6 +556,64 @@ final class MemberResolverTest extends TestCase
         self::assertNotContains($parentPrivate, $result);
     }
 
+    public function testGetPropertiesFiltersStatic(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $instanceProp = $this->createPropertyInfo('instance', Visibility::Public, $className, isStatic: false);
+        $staticProp = $this->createPropertyInfo('static', Visibility::Public, $className, isStatic: true);
+
+        $classInfo = $this->createClassInfo($className, properties: [
+            'instance' => $instanceProp,
+            'static' => $staticProp,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $staticOnly = $resolver->getProperties($className, Visibility::Public, static: true);
+        $instanceOnly = $resolver->getProperties($className, Visibility::Public, static: false);
+
+        self::assertSame([$staticProp], $staticOnly);
+        self::assertSame([$instanceProp], $instanceOnly);
+    }
+
+    public function testGetPropertiesIncludesTraitProperties(): void
+    {
+        $traitName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+
+        $traitProp = $this->createPropertyInfo('traitProp', Visibility::Public, $traitName);
+        $classProp = $this->createPropertyInfo('classProp', Visibility::Public, $className);
+
+        $traitInfo = $this->createClassInfo(
+            $traitName,
+            kind: ClassKind::Trait_,
+            properties: ['traitProp' => $traitProp],
+        );
+        $classInfo = $this->createClassInfo($className, traits: [$traitName], properties: [
+            'classProp' => $classProp,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $traitName->fqn => $traitInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getProperties($className, Visibility::Public);
+
+        self::assertCount(2, $result);
+        self::assertContains($classProp, $result);
+        self::assertContains($traitProp, $result);
+    }
+
     public function testGetConstantsReturnsAllAccessibleConstants(): void
     {
         $className = new ClassName(self::fakeClass());
@@ -461,6 +629,72 @@ final class MemberResolverTest extends TestCase
         $result = $resolver->getConstants($className, Visibility::Public);
 
         self::assertSame([$const1], $result);
+    }
+
+    public function testGetConstantsIncludesParentConstants(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $parentConst = $this->createConstantInfo('PARENT_CONST', Visibility::Public, $parentName);
+        $childConst = $this->createConstantInfo('CHILD_CONST', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, constants: ['PARENT_CONST' => $parentConst]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName, constants: [
+            'CHILD_CONST' => $childConst,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($childName, Visibility::Public);
+
+        self::assertCount(2, $result);
+        self::assertContains($childConst, $result);
+        self::assertContains($parentConst, $result);
+    }
+
+    public function testGetConstantsIncludesTraitConstants(): void
+    {
+        $traitName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+
+        $traitConst = $this->createConstantInfo('TRAIT_CONST', Visibility::Public, $traitName);
+        $classConst = $this->createConstantInfo('CLASS_CONST', Visibility::Public, $className);
+
+        $traitInfo = $this->createClassInfo(
+            $traitName,
+            kind: ClassKind::Trait_,
+            constants: ['TRAIT_CONST' => $traitConst],
+        );
+        $classInfo = $this->createClassInfo($className, traits: [$traitName], constants: [
+            'CLASS_CONST' => $classConst,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $traitName->fqn => $traitInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($className, Visibility::Public);
+
+        self::assertCount(2, $result);
+        self::assertContains($classConst, $result);
+        self::assertContains($traitConst, $result);
     }
 
     public function testGetEnumCasesReturnsAllCases(): void
@@ -517,6 +751,292 @@ final class MemberResolverTest extends TestCase
         $resolver = new MemberResolver($repo);
 
         $result = $resolver->getMethods($childName, Visibility::Public);
+
+        self::assertCount(1, $result);
+    }
+
+    public function testFindMethodWithDiamondInheritanceHitsSeenCheck(): void
+    {
+        // Diamond where the method doesn't exist anywhere, forcing full traversal
+        // This hits the $seen check when trait2 tries to traverse baseTrait (already seen via trait1)
+        $baseTrait = new ClassName(self::fakeClass());
+        $trait1 = new ClassName(self::fakeClass());
+        $trait2 = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $baseTraitInfo = $this->createClassInfo($baseTrait, kind: ClassKind::Trait_);
+        $trait1Info = $this->createClassInfo($trait1, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $trait2Info = $this->createClassInfo($trait2, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $childInfo = $this->createClassInfo($childName, traits: [$trait1, $trait2]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $baseTrait->fqn => $baseTraitInfo,
+                $trait1->fqn => $trait1Info,
+                $trait2->fqn => $trait2Info,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($childName, new MethodName('nonexistent'), Visibility::Public);
+
+        self::assertNull($result);
+    }
+
+    public function testFindPropertyWithDiamondInheritanceHitsSeenCheck(): void
+    {
+        $baseTrait = new ClassName(self::fakeClass());
+        $trait1 = new ClassName(self::fakeClass());
+        $trait2 = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $baseTraitInfo = $this->createClassInfo($baseTrait, kind: ClassKind::Trait_);
+        $trait1Info = $this->createClassInfo($trait1, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $trait2Info = $this->createClassInfo($trait2, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $childInfo = $this->createClassInfo($childName, traits: [$trait1, $trait2]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $baseTrait->fqn => $baseTraitInfo,
+                $trait1->fqn => $trait1Info,
+                $trait2->fqn => $trait2Info,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findProperty($childName, new PropertyName('nonexistent'), Visibility::Public);
+
+        self::assertNull($result);
+    }
+
+    public function testFindConstantWithDiamondInheritanceHitsSeenCheck(): void
+    {
+        $baseTrait = new ClassName(self::fakeClass());
+        $trait1 = new ClassName(self::fakeClass());
+        $trait2 = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $baseTraitInfo = $this->createClassInfo($baseTrait, kind: ClassKind::Trait_);
+        $trait1Info = $this->createClassInfo($trait1, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $trait2Info = $this->createClassInfo($trait2, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $childInfo = $this->createClassInfo($childName, traits: [$trait1, $trait2]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $baseTrait->fqn => $baseTraitInfo,
+                $trait1->fqn => $trait1Info,
+                $trait2->fqn => $trait2Info,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant($childName, new ConstantName('NONEXISTENT'), Visibility::Public);
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodSkipsNonMatchingMethods(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $method1 = $this->createMethodInfo('method1', Visibility::Public, $className);
+        $method2 = $this->createMethodInfo('method2', Visibility::Public, $className);
+
+        $classInfo = $this->createClassInfo($className, methods: [
+            'method1' => $method1,
+            'method2' => $method2,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($className, new MethodName('method2'), Visibility::Public);
+
+        self::assertSame($method2, $result);
+    }
+
+    public function testGetConstantsFiltersInaccessibleConstants(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $publicConst = $this->createConstantInfo('PUBLIC', Visibility::Public, $className);
+        $privateConst = $this->createConstantInfo('PRIVATE', Visibility::Private, $className);
+
+        $classInfo = $this->createClassInfo($className, constants: [
+            'PUBLIC' => $publicConst,
+            'PRIVATE' => $privateConst,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($className, Visibility::Public);
+
+        self::assertSame([$publicConst], $result);
+    }
+
+    public function testGetMethodsChildOverridesParent(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $parentMethod = $this->createMethodInfo('method', Visibility::Public, $parentName);
+        $childMethod = $this->createMethodInfo('method', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, methods: ['method' => $parentMethod]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName, methods: ['method' => $childMethod]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getMethods($childName, Visibility::Public);
+
+        self::assertCount(1, $result);
+        self::assertSame($childMethod, $result[0]);
+    }
+
+    public function testGetPropertiesChildOverridesParent(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $parentProp = $this->createPropertyInfo('prop', Visibility::Public, $parentName);
+        $childProp = $this->createPropertyInfo('prop', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, properties: ['prop' => $parentProp]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName, properties: ['prop' => $childProp]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getProperties($childName, Visibility::Public);
+
+        self::assertCount(1, $result);
+        self::assertSame($childProp, $result[0]);
+    }
+
+    public function testGetConstantsChildOverridesParent(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $parentConst = $this->createConstantInfo('CONST', Visibility::Public, $parentName);
+        $childConst = $this->createConstantInfo('CONST', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, constants: ['CONST' => $parentConst]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName, constants: ['CONST' => $childConst]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($childName, Visibility::Public);
+
+        self::assertCount(1, $result);
+        self::assertSame($childConst, $result[0]);
+    }
+
+    public function testGetPropertiesDiamondInheritance(): void
+    {
+        $baseTrait = new ClassName(self::fakeClass());
+        $trait1 = new ClassName(self::fakeClass());
+        $trait2 = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $sharedProp = $this->createPropertyInfo('sharedProp', Visibility::Public, $baseTrait);
+
+        $baseTraitInfo = $this->createClassInfo($baseTrait, kind: ClassKind::Trait_, properties: [
+            'sharedProp' => $sharedProp,
+        ]);
+        $trait1Info = $this->createClassInfo($trait1, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $trait2Info = $this->createClassInfo($trait2, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $childInfo = $this->createClassInfo($childName, traits: [$trait1, $trait2]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $baseTrait->fqn => $baseTraitInfo,
+                $trait1->fqn => $trait1Info,
+                $trait2->fqn => $trait2Info,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getProperties($childName, Visibility::Public);
+
+        self::assertCount(1, $result);
+    }
+
+    public function testGetConstantsDiamondInheritance(): void
+    {
+        $baseTrait = new ClassName(self::fakeClass());
+        $trait1 = new ClassName(self::fakeClass());
+        $trait2 = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $sharedConst = $this->createConstantInfo('SHARED', Visibility::Public, $baseTrait);
+
+        $baseTraitInfo = $this->createClassInfo($baseTrait, kind: ClassKind::Trait_, constants: [
+            'SHARED' => $sharedConst,
+        ]);
+        $trait1Info = $this->createClassInfo($trait1, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $trait2Info = $this->createClassInfo($trait2, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $childInfo = $this->createClassInfo($childName, traits: [$trait1, $trait2]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $baseTrait->fqn => $baseTraitInfo,
+                $trait1->fqn => $trait1Info,
+                $trait2->fqn => $trait2Info,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($childName, Visibility::Public);
 
         self::assertCount(1, $result);
     }

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -1,0 +1,516 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Repository;
+
+use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\ClassKind;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\ConstantInfo;
+use Firehed\PhpLsp\Domain\ConstantName;
+use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MemberResolver::class)]
+final class MemberResolverTest extends TestCase
+{
+    public function testFindMethodReturnsNullForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod(
+            new ClassName(self::fakeClass()),
+            new MethodName('foo'),
+            Visibility::Public,
+        );
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodReturnsMethodFromClass(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $methodInfo = $this->createMethodInfo('doSomething', Visibility::Public, $className);
+        $classInfo = $this->createClassInfo($className, methods: ['doSomething' => $methodInfo]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnMap([
+            [$className, $classInfo],
+        ]);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($className, new MethodName('doSomething'), Visibility::Public);
+
+        self::assertSame($methodInfo, $result);
+    }
+
+    public function testFindMethodReturnsMethodFromParent(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+        $methodInfo = $this->createMethodInfo('parentMethod', Visibility::Public, $parentName);
+
+        $parentInfo = $this->createClassInfo($parentName, methods: ['parentMethod' => $methodInfo]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($childName, new MethodName('parentMethod'), Visibility::Public);
+
+        self::assertSame($methodInfo, $result);
+    }
+
+    public function testFindMethodReturnsMethodFromTrait(): void
+    {
+        $traitName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+        $methodInfo = $this->createMethodInfo('traitMethod', Visibility::Public, $traitName);
+
+        $traitInfo = $this->createClassInfo(
+            $traitName,
+            kind: ClassKind::Trait_,
+            methods: ['traitMethod' => $methodInfo],
+        );
+        $classInfo = $this->createClassInfo($className, traits: [$traitName]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $traitName->fqn => $traitInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($className, new MethodName('traitMethod'), Visibility::Public);
+
+        self::assertSame($methodInfo, $result);
+    }
+
+    public function testFindMethodFiltersVisibility(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $privateMethod = $this->createMethodInfo('privateMethod', Visibility::Private, $className);
+        $classInfo = $this->createClassInfo($className, methods: ['privateMethod' => $privateMethod]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($className, new MethodName('privateMethod'), Visibility::Public);
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodExcludesParentPrivateMethods(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+        $privateMethod = $this->createMethodInfo('privateMethod', Visibility::Private, $parentName);
+
+        $parentInfo = $this->createClassInfo($parentName, methods: ['privateMethod' => $privateMethod]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($childName, new MethodName('privateMethod'), Visibility::Private);
+
+        self::assertNull($result);
+    }
+
+    public function testFindMethodIncludesTraitPrivateMethods(): void
+    {
+        $traitName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+        $privateMethod = $this->createMethodInfo('privateMethod', Visibility::Private, $traitName);
+
+        $traitInfo = $this->createClassInfo(
+            $traitName,
+            kind: ClassKind::Trait_,
+            methods: ['privateMethod' => $privateMethod],
+        );
+        $classInfo = $this->createClassInfo($className, traits: [$traitName]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $traitName->fqn => $traitInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($className, new MethodName('privateMethod'), Visibility::Private);
+
+        self::assertSame($privateMethod, $result);
+    }
+
+    public function testFindPropertyReturnsPropertyFromClass(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $propInfo = $this->createPropertyInfo('myProp', Visibility::Public, $className);
+        $classInfo = $this->createClassInfo($className, properties: ['myProp' => $propInfo]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findProperty($className, new PropertyName('myProp'), Visibility::Public);
+
+        self::assertSame($propInfo, $result);
+    }
+
+    public function testFindConstantReturnsConstantFromClass(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $constInfo = $this->createConstantInfo('MY_CONST', Visibility::Public, $className);
+        $classInfo = $this->createClassInfo($className, constants: ['MY_CONST' => $constInfo]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant($className, new ConstantName('MY_CONST'), Visibility::Public);
+
+        self::assertSame($constInfo, $result);
+    }
+
+    public function testGetMethodsReturnsAllAccessibleMethods(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $parentPublic = $this->createMethodInfo('parentPublic', Visibility::Public, $parentName);
+        $parentProtected = $this->createMethodInfo('parentProtected', Visibility::Protected, $parentName);
+        $parentPrivate = $this->createMethodInfo('parentPrivate', Visibility::Private, $parentName);
+
+        $childMethod = $this->createMethodInfo('childMethod', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, methods: [
+            'parentPublic' => $parentPublic,
+            'parentProtected' => $parentProtected,
+            'parentPrivate' => $parentPrivate,
+        ]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName, methods: [
+            'childMethod' => $childMethod,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getMethods($childName, Visibility::Private);
+
+        self::assertCount(3, $result);
+        self::assertContains($childMethod, $result);
+        self::assertContains($parentPublic, $result);
+        self::assertContains($parentProtected, $result);
+        self::assertNotContains($parentPrivate, $result);
+    }
+
+    public function testGetMethodsFiltersStatic(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $instanceMethod = $this->createMethodInfo('instance', Visibility::Public, $className, isStatic: false);
+        $staticMethod = $this->createMethodInfo('static', Visibility::Public, $className, isStatic: true);
+
+        $classInfo = $this->createClassInfo($className, methods: [
+            'instance' => $instanceMethod,
+            'static' => $staticMethod,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $staticOnly = $resolver->getMethods($className, Visibility::Public, static: true);
+        $instanceOnly = $resolver->getMethods($className, Visibility::Public, static: false);
+
+        self::assertSame([$staticMethod], $staticOnly);
+        self::assertSame([$instanceMethod], $instanceOnly);
+    }
+
+    public function testGetPropertiesReturnsAllAccessibleProperties(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $prop1 = $this->createPropertyInfo('prop1', Visibility::Public, $className);
+        $prop2 = $this->createPropertyInfo('prop2', Visibility::Protected, $className);
+
+        $classInfo = $this->createClassInfo($className, properties: [
+            'prop1' => $prop1,
+            'prop2' => $prop2,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getProperties($className, Visibility::Protected);
+
+        self::assertCount(2, $result);
+    }
+
+    public function testGetConstantsReturnsAllAccessibleConstants(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $const1 = $this->createConstantInfo('CONST1', Visibility::Public, $className);
+
+        $classInfo = $this->createClassInfo($className, constants: ['CONST1' => $const1]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($className, Visibility::Public);
+
+        self::assertSame([$const1], $result);
+    }
+
+    public function testGetEnumCasesReturnsAllCases(): void
+    {
+        $enumName = new ClassName(self::fakeClass());
+        $case1 = $this->createEnumCaseInfo('Case1', $enumName);
+        $case2 = $this->createEnumCaseInfo('Case2', $enumName);
+
+        $enumInfo = $this->createClassInfo($enumName, kind: ClassKind::Enum_, enumCases: [
+            'Case1' => $case1,
+            'Case2' => $case2,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($enumInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getEnumCases($enumName);
+
+        self::assertCount(2, $result);
+        self::assertContains($case1, $result);
+        self::assertContains($case2, $result);
+    }
+
+    public function testDiamondInheritanceNoDuplicates(): void
+    {
+        // Diamond: Child uses Trait1 and Trait2, both use BaseTrait
+        $baseTrait = new ClassName(self::fakeClass());
+        $trait1 = new ClassName(self::fakeClass());
+        $trait2 = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $sharedMethod = $this->createMethodInfo('sharedMethod', Visibility::Public, $baseTrait);
+
+        $baseTraitInfo = $this->createClassInfo($baseTrait, kind: ClassKind::Trait_, methods: [
+            'sharedMethod' => $sharedMethod,
+        ]);
+        $trait1Info = $this->createClassInfo($trait1, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $trait2Info = $this->createClassInfo($trait2, kind: ClassKind::Trait_, traits: [$baseTrait]);
+        $childInfo = $this->createClassInfo($childName, traits: [$trait1, $trait2]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $baseTrait->fqn => $baseTraitInfo,
+                $trait1->fqn => $trait1Info,
+                $trait2->fqn => $trait2Info,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getMethods($childName, Visibility::Public);
+
+        self::assertCount(1, $result);
+    }
+
+    public function testChildMethodOverridesParent(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $parentMethod = $this->createMethodInfo('method', Visibility::Public, $parentName);
+        $childMethod = $this->createMethodInfo('method', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, methods: ['method' => $parentMethod]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName, methods: ['method' => $childMethod]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($childName, new MethodName('method'), Visibility::Public);
+
+        self::assertSame($childMethod, $result);
+    }
+
+    /**
+     * @return class-string
+     */
+    private static function fakeClass(): string
+    {
+        // @phpstan-ignore return.type
+        return 'Fake\\Class' . random_int(0, PHP_INT_MAX);
+    }
+
+    /**
+     * @param array<string, MethodInfo> $methods
+     * @param array<string, PropertyInfo> $properties
+     * @param array<string, ConstantInfo> $constants
+     * @param array<string, EnumCaseInfo> $enumCases
+     * @param list<ClassName> $traits
+     */
+    private function createClassInfo(
+        ClassName $name,
+        ClassKind $kind = ClassKind::Class_,
+        ?ClassName $parent = null,
+        array $methods = [],
+        array $properties = [],
+        array $constants = [],
+        array $enumCases = [],
+        array $traits = [],
+    ): ClassInfo {
+        return new ClassInfo(
+            name: $name,
+            kind: $kind,
+            isAbstract: false,
+            isFinal: false,
+            isReadonly: false,
+            parent: $parent,
+            interfaces: [],
+            traits: $traits,
+            methods: $methods,
+            properties: $properties,
+            constants: $constants,
+            enumCases: $enumCases,
+            docblock: null,
+            file: null,
+            line: null,
+        );
+    }
+
+    private function createMethodInfo(
+        string $name,
+        Visibility $visibility,
+        ClassName $declaringClass,
+        bool $isStatic = false,
+    ): MethodInfo {
+        return new MethodInfo(
+            name: new MethodName($name),
+            visibility: $visibility,
+            isStatic: $isStatic,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [],
+            returnType: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+    }
+
+    private function createPropertyInfo(
+        string $name,
+        Visibility $visibility,
+        ClassName $declaringClass,
+        bool $isStatic = false,
+    ): PropertyInfo {
+        return new PropertyInfo(
+            name: new PropertyName($name),
+            visibility: $visibility,
+            isStatic: $isStatic,
+            isReadonly: false,
+            isPromoted: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+    }
+
+    private function createConstantInfo(
+        string $name,
+        Visibility $visibility,
+        ClassName $declaringClass,
+    ): ConstantInfo {
+        return new ConstantInfo(
+            name: new ConstantName($name),
+            visibility: $visibility,
+            isFinal: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+    }
+
+    private function createEnumCaseInfo(string $name, ClassName $declaringClass): EnumCaseInfo
+    {
+        return new EnumCaseInfo(
+            name: new EnumCaseName($name),
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+    }
+}

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -198,6 +198,60 @@ final class MemberResolverTest extends TestCase
         self::assertSame($propInfo, $result);
     }
 
+    public function testFindPropertyReturnsPropertyFromParent(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+        $propInfo = $this->createPropertyInfo('parentProp', Visibility::Public, $parentName);
+
+        $parentInfo = $this->createClassInfo($parentName, properties: ['parentProp' => $propInfo]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findProperty($childName, new PropertyName('parentProp'), Visibility::Public);
+
+        self::assertSame($propInfo, $result);
+    }
+
+    public function testFindPropertyReturnsPropertyFromTrait(): void
+    {
+        $traitName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+        $propInfo = $this->createPropertyInfo('traitProp', Visibility::Public, $traitName);
+
+        $traitInfo = $this->createClassInfo(
+            $traitName,
+            kind: ClassKind::Trait_,
+            properties: ['traitProp' => $propInfo],
+        );
+        $classInfo = $this->createClassInfo($className, traits: [$traitName]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $traitName->fqn => $traitInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findProperty($className, new PropertyName('traitProp'), Visibility::Public);
+
+        self::assertSame($propInfo, $result);
+    }
+
     public function testFindConstantReturnsConstantFromClass(): void
     {
         $className = new ClassName(self::fakeClass());
@@ -210,6 +264,60 @@ final class MemberResolverTest extends TestCase
         $resolver = new MemberResolver($repo);
 
         $result = $resolver->findConstant($className, new ConstantName('MY_CONST'), Visibility::Public);
+
+        self::assertSame($constInfo, $result);
+    }
+
+    public function testFindConstantReturnsConstantFromParent(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+        $constInfo = $this->createConstantInfo('PARENT_CONST', Visibility::Public, $parentName);
+
+        $parentInfo = $this->createClassInfo($parentName, constants: ['PARENT_CONST' => $constInfo]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant($childName, new ConstantName('PARENT_CONST'), Visibility::Public);
+
+        self::assertSame($constInfo, $result);
+    }
+
+    public function testFindConstantReturnsConstantFromTrait(): void
+    {
+        $traitName = new ClassName(self::fakeClass());
+        $className = new ClassName(self::fakeClass());
+        $constInfo = $this->createConstantInfo('TRAIT_CONST', Visibility::Public, $traitName);
+
+        $traitInfo = $this->createClassInfo(
+            $traitName,
+            kind: ClassKind::Trait_,
+            constants: ['TRAIT_CONST' => $constInfo],
+        );
+        $classInfo = $this->createClassInfo($className, traits: [$traitName]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $traitName->fqn => $traitInfo,
+                $className->fqn => $classInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant($className, new ConstantName('TRAIT_CONST'), Visibility::Public);
 
         self::assertSame($constInfo, $result);
     }
@@ -296,6 +404,46 @@ final class MemberResolverTest extends TestCase
         $result = $resolver->getProperties($className, Visibility::Protected);
 
         self::assertCount(2, $result);
+    }
+
+    public function testGetPropertiesIncludesParentProperties(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+
+        $parentPublic = $this->createPropertyInfo('parentPublic', Visibility::Public, $parentName);
+        $parentProtected = $this->createPropertyInfo('parentProtected', Visibility::Protected, $parentName);
+        $parentPrivate = $this->createPropertyInfo('parentPrivate', Visibility::Private, $parentName);
+
+        $childProp = $this->createPropertyInfo('childProp', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, properties: [
+            'parentPublic' => $parentPublic,
+            'parentProtected' => $parentProtected,
+            'parentPrivate' => $parentPrivate,
+        ]);
+        $childInfo = $this->createClassInfo($childName, parent: $parentName, properties: [
+            'childProp' => $childProp,
+        ]);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getProperties($childName, Visibility::Private);
+
+        self::assertCount(3, $result);
+        self::assertContains($childProp, $result);
+        self::assertContains($parentPublic, $result);
+        self::assertContains($parentProtected, $result);
+        self::assertNotContains($parentPrivate, $result);
     }
 
     public function testGetConstantsReturnsAllAccessibleConstants(): void


### PR DESCRIPTION
## Summary

Implements `MemberResolver` - the single public API for member resolution with inheritance traversal.

Closes #119

- Adds `find*` methods for specific member lookup (method, property, constant)
- Adds `get*` methods for collecting all accessible members
- Implements inheritance traversal: class → traits → parent → interfaces
- Handles visibility filtering with `minVisibility` parameter
- Trait private members accessible from using class (PHP semantics)
- Parent private members excluded
- Diamond inheritance handled (no duplicates via `$seen` tracking)
- Interface constants included in constant resolution

## Test plan

- [x] `find*` methods return correct member from anywhere in hierarchy
- [x] `get*` methods return all accessible members with correct visibility filtering
- [x] Trait private members included when accessed from using class
- [x] Parent private members excluded
- [x] No duplicate members from diamond inheritance
- [x] Grandparent inheritance works
- [x] Interface constants resolved
- [x] PHPStan clean
- [x] 19 unit tests covering inheritance scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)