### PR TITLE
Arch Phase 4b: Migrate HoverHandler

### DIFF
--- a/src/Domain/Visibility.php
+++ b/src/Domain/Visibility.php
@@ -17,4 +17,13 @@ enum Visibility: int
     {
         return $this->value >= $minimumRequired->value;
     }
+
+    public function toKeyword(): string
+    {
+        return match ($this) {
+            self::Private => 'private',
+            self::Protected => 'protected',
+            self::Public => 'public',
+        };
+    }
 }

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -16,7 +16,6 @@ use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
@@ -47,7 +46,6 @@ final class HoverHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ClassRepository $classRepository,
-        private readonly ClassInfoFactory $classInfoFactory,
         private readonly MemberResolver $memberResolver,
         private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
@@ -93,9 +91,6 @@ final class HoverHandler implements HandlerInterface
         if ($ast === null) {
             return null;
         }
-
-        // Register document classes with repository for member resolution
-        $this->registerDocumentClasses($uri, $ast);
 
         $offset = $document->offsetAt($line, $character);
         $nodeFinder = new NodeAtPosition();
@@ -603,38 +598,5 @@ final class HoverHandler implements HandlerInterface
         $parts[] = '```php' . "\n" . $signature . "\n```";
 
         return implode("\n\n", $parts);
-    }
-
-    /**
-     * Register all classes from the document with the class repository.
-     *
-     * @param array<Stmt> $ast
-     */
-    private function registerDocumentClasses(string $uri, array $ast): void
-    {
-        $classes = [];
-        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
-            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
-                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
-            }
-        }
-        $this->classRepository->updateDocument($uri, $classes);
-    }
-
-    /**
-     * Iterate top-level statements, flattening namespace contents.
-     *
-     * @param array<Stmt> $ast
-     * @return \Generator<Stmt>
-     */
-    private function iterateTopLevelStatements(array $ast): \Generator
-    {
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                yield from $stmt->stmts;
-            } else {
-                yield $stmt;
-            }
-        }
     }
 }

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -397,11 +397,7 @@ final class HoverHandler implements HandlerInterface
             $parts[] = DocblockParser::extractDescription($method->docblock);
         }
 
-        $visibility = match ($method->visibility) {
-            Visibility::Private => 'private ',
-            Visibility::Protected => 'protected ',
-            Visibility::Public => 'public ',
-        };
+        $visibility = $method->visibility->toKeyword() . ' ';
         $static = $method->isStatic ? 'static ' : '';
 
         $params = [];
@@ -440,11 +436,7 @@ final class HoverHandler implements HandlerInterface
             $parts[] = DocblockParser::extractDescription($property->docblock);
         }
 
-        $visibility = match ($property->visibility) {
-            Visibility::Private => 'private ',
-            Visibility::Protected => 'protected ',
-            Visibility::Public => 'public ',
-        };
+        $visibility = $property->visibility->toKeyword() . ' ';
         $static = $property->isStatic ? 'static ' : '';
         $readonly = $property->isReadonly ? 'readonly ' : '';
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -21,7 +21,6 @@ use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
-use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
@@ -37,8 +36,6 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ReflectionException;
 use ReflectionFunction;
-use ReflectionMethod;
-use ReflectionProperty;
 
 final class HoverHandler implements HandlerInterface
 {
@@ -377,11 +374,11 @@ final class HoverHandler implements HandlerInterface
         $methodName = new MethodName($methodNameStr);
 
         $methodInfo = $this->memberResolver->findMethod($className, $methodName, Visibility::Private);
-        if ($methodInfo !== null) {
-            return $this->formatMethodHover($methodInfo);
+        if ($methodInfo === null) {
+            return null;
         }
 
-        return $this->getReflectionMethodHover($classNameStr, $methodNameStr);
+        return $this->formatMethodHover($methodInfo);
     }
 
     private function getPropertyHoverForClass(string $classNameStr, string $propertyNameStr): ?string
@@ -391,11 +388,11 @@ final class HoverHandler implements HandlerInterface
         $propertyName = new PropertyName($propertyNameStr);
 
         $propertyInfo = $this->memberResolver->findProperty($className, $propertyName, Visibility::Private);
-        if ($propertyInfo !== null) {
-            return $this->formatPropertyHover($propertyInfo);
+        if ($propertyInfo === null) {
+            return null;
         }
 
-        return $this->getReflectionPropertyHover($classNameStr, $propertyNameStr);
+        return $this->formatPropertyHover($propertyInfo);
     }
 
     private function formatMethodHover(MethodInfo $method): string
@@ -470,26 +467,6 @@ final class HoverHandler implements HandlerInterface
         }
     }
 
-    private function getReflectionMethodHover(string $className, string $methodName): ?string
-    {
-        $classReflection = ReflectionHelper::getClass($className);
-        if ($classReflection === null || !$classReflection->hasMethod($methodName)) {
-            return null;
-        }
-        $reflection = $classReflection->getMethod($methodName);
-        return $this->formatReflectionMethod($reflection);
-    }
-
-    private function getReflectionPropertyHover(string $className, string $propertyName): ?string
-    {
-        $classReflection = ReflectionHelper::getClass($className);
-        if ($classReflection === null || !$classReflection->hasProperty($propertyName)) {
-            return null;
-        }
-        $reflection = $classReflection->getProperty($propertyName);
-        return $this->formatReflectionProperty($reflection);
-    }
-
     private function formatReflectionFunction(ReflectionFunction $func): string
     {
         $parts = [];
@@ -522,78 +499,6 @@ final class HoverHandler implements HandlerInterface
         if ($returnType !== null) {
             $signature .= ': ' . TypeFormatter::formatReflection($returnType);
         }
-
-        $parts[] = '```php' . "\n" . $signature . "\n```";
-
-        return implode("\n\n", $parts);
-    }
-
-    private function formatReflectionMethod(ReflectionMethod $method): string
-    {
-        $parts = [];
-
-        $docComment = $method->getDocComment();
-        if ($docComment !== false) {
-            $parts[] = DocblockParser::extractDescription($docComment);
-        }
-
-        $visibility = match (true) {
-            $method->isPrivate() => 'private ',
-            $method->isProtected() => 'protected ',
-            default => 'public ',
-        };
-        $static = $method->isStatic() ? 'static ' : '';
-
-        $params = [];
-        foreach ($method->getParameters() as $param) {
-            $paramStr = '';
-            $type = $param->getType();
-            if ($type !== null) {
-                $paramStr .= TypeFormatter::formatReflection($type) . ' ';
-            }
-            if ($param->isVariadic()) {
-                $paramStr .= '...';
-            }
-            $paramStr .= '$' . $param->getName();
-            if ($param->isOptional() && !$param->isVariadic()) {
-                $paramStr .= ' = ...';
-            }
-            $params[] = $paramStr;
-        }
-
-        $signature = $visibility . $static . 'function ' . $method->getName() . '(' . implode(', ', $params) . ')';
-
-        $returnType = $method->getReturnType();
-        if ($returnType !== null) {
-            $signature .= ': ' . TypeFormatter::formatReflection($returnType);
-        }
-
-        $parts[] = '```php' . "\n" . $signature . "\n```";
-
-        return implode("\n\n", $parts);
-    }
-
-    private function formatReflectionProperty(ReflectionProperty $property): string
-    {
-        $parts = [];
-
-        $docComment = $property->getDocComment();
-        if ($docComment !== false) {
-            $parts[] = DocblockParser::extractDescription($docComment);
-        }
-
-        $visibility = match (true) {
-            $property->isPrivate() => 'private ',
-            $property->isProtected() => 'protected ',
-            default => 'public ',
-        };
-        $static = $property->isStatic() ? 'static ' : '';
-        $readonly = $property->isReadOnly() ? 'readonly ' : '';
-
-        $type = $property->getType();
-        $typeStr = $type !== null ? TypeFormatter::formatReflection($type) . ' ' : '';
-
-        $signature = $visibility . $static . $readonly . $typeStr . '$' . $property->getName();
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -5,16 +5,22 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\ClassKind;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
+use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Repository\ClassInfoFactory;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
-use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\MemberFinder;
-use Firehed\PhpLsp\Utility\PropertyInfo;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -25,7 +31,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -41,7 +46,9 @@ final class HoverHandler implements HandlerInterface
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
-        private readonly ?ComposerClassLocator $classLocator,
+        private readonly ClassRepository $classRepository,
+        private readonly ClassInfoFactory $classInfoFactory,
+        private readonly MemberResolver $memberResolver,
         private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
@@ -87,6 +94,9 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
+        // Register document classes with repository for member resolution
+        $this->registerDocumentClasses($uri, $ast);
+
         $offset = $document->offsetAt($line, $character);
         $nodeFinder = new NodeAtPosition();
         $node = $nodeFinder->find($ast, $offset);
@@ -95,7 +105,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $hoverContent = $this->getHoverContent($node, $ast, $document);
+        $hoverContent = $this->getHoverContent($node, $ast);
 
         if ($hoverContent === null) {
             return null;
@@ -107,7 +117,7 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function getHoverContent(Node $node, array $ast, TextDocument $document): ?string
+    private function getHoverContent(Node $node, array $ast): ?string
     {
         // Name node - could be class reference or function call
         if ($node instanceof Name) {
@@ -124,16 +134,16 @@ final class HoverHandler implements HandlerInterface
 
             // Static method call: ClassName::method()
             if ($parent instanceof StaticCall) {
-                return $this->getClassHover($node, $ast, $document);
+                return $this->getClassHover($node);
             }
 
             // Static property fetch: ClassName::$property
             if ($parent instanceof StaticPropertyFetch) {
-                return $this->getClassHover($node, $ast, $document);
+                return $this->getClassHover($node);
             }
 
             // Fall through to class hover for class references
-            return $this->getClassHover($node, $ast, $document);
+            return $this->getClassHover($node);
         }
 
         // Identifier node - could be method name, property name, or function call
@@ -142,22 +152,22 @@ final class HoverHandler implements HandlerInterface
 
             // Method call: $obj->method() or $this->method()
             if ($parent instanceof MethodCall) {
-                return $this->getMethodHover($parent, $ast, $document);
+                return $this->getMethodHover($parent, $ast);
             }
 
             // Static method call: ClassName::method()
             if ($parent instanceof StaticCall) {
-                return $this->getStaticMethodHover($parent, $ast, $document);
+                return $this->getStaticMethodHover($parent, $ast);
             }
 
             // Property fetch: $obj->property or $this->property
             if ($parent instanceof PropertyFetch) {
-                return $this->getPropertyHover($parent, $ast, $document);
+                return $this->getPropertyHover($parent, $ast);
             }
 
             // Static property fetch: ClassName::$property
             if ($parent instanceof StaticPropertyFetch) {
-                return $this->getStaticPropertyHover($parent, $ast, $document);
+                return $this->getStaticPropertyHover($parent, $ast);
             }
 
             if ($parent instanceof FuncCall) {
@@ -168,54 +178,51 @@ final class HoverHandler implements HandlerInterface
         return null;
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getClassHover(Name $node, array $ast, TextDocument $document): ?string
+    private function getClassHover(Name $node): ?string
     {
-        $className = ScopeFinder::resolveName($node);
+        $classNameStr = ScopeFinder::resolveName($node);
 
-        $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
+        /** @var class-string $classNameStr */
+        $classInfo = $this->classRepository->get(new ClassName($classNameStr));
 
-        if ($classNode === null) {
+        if ($classInfo === null) {
             return null;
         }
 
-        return $this->formatClassHover($classNode);
+        return $this->formatClassHover($classInfo);
     }
 
-    private function formatClassHover(Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $node): string
+    private function formatClassHover(ClassInfo $classInfo): string
     {
         $parts = [];
 
         // Add docblock if present
-        $docComment = $node->getDocComment();
-        if ($docComment !== null) {
-            $parts[] = DocblockParser::extractDescription($docComment->getText());
+        if ($classInfo->docblock !== null) {
+            $parts[] = DocblockParser::extractDescription($classInfo->docblock);
         }
 
         // Add signature
-        $keyword = match (true) {
-            $node instanceof Stmt\Interface_ => 'interface',
-            $node instanceof Stmt\Trait_ => 'trait',
-            $node instanceof Stmt\Enum_ => 'enum',
+        $keyword = match ($classInfo->kind) {
+            ClassKind::Interface_ => 'interface',
+            ClassKind::Trait_ => 'trait',
+            ClassKind::Enum_ => 'enum',
             default => 'class',
         };
 
-        $signature = $keyword . ' ' . $node->name;
+        $signature = $keyword . ' ' . $classInfo->name->shortName();
 
-        if ($node instanceof Stmt\Class_) {
-            if ($node->extends !== null) {
-                $signature .= ' extends ' . $node->extends->toString();
+        if ($classInfo->kind === ClassKind::Class_) {
+            if ($classInfo->parent !== null) {
+                $signature .= ' extends ' . $classInfo->parent->shortName();
             }
-            if ($node->implements !== []) {
-                $implements = array_map(fn($n) => $n->toString(), $node->implements);
+            if ($classInfo->interfaces !== []) {
+                $implements = array_map(fn($n) => $n->shortName(), $classInfo->interfaces);
                 $signature .= ' implements ' . implode(', ', $implements);
             }
         }
 
-        if ($node instanceof Stmt\Interface_ && $node->extends !== []) {
-            $extends = array_map(fn($n) => $n->toString(), $node->extends);
+        if ($classInfo->kind === ClassKind::Interface_ && $classInfo->interfaces !== []) {
+            $extends = array_map(fn($n) => $n->shortName(), $classInfo->interfaces);
             $signature .= ' extends ' . implode(', ', $extends);
         }
 
@@ -295,7 +302,7 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function getMethodHover(MethodCall $call, array $ast, TextDocument $document): ?string
+    private function getMethodHover(MethodCall $call, array $ast): ?string
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
@@ -307,13 +314,13 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        return $this->getMethodHoverForClass($className, $methodName->toString(), $ast, $document);
+        return $this->getMethodHoverForClass($className, $methodName->toString());
     }
 
     /**
      * @param array<Stmt> $ast
      */
-    private function getStaticMethodHover(StaticCall $call, array $ast, TextDocument $document): ?string
+    private function getStaticMethodHover(StaticCall $call, array $ast): ?string
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
@@ -327,13 +334,13 @@ final class HoverHandler implements HandlerInterface
 
         $className = ScopeFinder::resolveName($class);
 
-        return $this->getMethodHoverForClass($className, $methodName->toString(), $ast, $document);
+        return $this->getMethodHoverForClass($className, $methodName->toString());
     }
 
     /**
      * @param array<Stmt> $ast
      */
-    private function getPropertyHover(PropertyFetch $fetch, array $ast, TextDocument $document): ?string
+    private function getPropertyHover(PropertyFetch $fetch, array $ast): ?string
     {
         $propertyName = $fetch->name;
         if (!$propertyName instanceof Identifier) {
@@ -345,13 +352,13 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        return $this->getPropertyHoverForClass($className, $propertyName->toString(), $ast, $document);
+        return $this->getPropertyHoverForClass($className, $propertyName->toString());
     }
 
     /**
      * @param array<Stmt> $ast
      */
-    private function getStaticPropertyHover(StaticPropertyFetch $fetch, array $ast, TextDocument $document): ?string
+    private function getStaticPropertyHover(StaticPropertyFetch $fetch, array $ast): ?string
     {
         $propertyName = $fetch->name;
         if (!$propertyName instanceof Node\VarLikeIdentifier) {
@@ -365,73 +372,67 @@ final class HoverHandler implements HandlerInterface
 
         $className = ScopeFinder::resolveName($class);
 
-        return $this->getPropertyHoverForClass($className, $propertyName->toString(), $ast, $document);
+        return $this->getPropertyHoverForClass($className, $propertyName->toString());
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getMethodHoverForClass(
-        string $className,
-        string $methodName,
-        array $ast,
-        TextDocument $document,
-    ): ?string {
-        $methodNode = MemberFinder::findMethod($className, $methodName, $ast, $this->classLocator, $this->parser);
-        if ($methodNode !== null) {
-            return $this->formatMethodHover($methodNode);
+    private function getMethodHoverForClass(string $classNameStr, string $methodNameStr): ?string
+    {
+        /** @var class-string $classNameStr */
+        $className = new ClassName($classNameStr);
+        $methodName = new MethodName($methodNameStr);
+
+        $methodInfo = $this->memberResolver->findMethod($className, $methodName, Visibility::Private);
+        if ($methodInfo !== null) {
+            return $this->formatMethodHover($methodInfo);
         }
 
-        return $this->getReflectionMethodHover($className, $methodName);
+        return $this->getReflectionMethodHover($classNameStr, $methodNameStr);
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getPropertyHoverForClass(
-        string $className,
-        string $propertyName,
-        array $ast,
-        TextDocument $document,
-    ): ?string {
-        $property = MemberFinder::findProperty($className, $propertyName, $ast, $this->classLocator, $this->parser);
-        if ($property !== null) {
-            return $this->formatPropertyHover($property);
+    private function getPropertyHoverForClass(string $classNameStr, string $propertyNameStr): ?string
+    {
+        /** @var class-string $classNameStr */
+        $className = new ClassName($classNameStr);
+        $propertyName = new PropertyName($propertyNameStr);
+
+        $propertyInfo = $this->memberResolver->findProperty($className, $propertyName, Visibility::Private);
+        if ($propertyInfo !== null) {
+            return $this->formatPropertyHover($propertyInfo);
         }
 
-        return $this->getReflectionPropertyHover($className, $propertyName);
+        return $this->getReflectionPropertyHover($classNameStr, $propertyNameStr);
     }
 
-    private function formatMethodHover(Stmt\ClassMethod $method): string
+    private function formatMethodHover(MethodInfo $method): string
     {
         $parts = [];
 
-        $docComment = $method->getDocComment();
-        if ($docComment !== null) {
-            $parts[] = DocblockParser::extractDescription($docComment->getText());
+        if ($method->docblock !== null) {
+            $parts[] = DocblockParser::extractDescription($method->docblock);
         }
 
-        $visibility = $this->getVisibility($method);
-        $static = $method->isStatic() ? 'static ' : '';
+        $visibility = match ($method->visibility) {
+            Visibility::Private => 'private ',
+            Visibility::Protected => 'protected ',
+            Visibility::Public => 'public ',
+        };
+        $static = $method->isStatic ? 'static ' : '';
 
         $params = [];
-        foreach ($method->params as $param) {
+        foreach ($method->parameters as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
+                $paramStr .= $param->type . ' ';
             }
-            $var = $param->var;
-            if ($var instanceof Variable && is_string($var->name)) {
-                $paramStr .= '$' . $var->name;
-            }
+            $paramStr .= '$' . $param->name;
             $params[] = $paramStr;
         }
 
-        $signature = $visibility . $static . 'function ' . $method->name->toString()
+        $signature = $visibility . $static . 'function ' . $method->name->name
             . '(' . implode(', ', $params) . ')';
 
         if ($method->returnType !== null) {
-            $signature .= ': ' . TypeFormatter::formatNode($method->returnType);
+            $signature .= ': ' . $method->returnType;
         }
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
@@ -439,40 +440,29 @@ final class HoverHandler implements HandlerInterface
         return implode("\n\n", $parts);
     }
 
-    private function formatPropertyHover(PropertyInfo $property): string
+    private function formatPropertyHover(DomainPropertyInfo $property): string
     {
         $parts = [];
 
-        if ($property->docComment !== null) {
-            $parts[] = DocblockParser::extractDescription($property->docComment);
+        if ($property->docblock !== null) {
+            $parts[] = DocblockParser::extractDescription($property->docblock);
         }
 
-        $visibility = match (true) {
-            $property->isPrivate => 'private ',
-            $property->isProtected => 'protected ',
-            default => 'public ',
+        $visibility = match ($property->visibility) {
+            Visibility::Private => 'private ',
+            Visibility::Protected => 'protected ',
+            Visibility::Public => 'public ',
         };
         $static = $property->isStatic ? 'static ' : '';
         $readonly = $property->isReadonly ? 'readonly ' : '';
 
         $type = $property->type !== null ? $property->type . ' ' : '';
 
-        $signature = $visibility . $static . $readonly . $type . '$' . $property->name;
+        $signature = $visibility . $static . $readonly . $type . '$' . $property->name->name;
 
         $parts[] = '```php' . "\n" . $signature . "\n```";
 
         return implode("\n\n", $parts);
-    }
-
-    private function getVisibility(Stmt\ClassMethod $method): string
-    {
-        if ($method->isPrivate()) {
-            return 'private ';
-        }
-        if ($method->isProtected()) {
-            return 'protected ';
-        }
-        return 'public ';
     }
 
     private function getBuiltinFunctionHover(string $functionName): ?string
@@ -613,5 +603,38 @@ final class HoverHandler implements HandlerInterface
         $parts[] = '```php' . "\n" . $signature . "\n```";
 
         return implode("\n\n", $parts);
+    }
+
+    /**
+     * Register all classes from the document with the class repository.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function registerDocumentClasses(string $uri, array $ast): void
+    {
+        $classes = [];
+        foreach ($this->iterateTopLevelStatements($ast) as $stmt) {
+            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
+                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
+            }
+        }
+        $this->classRepository->updateDocument($uri, $classes);
+    }
+
+    /**
+     * Iterate top-level statements, flattening namespace contents.
+     *
+     * @param array<Stmt> $ast
+     * @return \Generator<Stmt>
+     */
+    private function iterateTopLevelStatements(array $ast): \Generator
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                yield from $stmt->stmts;
+            } else {
+                yield $stmt;
+            }
+        }
     }
 }

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -149,7 +149,7 @@ final class HoverHandler implements HandlerInterface
 
             // Static method call: ClassName::method()
             if ($parent instanceof StaticCall) {
-                return $this->getStaticMethodHover($parent, $ast);
+                return $this->getStaticMethodHover($parent);
             }
 
             // Property fetch: $obj->property or $this->property
@@ -159,7 +159,7 @@ final class HoverHandler implements HandlerInterface
 
             // Static property fetch: ClassName::$property
             if ($parent instanceof StaticPropertyFetch) {
-                return $this->getStaticPropertyHover($parent, $ast);
+                return $this->getStaticPropertyHover($parent);
             }
 
             if ($parent instanceof FuncCall) {
@@ -309,10 +309,7 @@ final class HoverHandler implements HandlerInterface
         return $this->getMethodHoverForClass($className, $methodName->toString());
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getStaticMethodHover(StaticCall $call, array $ast): ?string
+    private function getStaticMethodHover(StaticCall $call): ?string
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
@@ -347,10 +344,7 @@ final class HoverHandler implements HandlerInterface
         return $this->getPropertyHoverForClass($className, $propertyName->toString());
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getStaticPropertyHover(StaticPropertyFetch $fetch, array $ast): ?string
+    private function getStaticPropertyHover(StaticPropertyFetch $fetch): ?string
     {
         $propertyName = $fetch->name;
         if (!$propertyName instanceof Node\VarLikeIdentifier) {
@@ -416,7 +410,13 @@ final class HoverHandler implements HandlerInterface
             if ($param->type !== null) {
                 $paramStr .= $param->type . ' ';
             }
+            if ($param->isVariadic) {
+                $paramStr .= '...';
+            }
             $paramStr .= '$' . $param->name;
+            if ($param->hasDefault && !$param->isVariadic) {
+                $paramStr .= ' = ...';
+            }
             $params[] = $paramStr;
         }
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -367,6 +367,7 @@ final class HoverHandler implements HandlerInterface
         $className = new ClassName($classNameStr);
         $methodName = new MethodName($methodNameStr);
 
+        // Hover shows all members regardless of caller context
         $methodInfo = $this->memberResolver->findMethod($className, $methodName, Visibility::Private);
         if ($methodInfo === null) {
             return null;
@@ -381,6 +382,7 @@ final class HoverHandler implements HandlerInterface
         $className = new ClassName($classNameStr);
         $propertyName = new PropertyName($propertyNameStr);
 
+        // Hover shows all members regardless of caller context
         $propertyInfo = $this->memberResolver->findProperty($className, $propertyName, Visibility::Private);
         if ($propertyInfo === null) {
             return null;

--- a/src/Server.php
+++ b/src/Server.php
@@ -70,7 +70,14 @@ final class Server
             $classLocator,
             $typeResolver,
         );
-        $this->handlers[] = new HoverHandler($this->documentManager, $parser, $classLocator, $typeResolver);
+        $this->handlers[] = new HoverHandler(
+            $this->documentManager,
+            $parser,
+            $classRepository,
+            $classInfoFactory,
+            $memberResolver,
+            $typeResolver,
+        );
         $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator, $typeResolver);
         $this->handlers[] = new CompletionHandler(
             $this->documentManager,

--- a/src/Server.php
+++ b/src/Server.php
@@ -80,7 +80,6 @@ final class Server
             $this->documentManager,
             $parser,
             $classRepository,
-            $classInfoFactory,
             $memberResolver,
             $typeResolver,
         );

--- a/tests/Domain/VisibilityTest.php
+++ b/tests/Domain/VisibilityTest.php
@@ -37,4 +37,23 @@ class VisibilityTest extends TestCase
     ): void {
         self::assertSame($expected, $member->isAccessibleFrom($required));
     }
+
+    /**
+     * @return array<string, array{Visibility, string}>
+     * @codeCoverageIgnore
+     */
+    public static function keywordProvider(): array
+    {
+        return [
+            'private' => [Visibility::Private, 'private'],
+            'protected' => [Visibility::Protected, 'protected'],
+            'public' => [Visibility::Public, 'public'],
+        ];
+    }
+
+    #[DataProvider('keywordProvider')]
+    public function testToKeyword(Visibility $visibility, string $expected): void
+    {
+        self::assertSame($expected, $visibility->toKeyword());
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -25,6 +25,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CompletionHandler::class)]
 class CompletionHandlerTest extends TestCase
 {
+    use OpensDocumentsTrait;
+
     private DocumentManager $documents;
     private ParserService $parser;
     private SymbolIndex $symbolIndex;
@@ -59,22 +61,6 @@ class CompletionHandlerTest extends TestCase
             $this->classRepository,
             $this->classInfoFactory,
         );
-    }
-
-    private function openDocument(string $uri, string $code): void
-    {
-        $this->syncHandler->handle(NotificationMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'method' => 'textDocument/didOpen',
-            'params' => [
-                'textDocument' => [
-                    'uri' => $uri,
-                    'languageId' => 'php',
-                    'version' => 1,
-                    'text' => $code,
-                ],
-            ],
-        ]));
     }
 
     public function testSupports(): void

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -827,4 +827,108 @@ PHP;
         self::assertStringContainsString('Child property', $result['contents']);
         self::assertStringNotContainsString('Parent property', $result['contents']);
     }
+
+    public function testHoverOnStaticProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Config
+{
+    /**
+     * Application name.
+     */
+    public static string $appName = 'MyApp';
+}
+
+$name = Config::$appName;
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 18],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$appName', $result['contents']);
+        self::assertStringContainsString('static', $result['contents']);
+        self::assertStringContainsString('Application name', $result['contents']);
+    }
+
+    public function testHoverOnBuiltinClassMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(ArrayObject $obj): void
+{
+    $obj->getArrayCopy();
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $handlerWithResolver = new HoverHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $this->memberResolver,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 12],
+            ],
+        ]);
+
+        $result = $handlerWithResolver->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('getArrayCopy', $result['contents']);
+    }
+
+    public function testHoverOnBuiltinClassProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(Exception $e): void
+{
+    $e->message;
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $handlerWithResolver = new HoverHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $this->memberResolver,
+            new BasicTypeResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 9],
+            ],
+        ]);
+
+        $result = $handlerWithResolver->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$message', $result['contents']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -931,4 +931,72 @@ PHP;
         self::assertIsArray($result);
         self::assertStringContainsString('$message', $result['contents']);
     }
+
+    public function testHoverOnMethodWithVariadicParameter(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Logger
+{
+    public function log(string $level, string ...$messages): void {}
+
+    public function test(): void
+    {
+        $this->log('info', 'a', 'b');
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('...$messages', $result['contents']);
+    }
+
+    public function testHoverOnMethodWithOptionalParameter(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Greeter
+{
+    public function greet(string $name, string $prefix = 'Hello'): string
+    {
+        return "$prefix, $name!";
+    }
+
+    public function test(): void
+    {
+        $this->greet('World');
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$prefix = ...', $result['contents']);
+        self::assertStringNotContainsString('$name = ...', $result['contents']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -6,9 +6,12 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\HoverHandler;
-use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -18,13 +21,30 @@ class HoverHandlerTest extends TestCase
 {
     private DocumentManager $documents;
     private ParserService $parser;
+    private DefaultClassRepository $classRepository;
+    private DefaultClassInfoFactory $classInfoFactory;
+    private MemberResolver $memberResolver;
     private HoverHandler $handler;
 
     protected function setUp(): void
     {
         $this->documents = new DocumentManager();
         $this->parser = new ParserService();
-        $this->handler = new HoverHandler($this->documents, $this->parser, null);
+        $this->classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $this->classRepository = new DefaultClassRepository(
+            $this->classInfoFactory,
+            $locator,
+            $this->parser,
+        );
+        $this->memberResolver = new MemberResolver($this->classRepository);
+        $this->handler = new HoverHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
+        );
     }
 
     public function testSupports(): void
@@ -312,7 +332,9 @@ PHP;
         $handlerWithResolver = new HoverHandler(
             $this->documents,
             $this->parser,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 
@@ -359,7 +381,9 @@ PHP;
         $handlerWithResolver = new HoverHandler(
             $this->documents,
             $this->parser,
-            null,
+            $this->classRepository,
+            $this->classInfoFactory,
+            $this->memberResolver,
             new BasicTypeResolver(),
         );
 

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -6,9 +6,11 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\HoverHandler;
-use Firehed\PhpLsp\Repository\ClassLocator;
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -19,12 +21,15 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(HoverHandler::class)]
 class HoverHandlerTest extends TestCase
 {
+    use OpensDocumentsTrait;
+
     private DocumentManager $documents;
     private ParserService $parser;
     private DefaultClassRepository $classRepository;
     private DefaultClassInfoFactory $classInfoFactory;
     private MemberResolver $memberResolver;
     private HoverHandler $handler;
+    private TextDocumentSyncHandler $syncHandler;
 
     protected function setUp(): void
     {
@@ -42,8 +47,13 @@ class HoverHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
+        );
+        $this->syncHandler = new TextDocumentSyncHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $this->classInfoFactory,
         );
     }
 
@@ -67,7 +77,7 @@ class MyClass
 
 $x = new MyClass();
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -99,7 +109,7 @@ class User {}
 
 $u = new User();
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -120,7 +130,7 @@ PHP;
     public function testHoverReturnsNullForUnknownPosition(): void
     {
         $code = '<?php // just a comment';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -151,7 +161,7 @@ function add(int $a, int $b): int
 
 $sum = add(1, 2);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -190,7 +200,7 @@ class Calculator
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -226,7 +236,7 @@ class Person
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -252,7 +262,7 @@ PHP;
 $arr = [3, 1, 2];
 sort($arr);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -287,7 +297,7 @@ class Math
 
 $result = Math::abs(-5);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -326,14 +336,13 @@ function useCalculator(Calculator $calc): void
     $calc->add(1, 2);
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         // Create handler with type resolver
         $handlerWithResolver = new HoverHandler(
             $this->documents,
             $this->parser,
             $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -376,13 +385,12 @@ function test(): void
     $greeter->greet("World");
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $handlerWithResolver = new HoverHandler(
             $this->documents,
             $this->parser,
             $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -424,7 +432,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -463,7 +471,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -506,7 +514,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -549,7 +557,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -590,7 +598,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -635,7 +643,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -674,7 +682,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -712,7 +720,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -755,7 +763,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -800,7 +808,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',

--- a/tests/Handler/OpensDocumentsTrait.php
+++ b/tests/Handler/OpensDocumentsTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Handler;
+
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Protocol\NotificationMessage;
+
+/**
+ * Provides document opening helper for handler tests.
+ *
+ * @property TextDocumentSyncHandler $syncHandler
+ */
+trait OpensDocumentsTrait
+{
+    private function openDocument(string $uri, string $code): void
+    {
+        $this->syncHandler->handle(NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didOpen',
+            'params' => [
+                'textDocument' => [
+                    'uri' => $uri,
+                    'languageId' => 'php',
+                    'version' => 1,
+                    'text' => $code,
+                ],
+            ],
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Migrates `HoverHandler` to use `MemberResolver` and the new domain model types, completing Phase 4b of the architecture refactor.

- Replaced `ComposerClassLocator` with `ClassRepository`, `MemberResolver`
- `MemberResolver::findMethod()` and `findProperty()` replace `MemberFinder` for member lookup
- `ClassRepository::get()` replaces `ClassFinder::findWithLocator()` for class hover
- Formatting methods now use domain types (`MethodInfo`, `PropertyInfo`, `ClassInfo`) instead of AST nodes
- Removed `array $ast` parameters from methods that no longer need direct AST access
- Document class registration handled by `TextDocumentSyncHandler` (no duplication)
- Added `OpensDocumentsTrait` for shared test helpers

Closes #123

## Test plan

- [x] All 504 tests pass
- [x] Full test suite passes
- [x] PHPStan clean
- [x] PHPCS clean

🤖 Generated with [Claude Code](https://claude.ai/code)
