### PR TITLE
PropertyInfo implements Formattable

### DIFF
--- a/src/Domain/PropertyInfo.php
+++ b/src/Domain/PropertyInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a class property.
  */
-final readonly class PropertyInfo
+final readonly class PropertyInfo implements Formattable
 {
     public function __construct(
         public PropertyName $name,
@@ -21,5 +21,21 @@ final readonly class PropertyInfo
         public ?int $line,
         public ClassName $declaringClass,
     ) {
+    }
+
+    public function format(): string
+    {
+        $parts = [$this->visibility->format()];
+        if ($this->isStatic) {
+            $parts[] = 'static';
+        }
+        if ($this->isReadonly) {
+            $parts[] = 'readonly';
+        }
+        if ($this->type !== null) {
+            $parts[] = $this->type;
+        }
+        $parts[] = '$' . $this->name->name;
+        return implode(' ', $parts);
     }
 }

--- a/tests/Domain/PropertyInfoTest.php
+++ b/tests/Domain/PropertyInfoTest.php
@@ -36,4 +36,94 @@ class PropertyInfoTest extends TestCase
         self::assertSame(10, $property->line);
         self::assertSame(PropertyInfo::class, $property->declaringClass->fqn);
     }
+
+    public function testFormatSimple(): void
+    {
+        $property = new PropertyInfo(
+            name: new PropertyName('name'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isReadonly: false,
+            isPromoted: false,
+            type: 'string',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('public string $name', $property->format());
+    }
+
+    public function testFormatStatic(): void
+    {
+        $property = new PropertyInfo(
+            name: new PropertyName('instance'),
+            visibility: Visibility::Private,
+            isStatic: true,
+            isReadonly: false,
+            isPromoted: false,
+            type: 'self',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('private static self $instance', $property->format());
+    }
+
+    public function testFormatReadonly(): void
+    {
+        $property = new PropertyInfo(
+            name: new PropertyName('id'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isReadonly: true,
+            isPromoted: false,
+            type: 'int',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('public readonly int $id', $property->format());
+    }
+
+    public function testFormatNoType(): void
+    {
+        $property = new PropertyInfo(
+            name: new PropertyName('data'),
+            visibility: Visibility::Protected,
+            isStatic: false,
+            isReadonly: false,
+            isPromoted: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('protected $data', $property->format());
+    }
+
+    public function testFormatAllModifiers(): void
+    {
+        $property = new PropertyInfo(
+            name: new PropertyName('cache'),
+            visibility: Visibility::Private,
+            isStatic: true,
+            isReadonly: true,
+            isPromoted: false,
+            type: 'array',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('private static readonly array $cache', $property->format());
+    }
 }


### PR DESCRIPTION
## Summary

PropertyInfo implements Formattable with format() returning the full property signature.

Closes #152

## Test plan

- [x] Unit tests for format()
- [x] PHPStan clean
- [x] Full test suite passes

Generated with Claude Code