### PR TITLE
EnumCaseInfo implements Formattable

### DIFF
--- a/src/Domain/EnumCaseInfo.php
+++ b/src/Domain/EnumCaseInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about an enum case.
  */
-final readonly class EnumCaseInfo
+final readonly class EnumCaseInfo implements Formattable
 {
     public function __construct(
         public EnumCaseName $name,
@@ -17,5 +17,16 @@ final readonly class EnumCaseInfo
         public ?int $line,
         public ClassName $declaringClass,
     ) {
+    }
+
+    public function format(): string
+    {
+        $str = 'case ' . $this->name->name;
+        if ($this->backingValue !== null) {
+            $str .= is_string($this->backingValue)
+                ? " = '" . $this->backingValue . "'"
+                : ' = ' . $this->backingValue;
+        }
+        return $str;
     }
 }

--- a/tests/Domain/EnumCaseInfoTest.php
+++ b/tests/Domain/EnumCaseInfoTest.php
@@ -28,4 +28,46 @@ class EnumCaseInfoTest extends TestCase
         self::assertSame(8, $case->line);
         self::assertSame(ClassKind::class, $case->declaringClass->fqn);
     }
+
+    public function testFormatUnitEnum(): void
+    {
+        $case = new EnumCaseInfo(
+            name: new EnumCaseName('Pending'),
+            backingValue: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(ClassKind::class),
+        );
+
+        self::assertSame('case Pending', $case->format());
+    }
+
+    public function testFormatIntBackedEnum(): void
+    {
+        $case = new EnumCaseInfo(
+            name: new EnumCaseName('Active'),
+            backingValue: 1,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(ClassKind::class),
+        );
+
+        self::assertSame('case Active = 1', $case->format());
+    }
+
+    public function testFormatStringBackedEnum(): void
+    {
+        $case = new EnumCaseInfo(
+            name: new EnumCaseName('Draft'),
+            backingValue: 'draft',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(ClassKind::class),
+        );
+
+        self::assertSame("case Draft = 'draft'", $case->format());
+    }
 }


### PR DESCRIPTION
## Summary

EnumCaseInfo implements Formattable with format() returning the enum case signature.

Closes #154

## Test plan

- [x] Unit tests for format() (unit enum, int-backed, string-backed)
- [x] PHPStan clean
- [x] Full test suite passes

Generated with Claude Code