### PR TITLE
Formattable interface + MethodInfo::format()

### DIFF
--- a/src/Domain/Formattable.php
+++ b/src/Domain/Formattable.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+interface Formattable
+{
+    public function format(): string;
+}

--- a/src/Domain/MethodInfo.php
+++ b/src/Domain/MethodInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a class method.
  */
-final readonly class MethodInfo
+final readonly class MethodInfo implements Formattable
 {
     /**
      * @param list<ParameterInfo> $parameters
@@ -25,5 +25,15 @@ final readonly class MethodInfo
         public ?int $line,
         public ClassName $declaringClass,
     ) {
+    }
+
+    public function format(): string
+    {
+        $params = array_map(fn($p) => $p->format(), $this->parameters);
+        $sig = $this->name->name . '(' . implode(', ', $params) . ')';
+        if ($this->returnType !== null) {
+            $sig .= ': ' . $this->returnType;
+        }
+        return $sig;
     }
 }

--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a method or function parameter.
  */
-final readonly class ParameterInfo
+final readonly class ParameterInfo implements Formattable
 {
     public function __construct(
         public string $name,

--- a/tests/Domain/MethodInfoTest.php
+++ b/tests/Domain/MethodInfoTest.php
@@ -38,4 +38,128 @@ class MethodInfoTest extends TestCase
         self::assertSame(42, $method->line);
         self::assertSame(MethodInfo::class, $method->declaringClass->fqn);
     }
+
+    public function testFormatNoParamsNoReturnType(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('doSomething'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [],
+            returnType: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('doSomething()', $method->format());
+    }
+
+    public function testFormatWithReturnType(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('getName'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [],
+            returnType: 'string',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('getName(): string', $method->format());
+    }
+
+    public function testFormatWithParameters(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('setName'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [
+                new ParameterInfo('name', 'string', false, false, false),
+            ],
+            returnType: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('setName(string $name)', $method->format());
+    }
+
+    public function testFormatWithMultipleParametersAndReturnType(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('calculate'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [
+                new ParameterInfo('a', 'int', false, false, false),
+                new ParameterInfo('b', 'int', false, false, false),
+            ],
+            returnType: 'int',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('calculate(int $a, int $b): int', $method->format());
+    }
+
+    public function testFormatWithVariadicParameter(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('merge'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [
+                new ParameterInfo('arrays', 'array', false, true, false),
+            ],
+            returnType: 'array',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('merge(array ...$arrays): array', $method->format());
+    }
+
+    public function testFormatWithReferenceParameter(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('swap'),
+            visibility: Visibility::Public,
+            isStatic: true,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [
+                new ParameterInfo('a', 'mixed', false, false, true),
+                new ParameterInfo('b', 'mixed', false, false, true),
+            ],
+            returnType: 'void',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('swap(mixed &$a, mixed &$b): void', $method->format());
+    }
 }


### PR DESCRIPTION
## Summary

- Create Formattable interface with format(): string method
- ParameterInfo implements Formattable (format() already existed from #138)
- MethodInfo implements Formattable with new format() method that composes ParameterInfo::format() calls

Closes #140

## Test plan

- [x] Unit tests for MethodInfo::format() covering: no params, with return type, with params, variadic, reference params
- [x] PHPStan clean
- [x] Full test suite passes

Generated with Claude Code