### PR TITLE
Arch Phase 4d: Migrate SignatureHelpHandler

### DIFF
--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -17,4 +17,20 @@ final readonly class ParameterInfo
         public bool $isPassedByReference,
     ) {
     }
+
+    public function format(bool $showDefault = false): string
+    {
+        $str = '';
+        if ($this->type !== null) {
+            $str .= $this->type . ' ';
+        }
+        if ($this->isVariadic) {
+            $str .= '...';
+        }
+        $str .= '$' . $this->name;
+        if ($showDefault && $this->hasDefault && !$this->isVariadic) {
+            $str .= ' = ...';
+        }
+        return $str;
+    }
 }

--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -24,6 +24,9 @@ final readonly class ParameterInfo
         if ($this->type !== null) {
             $str .= $this->type . ' ';
         }
+        if ($this->isPassedByReference) {
+            $str .= '&';
+        }
         if ($this->isVariadic) {
             $str .= '...';
         }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -529,12 +529,7 @@ final class CompletionHandler implements HandlerInterface
     {
         $params = [];
         foreach ($method->parameters as $param) {
-            $paramStr = '';
-            if ($param->type !== null) {
-                $paramStr .= $param->type . ' ';
-            }
-            $paramStr .= '$' . $param->name;
-            $params[] = $paramStr;
+            $params[] = $param->format();
         }
 
         $detail = $method->name->name . '(' . implode(', ', $params) . ')';

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -404,18 +404,7 @@ final class HoverHandler implements HandlerInterface
 
         $params = [];
         foreach ($method->parameters as $param) {
-            $paramStr = '';
-            if ($param->type !== null) {
-                $paramStr .= $param->type . ' ';
-            }
-            if ($param->isVariadic) {
-                $paramStr .= '...';
-            }
-            $paramStr .= '$' . $param->name;
-            if ($param->hasDefault && !$param->isVariadic) {
-                $paramStr .= ' = ...';
-            }
-            $params[] = $paramStr;
+            $params[] = $param->format(showDefault: true);
         }
 
         $signature = $visibility . $static . 'function ' . $method->name->name

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -387,14 +387,7 @@ final class SignatureHelpHandler implements HandlerInterface
         $paramLabels = [];
 
         foreach ($method->parameters as $param) {
-            $paramStr = '';
-            if ($param->type !== null) {
-                $paramStr .= $param->type . ' ';
-            }
-            if ($param->isVariadic) {
-                $paramStr .= '...';
-            }
-            $paramStr .= '$' . $param->name;
+            $paramStr = $param->format();
             $paramLabels[] = $paramStr;
             $params[] = ['label' => $paramStr];
         }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\MemberFinder;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
-use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
@@ -46,7 +47,7 @@ final class SignatureHelpHandler implements HandlerInterface
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
-        private readonly ?ComposerClassLocator $classLocator,
+        private readonly MemberResolver $memberResolver,
         private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
@@ -102,7 +103,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
         [$callNode, $activeParameter] = $callInfo;
 
-        $signature = $this->getSignature($callNode, $ast, $document);
+        $signature = $this->getSignature($callNode, $ast);
         if ($signature === null) {
             return null;
         }
@@ -181,22 +182,22 @@ final class SignatureHelpHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return SignatureInfo|null
      */
-    private function getSignature(Node $call, array $ast, TextDocument $document): ?array
+    private function getSignature(Node $call, array $ast): ?array
     {
         if ($call instanceof FuncCall) {
             return $this->getFunctionSignature($call, $ast);
         }
 
         if ($call instanceof MethodCall) {
-            return $this->getMethodSignature($call, $ast, $document);
+            return $this->getMethodSignature($call, $ast);
         }
 
         if ($call instanceof StaticCall) {
-            return $this->getStaticMethodSignature($call, $ast, $document);
+            return $this->getStaticMethodSignature($call);
         }
 
         // Must be New_ at this point based on the type hint
-        return $this->getConstructorSignature($call, $ast, $document);
+        return $this->getConstructorSignature($call);
     }
 
     /**
@@ -231,7 +232,7 @@ final class SignatureHelpHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return SignatureInfo|null
      */
-    private function getMethodSignature(MethodCall $call, array $ast, TextDocument $document): ?array
+    private function getMethodSignature(MethodCall $call, array $ast): ?array
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
@@ -243,14 +244,13 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        return $this->getMethodSignatureForClass($className, $methodName->toString(), $ast, $document);
+        return $this->getMethodSignatureForClass($className, $methodName->toString());
     }
 
     /**
-     * @param array<Stmt> $ast
      * @return SignatureInfo|null
      */
-    private function getStaticMethodSignature(StaticCall $call, array $ast, TextDocument $document): ?array
+    private function getStaticMethodSignature(StaticCall $call): ?array
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
@@ -273,14 +273,13 @@ final class SignatureHelpHandler implements HandlerInterface
             $className = $enclosingClass;
         }
 
-        return $this->getMethodSignatureForClass($className, $methodName->toString(), $ast, $document);
+        return $this->getMethodSignatureForClass($className, $methodName->toString());
     }
 
     /**
-     * @param array<Stmt> $ast
      * @return SignatureInfo|null
      */
-    private function getConstructorSignature(New_ $call, array $ast, TextDocument $document): ?array
+    private function getConstructorSignature(New_ $call): ?array
     {
         $class = $call->class;
         if (!$class instanceof Name) {
@@ -289,30 +288,26 @@ final class SignatureHelpHandler implements HandlerInterface
 
         $className = ScopeFinder::resolveName($class);
 
-        return $this->getMethodSignatureForClass($className, '__construct', $ast, $document);
+        return $this->getMethodSignatureForClass($className, '__construct');
     }
 
     /**
-     * @param array<Stmt> $ast
      * @return SignatureInfo|null
      */
     private function getMethodSignatureForClass(
-        string $className,
-        string $methodName,
-        array $ast,
-        TextDocument $document,
+        string $classNameStr,
+        string $methodNameStr,
     ): ?array {
-        $methodNode = MemberFinder::findMethod($className, $methodName, $ast, $this->classLocator, $this->parser);
-        if ($methodNode !== null) {
-            return $this->formatMethodNodeSignature($methodNode);
+        /** @var class-string $classNameStr */
+        $className = new ClassName($classNameStr);
+        $methodName = new MethodName($methodNameStr);
+
+        $methodInfo = $this->memberResolver->findMethod($className, $methodName, Visibility::Private);
+        if ($methodInfo !== null) {
+            return $this->formatMethodInfoSignature($methodInfo);
         }
 
-        $classReflection = ReflectionHelper::getClass($className);
-        if ($classReflection === null || !$classReflection->hasMethod($methodName)) {
-            return null;
-        }
-        $reflection = $classReflection->getMethod($methodName);
-        return $this->formatReflectionSignature($reflection);
+        return null;
     }
 
     /**
@@ -386,27 +381,27 @@ final class SignatureHelpHandler implements HandlerInterface
     /**
      * @return SignatureInfo
      */
-    private function formatMethodNodeSignature(Stmt\ClassMethod $method): array
+    private function formatMethodInfoSignature(MethodInfo $method): array
     {
         $params = [];
         $paramLabels = [];
 
-        foreach ($method->params as $param) {
+        foreach ($method->parameters as $param) {
             $paramStr = '';
             if ($param->type !== null) {
-                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
+                $paramStr .= $param->type . ' ';
             }
-            $var = $param->var;
-            if ($var instanceof Variable && is_string($var->name)) {
-                $paramStr .= '$' . $var->name;
+            if ($param->isVariadic) {
+                $paramStr .= '...';
             }
+            $paramStr .= '$' . $param->name;
             $paramLabels[] = $paramStr;
             $params[] = ['label' => $paramStr];
         }
 
-        $label = $method->name->toString() . '(' . implode(', ', $paramLabels) . ')';
+        $label = $method->name->name . '(' . implode(', ', $paramLabels) . ')';
         if ($method->returnType !== null) {
-            $label .= ': ' . TypeFormatter::formatNode($method->returnType);
+            $label .= ': ' . $method->returnType;
         }
 
         $result = [
@@ -414,9 +409,8 @@ final class SignatureHelpHandler implements HandlerInterface
             'parameters' => $params,
         ];
 
-        $docComment = $method->getDocComment();
-        if ($docComment !== null) {
-            $result['documentation'] = DocblockParser::extractDescription($docComment->getText());
+        if ($method->docblock !== null) {
+            $result['documentation'] = DocblockParser::extractDescription($method->docblock);
         }
 
         return $result;

--- a/src/Server.php
+++ b/src/Server.php
@@ -83,7 +83,12 @@ final class Server
             $memberResolver,
             $typeResolver,
         );
-        $this->handlers[] = new SignatureHelpHandler($this->documentManager, $parser, $classLocator, $typeResolver);
+        $this->handlers[] = new SignatureHelpHandler(
+            $this->documentManager,
+            $parser,
+            $memberResolver,
+            $typeResolver,
+        );
         $this->handlers[] = new CompletionHandler(
             $this->documentManager,
             $parser,

--- a/tests/Domain/ParameterInfoTest.php
+++ b/tests/Domain/ParameterInfoTest.php
@@ -118,4 +118,30 @@ class ParameterInfoTest extends TestCase
 
         self::assertSame('string ...$args', $param->format(showDefault: true));
     }
+
+    public function testFormatPassedByReference(): void
+    {
+        $param = new ParameterInfo(
+            name: 'value',
+            type: 'string',
+            hasDefault: false,
+            isVariadic: false,
+            isPassedByReference: true,
+        );
+
+        self::assertSame('string &$value', $param->format());
+    }
+
+    public function testFormatVariadicByReference(): void
+    {
+        $param = new ParameterInfo(
+            name: 'args',
+            type: 'array',
+            hasDefault: false,
+            isVariadic: true,
+            isPassedByReference: true,
+        );
+
+        self::assertSame('array &...$args', $param->format());
+    }
 }

--- a/tests/Domain/ParameterInfoTest.php
+++ b/tests/Domain/ParameterInfoTest.php
@@ -40,4 +40,82 @@ class ParameterInfoTest extends TestCase
         self::assertNull($param->type);
         self::assertTrue($param->isVariadic);
     }
+
+    public function testFormatSimple(): void
+    {
+        $param = new ParameterInfo(
+            name: 'value',
+            type: 'string',
+            hasDefault: false,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('string $value', $param->format());
+    }
+
+    public function testFormatNoType(): void
+    {
+        $param = new ParameterInfo(
+            name: 'value',
+            type: null,
+            hasDefault: false,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('$value', $param->format());
+    }
+
+    public function testFormatVariadic(): void
+    {
+        $param = new ParameterInfo(
+            name: 'args',
+            type: 'string',
+            hasDefault: false,
+            isVariadic: true,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('string ...$args', $param->format());
+    }
+
+    public function testFormatWithDefaultHidden(): void
+    {
+        $param = new ParameterInfo(
+            name: 'value',
+            type: 'int',
+            hasDefault: true,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('int $value', $param->format());
+    }
+
+    public function testFormatWithDefaultShown(): void
+    {
+        $param = new ParameterInfo(
+            name: 'value',
+            type: 'int',
+            hasDefault: true,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('int $value = ...', $param->format(showDefault: true));
+    }
+
+    public function testFormatVariadicIgnoresDefault(): void
+    {
+        $param = new ParameterInfo(
+            name: 'args',
+            type: 'string',
+            hasDefault: true,
+            isVariadic: true,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('string ...$args', $param->format(showDefault: true));
+    }
 }

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -13,6 +13,7 @@ use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -45,6 +46,7 @@ class SignatureHelpHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->memberResolver,
+            new BasicTypeResolver(),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -6,24 +6,52 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
-use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Repository\ClassLocator;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(SignatureHelpHandler::class)]
 class SignatureHelpHandlerTest extends TestCase
 {
+    use OpensDocumentsTrait;
+
     private DocumentManager $documents;
     private ParserService $parser;
+    private DefaultClassRepository $classRepository;
+    private DefaultClassInfoFactory $classInfoFactory;
+    private MemberResolver $memberResolver;
     private SignatureHelpHandler $handler;
+    private TextDocumentSyncHandler $syncHandler;
 
     protected function setUp(): void
     {
         $this->documents = new DocumentManager();
         $this->parser = new ParserService();
-        $this->handler = new SignatureHelpHandler($this->documents, $this->parser, null);
+        $this->classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $this->classRepository = new DefaultClassRepository(
+            $this->classInfoFactory,
+            $locator,
+            $this->parser,
+        );
+        $this->memberResolver = new MemberResolver($this->classRepository);
+        $this->handler = new SignatureHelpHandler(
+            $this->documents,
+            $this->parser,
+            $this->memberResolver,
+        );
+        $this->syncHandler = new TextDocumentSyncHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $this->classInfoFactory,
+        );
     }
 
     public function testSupports(): void
@@ -46,7 +74,7 @@ function add(int $a, int $b): int
 
 $sum = add(1, 2);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -79,7 +107,7 @@ function greet(string $name, int $age): string
 
 greet("Alice", 30);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -104,7 +132,7 @@ PHP;
 $arr = [3, 1, 2];
 array_map(fn($x) => $x * 2, $arr);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -142,7 +170,7 @@ class Calculator
     }
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -175,7 +203,7 @@ class Math
 
 $result = Math::abs(-5);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -207,7 +235,7 @@ class User
 
 $user = new User("Alice", 30);
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -229,7 +257,7 @@ PHP;
     public function testSignatureHelpReturnsNullOutsideCall(): void
     {
         $code = '<?php $x = 1;';
-        $this->documents->open('file:///test.php', 'php', 1, $code);
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -266,15 +294,7 @@ function useCalculator(Calculator $calc): void
     $calc->multiply(2, 3);
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
-
-        // Create handler with type resolver
-        $handlerWithResolver = new SignatureHelpHandler(
-            $this->documents,
-            $this->parser,
-            null,
-            new BasicTypeResolver(),
-        );
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -286,7 +306,7 @@ PHP;
             ],
         ]);
 
-        $result = $handlerWithResolver->handle($request);
+        $result = $this->handler->handle($request);
 
         self::assertIsArray($result);
         self::assertStringContainsString('multiply', $result['signatures'][0]['label']);
@@ -314,14 +334,7 @@ function test(): void
     $greeter->greet("World");
 }
 PHP;
-        $this->documents->open('file:///test.php', 'php', 1, $code);
-
-        $handlerWithResolver = new SignatureHelpHandler(
-            $this->documents,
-            $this->parser,
-            null,
-            new BasicTypeResolver(),
-        );
+        $this->openDocument('file:///test.php', $code);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -333,7 +346,7 @@ PHP;
             ],
         ]);
 
-        $result = $handlerWithResolver->handle($request);
+        $result = $this->handler->handle($request);
 
         self::assertIsArray($result);
         self::assertStringContainsString('greet', $result['signatures'][0]['label']);


### PR DESCRIPTION
## Summary

- Migrate `SignatureHelpHandler` to use `MemberResolver` for method lookups
- Add `ParameterInfo::format()` method to eliminate duplicate parameter formatting logic
- Apply `ParameterInfo::format()` to `HoverHandler` and `CompletionHandler` as well

Closes #125

## Test plan

- [x] All existing SignatureHelpHandler tests pass
- [x] PHPStan clean
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.ai/code)