### PR TITLE
Arch Phase 4c: Migrate DefinitionHandler

### DIFF
--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -131,18 +131,11 @@ final class DefinitionHandler implements HandlerInterface
 
         /** @var class-string $symbolName */
         $classInfo = $this->classRepository->get(new ClassName($symbolName));
-        if ($classInfo !== null && $classInfo->file !== null && $classInfo->line !== null) {
-            $location = new Location(
-                $this->pathToUri($classInfo->file),
-                $classInfo->line - 1,
-                0,
-                $classInfo->line - 1,
-                0,
-            );
-            return $location->toLspLocation();
+        if ($classInfo === null) {
+            return null;
         }
 
-        return null;
+        return $this->createLocationFromFileLine($classInfo->file, $classInfo->line);
     }
 
     /**
@@ -253,26 +246,31 @@ final class DefinitionHandler implements HandlerInterface
      */
     private function methodInfoToLocation(?MethodInfo $methodInfo): ?array
     {
-        if ($methodInfo === null || $methodInfo->file === null || $methodInfo->line === null) {
+        if ($methodInfo === null) {
             return null;
         }
 
-        $location = new Location(
-            $this->pathToUri($methodInfo->file),
-            $methodInfo->line - 1,
-            0,
-            $methodInfo->line - 1,
-            0,
-        );
-
-        return $location->toLspLocation();
+        return $this->createLocationFromFileLine($methodInfo->file, $methodInfo->line);
     }
 
-    private function pathToUri(string $path): string
+    /**
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function createLocationFromFileLine(?string $file, ?int $line): ?array
     {
-        if (str_starts_with($path, 'file://')) {
-            return $path;
+        if ($file === null || $line === null) {
+            return null;
         }
-        return 'file://' . $path;
+
+        $uri = str_starts_with($file, 'file://') ? $file : 'file://' . $file;
+        $location = new Location($uri, $line - 1, 0, $line - 1, 0);
+
+        return $location->toLspLocation();
     }
 }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\NodeAtPosition;
-use Firehed\PhpLsp\Index\SymbolExtractor;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
-use Firehed\PhpLsp\Utility\ClassFinder;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
@@ -29,8 +29,8 @@ final class DefinitionHandler implements HandlerInterface
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
-        private readonly SymbolIndex $symbolIndex,
-        private readonly ?ComposerClassLocator $classLocator = null,
+        private readonly MemberResolver $memberResolver,
+        private readonly ClassRepository $classRepository,
         private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
@@ -99,7 +99,7 @@ final class DefinitionHandler implements HandlerInterface
 
             // Static method call: ClassName::method()
             if ($parent instanceof StaticCall) {
-                return $this->handleStaticMethodDefinition($parent, $ast);
+                return $this->handleStaticMethodDefinition($parent);
             }
 
             // Instance method call: $obj->method()
@@ -129,25 +129,25 @@ final class DefinitionHandler implements HandlerInterface
     {
         $symbolName = ScopeFinder::resolveName($node);
 
-        // Look up in index first (for open files)
-        $symbol = $this->symbolIndex->findByFqn($symbolName);
-        if ($symbol === null) {
-            $matches = $this->symbolIndex->findByName($symbolName);
-            $symbol = $matches[0] ?? null;
+        /** @var class-string $symbolName */
+        $classInfo = $this->classRepository->get(new ClassName($symbolName));
+        if ($classInfo !== null && $classInfo->file !== null && $classInfo->line !== null) {
+            $location = new Location(
+                $this->pathToUri($classInfo->file),
+                $classInfo->line - 1,
+                0,
+                $classInfo->line - 1,
+                0,
+            );
+            return $location->toLspLocation();
         }
 
-        if ($symbol !== null) {
-            return $symbol->location->toLspLocation();
-        }
-
-        // Not in index - try to locate via Composer autoload
-        return $this->locateViaComposer($symbolName)?->toLspLocation();
+        return null;
     }
 
     /**
      * Handle definition for static method call: ClassName::method()
      *
-     * @param array<Stmt> $ast
      * @return array{
      *   uri: string,
      *   range: array{
@@ -156,7 +156,7 @@ final class DefinitionHandler implements HandlerInterface
      *   },
      * }|null
      */
-    private function handleStaticMethodDefinition(StaticCall $call, array $ast): ?array
+    private function handleStaticMethodDefinition(StaticCall $call): ?array
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
@@ -189,7 +189,7 @@ final class DefinitionHandler implements HandlerInterface
             $className = $enclosingClassName;
         }
 
-        return $this->findMethodDefinition($className, $methodName->toString(), $ast);
+        return $this->findMethodDefinition($className, $methodName->toString());
     }
 
     /**
@@ -216,13 +216,12 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        return $this->findMethodDefinition($className, $methodName->toString(), $ast);
+        return $this->findMethodDefinition($className, $methodName->toString());
     }
 
     /**
      * Find the definition of a method in a class.
      *
-     * @param array<Stmt> $ast
      * @return array{
      *   uri: string,
      *   range: array{
@@ -231,51 +230,19 @@ final class DefinitionHandler implements HandlerInterface
      *   },
      * }|null
      */
-    private function findMethodDefinition(string $className, string $methodName, array $ast): ?array
+    private function findMethodDefinition(string $className, string $methodName): ?array
     {
-        [$classNode, $classUri] = $this->findClassWithUri($className, $ast);
+        /** @var class-string $className */
+        $methodInfo = $this->memberResolver->findMethod(
+            new ClassName($className),
+            new MethodName($methodName),
+            Visibility::Public,
+        );
 
-        if ($classNode === null || $classUri === null) {
-            return null;
-        }
-
-        // Search for the method in the class
-        foreach ($classNode->stmts as $stmt) {
-            if ($stmt instanceof Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
-                return $this->createMethodLocationWithUri($stmt, $classUri);
-            }
-        }
-
-        // PHP method resolution order: class -> traits -> parent
-        // Search in traits first (before parent)
-        foreach ($classNode->stmts as $stmt) {
-            if ($stmt instanceof Stmt\TraitUse) {
-                foreach ($stmt->traits as $traitName) {
-                    $traitResult = $this->findMethodDefinition(ScopeFinder::resolveName($traitName), $methodName, $ast);
-                    if ($traitResult !== null) {
-                        return $traitResult;
-                    }
-                }
-            }
-        }
-
-        // Search in parent class
-        if ($classNode instanceof Stmt\Class_) {
-            $parentName = ScopeFinder::resolveExtendsName($classNode);
-            if ($parentName !== null) {
-                $parentResult = $this->findMethodDefinition($parentName, $methodName, $ast);
-                if ($parentResult !== null) {
-                    return $parentResult;
-                }
-            }
-        }
-
-        return null;
+        return $this->methodInfoToLocation($methodInfo);
     }
 
     /**
-     * Create a Location for a method definition with a known URI.
-     *
      * @return array{
      *   uri: string,
      *   range: array{
@@ -284,153 +251,28 @@ final class DefinitionHandler implements HandlerInterface
      *   },
      * }|null
      */
-    private function createMethodLocationWithUri(Stmt\ClassMethod $method, string $uri): ?array
+    private function methodInfoToLocation(?MethodInfo $methodInfo): ?array
     {
-        $startLine = $method->getStartLine();
-        $endLine = $method->getEndLine();
-
-        if ($startLine === -1 || $endLine === -1) {
+        if ($methodInfo === null || $methodInfo->file === null || $methodInfo->line === null) {
             return null;
         }
 
-        // Convert to 0-based line numbers
         $location = new Location(
-            $uri,
-            $startLine - 1,
+            $this->pathToUri($methodInfo->file),
+            $methodInfo->line - 1,
             0,
-            $endLine - 1,
+            $methodInfo->line - 1,
             0,
         );
 
         return $location->toLspLocation();
     }
 
-    /**
-     * Get the URI for a class node.
-     */
-    private function getClassUri(Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $classNode): ?string
+    private function pathToUri(string $path): string
     {
-        // First check if this class is in the symbol index
-        $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
-        if ($className !== null) {
-            $symbol = $this->symbolIndex->findByFqn($className);
-            if ($symbol !== null) {
-                return $symbol->location->uri;
-            }
-
-            // Try to locate via Composer
-            if ($this->classLocator !== null) {
-                $filePath = $this->classLocator->locateClass($className);
-                if ($filePath !== null) {
-                    return 'file://' . $filePath;
-                }
-            }
+        if (str_starts_with($path, 'file://')) {
+            return $path;
         }
-
-        return null;
-    }
-
-    /**
-     * Find a class node and its URI.
-     *
-     * Searches in order:
-     * 1. Current AST
-     * 2. SymbolIndex (for open files)
-     * 3. Composer autoload (for external dependencies)
-     *
-     * @param array<Stmt> $ast
-     * @return array{
-     *   0: Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null,
-     *   1: string|null,
-     * }
-     */
-    private function findClassWithUri(string $className, array $ast): array
-    {
-        // First, try to find the class in the current AST
-        $classNode = ClassFinder::findInAst($className, $ast);
-        if ($classNode !== null) {
-            $uri = $this->getClassUri($classNode);
-            return [$classNode, $uri];
-        }
-
-        // Try to find via SymbolIndex
-        $symbol = $this->symbolIndex->findByFqn($className);
-        if ($symbol === null) {
-            $matches = $this->symbolIndex->findByName($className);
-            $symbol = $matches[0] ?? null;
-        }
-
-        if ($symbol !== null) {
-            $classUri = $symbol->location->uri;
-            $document = $this->documentManager->get($classUri);
-            if ($document === null) {
-                $filePath = str_starts_with($classUri, 'file://') ? substr($classUri, 7) : $classUri;
-                $content = @file_get_contents($filePath);
-                if ($content !== false) {
-                    $document = new TextDocument($classUri, 'php', 0, $content);
-                }
-            }
-
-            if ($document !== null) {
-                $classAst = $this->parser->parse($document);
-                if ($classAst !== null) {
-                    $classNode = ClassFinder::findInAst($className, $classAst);
-                    if ($classNode !== null) {
-                        return [$classNode, $classUri];
-                    }
-                }
-            }
-        }
-
-        // Try Composer locator as fallback
-        if ($this->classLocator !== null) {
-            $classNode = ClassFinder::findWithLocator($className, $ast, $this->classLocator, $this->parser);
-            if ($classNode !== null) {
-                $filePath = $this->classLocator->locateClass($className);
-                if ($filePath !== null) {
-                    return [$classNode, 'file://' . $filePath];
-                }
-            }
-        }
-
-        return [null, null];
-    }
-
-    private function locateViaComposer(string $className): ?Location
-    {
-        if ($this->classLocator === null) {
-            return null;
-        }
-
-        $filePath = $this->classLocator->locateClass($className);
-        if ($filePath === null) {
-            return null;
-        }
-
-        $content = file_get_contents($filePath);
-        if ($content === false) {
-            return null;
-        }
-
-        $uri = 'file://' . $filePath;
-        $document = new TextDocument($uri, 'php', 0, $content);
-
-        $ast = $this->parser->parse($document);
-        if ($ast === null) {
-            return null;
-        }
-
-        // Extract symbols and find our class
-        $extractor = new SymbolExtractor();
-        $symbols = $extractor->extract($document, $ast);
-
-        foreach ($symbols as $symbol) {
-            if ($symbol->fullyQualifiedName === $className) {
-                return $symbol->location;
-            }
-        }
-
-        // Fallback: return start of file
-        return new Location($uri, 0, 0, 0, 0);
+        return 'file://' . $path;
     }
 }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -234,7 +234,7 @@ final class DefinitionHandler implements HandlerInterface
         $methodInfo = $this->memberResolver->findMethod(
             new ClassName($className),
             new MethodName($methodName),
-            Visibility::Public,
+            Visibility::Private,
         );
 
         if ($methodInfo === null) {

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -80,7 +80,9 @@ final class DefinitionHandler implements HandlerInterface
         // Parse the document
         $ast = $this->parser->parse($document);
         if ($ast === null) {
-            return null;
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('Parser returned null with error-collecting handler');
+            // @codeCoverageIgnoreEnd
         }
 
         // Find node at position
@@ -152,7 +154,9 @@ final class DefinitionHandler implements HandlerInterface
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
-            return null;
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('handleStaticMethodDefinition called with non-Identifier method name');
+            // @codeCoverageIgnoreEnd
         }
 
         $class = $call->class;
@@ -200,7 +204,9 @@ final class DefinitionHandler implements HandlerInterface
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
-            return null;
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('handleInstanceMethodDefinition called with non-Identifier method name');
+            // @codeCoverageIgnoreEnd
         }
 
         $className = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -6,7 +6,6 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\Location;
@@ -232,20 +231,6 @@ final class DefinitionHandler implements HandlerInterface
             Visibility::Public,
         );
 
-        return $this->methodInfoToLocation($methodInfo);
-    }
-
-    /**
-     * @return array{
-     *   uri: string,
-     *   range: array{
-     *     start: array{line: int, character: int},
-     *     end: array{line: int, character: int},
-     *   },
-     * }|null
-     */
-    private function methodInfoToLocation(?MethodInfo $methodInfo): ?array
-    {
         if ($methodInfo === null) {
             return null;
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -72,8 +72,8 @@ final class Server
         $this->handlers[] = new DefinitionHandler(
             $this->documentManager,
             $parser,
-            $symbolIndex,
-            $classLocator,
+            $memberResolver,
+            $classRepository,
             $typeResolver,
         );
         $this->handlers[] = new HoverHandler(

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -7,7 +7,6 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
@@ -24,7 +23,6 @@ class DefinitionHandlerTest extends TestCase
     use OpensDocumentsTrait;
 
     private DocumentManager $documents;
-    private SymbolIndex $index;
     private ParserService $parser;
     private DefaultClassRepository $classRepository;
     private MemberResolver $memberResolver;
@@ -34,7 +32,6 @@ class DefinitionHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->documents = new DocumentManager();
-        $this->index = new SymbolIndex();
         $this->parser = new ParserService();
         $classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
@@ -47,7 +44,6 @@ class DefinitionHandlerTest extends TestCase
         $this->handler = new DefinitionHandler(
             $this->documents,
             $this->parser,
-            $this->index,
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver(),

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -643,7 +643,7 @@ PHP;
         self::assertSame(2, $result['range']['start']['line']);
     }
 
-    public function testGoToStaticMethodDefinition2(): void
+    public function testGoToStaticKeywordMethodDefinition(): void
     {
         $code = <<<'PHP'
 <?php

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -6,10 +6,14 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
-use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Repository\ClassLocator;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -17,22 +21,42 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DefinitionHandler::class)]
 class DefinitionHandlerTest extends TestCase
 {
+    use OpensDocumentsTrait;
+
     private DocumentManager $documents;
     private SymbolIndex $index;
     private ParserService $parser;
+    private DefaultClassRepository $classRepository;
+    private MemberResolver $memberResolver;
     private DefinitionHandler $handler;
+    private TextDocumentSyncHandler $syncHandler;
 
     protected function setUp(): void
     {
         $this->documents = new DocumentManager();
         $this->index = new SymbolIndex();
         $this->parser = new ParserService();
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $this->classRepository = new DefaultClassRepository(
+            $classInfoFactory,
+            $locator,
+            $this->parser,
+        );
+        $this->memberResolver = new MemberResolver($this->classRepository);
         $this->handler = new DefinitionHandler(
             $this->documents,
             $this->parser,
             $this->index,
-            classLocator: null,
-            typeResolver: new BasicTypeResolver(),
+            $this->memberResolver,
+            $this->classRepository,
+            new BasicTypeResolver(),
+        );
+        $this->syncHandler = new TextDocumentSyncHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $classInfoFactory,
         );
     }
 
@@ -44,21 +68,8 @@ class DefinitionHandlerTest extends TestCase
 
     public function testGoToClassDefinition(): void
     {
-        // Set up a class definition
-        $classCode = '<?php class MyClass {}';
-        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
-        $classDoc = $this->documents->get('file:///MyClass.php');
-        self::assertNotNull($classDoc);
-        $ast = $this->parser->parse($classDoc);
-        self::assertNotNull($ast);
-        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
-        foreach ($symbols as $symbol) {
-            $this->index->add($symbol);
-        }
-
-        // Set up usage
-        $usageCode = '<?php new MyClass();';
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///MyClass.php', '<?php class MyClass {}');
+        $this->openDocument('file:///usage.php', '<?php new MyClass();');
 
         // Request definition at "MyClass" in usage (position after "new ")
         $request = RequestMessage::fromArray([
@@ -80,8 +91,7 @@ class DefinitionHandlerTest extends TestCase
 
     public function testReturnsNullForUnknownSymbol(): void
     {
-        $code = '<?php new UnknownClass();';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', '<?php new UnknownClass();');
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -117,26 +127,14 @@ class DefinitionHandlerTest extends TestCase
 
     public function testGoToStaticMethodDefinition(): void
     {
-        // Class with a static method
         $classCode = <<<'PHP'
 <?php
 class MyClass {
     public static function myStaticMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
-        $classDoc = $this->documents->get('file:///MyClass.php');
-        self::assertNotNull($classDoc);
-        $ast = $this->parser->parse($classDoc);
-        self::assertNotNull($ast);
-        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
-        foreach ($symbols as $symbol) {
-            $this->index->add($symbol);
-        }
-
-        // Usage: MyClass::myStaticMethod()
-        $usageCode = '<?php MyClass::myStaticMethod();';
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///MyClass.php', $classCode);
+        $this->openDocument('file:///usage.php', '<?php MyClass::myStaticMethod();');
 
         // Request definition at "myStaticMethod" (character 15 is on the method name)
         $request = RequestMessage::fromArray([
@@ -159,31 +157,21 @@ PHP;
 
     public function testGoToInstanceMethodDefinition(): void
     {
-        // Class with an instance method
         $classCode = <<<'PHP'
 <?php
 class MyClass {
     public function myMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
-        $classDoc = $this->documents->get('file:///MyClass.php');
-        self::assertNotNull($classDoc);
-        $ast = $this->parser->parse($classDoc);
-        self::assertNotNull($ast);
-        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
-        foreach ($symbols as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///MyClass.php', $classCode);
 
-        // Usage: $obj->myMethod() where $obj is typed
         $usageCode = <<<'PHP'
 <?php
 function test(MyClass $obj): void {
     $obj->myMethod();
 }
 PHP;
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///usage.php', $usageCode);
 
         // Request definition at "myMethod" on line 2 (0-indexed)
         // "$obj->myMethod()" - "myMethod" starts at character 10
@@ -206,24 +194,14 @@ PHP;
 
     public function testGoToMethodDefinitionViaAssignment(): void
     {
-        // Class with an instance method
         $classCode = <<<'PHP'
 <?php
 class MyClass {
     public function myMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
-        $classDoc = $this->documents->get('file:///MyClass.php');
-        self::assertNotNull($classDoc);
-        $ast = $this->parser->parse($classDoc);
-        self::assertNotNull($ast);
-        $symbols = (new SymbolExtractor())->extract($classDoc, $ast);
-        foreach ($symbols as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///MyClass.php', $classCode);
 
-        // Usage: $obj = new MyClass(); $obj->myMethod();
         $usageCode = <<<'PHP'
 <?php
 function test(): void {
@@ -231,7 +209,7 @@ function test(): void {
     $obj->myMethod();
 }
 PHP;
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///usage.php', $usageCode);
 
         // Request definition at "myMethod" on line 3 (0-indexed)
         $request = RequestMessage::fromArray([
@@ -259,7 +237,7 @@ function test($obj): void {
     $obj->unknownMethod();
 }
 PHP;
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///usage.php', $usageCode);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -278,45 +256,28 @@ PHP;
 
     public function testGoToInheritedMethodDefinition(): void
     {
-        // Parent class with method
         $parentCode = <<<'PHP'
 <?php
 class ParentClass {
     public function inheritedMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
-        $parentDoc = $this->documents->get('file:///ParentClass.php');
-        self::assertNotNull($parentDoc);
-        $parentAst = $this->parser->parse($parentDoc);
-        self::assertNotNull($parentAst);
-        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ParentClass.php', $parentCode);
 
-        // Child class that extends parent
         $childCode = <<<'PHP'
 <?php
 class ChildClass extends ParentClass {
 }
 PHP;
-        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
-        $childDoc = $this->documents->get('file:///ChildClass.php');
-        self::assertNotNull($childDoc);
-        $childAst = $this->parser->parse($childDoc);
-        self::assertNotNull($childAst);
-        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ChildClass.php', $childCode);
 
-        // Usage: $child->inheritedMethod()
         $usageCode = <<<'PHP'
 <?php
 function test(ChildClass $child): void {
     $child->inheritedMethod();
 }
 PHP;
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///usage.php', $usageCode);
 
         // Request definition at "inheritedMethod"
         $request = RequestMessage::fromArray([
@@ -339,46 +300,29 @@ PHP;
 
     public function testGoToOverriddenMethodDefinition(): void
     {
-        // Parent class with method
         $parentCode = <<<'PHP'
 <?php
 class ParentClass {
     public function overriddenMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
-        $parentDoc = $this->documents->get('file:///ParentClass.php');
-        self::assertNotNull($parentDoc);
-        $parentAst = $this->parser->parse($parentDoc);
-        self::assertNotNull($parentAst);
-        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ParentClass.php', $parentCode);
 
-        // Child class that overrides the method
         $childCode = <<<'PHP'
 <?php
 class ChildClass extends ParentClass {
     public function overriddenMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
-        $childDoc = $this->documents->get('file:///ChildClass.php');
-        self::assertNotNull($childDoc);
-        $childAst = $this->parser->parse($childDoc);
-        self::assertNotNull($childAst);
-        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ChildClass.php', $childCode);
 
-        // Usage: $child->overriddenMethod()
         $usageCode = <<<'PHP'
 <?php
 function test(ChildClass $child): void {
     $child->overriddenMethod();
 }
 PHP;
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///usage.php', $usageCode);
 
         // Request definition at "overriddenMethod"
         $request = RequestMessage::fromArray([
@@ -401,23 +345,14 @@ PHP;
 
     public function testGoToParentMethodDefinition(): void
     {
-        // Parent class with method
         $parentCode = <<<'PHP'
 <?php
 class ParentClass {
     public function doFoo(): void {}
 }
 PHP;
-        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
-        $parentDoc = $this->documents->get('file:///ParentClass.php');
-        self::assertNotNull($parentDoc);
-        $parentAst = $this->parser->parse($parentDoc);
-        self::assertNotNull($parentAst);
-        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ParentClass.php', $parentCode);
 
-        // Child class that calls parent::doFoo()
         $childCode = <<<'PHP'
 <?php
 class ChildClass extends ParentClass {
@@ -426,14 +361,7 @@ class ChildClass extends ParentClass {
     }
 }
 PHP;
-        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
-        $childDoc = $this->documents->get('file:///ChildClass.php');
-        self::assertNotNull($childDoc);
-        $childAst = $this->parser->parse($childDoc);
-        self::assertNotNull($childAst);
-        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ChildClass.php', $childCode);
 
         // Request definition at "doFoo" in parent::doFoo() on line 3
         // "        parent::doFoo();" - doFoo starts at character 16
@@ -457,46 +385,29 @@ PHP;
 
     public function testGoToTraitMethodDefinition(): void
     {
-        // Trait with method
         $traitCode = <<<'PHP'
 <?php
 trait MyTrait {
     public function traitMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///MyTrait.php', 'php', 1, $traitCode);
-        $traitDoc = $this->documents->get('file:///MyTrait.php');
-        self::assertNotNull($traitDoc);
-        $traitAst = $this->parser->parse($traitDoc);
-        self::assertNotNull($traitAst);
-        foreach ((new SymbolExtractor())->extract($traitDoc, $traitAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///MyTrait.php', $traitCode);
 
-        // Class that uses the trait
         $classCode = <<<'PHP'
 <?php
 class MyClass {
     use MyTrait;
 }
 PHP;
-        $this->documents->open('file:///MyClass.php', 'php', 1, $classCode);
-        $classDoc = $this->documents->get('file:///MyClass.php');
-        self::assertNotNull($classDoc);
-        $classAst = $this->parser->parse($classDoc);
-        self::assertNotNull($classAst);
-        foreach ((new SymbolExtractor())->extract($classDoc, $classAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///MyClass.php', $classCode);
 
-        // Usage: $obj->traitMethod()
         $usageCode = <<<'PHP'
 <?php
 function test(MyClass $obj): void {
     $obj->traitMethod();
 }
 PHP;
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///usage.php', $usageCode);
 
         // Request definition at "traitMethod"
         $request = RequestMessage::fromArray([
@@ -519,62 +430,37 @@ PHP;
 
     public function testTraitMethodTakesPrecedenceOverParent(): void
     {
-        // Parent class with method
         $parentCode = <<<'PHP'
 <?php
 class ParentClass {
     public function sharedMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///ParentClass.php', 'php', 1, $parentCode);
-        $parentDoc = $this->documents->get('file:///ParentClass.php');
-        self::assertNotNull($parentDoc);
-        $parentAst = $this->parser->parse($parentDoc);
-        self::assertNotNull($parentAst);
-        foreach ((new SymbolExtractor())->extract($parentDoc, $parentAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ParentClass.php', $parentCode);
 
-        // Trait with same method
         $traitCode = <<<'PHP'
 <?php
 trait MyTrait {
     public function sharedMethod(): void {}
 }
 PHP;
-        $this->documents->open('file:///MyTrait.php', 'php', 1, $traitCode);
-        $traitDoc = $this->documents->get('file:///MyTrait.php');
-        self::assertNotNull($traitDoc);
-        $traitAst = $this->parser->parse($traitDoc);
-        self::assertNotNull($traitAst);
-        foreach ((new SymbolExtractor())->extract($traitDoc, $traitAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///MyTrait.php', $traitCode);
 
-        // Child class extends ParentClass and uses MyTrait
         $childCode = <<<'PHP'
 <?php
 class ChildClass extends ParentClass {
     use MyTrait;
 }
 PHP;
-        $this->documents->open('file:///ChildClass.php', 'php', 1, $childCode);
-        $childDoc = $this->documents->get('file:///ChildClass.php');
-        self::assertNotNull($childDoc);
-        $childAst = $this->parser->parse($childDoc);
-        self::assertNotNull($childAst);
-        foreach ((new SymbolExtractor())->extract($childDoc, $childAst) as $symbol) {
-            $this->index->add($symbol);
-        }
+        $this->openDocument('file:///ChildClass.php', $childCode);
 
-        // Usage: $obj->sharedMethod()
         $usageCode = <<<'PHP'
 <?php
 function test(ChildClass $obj): void {
     $obj->sharedMethod();
 }
 PHP;
-        $this->documents->open('file:///usage.php', 'php', 1, $usageCode);
+        $this->openDocument('file:///usage.php', $usageCode);
 
         // Request definition at "sharedMethod"
         $request = RequestMessage::fromArray([

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -476,4 +476,346 @@ PHP;
         self::assertSame('file:///MyTrait.php', $result['uri']);
         self::assertSame(2, $result['range']['start']['line']);
     }
+
+    public function testReturnsNullForInvalidTextDocumentParam(): void
+    {
+        $this->openDocument('file:///test.php', '<?php class Foo {}');
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => 'not-an-array',
+                'position' => ['line' => 0, 'character' => 10],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForInvalidUriParam(): void
+    {
+        $this->openDocument('file:///test.php', '<?php class Foo {}');
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 123],
+                'position' => ['line' => 0, 'character' => 10],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForInvalidPositionParam(): void
+    {
+        $this->openDocument('file:///test.php', '<?php class Foo {}');
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => 'not-an-array',
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForInvalidLineCharacterParams(): void
+    {
+        $this->openDocument('file:///test.php', '<?php class Foo {}');
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 'not-int', 'character' => 0],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForPositionOutsideCode(): void
+    {
+        $this->openDocument('file:///test.php', '<?php class Foo {}');
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 0],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForDynamicStaticMethodName(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public static function test(): void {
+        $method = 'foo';
+        self::$method();
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        // Position on $method in self::$method()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 4, 'character' => 15],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForDynamicClassName(): void
+    {
+        $code = <<<'PHP'
+<?php
+$class = 'MyClass';
+$class::method();
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        // Position on ::method
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 2, 'character' => 10],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testGoToSelfMethodDefinition(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public static function foo(): void {}
+    public static function bar(): void {
+        self::foo();
+    }
+}
+PHP;
+        $this->openDocument('file:///MyClass.php', $code);
+
+        // Position on foo in self::foo()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///MyClass.php'],
+                'position' => ['line' => 4, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testGoToStaticMethodDefinition2(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public static function foo(): void {}
+    public function bar(): void {
+        static::foo();
+    }
+}
+PHP;
+        $this->openDocument('file:///MyClass.php', $code);
+
+        // Position on foo in static::foo()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///MyClass.php'],
+                'position' => ['line' => 4, 'character' => 17],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testReturnsNullForUnknownMethod(): void
+    {
+        $classCode = <<<'PHP'
+<?php
+class MyClass {
+    public function existingMethod(): void {}
+}
+PHP;
+        $this->openDocument('file:///MyClass.php', $classCode);
+
+        $usageCode = <<<'PHP'
+<?php
+function test(MyClass $obj): void {
+    $obj->nonExistentMethod();
+}
+PHP;
+        $this->openDocument('file:///usage.php', $usageCode);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 12],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForDynamicInstanceMethodName(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {}
+function test(MyClass $obj): void {
+    $method = 'foo';
+    $obj->$method();
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        // Position on $method in $obj->$method()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 4, 'character' => 11],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForParentWithoutExtends(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    public function test(): void {
+        parent::foo();
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        // Position on foo in parent::foo()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 17],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForSelfOutsideClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+self::foo();
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        // Position on foo in self::foo()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 1, 'character' => 7],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForBuiltInClassMethod(): void
+    {
+        // Built-in classes from reflection have no file location
+        $code = '<?php DateTime::createFromFormat("Y", "2024");';
+        $this->openDocument('file:///test.php', $code);
+
+        // Position on createFromFormat
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 18],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
+
+    public function testReturnsNullForBuiltInClass(): void
+    {
+        // Built-in classes from reflection have no file location
+        $code = '<?php new DateTime();';
+        $this->openDocument('file:///test.php', $code);
+
+        // Position on DateTime
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 12],
+            ],
+        ]);
+
+        self::assertNull($this->handler->handle($request));
+    }
 }

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -818,4 +818,66 @@ PHP;
 
         self::assertNull($this->handler->handle($request));
     }
+
+    public function testGoToPrivateMethodDefinition(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    private function privateMethod(): void {}
+    public function publicMethod(): void {
+        $this->privateMethod();
+    }
+}
+PHP;
+        $this->openDocument('file:///MyClass.php', $code);
+
+        // Position on privateMethod in $this->privateMethod()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///MyClass.php'],
+                'position' => ['line' => 4, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testGoToProtectedMethodDefinition(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass {
+    protected function protectedMethod(): void {}
+    public function publicMethod(): void {
+        $this->protectedMethod();
+    }
+}
+PHP;
+        $this->openDocument('file:///MyClass.php', $code);
+
+        // Position on protectedMethod in $this->protectedMethod()
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///MyClass.php'],
+                'position' => ['line' => 4, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
 }


### PR DESCRIPTION
## Summary

- Migrate `DefinitionHandler` to use `MemberResolver` and `ClassRepository`
- Remove direct `ClassFinder` and `ComposerClassLocator` usage
- Remove `SymbolIndex` dependency (class resolution now via `ClassRepository`)
- Remove `array $ast` parameters from internal methods
- Extract `createLocationFromFileLine` helper to deduplicate location creation
- Add `LogicException` guards for unreachable code paths
- Add comprehensive edge case tests for 100% coverage

Closes #124

## Test plan

- [x] All existing tests pass
- [x] Go-to-definition works for classes, methods, properties
- [x] Inheritance and trait method resolution works
- [x] `parent::`, `self::`, `static::` resolution works
- [x] PHPStan clean
- [x] 100% code coverage

🤖 Generated with [Claude Code](https://claude.ai/claude-code)