### PR TITLE
ParameterInfo::fromNode() factory

### DIFF
--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
+use Firehed\PhpLsp\Utility\TypeFormatter;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Param;
+
 /**
  * Metadata about a method or function parameter.
  */
@@ -16,6 +20,21 @@ final readonly class ParameterInfo implements Formattable
         public bool $isVariadic,
         public bool $isPassedByReference,
     ) {
+    }
+
+    public static function fromNode(Param $param): ?self
+    {
+        if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+            return null;
+        }
+
+        return new self(
+            name: $param->var->name,
+            type: TypeFormatter::formatNode($param->type),
+            hasDefault: $param->default !== null,
+            isVariadic: $param->variadic,
+            isPassedByReference: $param->byRef,
+        );
     }
 
     public function format(bool $showDefault = false): string

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -323,17 +323,10 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
     {
         $result = [];
         foreach ($params as $param) {
-            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
-                continue;
+            $info = ParameterInfo::fromNode($param);
+            if ($info !== null) {
+                $result[] = $info;
             }
-
-            $result[] = new ParameterInfo(
-                name: $param->var->name,
-                type: TypeFormatter::formatNode($param->type),
-                hasDefault: $param->default !== null,
-                isVariadic: $param->variadic,
-                isPassedByReference: $param->byRef,
-            );
         }
         return $result;
     }

--- a/tests/Domain/ParameterInfoTest.php
+++ b/tests/Domain/ParameterInfoTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Param;
+use PhpParser\Node\Scalar\Int_;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -143,5 +147,96 @@ class ParameterInfoTest extends TestCase
         );
 
         self::assertSame('array &...$args', $param->format());
+    }
+
+    public function testFromNodeSimple(): void
+    {
+        $node = new Param(
+            var: new Variable('name'),
+            default: null,
+            type: new Identifier('string'),
+        );
+
+        $param = ParameterInfo::fromNode($node);
+
+        self::assertNotNull($param);
+        self::assertSame('name', $param->name);
+        self::assertSame('string', $param->type);
+        self::assertFalse($param->hasDefault);
+        self::assertFalse($param->isVariadic);
+        self::assertFalse($param->isPassedByReference);
+    }
+
+    public function testFromNodeWithDefault(): void
+    {
+        $node = new Param(
+            var: new Variable('count'),
+            default: new Int_(0),
+            type: new Identifier('int'),
+        );
+
+        $param = ParameterInfo::fromNode($node);
+
+        self::assertNotNull($param);
+        self::assertSame('count', $param->name);
+        self::assertTrue($param->hasDefault);
+    }
+
+    public function testFromNodeVariadic(): void
+    {
+        $node = new Param(
+            var: new Variable('args'),
+            default: null,
+            type: new Identifier('string'),
+            variadic: true,
+        );
+
+        $param = ParameterInfo::fromNode($node);
+
+        self::assertNotNull($param);
+        self::assertTrue($param->isVariadic);
+    }
+
+    public function testFromNodeByReference(): void
+    {
+        $node = new Param(
+            var: new Variable('value'),
+            default: null,
+            type: new Identifier('int'),
+            byRef: true,
+        );
+
+        $param = ParameterInfo::fromNode($node);
+
+        self::assertNotNull($param);
+        self::assertTrue($param->isPassedByReference);
+    }
+
+    public function testFromNodeNoType(): void
+    {
+        $node = new Param(
+            var: new Variable('data'),
+            default: null,
+            type: null,
+        );
+
+        $param = ParameterInfo::fromNode($node);
+
+        self::assertNotNull($param);
+        self::assertNull($param->type);
+    }
+
+    public function testFromNodeReturnsNullForNonStringVariableName(): void
+    {
+        $var = new Variable(new Int_(0));
+        $node = new Param(
+            var: $var,
+            default: null,
+            type: null,
+        );
+
+        $param = ParameterInfo::fromNode($node);
+
+        self::assertNull($param);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `ParameterInfo::fromNode()` factory method for AST-based parameter extraction
- Updates DefaultClassInfoFactory to use the new factory method
- Establishes consistency with `ParameterInfo::fromReflection()` pattern

Fixes #139

## Test plan
- [x] All existing tests pass
- [x] New unit tests for fromNode() covering: simple, default, variadic, by-reference, no-type, invalid variable name

🤖 Generated with [Claude Code](https://claude.ai/code)