### PR TITLE
Move document class registration to TextDocumentSyncHandler

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -13,8 +13,6 @@ use Firehed\PhpLsp\Domain\EnumCaseInfo;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
 use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Repository\ClassInfoFactory;
-use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
@@ -74,29 +72,11 @@ final class CompletionHandler implements HandlerInterface
         return $item;
     }
 
-    /**
-     * Iterate top-level statements, flattening namespace contents.
-     *
-     * @param array<Stmt> $ast
-     * @return \Generator<Stmt>
-     */
-    private static function iterateTopLevelStatements(array $ast): \Generator
-    {
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                yield from $stmt->stmts;
-            } else {
-                yield $stmt;
-            }
-        }
-    }
 
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
-        private readonly ClassRepository $classRepository,
-        private readonly ClassInfoFactory $classInfoFactory,
         private readonly MemberResolver $memberResolver,
         private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
@@ -156,9 +136,6 @@ final class CompletionHandler implements HandlerInterface
             throw new \LogicException('Parser returned null with error-collecting handler');
             // @codeCoverageIgnoreEnd
         }
-
-        // Register document classes with repository for member resolution
-        $this->registerDocumentClasses($uri, $ast);
 
         // Get text before cursor to determine completion context
         $lineText = $document->getLine($line);
@@ -538,28 +515,12 @@ final class CompletionHandler implements HandlerInterface
      */
     private function findFirstClass(array $ast): ?Stmt\Class_
     {
-        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
+        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
             if ($stmt instanceof Stmt\Class_) {
                 return $stmt;
             }
         }
         return null;
-    }
-
-    /**
-     * Register all classes from the document with the class repository.
-     *
-     * @param array<Stmt> $ast
-     */
-    private function registerDocumentClasses(string $uri, array $ast): void
-    {
-        $classes = [];
-        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
-            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
-                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
-            }
-        }
-        $this->classRepository->updateDocument($uri, $classes);
     }
 
     /**
@@ -712,7 +673,7 @@ final class CompletionHandler implements HandlerInterface
     {
         $imports = [];
 
-        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
+        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
             $this->extractImportsFromUse($stmt, $imports);
         }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -72,7 +72,6 @@ final class CompletionHandler implements HandlerInterface
         return $item;
     }
 
-
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,

--- a/src/Handler/TextDocumentSyncHandler.php
+++ b/src/Handler/TextDocumentSyncHandler.php
@@ -120,9 +120,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
     private function indexDocument(string $uri): void
     {
         $document = $this->documentManager->get($uri);
-        if ($document === null) {
-            return;
-        }
+        assert($document !== null);
 
         $ast = $this->parser->parse($document);
         if ($ast !== null) {

--- a/src/Handler/TextDocumentSyncHandler.php
+++ b/src/Handler/TextDocumentSyncHandler.php
@@ -6,7 +6,12 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Repository\ClassInfoFactory;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Utility\ScopeFinder;
+use PhpParser\Node\Stmt;
 
 final class TextDocumentSyncHandler implements HandlerInterface
 {
@@ -18,6 +23,9 @@ final class TextDocumentSyncHandler implements HandlerInterface
 
     public function __construct(
         private readonly DocumentManager $documentManager,
+        private readonly ParserService $parser,
+        private readonly ClassRepository $classRepository,
+        private readonly ClassInfoFactory $classInfoFactory,
         private readonly ?DocumentIndexer $indexer = null,
     ) {
     }
@@ -103,6 +111,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         assert(is_string($uri));
 
         $this->indexer?->remove($uri);
+        $this->classRepository->removeDocument($uri);
         $this->documentManager->close($uri);
 
         return null;
@@ -111,8 +120,29 @@ final class TextDocumentSyncHandler implements HandlerInterface
     private function indexDocument(string $uri): void
     {
         $document = $this->documentManager->get($uri);
-        if ($document !== null && $this->indexer !== null) {
-            $this->indexer->index($document);
+        if ($document === null) {
+            return;
         }
+
+        $ast = $this->parser->parse($document);
+        if ($ast !== null) {
+            $this->registerDocumentClasses($uri, $ast);
+        }
+
+        $this->indexer?->index($document);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function registerDocumentClasses(string $uri, array $ast): void
+    {
+        $classes = [];
+        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
+            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
+                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
+            }
+        }
+        $this->classRepository->updateDocument($uri, $classes);
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -62,7 +62,13 @@ final class Server
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
-        $this->handlers[] = new TextDocumentSyncHandler($this->documentManager, $indexer);
+        $this->handlers[] = new TextDocumentSyncHandler(
+            $this->documentManager,
+            $parser,
+            $classRepository,
+            $classInfoFactory,
+            $indexer,
+        );
         $this->handlers[] = new DefinitionHandler(
             $this->documentManager,
             $parser,
@@ -76,8 +82,6 @@ final class Server
             $this->documentManager,
             $parser,
             $symbolIndex,
-            $classRepository,
-            $classInfoFactory,
             $memberResolver,
             $typeResolver,
         );

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -151,4 +151,21 @@ final class ScopeFinder
 
         return $visitor->found;
     }
+
+    /**
+     * Iterate top-level statements, flattening namespace contents.
+     *
+     * @param array<Stmt> $ast
+     * @return \Generator<Stmt>
+     */
+    public static function iterateTopLevelStatements(array $ast): \Generator
+    {
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                yield from $stmt->stmts;
+            } else {
+                yield $stmt;
+            }
+        }
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -6,19 +6,19 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\Symbol;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
-use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node\Stmt\ClassLike;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +32,7 @@ class CompletionHandlerTest extends TestCase
     private DefaultClassInfoFactory $classInfoFactory;
     private MemberResolver $memberResolver;
     private CompletionHandler $handler;
+    private TextDocumentSyncHandler $syncHandler;
 
     protected function setUp(): void
     {
@@ -52,23 +53,28 @@ class CompletionHandlerTest extends TestCase
             $this->symbolIndex,
             $this->memberResolver,
         );
+        $this->syncHandler = new TextDocumentSyncHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $this->classInfoFactory,
+        );
     }
 
     private function openDocument(string $uri, string $code): void
     {
-        $this->documents->open($uri, 'php', 1, $code);
-        $document = $this->documents->get($uri);
-        assert($document !== null);
-        $ast = $this->parser->parse($document);
-        if ($ast !== null) {
-            $classes = [];
-            foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
-                if ($stmt instanceof ClassLike && $stmt->name !== null) {
-                    $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
-                }
-            }
-            $this->classRepository->updateDocument($uri, $classes);
-        }
+        $this->syncHandler->handle(NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didOpen',
+            'params' => [
+                'textDocument' => [
+                    'uri' => $uri,
+                    'languageId' => 'php',
+                    'version' => 1,
+                    'text' => $code,
+                ],
+            ],
+        ]));
     }
 
     public function testSupports(): void

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -48,10 +48,31 @@ class CompletionHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
         );
+    }
+
+    private function openDocument(string $uri, string $code): void
+    {
+        $this->documents->open($uri, 'php', 1, $code);
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+        $ast = $this->parser->parse($document);
+        if ($ast !== null) {
+            $classes = [];
+            foreach ($ast as $stmt) {
+                if ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
+                    foreach ($stmt->stmts as $inner) {
+                        if ($inner instanceof \PhpParser\Node\Stmt\ClassLike && $inner->name !== null) {
+                            $classes[] = $this->classInfoFactory->fromAstNode($inner, $uri);
+                        }
+                    }
+                } elseif ($stmt instanceof \PhpParser\Node\Stmt\ClassLike && $stmt->name !== null) {
+                    $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
+                }
+            }
+            $this->classRepository->updateDocument($uri, $classes);
+        }
     }
 
     public function testSupports(): void
@@ -82,7 +103,7 @@ class MyClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -120,7 +141,7 @@ class MyClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -155,7 +176,7 @@ class MyClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -194,7 +215,7 @@ class Math
 
 $result = Math::
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -228,7 +249,7 @@ class Status
 
 $status = Status::
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -273,7 +294,7 @@ class UserController
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -318,7 +339,7 @@ class Controller
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -360,7 +381,7 @@ class Other
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -400,7 +421,7 @@ class MyClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -440,7 +461,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -469,7 +490,7 @@ function myCustomFunction(): void {}
 
 $x = arr
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -501,7 +522,7 @@ function foo() {
     $x = Us
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -538,7 +559,7 @@ function foo() {
     $x = Rep
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -575,7 +596,7 @@ function foo() {
     $x = Us
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -613,7 +634,7 @@ PHP;
         ));
 
         $code = '<?php $x = new MyIn';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -649,7 +670,7 @@ PHP;
         ));
 
         $code = '<?php $x = new My';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -695,7 +716,7 @@ PHP;
 
         // Expression context (not `new`)
         $code = '<?php $x = My';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -720,7 +741,7 @@ PHP;
     public function testTypeHintCompletionInReturnType(): void
     {
         $code = '<?php function foo(): str';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -745,7 +766,7 @@ PHP;
     public function testTypeHintCompletionInParameter(): void
     {
         $code = '<?php function foo(str';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -767,7 +788,7 @@ PHP;
     public function testTypeHintCompletionIncludesBuiltinTypes(): void
     {
         $code = '<?php function foo(): ';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -794,7 +815,7 @@ PHP;
     public function testTypeHintCompletionForPropertyType(): void
     {
         $code = '<?php class Foo { private str';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -817,7 +838,7 @@ PHP;
     {
         // Nullable type context (after ?)
         $code = '<?php trait MyTrait {} class Foo { private ?';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -852,7 +873,7 @@ PHP;
     {
         // Union type context (after |)
         $code = '<?php trait MyTrait {} class Foo { private int|';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -887,7 +908,7 @@ PHP;
     {
         // Intersection type context (after &)
         $code = '<?php trait MyTrait {} class Foo { private Countable&';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -921,7 +942,7 @@ PHP;
     public function testParameterTypeExcludesInvalidTypes(): void
     {
         $code = '<?php trait MyTrait {} function foo(';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -957,7 +978,7 @@ PHP;
     public function testReturnTypeIncludesAllValidTypes(): void
     {
         $code = '<?php trait MyTrait {} function foo(): ';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -991,7 +1012,7 @@ PHP;
     public function testReturnTypeUnionIncludesAllReturnTypes(): void
     {
         $code = '<?php trait MyTrait {} function foo(): int|';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1025,7 +1046,7 @@ PHP;
     public function testReturnTypeIntersectionIncludesAllReturnTypes(): void
     {
         $code = '<?php trait MyTrait {} function foo(): Countable&';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1060,7 +1081,7 @@ PHP;
     {
         // Nullable return type context (after ?)
         $code = '<?php function foo(): ?';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1092,7 +1113,7 @@ PHP;
     {
         // Edge case: space after ? in nullable return type (cursor after space, before typing)
         $code = '<?php function foo(): ? ';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1120,7 +1141,7 @@ PHP;
     public function testKeywordCompletions(): void
     {
         $code = '<?php fore';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1142,7 +1163,7 @@ PHP;
     public function testKeywordCompletionsIncludeControlFlow(): void
     {
         $code = '<?php ret';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1164,7 +1185,7 @@ PHP;
     public function testKeywordCompletionsIncludeDeclarations(): void
     {
         $code = '<?php cla';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1186,7 +1207,7 @@ PHP;
     public function testClassBodyOnlySuggestsClassLevelKeywords(): void
     {
         $code = '<?php class Foo { p';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1214,7 +1235,7 @@ PHP;
     public function testAfterVisibilityKeywordSuggestsFunction(): void
     {
         $code = '<?php class Foo { public f';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1236,7 +1257,7 @@ PHP;
     public function testAfterVisibilityKeywordSuggestsModifiers(): void
     {
         $code = '<?php class Foo { public s';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1259,7 +1280,7 @@ PHP;
     public function testKeywordsNotSuggestedInTypeHintContext(): void
     {
         $code = '<?php function foo(): ret';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1282,7 +1303,7 @@ PHP;
     public function testVariableCompletionSuggestsParameters(): void
     {
         $code = '<?php function foo(string $name, int $age) { $n; }';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1305,7 +1326,7 @@ PHP;
     public function testVariableCompletionSuggestsLocalVariables(): void
     {
         $code = '<?php function foo() { $logger = new Logger(); $l; }';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1327,7 +1348,7 @@ PHP;
     public function testVariableCompletionSuggestsThisInMethod(): void
     {
         $code = '<?php class Foo { public function bar() { $t; } }';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1349,7 +1370,7 @@ PHP;
     public function testVariableCompletionWorksInClosures(): void
     {
         $code = '<?php $fn = function ($param) { $localVar = 1; $l; };';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1371,7 +1392,7 @@ PHP;
     public function testVariableCompletionSuggestsForeachVariables(): void
     {
         $code = '<?php function foo() { foreach ([1,2] as $item) { $i; } }';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1400,7 +1421,7 @@ $a = [
     'y' => function () { $siteDir = 2; $s; },
 ];
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1423,7 +1444,7 @@ PHP;
     public function testVariableCompletionShowsTypeInDetail(): void
     {
         $code = '<?php function foo(string $name) { $x; }';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1447,7 +1468,7 @@ PHP;
     public function testCompletionReturnsEmptyForUnknownContext(): void
     {
         $code = '<?php $x = 1;';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1478,7 +1499,7 @@ enum Status
 
 $status = Status::A
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1511,7 +1532,7 @@ enum Status
 
 $status = Status::
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1550,7 +1571,7 @@ enum Status
 
 $cases = Status::c
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1583,7 +1604,7 @@ enum Priority: int
 
 $p = Priority::
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1636,7 +1657,7 @@ enum Color: string
 
 $c = Color::
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1686,7 +1707,7 @@ enum Priority: int
 
 $p = Priority::f
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -1725,14 +1746,12 @@ function processUser(User $user): void
     $user->
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $handler = new CompletionHandler(
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -1773,14 +1792,12 @@ function foo(): void
     $logger->
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $handler = new CompletionHandler(
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -1819,14 +1836,12 @@ function processUser(User $user): void
     $user->get
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $handler = new CompletionHandler(
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -1859,14 +1874,12 @@ function foo(): void
     $unknown->
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $handler = new CompletionHandler(
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -1896,14 +1909,12 @@ function foo(ArrayObject $obj): void
     $obj->
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $handler = new CompletionHandler(
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -1948,14 +1959,12 @@ function foo(User $user): void
     $user->
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $handler = new CompletionHandler(
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $this->classInfoFactory,
             $this->memberResolver,
             new BasicTypeResolver(),
         );
@@ -1999,7 +2008,7 @@ class Foo
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2038,7 +2047,7 @@ class Foo
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2075,7 +2084,7 @@ class Foo
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2112,7 +2121,7 @@ class Foo
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2147,7 +2156,7 @@ $obj = new class {
     }
 };
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2185,7 +2194,7 @@ class Second
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2221,7 +2230,7 @@ class Foo
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2257,7 +2266,7 @@ class Foo
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2287,7 +2296,7 @@ function foo(): void
     self::
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2324,7 +2333,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2357,7 +2366,7 @@ class MyClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2395,7 +2404,7 @@ class ChildClass extends ParentClass
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2430,7 +2439,7 @@ function foo(User $user): void
     $user->
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         // Handler without type resolver (uses default from setUp)
         $request = RequestMessage::fromArray([
@@ -2545,7 +2554,7 @@ PHP;
 <?php
 $this->
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2573,7 +2582,7 @@ $x = new class {
     }
 };
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2607,7 +2616,7 @@ $x = new class {
     }
 };
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2645,7 +2654,7 @@ class InheritanceChild extends InheritanceParent
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -2676,7 +2685,7 @@ class NoNamespace
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -17,6 +17,8 @@ use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Utility\ScopeFinder;
+use PhpParser\Node\Stmt\ClassLike;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -60,14 +62,8 @@ class CompletionHandlerTest extends TestCase
         $ast = $this->parser->parse($document);
         if ($ast !== null) {
             $classes = [];
-            foreach ($ast as $stmt) {
-                if ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
-                    foreach ($stmt->stmts as $inner) {
-                        if ($inner instanceof \PhpParser\Node\Stmt\ClassLike && $inner->name !== null) {
-                            $classes[] = $this->classInfoFactory->fromAstNode($inner, $uri);
-                        }
-                    }
-                } elseif ($stmt instanceof \PhpParser\Node\Stmt\ClassLike && $stmt->name !== null) {
+            foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
+                if ($stmt instanceof ClassLike && $stmt->name !== null) {
                     $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
                 }
             }

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -18,30 +18,37 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TextDocumentSyncHandler::class)]
 class TextDocumentSyncHandlerTest extends TestCase
 {
-    private function createHandler(DocumentManager $manager): TextDocumentSyncHandler
+    private DocumentManager $manager;
+    private ParserService $parser;
+    private DefaultClassInfoFactory $classInfoFactory;
+    private DefaultClassRepository $classRepository;
+    private TextDocumentSyncHandler $handler;
+
+    protected function setUp(): void
     {
-        $parser = new ParserService();
-        $classInfoFactory = new DefaultClassInfoFactory();
+        $this->manager = new DocumentManager();
+        $this->parser = new ParserService();
+        $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
-        return new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
+        $this->classRepository = new DefaultClassRepository($this->classInfoFactory, $locator, $this->parser);
+        $this->handler = new TextDocumentSyncHandler(
+            $this->manager,
+            $this->parser,
+            $this->classRepository,
+            $this->classInfoFactory,
+        );
     }
 
     public function testSupports(): void
     {
-        $handler = $this->createHandler(new DocumentManager());
-
-        self::assertTrue($handler->supports('textDocument/didOpen'));
-        self::assertTrue($handler->supports('textDocument/didChange'));
-        self::assertTrue($handler->supports('textDocument/didClose'));
-        self::assertFalse($handler->supports('textDocument/hover'));
+        self::assertTrue($this->handler->supports('textDocument/didOpen'));
+        self::assertTrue($this->handler->supports('textDocument/didChange'));
+        self::assertTrue($this->handler->supports('textDocument/didClose'));
+        self::assertFalse($this->handler->supports('textDocument/hover'));
     }
 
     public function testDidOpen(): void
     {
-        $manager = new DocumentManager();
-        $handler = $this->createHandler($manager);
-
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
             'method' => 'textDocument/didOpen',
@@ -55,22 +62,17 @@ class TextDocumentSyncHandlerTest extends TestCase
             ],
         ]);
 
-        $handler->handle($notification);
+        $this->handler->handle($notification);
 
-        $doc = $manager->get('file:///test.php');
+        $doc = $this->manager->get('file:///test.php');
         self::assertNotNull($doc);
         self::assertSame('<?php echo "hello";', $doc->getContent());
     }
 
     public function testDidChange(): void
     {
-        $manager = new DocumentManager();
-        $handler = $this->createHandler($manager);
+        $this->manager->open('file:///test.php', 'php', 1, '<?php echo "v1";');
 
-        // First open
-        $manager->open('file:///test.php', 'php', 1, '<?php echo "v1";');
-
-        // Then change (full sync)
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
             'method' => 'textDocument/didChange',
@@ -85,9 +87,9 @@ class TextDocumentSyncHandlerTest extends TestCase
             ],
         ]);
 
-        $handler->handle($notification);
+        $this->handler->handle($notification);
 
-        $doc = $manager->get('file:///test.php');
+        $doc = $this->manager->get('file:///test.php');
         self::assertNotNull($doc);
         self::assertSame('<?php echo "v2";', $doc->getContent());
         self::assertSame(2, $doc->version);
@@ -95,10 +97,7 @@ class TextDocumentSyncHandlerTest extends TestCase
 
     public function testDidClose(): void
     {
-        $manager = new DocumentManager();
-        $handler = $this->createHandler($manager);
-
-        $manager->open('file:///test.php', 'php', 1, '<?php');
+        $this->manager->open('file:///test.php', 'php', 1, '<?php');
 
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -110,21 +109,13 @@ class TextDocumentSyncHandlerTest extends TestCase
             ],
         ]);
 
-        $handler->handle($notification);
+        $this->handler->handle($notification);
 
-        self::assertNull($manager->get('file:///test.php'));
+        self::assertNull($this->manager->get('file:///test.php'));
     }
 
     public function testDidOpenRegistersClasses(): void
     {
-        $manager = new DocumentManager();
-        $parser = new ParserService();
-        $classInfoFactory = new DefaultClassInfoFactory();
-        $locator = self::createStub(ClassLocator::class);
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
-
-        $handler = new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
-
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
             'method' => 'textDocument/didOpen',
@@ -138,35 +129,26 @@ class TextDocumentSyncHandlerTest extends TestCase
             ],
         ]);
 
-        $handler->handle($notification);
+        $this->handler->handle($notification);
 
         /** @var class-string $className */
         $className = 'MyTestClass'; // @phpstan-ignore varTag.nativeType
-        $classInfo = $classRepository->get(new ClassName($className));
+        $classInfo = $this->classRepository->get(new ClassName($className));
         self::assertNotNull($classInfo);
         self::assertSame('MyTestClass', $classInfo->name->shortName());
     }
 
     public function testDidChangeUpdatesClasses(): void
     {
-        $manager = new DocumentManager();
-        $parser = new ParserService();
-        $classInfoFactory = new DefaultClassInfoFactory();
-        $locator = self::createStub(ClassLocator::class);
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
-
-        $handler = new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
-
         // Open with initial class
-        $manager->open('file:///test.php', 'php', 1, '<?php class OldClass {}');
-        $classRepository->updateDocument('file:///test.php', [
-            $classInfoFactory->fromAstNode(
+        $this->manager->open('file:///test.php', 'php', 1, '<?php class OldClass {}');
+        $this->classRepository->updateDocument('file:///test.php', [
+            $this->classInfoFactory->fromAstNode(
                 new \PhpParser\Node\Stmt\Class_('OldClass'),
                 'file:///test.php',
             ),
         ]);
 
-        // Change to new class
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
             'method' => 'textDocument/didChange',
@@ -181,32 +163,23 @@ class TextDocumentSyncHandlerTest extends TestCase
             ],
         ]);
 
-        $handler->handle($notification);
+        $this->handler->handle($notification);
 
         /** @var class-string $oldClassName */
         $oldClassName = 'OldClass'; // @phpstan-ignore varTag.nativeType
         /** @var class-string $newClassName */
         $newClassName = 'NewClass'; // @phpstan-ignore varTag.nativeType
-        self::assertNull($classRepository->get(new ClassName($oldClassName)));
-        $newClass = $classRepository->get(new ClassName($newClassName));
+        self::assertNull($this->classRepository->get(new ClassName($oldClassName)));
+        $newClass = $this->classRepository->get(new ClassName($newClassName));
         self::assertNotNull($newClass);
         self::assertSame('NewClass', $newClass->name->shortName());
     }
 
     public function testDidCloseRemovesClasses(): void
     {
-        $manager = new DocumentManager();
-        $parser = new ParserService();
-        $classInfoFactory = new DefaultClassInfoFactory();
-        $locator = self::createStub(ClassLocator::class);
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
-
-        $handler = new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
-
         /** @var class-string $className */
         $className = 'ToBeRemoved'; // @phpstan-ignore varTag.nativeType
 
-        // Open with a class
         $openNotification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
             'method' => 'textDocument/didOpen',
@@ -219,10 +192,9 @@ class TextDocumentSyncHandlerTest extends TestCase
                 ],
             ],
         ]);
-        $handler->handle($openNotification);
-        self::assertNotNull($classRepository->get(new ClassName($className)));
+        $this->handler->handle($openNotification);
+        self::assertNotNull($this->classRepository->get(new ClassName($className)));
 
-        // Close
         $closeNotification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
             'method' => 'textDocument/didClose',
@@ -232,8 +204,8 @@ class TextDocumentSyncHandlerTest extends TestCase
                 ],
             ],
         ]);
-        $handler->handle($closeNotification);
+        $this->handler->handle($closeNotification);
 
-        self::assertNull($classRepository->get(new ClassName($className)));
+        self::assertNull($this->classRepository->get(new ClassName($className)));
     }
 }

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
@@ -112,5 +113,127 @@ class TextDocumentSyncHandlerTest extends TestCase
         $handler->handle($notification);
 
         self::assertNull($manager->get('file:///test.php'));
+    }
+
+    public function testDidOpenRegistersClasses(): void
+    {
+        $manager = new DocumentManager();
+        $parser = new ParserService();
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+
+        $handler = new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
+
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didOpen',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                    'languageId' => 'php',
+                    'version' => 1,
+                    'text' => '<?php class MyTestClass {}',
+                ],
+            ],
+        ]);
+
+        $handler->handle($notification);
+
+        /** @var class-string $className */
+        $className = 'MyTestClass'; // @phpstan-ignore varTag.nativeType
+        $classInfo = $classRepository->get(new ClassName($className));
+        self::assertNotNull($classInfo);
+        self::assertSame('MyTestClass', $classInfo->name->shortName());
+    }
+
+    public function testDidChangeUpdatesClasses(): void
+    {
+        $manager = new DocumentManager();
+        $parser = new ParserService();
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+
+        $handler = new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
+
+        // Open with initial class
+        $manager->open('file:///test.php', 'php', 1, '<?php class OldClass {}');
+        $classRepository->updateDocument('file:///test.php', [
+            $classInfoFactory->fromAstNode(
+                new \PhpParser\Node\Stmt\Class_('OldClass'),
+                'file:///test.php',
+            ),
+        ]);
+
+        // Change to new class
+        $notification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didChange',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                    'version' => 2,
+                ],
+                'contentChanges' => [
+                    ['text' => '<?php class NewClass {}'],
+                ],
+            ],
+        ]);
+
+        $handler->handle($notification);
+
+        /** @var class-string $oldClassName */
+        $oldClassName = 'OldClass'; // @phpstan-ignore varTag.nativeType
+        /** @var class-string $newClassName */
+        $newClassName = 'NewClass'; // @phpstan-ignore varTag.nativeType
+        self::assertNull($classRepository->get(new ClassName($oldClassName)));
+        $newClass = $classRepository->get(new ClassName($newClassName));
+        self::assertNotNull($newClass);
+        self::assertSame('NewClass', $newClass->name->shortName());
+    }
+
+    public function testDidCloseRemovesClasses(): void
+    {
+        $manager = new DocumentManager();
+        $parser = new ParserService();
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+
+        $handler = new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
+
+        /** @var class-string $className */
+        $className = 'ToBeRemoved'; // @phpstan-ignore varTag.nativeType
+
+        // Open with a class
+        $openNotification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didOpen',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                    'languageId' => 'php',
+                    'version' => 1,
+                    'text' => '<?php class ToBeRemoved {}',
+                ],
+            ],
+        ]);
+        $handler->handle($openNotification);
+        self::assertNotNull($classRepository->get(new ClassName($className)));
+
+        // Close
+        $closeNotification = NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'textDocument/didClose',
+            'params' => [
+                'textDocument' => [
+                    'uri' => 'file:///test.php',
+                ],
+            ],
+        ]);
+        $handler->handle($closeNotification);
+
+        self::assertNull($classRepository->get(new ClassName($className)));
     }
 }

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -6,16 +6,29 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
+use Firehed\PhpLsp\Repository\ClassLocator;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(TextDocumentSyncHandler::class)]
 class TextDocumentSyncHandlerTest extends TestCase
 {
+    private function createHandler(DocumentManager $manager): TextDocumentSyncHandler
+    {
+        $parser = new ParserService();
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+        return new TextDocumentSyncHandler($manager, $parser, $classRepository, $classInfoFactory);
+    }
+
     public function testSupports(): void
     {
-        $handler = new TextDocumentSyncHandler(new DocumentManager());
+        $handler = $this->createHandler(new DocumentManager());
 
         self::assertTrue($handler->supports('textDocument/didOpen'));
         self::assertTrue($handler->supports('textDocument/didChange'));
@@ -26,7 +39,7 @@ class TextDocumentSyncHandlerTest extends TestCase
     public function testDidOpen(): void
     {
         $manager = new DocumentManager();
-        $handler = new TextDocumentSyncHandler($manager);
+        $handler = $this->createHandler($manager);
 
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -51,7 +64,7 @@ class TextDocumentSyncHandlerTest extends TestCase
     public function testDidChange(): void
     {
         $manager = new DocumentManager();
-        $handler = new TextDocumentSyncHandler($manager);
+        $handler = $this->createHandler($manager);
 
         // First open
         $manager->open('file:///test.php', 'php', 1, '<?php echo "v1";');
@@ -82,7 +95,7 @@ class TextDocumentSyncHandlerTest extends TestCase
     public function testDidClose(): void
     {
         $manager = new DocumentManager();
-        $handler = new TextDocumentSyncHandler($manager);
+        $handler = $this->createHandler($manager);
 
         $manager->open('file:///test.php', 'php', 1, '<?php');
 

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -424,4 +424,42 @@ PHP;
 
         self::assertSame('Other\Bar', ScopeFinder::resolveName($class->extends));
     }
+
+    public function testIterateTopLevelStatementsYieldsStatementsDirectly(): void
+    {
+        $code = <<<'PHP'
+<?php
+class First {}
+class Second {}
+function myFunc() {}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $statements = iterator_to_array(ScopeFinder::iterateTopLevelStatements($ast));
+
+        self::assertCount(3, $statements);
+        self::assertInstanceOf(Stmt\Class_::class, $statements[0]);
+        self::assertInstanceOf(Stmt\Class_::class, $statements[1]);
+        self::assertInstanceOf(Stmt\Function_::class, $statements[2]);
+    }
+
+    public function testIterateTopLevelStatementsFlattensNamespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App;
+
+class First {}
+class Second {}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $statements = iterator_to_array(ScopeFinder::iterateTopLevelStatements($ast));
+
+        self::assertCount(2, $statements);
+        self::assertInstanceOf(Stmt\Class_::class, $statements[0]);
+        self::assertSame('First', $statements[0]->name?->toString());
+        self::assertInstanceOf(Stmt\Class_::class, $statements[1]);
+        self::assertSame('Second', $statements[1]->name?->toString());
+    }
 }


### PR DESCRIPTION
## Summary

Moves document class registration from individual handlers to `TextDocumentSyncHandler`, where it belongs per the architecture spec in #116.

- Extracts `iterateTopLevelStatements` to `ScopeFinder` utility
- Removes `registerDocumentClasses` from `CompletionHandler`
- Adds class registration to `TextDocumentSyncHandler` on open/change
- Adds `removeDocument` call on close
- Simplifies `CompletionHandler` constructor (removes `ClassRepository`, `ClassInfoFactory`)

Closes #134

## Test plan

- [x] All 499 tests pass
- [x] PHPStan clean
- [x] PHPCS clean

🤖 Generated with [Claude Code](https://claude.ai/code)
