### PR TITLE
Arch Phase 4a: Migrate CompletionHandler

### DIFF
--- a/src/Domain/EnumCaseInfo.php
+++ b/src/Domain/EnumCaseInfo.php
@@ -11,6 +11,7 @@ final readonly class EnumCaseInfo
 {
     public function __construct(
         public EnumCaseName $name,
+        public int|string|null $backingValue,
         public ?string $docblock,
         public ?string $file,
         public ?int $line,

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -152,7 +152,9 @@ final class CompletionHandler implements HandlerInterface
 
         $ast = $this->parser->parse($document);
         if ($ast === null) {
-            return null;
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('Parser returned null with error-collecting handler');
+            // @codeCoverageIgnoreEnd
         }
 
         // Register document classes with repository for member resolution
@@ -306,7 +308,9 @@ final class CompletionHandler implements HandlerInterface
 
         $classNameStr = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
         if ($classNameStr === null) {
-            return [];
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('Top-level class found without name');
+            // @codeCoverageIgnoreEnd
         }
 
         /** @var class-string $classNameStr */

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -5,32 +5,40 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Completion\ContextDetector;
-use Firehed\PhpLsp\Completion\MemberFilter;
 use Firehed\PhpLsp\Completion\TypeHintContext;
-use Firehed\PhpLsp\Completion\VisibilityFilter;
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\ConstantInfo;
+use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Repository\ClassInfoFactory;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
-use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\MemberCollector;
-use Firehed\PhpLsp\Utility\PropertyInfo;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use ReflectionMethod;
-use ReflectionProperty;
 
+/**
+ * @phpstan-type CompletionItem array{
+ *   label: string,
+ *   kind?: int,
+ *   detail?: string,
+ *   documentation?: string,
+ * }
+ */
 final class CompletionHandler implements HandlerInterface
 {
     // LSP CompletionItemKind constants
@@ -52,8 +60,8 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * @param array{label: string, kind: int, detail?: string, documentation?: string} $item
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     * @param CompletionItem $item
+     * @return CompletionItem
      */
     private static function withDocumentation(array $item, string|false|null $docText): array
     {
@@ -87,7 +95,9 @@ final class CompletionHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
-        private readonly ?ComposerClassLocator $classLocator,
+        private readonly ClassRepository $classRepository,
+        private readonly ClassInfoFactory $classInfoFactory,
+        private readonly MemberResolver $memberResolver,
         private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
@@ -100,7 +110,7 @@ final class CompletionHandler implements HandlerInterface
     /**
      * @return array{
      *   isIncomplete: bool,
-     *   items: list<array{label: string, kind?: int, detail?: string, documentation?: string}>,
+     *   items: list<CompletionItem>,
      * }|null
      */
     public function handle(Message $message): ?array
@@ -145,6 +155,9 @@ final class CompletionHandler implements HandlerInterface
             return null;
         }
 
+        // Register document classes with repository for member resolution
+        $this->registerDocumentClasses($uri, $ast);
+
         // Get text before cursor to determine completion context
         $lineText = $document->getLine($line);
         $textBeforeCursor = substr($lineText, 0, $character);
@@ -159,7 +172,7 @@ final class CompletionHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @return list<CompletionItem>
      */
     private function getCompletionItems(string $textBeforeCursor, array $ast, int $line): array
     {
@@ -282,7 +295,7 @@ final class CompletionHandler implements HandlerInterface
 
     /**
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @return list<CompletionItem>
      */
     private function getThisMemberCompletions(string $prefix, array $ast): array
     {
@@ -291,16 +304,16 @@ final class CompletionHandler implements HandlerInterface
             return [];
         }
 
-        $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
-        if ($className === null) {
+        $classNameStr = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+        if ($classNameStr === null) {
             return [];
         }
 
+        /** @var class-string $classNameStr */
         return $this->getMemberCompletions(
-            $className,
-            $ast,
-            VisibilityFilter::All,
-            MemberFilter::Instance,
+            new ClassName($classNameStr),
+            Visibility::Private,
+            false,
             $prefix,
         );
     }
@@ -308,14 +321,12 @@ final class CompletionHandler implements HandlerInterface
     /**
      * Unified method to collect member completions with visibility and static/instance filters.
      *
-     * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @return list<CompletionItem>
      */
     private function getMemberCompletions(
-        string $className,
-        array $ast,
-        VisibilityFilter $visibility,
-        MemberFilter $memberFilter,
+        ClassName $className,
+        Visibility $minVisibility,
+        ?bool $static,
         string $prefix,
         bool $includeProperties = true,
         bool $includeConstants = false,
@@ -323,42 +334,29 @@ final class CompletionHandler implements HandlerInterface
     ): array {
         $items = [];
 
-        $classNode = ClassFinder::findWithLocator(
-            $className,
-            $ast,
-            $this->classLocator,
-            $this->parser,
-        );
-
-        $members = MemberCollector::collect($classNode, $visibility, $memberFilter);
-
-        foreach ($members['methods'] as $member) {
-            $name = $member['name'];
-            if (self::matchesPrefix($name, $prefix)) {
-                $items[] = $this->formatCallableCompletion($member['node'], self::KIND_METHOD);
+        foreach ($this->memberResolver->getMethods($className, $minVisibility, $static) as $method) {
+            if (self::matchesPrefix($method->name->name, $prefix)) {
+                $items[] = $this->formatMethodInfoCompletion($method);
             }
         }
 
         if ($includeProperties) {
-            foreach ($members['properties'] as $property) {
-                if (self::matchesPrefix($property->name, $prefix)) {
-                    $items[] = $this->formatPropertyCompletion($property);
+            foreach ($this->memberResolver->getProperties($className, $minVisibility, $static) as $property) {
+                if (self::matchesPrefix($property->name->name, $prefix)) {
+                    $items[] = $this->formatPropertyInfoCompletion($property);
                 }
             }
         }
 
         if ($includeConstants) {
-            foreach ($members['constants'] as $member) {
-                $name = $member['name'];
-                if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = $this->formatConstantCompletion($member['node'], $name);
+            foreach ($this->memberResolver->getConstants($className, $minVisibility) as $constant) {
+                if (self::matchesPrefix($constant->name->name, $prefix)) {
+                    $items[] = $this->formatConstantInfoCompletion($constant);
                 }
             }
 
             // ::class magic constant is always available for static access
-            if (
-                $memberFilter === MemberFilter::Static || $memberFilter === MemberFilter::Both
-            ) {
+            if ($static === true || $static === null) {
                 if (self::matchesPrefix('class', $prefix)) {
                     $items[] = [
                         'label' => 'class',
@@ -370,99 +368,9 @@ final class CompletionHandler implements HandlerInterface
         }
 
         if ($includeEnumCases) {
-            foreach ($members['enumCases'] as $member) {
-                $name = $member['name'];
-                if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = $this->formatEnumCaseCompletion($member['node']);
-                }
-            }
-
-            // Enum built-in methods
-            if ($classNode instanceof Stmt\Enum_) {
-                $items = array_merge($items, $this->getEnumBuiltinMethods($classNode, $prefix));
-            }
-        }
-
-        // Add inherited members via reflection
-        $items = array_merge(
-            $items,
-            $this->getReflectionMemberCompletions(
-                $className,
-                $prefix,
-                $visibility,
-                $memberFilter,
-                $items,
-                $includeConstants,
-                $includeProperties,
-            ),
-        );
-
-        return $items;
-    }
-
-    /**
-     * Get members via reflection for inherited/built-in classes.
-     *
-     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $existingItems
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
-     */
-    private function getReflectionMemberCompletions(
-        string $className,
-        string $prefix,
-        VisibilityFilter $visibility,
-        MemberFilter $memberFilter,
-        array $existingItems,
-        bool $includeConstants = false,
-        bool $includeProperties = true,
-    ): array {
-        $reflection = ReflectionHelper::getClass($className);
-        if ($reflection === null) {
-            return [];
-        }
-
-        $existingLabels = array_column($existingItems, 'label');
-        $items = [];
-
-        foreach ($reflection->getMethods($visibility->getMethodFlags()) as $method) {
-            if (!$memberFilter->matches($method->isStatic())) {
-                continue;
-            }
-            $name = $method->getName();
-            if (in_array($name, $existingLabels, true)) {
-                continue;
-            }
-            if (self::matchesPrefix($name, $prefix)) {
-                $items[] = $this->formatReflectionMethodCompletion($method);
-            }
-        }
-
-        if ($includeProperties) {
-            foreach ($reflection->getProperties($visibility->getPropertyFlags()) as $prop) {
-                if (!$memberFilter->matches($prop->isStatic())) {
-                    continue;
-                }
-                $name = $prop->getName();
-                if (in_array($name, $existingLabels, true)) {
-                    continue;
-                }
-                if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = $this->formatReflectionPropertyCompletion($prop);
-                }
-            }
-        }
-
-        if ($includeConstants) {
-            foreach ($reflection->getReflectionConstants($visibility->getConstantFlags()) as $const) {
-                $name = $const->getName();
-                if (in_array($name, $existingLabels, true)) {
-                    continue;
-                }
-                if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = [
-                        'label' => $name,
-                        'kind' => self::KIND_CONSTANT,
-                        'detail' => 'const ' . $name,
-                    ];
+            foreach ($this->memberResolver->getEnumCases($className) as $enumCase) {
+                if (self::matchesPrefix($enumCase->name->name, $prefix)) {
+                    $items[] = $this->formatEnumCaseInfoCompletion($enumCase);
                 }
             }
         }
@@ -474,7 +382,7 @@ final class CompletionHandler implements HandlerInterface
      * Get completions for parent:: - methods from the parent class.
      *
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @return list<CompletionItem>
      */
     private function getParentCompletions(string $prefix, array $ast, int $line): array
     {
@@ -486,11 +394,11 @@ final class CompletionHandler implements HandlerInterface
         $parentClassName = ScopeFinder::resolveExtendsName($classNode);
         assert($parentClassName !== null);
 
+        /** @var class-string $parentClassName */
         return $this->getMemberCompletions(
-            $parentClassName,
-            $ast,
-            VisibilityFilter::PublicProtected,
-            MemberFilter::Both,
+            new ClassName($parentClassName),
+            Visibility::Protected,
+            null,
             $prefix,
             includeProperties: false,
         );
@@ -500,7 +408,7 @@ final class CompletionHandler implements HandlerInterface
      * Get completions for a typed variable: $user-> where $user has a known type.
      *
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @return list<CompletionItem>
      */
     private function getTypedVariableMemberCompletions(
         string $variableName,
@@ -519,23 +427,23 @@ final class CompletionHandler implements HandlerInterface
         }
 
         // Resolve the variable's type
-        $className = $this->typeResolver->resolveVariableType($variableName, $scope, $line, $ast);
-        if ($className === null) {
+        $classNameStr = $this->typeResolver->resolveVariableType($variableName, $scope, $line, $ast);
+        if ($classNameStr === null) {
             return [];
         }
 
+        /** @var class-string $classNameStr */
         return $this->getMemberCompletions(
-            $className,
-            $ast,
-            VisibilityFilter::PublicOnly,
-            MemberFilter::Instance,
+            new ClassName($classNameStr),
+            Visibility::Public,
+            false,
             $prefix,
         );
     }
 
     /**
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @return list<CompletionItem>
      */
     private function getStaticCompletions(string $className, string $prefix, array $ast, int $line): array
     {
@@ -543,13 +451,13 @@ final class CompletionHandler implements HandlerInterface
         $resolvedClassName = $this->resolveClassName($className, $ast);
 
         $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
-        $visibility = VisibilityFilter::forClassAccess($enclosingClass, $resolvedClassName);
+        $minVisibility = $this->getMinVisibilityForAccess($enclosingClass, $resolvedClassName);
 
+        /** @var class-string $resolvedClassName */
         return $this->getMemberCompletions(
-            $resolvedClassName,
-            $ast,
-            $visibility,
-            MemberFilter::Static,
+            new ClassName($resolvedClassName),
+            $minVisibility,
+            true,
             $prefix,
             includeConstants: true,
             includeEnumCases: true,
@@ -557,8 +465,40 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
+     * Determine minimum visibility for accessing members of target class from enclosing class.
+     */
+    private function getMinVisibilityForAccess(?Stmt\Class_ $enclosingClass, string $targetClassName): Visibility
+    {
+        if ($enclosingClass === null) {
+            return Visibility::Public;
+        }
+
+        $enclosingClassName = $enclosingClass->namespacedName?->toString()
+            ?? $enclosingClass->name?->toString();
+        if ($enclosingClassName === null) {
+            return Visibility::Public;
+        }
+
+        if ($enclosingClassName === $targetClassName) {
+            return Visibility::Private;
+        }
+
+        // Check direct extends in AST
+        if (ScopeFinder::resolveExtendsName($enclosingClass) === $targetClassName) {
+            return Visibility::Protected;
+        }
+
+        // Check deeper inheritance via reflection
+        if (ReflectionHelper::getClass($enclosingClassName)?->isSubclassOf($targetClassName) === true) {
+            return Visibility::Protected;
+        }
+
+        return Visibility::Public;
+    }
+
+    /**
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @return list<CompletionItem>
      */
     private function getFunctionCompletions(string $prefix, array $ast): array
     {
@@ -603,94 +543,95 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     * Register all classes from the document with the class repository.
+     *
+     * @param array<Stmt> $ast
      */
-    private function formatPropertyCompletion(PropertyInfo $property): array
+    private function registerDocumentClasses(string $uri, array $ast): void
+    {
+        $classes = [];
+        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
+            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
+                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
+            }
+        }
+        $this->classRepository->updateDocument($uri, $classes);
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    private function formatMethodInfoCompletion(MethodInfo $method): array
+    {
+        $params = [];
+        foreach ($method->parameters as $param) {
+            $paramStr = '';
+            if ($param->type !== null) {
+                $paramStr .= $param->type . ' ';
+            }
+            $paramStr .= '$' . $param->name;
+            $params[] = $paramStr;
+        }
+
+        $detail = $method->name->name . '(' . implode(', ', $params) . ')';
+        if ($method->returnType !== null) {
+            $detail .= ': ' . $method->returnType;
+        }
+
+        return self::withDocumentation([
+            'label' => $method->name->name,
+            'kind' => self::KIND_METHOD,
+            'detail' => $detail,
+        ], $method->docblock);
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    private function formatPropertyInfoCompletion(DomainPropertyInfo $property): array
     {
         $type = $property->type ?? 'mixed';
 
         return self::withDocumentation([
-            'label' => $property->name,
+            'label' => $property->name->name,
             'kind' => self::KIND_PROPERTY,
-            'detail' => $type . ' $' . $property->name,
-        ], $property->docComment);
+            'detail' => $type . ' $' . $property->name->name,
+        ], $property->docblock);
     }
 
     /**
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     * @return CompletionItem
      */
-    private function formatConstantCompletion(Stmt\ClassConst $const, string $name): array
+    private function formatConstantInfoCompletion(ConstantInfo $constant): array
     {
         return self::withDocumentation([
-            'label' => $name,
+            'label' => $constant->name->name,
             'kind' => self::KIND_CONSTANT,
-            'detail' => 'const ' . $name,
-        ], $const->getDocComment()?->getText());
+            'detail' => 'const ' . $constant->name->name,
+        ], $constant->docblock);
     }
 
     /**
-     * @return array{label: string, kind: int, detail: string}
+     * @return CompletionItem
      */
-    private function formatEnumCaseCompletion(Stmt\EnumCase $case): array
+    private function formatEnumCaseInfoCompletion(EnumCaseInfo $enumCase): array
     {
-        $name = $case->name->toString();
-        $detail = 'case ' . $name;
-
-        if ($case->expr instanceof Node\Scalar\Int_) {
-            $detail .= ' = ' . $case->expr->value;
-        } elseif ($case->expr instanceof Node\Scalar\String_) {
-            $detail .= " = '" . $case->expr->value . "'";
+        $detail = 'case ' . $enumCase->name->name;
+        if ($enumCase->backingValue !== null) {
+            $detail .= is_string($enumCase->backingValue)
+                ? " = '" . $enumCase->backingValue . "'"
+                : ' = ' . $enumCase->backingValue;
         }
 
-        return [
-            'label' => $name,
+        return self::withDocumentation([
+            'label' => $enumCase->name->name,
             'kind' => self::KIND_ENUM_MEMBER,
             'detail' => $detail,
-        ];
+        ], $enumCase->docblock);
     }
 
     /**
-     * @return list<array{label: string, kind: int, detail: string}>
-     */
-    private function getEnumBuiltinMethods(Stmt\Enum_ $enum, string $prefix): array
-    {
-        $items = [];
-
-        // cases() is available on all enums
-        if (self::matchesPrefix('cases', $prefix)) {
-            $items[] = [
-                'label' => 'cases',
-                'kind' => self::KIND_METHOD,
-                'detail' => 'cases(): array',
-            ];
-        }
-
-        // from() and tryFrom() are only available on backed enums
-        if ($enum->scalarType !== null) {
-            $scalarType = $enum->scalarType->toString();
-
-            if (self::matchesPrefix('from', $prefix)) {
-                $items[] = [
-                    'label' => 'from',
-                    'kind' => self::KIND_METHOD,
-                    'detail' => "from($scalarType \$value): static",
-                ];
-            }
-
-            if (self::matchesPrefix('tryFrom', $prefix)) {
-                $items[] = [
-                    'label' => 'tryFrom',
-                    'kind' => self::KIND_METHOD,
-                    'detail' => "tryFrom($scalarType \$value): ?static",
-                ];
-            }
-        }
-
-        return $items;
-    }
-
-    /**
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
+     * @return CompletionItem
      */
     private function formatCallableCompletion(
         Stmt\ClassMethod|Stmt\Function_ $callable,
@@ -723,50 +664,6 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
-     */
-    private function formatReflectionMethodCompletion(ReflectionMethod $method): array
-    {
-        $params = [];
-        foreach ($method->getParameters() as $param) {
-            $paramStr = '';
-            $type = $param->getType();
-            if ($type !== null) {
-                $paramStr .= TypeFormatter::formatReflection($type) . ' ';
-            }
-            $paramStr .= '$' . $param->getName();
-            $params[] = $paramStr;
-        }
-
-        $detail = $method->getName() . '(' . implode(', ', $params) . ')';
-        $returnType = $method->getReturnType();
-        if ($returnType !== null) {
-            $detail .= ': ' . TypeFormatter::formatReflection($returnType);
-        }
-
-        return self::withDocumentation([
-            'label' => $method->getName(),
-            'kind' => self::KIND_METHOD,
-            'detail' => $detail,
-        ], $method->getDocComment());
-    }
-
-    /**
-     * @return array{label: string, kind: int, detail?: string, documentation?: string}
-     */
-    private function formatReflectionPropertyCompletion(ReflectionProperty $prop): array
-    {
-        $type = $prop->getType();
-        $typeStr = $type !== null ? TypeFormatter::formatReflection($type) : 'mixed';
-
-        return self::withDocumentation([
-            'label' => $prop->getName(),
-            'kind' => self::KIND_PROPERTY,
-            'detail' => $typeStr . ' $' . $prop->getName(),
-        ], $prop->getDocComment());
-    }
-
-    /**
      * Resolve a short class name to its FQCN using use statements.
      *
      * @param array<Stmt> $ast
@@ -781,7 +678,7 @@ final class CompletionHandler implements HandlerInterface
      * Get completions for imported classes (from use statements).
      *
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind: int, detail: string}>
+     * @return list<CompletionItem>
      */
     private function getImportedClassCompletions(string $prefix, array $ast): array
     {
@@ -843,7 +740,7 @@ final class CompletionHandler implements HandlerInterface
      * Get class completions from the workspace symbol index.
      *
      * @param list<SymbolKind> $kinds
-     * @return list<array{label: string, kind: int, detail: string}>
+     * @return list<CompletionItem>
      */
     private function getIndexedClassCompletions(string $prefix, array $kinds): array
     {
@@ -864,8 +761,8 @@ final class CompletionHandler implements HandlerInterface
     /**
      * Remove duplicate completions, preferring items that appear earlier.
      *
-     * @param list<array{label: string, kind?: int, detail?: string, documentation?: string}> $items
-     * @return list<array{label: string, kind?: int, detail?: string, documentation?: string}>
+     * @param list<CompletionItem> $items
+     * @return list<CompletionItem>
      */
     private function deduplicateCompletions(array $items): array
     {
@@ -887,7 +784,7 @@ final class CompletionHandler implements HandlerInterface
      * Get completions for type hint positions.
      *
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind?: int, detail?: string}>
+     * @return list<CompletionItem>
      */
     private function getTypeHintCompletions(string $prefix, array $ast, TypeHintContext $context): array
     {
@@ -961,7 +858,7 @@ final class CompletionHandler implements HandlerInterface
 
     /**
      * @param list<string> $keywords
-     * @return list<array{label: string, kind: int}>
+     * @return list<CompletionItem>
      */
     private function filterKeywords(array $keywords, string $prefix): array
     {
@@ -1036,7 +933,7 @@ final class CompletionHandler implements HandlerInterface
      * Get variable completions for the current scope.
      *
      * @param array<Stmt> $ast
-     * @return list<array{label: string, kind: int, detail?: string}>
+     * @return list<CompletionItem>
      */
     private function getVariableCompletions(string $prefix, array $ast, int $cursorLine): array
     {

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -233,6 +233,85 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
             );
         }
 
+        // Add built-in enum methods
+        if ($node instanceof Stmt\Enum_) {
+            $methods = array_merge($methods, $this->getEnumBuiltinMethods($node, $className));
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @return array<string, MethodInfo>
+     */
+    private function getEnumBuiltinMethods(Stmt\Enum_ $enum, ClassName $className): array
+    {
+        $methods = [];
+
+        // cases() is available on all enums
+        $methods['cases'] = new MethodInfo(
+            name: new MethodName('cases'),
+            visibility: Visibility::Public,
+            isStatic: true,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [],
+            returnType: 'array',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $className,
+        );
+
+        // from() and tryFrom() are only available on backed enums
+        if ($enum->scalarType !== null) {
+            $scalarType = $enum->scalarType->toString();
+
+            $methods['from'] = new MethodInfo(
+                name: new MethodName('from'),
+                visibility: Visibility::Public,
+                isStatic: true,
+                isAbstract: false,
+                isFinal: false,
+                parameters: [
+                    new ParameterInfo(
+                        name: 'value',
+                        type: $scalarType,
+                        hasDefault: false,
+                        isVariadic: false,
+                        isPassedByReference: false,
+                    ),
+                ],
+                returnType: 'static',
+                docblock: null,
+                file: null,
+                line: null,
+                declaringClass: $className,
+            );
+
+            $methods['tryFrom'] = new MethodInfo(
+                name: new MethodName('tryFrom'),
+                visibility: Visibility::Public,
+                isStatic: true,
+                isAbstract: false,
+                isFinal: false,
+                parameters: [
+                    new ParameterInfo(
+                        name: 'value',
+                        type: $scalarType,
+                        hasDefault: false,
+                        isVariadic: false,
+                        isPassedByReference: false,
+                    ),
+                ],
+                returnType: '?static',
+                docblock: null,
+                file: null,
+                line: null,
+                declaringClass: $className,
+            );
+        }
+
         return $methods;
     }
 
@@ -368,6 +447,7 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
             $name = $stmt->name->toString();
             $cases[$name] = new EnumCaseInfo(
                 name: new EnumCaseName($name),
+                backingValue: $this->extractEnumCaseBackingValue($stmt),
                 docblock: $stmt->getDocComment()?->getText(),
                 file: $filePath,
                 line: $stmt->getStartLine(),
@@ -376,6 +456,18 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
         }
 
         return $cases;
+    }
+
+    private function extractEnumCaseBackingValue(Stmt\EnumCase $case): int|string|null
+    {
+        $expr = $case->expr;
+        if ($expr instanceof \PhpParser\Node\Scalar\Int_) {
+            return $expr->value;
+        }
+        if ($expr instanceof \PhpParser\Node\Scalar\String_) {
+            return $expr->value;
+        }
+        return null;
     }
 
     /**
@@ -555,8 +647,12 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
             }
 
             $name = $constant->getName();
+            $enumCase = $constant->getValue();
+            $backingValue = $enumCase instanceof \BackedEnum ? $enumCase->value : null;
+
             $cases[$name] = new EnumCaseInfo(
                 name: new EnumCaseName($name),
+                backingValue: $backingValue,
                 docblock: $constant->getDocComment() !== false ? $constant->getDocComment() : null,
                 file: $class->getFileName() !== false ? $class->getFileName() : null,
                 line: null,

--- a/src/Repository/DefaultClassRepository.php
+++ b/src/Repository/DefaultClassRepository.php
@@ -25,7 +25,7 @@ final class DefaultClassRepository implements ClassRepository
 
     public function __construct(
         private readonly ClassInfoFactory $factory,
-        private readonly ?ClassLocator $locator,
+        private readonly ClassLocator $locator,
         private readonly ParserService $parser,
     ) {
     }
@@ -101,10 +101,6 @@ final class DefaultClassRepository implements ClassRepository
 
     private function locateAndParse(ClassName $name): ?ClassInfo
     {
-        if ($this->locator === null) {
-            return null;
-        }
-
         $filePath = $this->locator->locate($name);
         if ($filePath === null || !is_readable($filePath)) {
             return null;

--- a/src/Repository/DefaultClassRepository.php
+++ b/src/Repository/DefaultClassRepository.php
@@ -25,7 +25,7 @@ final class DefaultClassRepository implements ClassRepository
 
     public function __construct(
         private readonly ClassInfoFactory $factory,
-        private readonly ClassLocator $locator,
+        private readonly ?ClassLocator $locator,
         private readonly ParserService $parser,
     ) {
     }
@@ -101,6 +101,10 @@ final class DefaultClassRepository implements ClassRepository
 
     private function locateAndParse(ClassName $name): ?ClassInfo
     {
+        if ($this->locator === null) {
+            return null;
+        }
+
         $filePath = $this->locator->locate($name);
         if ($filePath === null || !is_readable($filePath)) {
             return null;

--- a/src/Server.php
+++ b/src/Server.php
@@ -39,15 +39,19 @@ final class Server
         ServerInfo $serverInfo,
         ?string $projectRoot = null,
     ) {
-        // Use provided root, or fall back to cwd
-        $cwd = getcwd();
-        $projectRoot ??= $cwd !== false ? $cwd : null;
+        if ($projectRoot === null) {
+            $cwd = getcwd();
+            if ($cwd === false) {
+                throw new \RuntimeException('Unable to determine project root: getcwd() failed');
+            }
+            $projectRoot = $cwd;
+        }
 
         $this->documentManager = new DocumentManager();
         $parser = new ParserService();
         $symbolIndex = new SymbolIndex();
         $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
-        $classLocator = $projectRoot !== null ? new ComposerClassLocator($projectRoot) : null;
+        $classLocator = new ComposerClassLocator($projectRoot);
         $typeResolver = new BasicTypeResolver();
 
         $classInfoFactory = new DefaultClassInfoFactory();

--- a/src/Server.php
+++ b/src/Server.php
@@ -42,7 +42,9 @@ final class Server
         if ($projectRoot === null) {
             $cwd = getcwd();
             if ($cwd === false) {
-                throw new \RuntimeException('Unable to determine project root: getcwd() failed');
+                // @codeCoverageIgnoreStart
+                throw new \LogicException('Unable to determine project root: getcwd() failed');
+                // @codeCoverageIgnoreEnd
             }
             $projectRoot = $cwd;
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -17,6 +17,9 @@ use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseError;
@@ -47,6 +50,10 @@ final class Server
         $classLocator = $projectRoot !== null ? new ComposerClassLocator($projectRoot) : null;
         $typeResolver = new BasicTypeResolver();
 
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
+        $memberResolver = new MemberResolver($classRepository);
+
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
         $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
@@ -63,7 +70,9 @@ final class Server
             $this->documentManager,
             $parser,
             $symbolIndex,
-            $classLocator,
+            $classRepository,
+            $classInfoFactory,
+            $memberResolver,
             $typeResolver,
         );
     }

--- a/tests/Domain/EnumCaseInfoTest.php
+++ b/tests/Domain/EnumCaseInfoTest.php
@@ -14,6 +14,7 @@ class EnumCaseInfoTest extends TestCase
     {
         $case = new EnumCaseInfo(
             name: new EnumCaseName('Active'),
+            backingValue: 1,
             docblock: null,
             file: '/path/to/file.php',
             line: 8,
@@ -21,6 +22,7 @@ class EnumCaseInfoTest extends TestCase
         );
 
         self::assertSame('Active', $case->name->name);
+        self::assertSame(1, $case->backingValue);
         self::assertNull($case->docblock);
         self::assertSame('/path/to/file.php', $case->file);
         self::assertSame(8, $case->line);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -12,6 +12,9 @@ use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +25,9 @@ class CompletionHandlerTest extends TestCase
     private DocumentManager $documents;
     private ParserService $parser;
     private SymbolIndex $symbolIndex;
+    private DefaultClassRepository $classRepository;
+    private DefaultClassInfoFactory $classInfoFactory;
+    private MemberResolver $memberResolver;
     private CompletionHandler $handler;
 
     protected function setUp(): void
@@ -29,7 +35,17 @@ class CompletionHandlerTest extends TestCase
         $this->documents = new DocumentManager();
         $this->parser = new ParserService();
         $this->symbolIndex = new SymbolIndex();
-        $this->handler = new CompletionHandler($this->documents, $this->parser, $this->symbolIndex, null);
+        $this->classInfoFactory = new DefaultClassInfoFactory();
+        $this->classRepository = new DefaultClassRepository($this->classInfoFactory, null, $this->parser);
+        $this->memberResolver = new MemberResolver($this->classRepository);
+        $this->handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
+        );
     }
 
     public function testSupports(): void
@@ -1709,7 +1725,9 @@ PHP;
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 
@@ -1755,7 +1773,9 @@ PHP;
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 
@@ -1799,7 +1819,9 @@ PHP;
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 
@@ -1837,7 +1859,9 @@ PHP;
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 
@@ -1872,7 +1896,9 @@ PHP;
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 
@@ -1922,7 +1948,9 @@ PHP;
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2590,4 +2590,108 @@ PHP;
         self::assertIsArray($result);
         self::assertEmpty($result['items']);
     }
+
+    public function testStaticCompletionFromAnonymousClassContext(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Target
+{
+    public static function publicMethod(): void {}
+    protected static function protectedMethod(): void {}
+}
+
+$x = new class {
+    public function foo(): void {
+        Target::
+    }
+};
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('publicMethod', $labels);
+        self::assertNotContains('protectedMethod', $labels);
+    }
+
+    public function testStaticCompletionWithDeeperInheritance(): void
+    {
+        // InheritanceChild extends InheritanceParent extends InheritanceGrandparent
+        // Test that Child can access protected members of Grandparent via reflection
+        $code = <<<'PHP'
+<?php
+namespace Firehed\PhpLsp\Tests\Repository;
+
+use Firehed\PhpLsp\Tests\Repository\InheritanceGrandparent;
+
+class InheritanceChild extends InheritanceParent
+{
+    public function foo(): void
+    {
+        InheritanceGrandparent::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 32],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('grandparentPublic', $labels);
+        self::assertContains('grandparentProtected', $labels);
+    }
+
+    public function testStaticCompletionInClassWithoutNamespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+class NoNamespace
+{
+    public static function test(): void {
+        self::
+    }
+}
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 4, 'character' => 14],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('test', $labels);
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -12,6 +12,7 @@ use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -36,7 +37,12 @@ class CompletionHandlerTest extends TestCase
         $this->parser = new ParserService();
         $this->symbolIndex = new SymbolIndex();
         $this->classInfoFactory = new DefaultClassInfoFactory();
-        $this->classRepository = new DefaultClassRepository($this->classInfoFactory, null, $this->parser);
+        $locator = self::createStub(ClassLocator::class);
+        $this->classRepository = new DefaultClassRepository(
+            $this->classInfoFactory,
+            $locator,
+            $this->parser,
+        );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $this->handler = new CompletionHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2538,4 +2538,56 @@ PHP;
         self::assertNotContains('PHP_VERSION', $labels);
         self::assertNotContains('PHP_INT_MAX', $labels);
     }
+
+    public function testThisCompletionOutsideClassReturnsEmpty(): void
+    {
+        $code = <<<'PHP'
+<?php
+$this->
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 1, 'character' => 7],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
+
+    public function testThisCompletionInAnonymousClassReturnsEmpty(): void
+    {
+        $code = <<<'PHP'
+<?php
+$x = new class {
+    public function foo(): void {
+        $this->
+    }
+};
+PHP;
+        $this->documents->open('file:///test.php', 'php', 1, $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
 }

--- a/tests/Repository/DefaultClassInfoFactoryTest.php
+++ b/tests/Repository/DefaultClassInfoFactoryTest.php
@@ -138,6 +138,65 @@ final class DefaultClassInfoFactoryTest extends TestCase
         self::assertSame('JsonSerializable', $info->interfaces[0]->fqn);
         self::assertCount(1, $info->enumCases);
         self::assertArrayHasKey('Active', $info->enumCases);
+        self::assertSame('active', $info->enumCases['Active']->backingValue);
+    }
+
+    public function testFromAstNodeExtractsIntBackedEnumCases(): void
+    {
+        $node = $this->parseClass('<?php enum Priority: int {
+            case Low = 1;
+            case High = 10;
+        }');
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertCount(2, $info->enumCases);
+        self::assertArrayHasKey('Low', $info->enumCases);
+        self::assertArrayHasKey('High', $info->enumCases);
+        self::assertSame(1, $info->enumCases['Low']->backingValue);
+        self::assertSame(10, $info->enumCases['High']->backingValue);
+    }
+
+    public function testFromAstNodeExtractsPureEnumCasesWithNullBackingValue(): void
+    {
+        $node = $this->parseClass('<?php enum Status { case Active; case Inactive; }');
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertCount(2, $info->enumCases);
+        self::assertNull($info->enumCases['Active']->backingValue);
+        self::assertNull($info->enumCases['Inactive']->backingValue);
+    }
+
+    public function testFromAstNodeSynthesizesEnumBuiltinMethods(): void
+    {
+        $node = $this->parseClass('<?php enum Status { case Active; }');
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertArrayHasKey('cases', $info->methods);
+        self::assertTrue($info->methods['cases']->isStatic);
+        self::assertSame('array', $info->methods['cases']->returnType);
+    }
+
+    public function testFromAstNodeSynthesizesBackedEnumMethods(): void
+    {
+        $node = $this->parseClass('<?php enum Priority: int {
+            case Low = 1;
+        }');
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertArrayHasKey('cases', $info->methods);
+        self::assertArrayHasKey('from', $info->methods);
+        self::assertArrayHasKey('tryFrom', $info->methods);
+
+        self::assertTrue($info->methods['from']->isStatic);
+        self::assertSame('static', $info->methods['from']->returnType);
+        self::assertCount(1, $info->methods['from']->parameters);
+        self::assertSame('int', $info->methods['from']->parameters[0]->type);
+
+        self::assertSame('?static', $info->methods['tryFrom']->returnType);
     }
 
     public function testFromAstNodeExtractsTraits(): void
@@ -341,6 +400,31 @@ final class DefaultClassInfoFactoryTest extends TestCase
         self::assertCount(2, $info->enumCases);
         self::assertArrayHasKey('Foo', $info->enumCases);
         self::assertArrayHasKey('Bar', $info->enumCases);
+        self::assertNull($info->enumCases['Foo']->backingValue);
+    }
+
+    public function testFromReflectionExtractsBackedEnum(): void
+    {
+        $reflection = new ReflectionClass(TestBackedEnum::class);
+
+        $info = $this->factory->fromReflection($reflection);
+
+        self::assertSame(ClassKind::Enum_, $info->kind);
+        self::assertCount(2, $info->enumCases);
+        self::assertSame(1, $info->enumCases['Low']->backingValue);
+        self::assertSame(10, $info->enumCases['High']->backingValue);
+    }
+
+    public function testFromReflectionExtractsEnumBuiltinMethods(): void
+    {
+        $reflection = new ReflectionClass(TestBackedEnum::class);
+
+        $info = $this->factory->fromReflection($reflection);
+
+        self::assertArrayHasKey('cases', $info->methods);
+        self::assertArrayHasKey('from', $info->methods);
+        self::assertArrayHasKey('tryFrom', $info->methods);
+        self::assertTrue($info->methods['cases']->isStatic);
     }
 
     public function testFromReflectionExtractsMethods(): void

--- a/tests/Repository/InheritanceChild.php
+++ b/tests/Repository/InheritanceChild.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Repository;
+
+class InheritanceChild extends InheritanceParent
+{
+}

--- a/tests/Repository/InheritanceGrandparent.php
+++ b/tests/Repository/InheritanceGrandparent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Repository;
+
+class InheritanceGrandparent
+{
+    public static function grandparentPublic(): void
+    {
+    }
+
+    protected static function grandparentProtected(): void
+    {
+    }
+}

--- a/tests/Repository/InheritanceParent.php
+++ b/tests/Repository/InheritanceParent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Repository;
+
+class InheritanceParent extends InheritanceGrandparent
+{
+}

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -1327,6 +1327,7 @@ final class MemberResolverTest extends TestCase
     {
         return new EnumCaseInfo(
             name: new EnumCaseName($name),
+            backingValue: null,
             docblock: null,
             file: null,
             line: null,

--- a/tests/Repository/TestBackedEnum.php
+++ b/tests/Repository/TestBackedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Repository;
+
+enum TestBackedEnum: int
+{
+    case Low = 1;
+    case High = 10;
+}


### PR DESCRIPTION
## Summary

Migrates `CompletionHandler` to use `ClassRepository` and `MemberResolver`, completing the first sub-task of #120.

- Replace `ClassFinder` + `MemberCollector` + reflection fallback with `MemberResolver`
- Inject `ClassRepository` and `ClassInfoFactory` for document class registration
- Use domain types (`ClassName`, `Visibility`, `MethodInfo`, etc.) throughout
- Remove `array $ast` parameter from `getMemberCompletions()` and related methods
- Add enum built-in methods (`cases`, `from`, `tryFrom`) to `ClassInfoFactory`
- Add `backingValue` to `EnumCaseInfo` for backed enum case display
- De-duplicate completion item docblocks with `@phpstan-type`

Closes #122

## Test plan

- [x] All 71 CompletionHandler tests pass
- [x] All 488 unit tests pass
- [x] PHPStan clean
- [x] PHPCS clean

🤖 Generated with [Claude Code](https://claude.ai/code)