### PR TITLE
Visibility implements Formattable

### DIFF
--- a/src/Domain/Visibility.php
+++ b/src/Domain/Visibility.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Member visibility level.
  */
-enum Visibility: int
+enum Visibility: int implements Formattable
 {
     case Private = 0;
     case Protected = 1;
@@ -18,7 +18,7 @@ enum Visibility: int
         return $this->value >= $minimumRequired->value;
     }
 
-    public function toKeyword(): string
+    public function format(): string
     {
         return match ($this) {
             self::Private => 'private',

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -399,7 +399,7 @@ final class HoverHandler implements HandlerInterface
             $parts[] = DocblockParser::extractDescription($method->docblock);
         }
 
-        $visibility = $method->visibility->toKeyword() . ' ';
+        $visibility = $method->visibility->format() . ' ';
         $static = $method->isStatic ? 'static ' : '';
 
         $params = [];
@@ -427,7 +427,7 @@ final class HoverHandler implements HandlerInterface
             $parts[] = DocblockParser::extractDescription($property->docblock);
         }
 
-        $visibility = $property->visibility->toKeyword() . ' ';
+        $visibility = $property->visibility->format() . ' ';
         $static = $property->isStatic ? 'static ' : '';
         $readonly = $property->isReadonly ? 'readonly ' : '';
 

--- a/tests/Domain/VisibilityTest.php
+++ b/tests/Domain/VisibilityTest.php
@@ -42,7 +42,7 @@ class VisibilityTest extends TestCase
      * @return array<string, array{Visibility, string}>
      * @codeCoverageIgnore
      */
-    public static function keywordProvider(): array
+    public static function formatProvider(): array
     {
         return [
             'private' => [Visibility::Private, 'private'],
@@ -51,9 +51,9 @@ class VisibilityTest extends TestCase
         ];
     }
 
-    #[DataProvider('keywordProvider')]
-    public function testToKeyword(Visibility $visibility, string $expected): void
+    #[DataProvider('formatProvider')]
+    public function testFormat(Visibility $visibility, string $expected): void
     {
-        self::assertSame($expected, $visibility->toKeyword());
+        self::assertSame($expected, $visibility->format());
     }
 }


### PR DESCRIPTION
## Summary

- Visibility implements Formattable
- Rename toKeyword() to format() for consistency
- Update all call sites

Closes #150

## Test plan

- [x] PHPStan clean
- [x] Full test suite passes

Generated with Claude Code