### PR TITLE
ConstantInfo implements Formattable

### DIFF
--- a/src/Domain/ConstantInfo.php
+++ b/src/Domain/ConstantInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a class constant.
  */
-final readonly class ConstantInfo
+final readonly class ConstantInfo implements Formattable
 {
     public function __construct(
         public ConstantName $name,
@@ -19,5 +19,19 @@ final readonly class ConstantInfo
         public ?int $line,
         public ClassName $declaringClass,
     ) {
+    }
+
+    public function format(): string
+    {
+        $parts = [$this->visibility->format()];
+        if ($this->isFinal) {
+            $parts[] = 'final';
+        }
+        $parts[] = 'const';
+        if ($this->type !== null) {
+            $parts[] = $this->type;
+        }
+        $parts[] = $this->name->name;
+        return implode(' ', $parts);
     }
 }

--- a/tests/Domain/ConstantInfoTest.php
+++ b/tests/Domain/ConstantInfoTest.php
@@ -32,4 +32,68 @@ class ConstantInfoTest extends TestCase
         self::assertSame(5, $constant->line);
         self::assertSame(ConstantInfo::class, $constant->declaringClass->fqn);
     }
+
+    public function testFormatSimple(): void
+    {
+        $constant = new ConstantInfo(
+            name: new ConstantName('FOO'),
+            visibility: Visibility::Public,
+            isFinal: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('public const FOO', $constant->format());
+    }
+
+    public function testFormatWithType(): void
+    {
+        $constant = new ConstantInfo(
+            name: new ConstantName('MAX_SIZE'),
+            visibility: Visibility::Public,
+            isFinal: false,
+            type: 'int',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('public const int MAX_SIZE', $constant->format());
+    }
+
+    public function testFormatFinal(): void
+    {
+        $constant = new ConstantInfo(
+            name: new ConstantName('VERSION'),
+            visibility: Visibility::Public,
+            isFinal: true,
+            type: 'string',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('public final const string VERSION', $constant->format());
+    }
+
+    public function testFormatPrivate(): void
+    {
+        $constant = new ConstantInfo(
+            name: new ConstantName('INTERNAL'),
+            visibility: Visibility::Private,
+            isFinal: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('private const INTERNAL', $constant->format());
+    }
 }


### PR DESCRIPTION
## Summary

ConstantInfo implements Formattable with format() returning the full constant signature.

Closes #153

## Test plan

- [x] Unit tests for format()
- [x] PHPStan clean
- [x] Full test suite passes

Generated with Claude Code