### PR TITLE
Add ParameterInfo::fromReflection() factory method

### DIFF
--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
+use Firehed\PhpLsp\Utility\TypeFormatter;
+use ReflectionParameter;
+
 /**
  * Metadata about a method or function parameter.
  */
@@ -16,6 +19,19 @@ final readonly class ParameterInfo implements Formattable
         public bool $isVariadic,
         public bool $isPassedByReference,
     ) {
+    }
+
+    public static function fromReflection(ReflectionParameter $param): self
+    {
+        return new self(
+            name: $param->getName(),
+            type: $param->getType() !== null
+                ? TypeFormatter::formatReflection($param->getType())
+                : null,
+            hasDefault: $param->isDefaultValueAvailable(),
+            isVariadic: $param->isVariadic(),
+            isPassedByReference: $param->isPassedByReference(),
+        );
     }
 
     public function format(bool $showDefault = false): string

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Visibility;
@@ -459,22 +460,10 @@ final class HoverHandler implements HandlerInterface
             $parts[] = DocblockParser::extractDescription($docComment);
         }
 
-        $params = [];
-        foreach ($func->getParameters() as $param) {
-            $paramStr = '';
-            $type = $param->getType();
-            if ($type !== null) {
-                $paramStr .= TypeFormatter::formatReflection($type) . ' ';
-            }
-            if ($param->isVariadic()) {
-                $paramStr .= '...';
-            }
-            $paramStr .= '$' . $param->getName();
-            if ($param->isOptional() && !$param->isVariadic()) {
-                $paramStr .= ' = ...';
-            }
-            $params[] = $paramStr;
-        }
+        $params = array_map(
+            fn($p) => ParameterInfo::fromReflection($p)->format(showDefault: true),
+            $func->getParameters(),
+        );
 
         $signature = 'function ' . $func->getName() . '(' . implode(', ', $params) . ')';
 

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
@@ -35,11 +36,11 @@ use ReflectionMethod;
 use ReflectionParameter;
 
 /**
- * @phpstan-type ParameterInfo array{label: string, documentation?: string}
+ * @phpstan-type ParameterInfoShape array{label: string, documentation?: string}
  * @phpstan-type SignatureInfo array{
  *   label: string,
  *   documentation?: string,
- *   parameters?: list<ParameterInfo>,
+ *   parameters?: list<ParameterInfoShape>,
  * }
  */
 final class SignatureHelpHandler implements HandlerInterface
@@ -449,16 +450,6 @@ final class SignatureHelpHandler implements HandlerInterface
 
     private function formatReflectionParameter(ReflectionParameter $param): string
     {
-        $paramStr = '';
-        $type = $param->getType();
-        if ($type !== null) {
-            $paramStr .= TypeFormatter::formatReflection($type) . ' ';
-        }
-        if ($param->isVariadic()) {
-            $paramStr .= '...';
-        }
-        $paramStr .= '$' . $param->getName();
-
-        return $paramStr;
+        return ParameterInfo::fromReflection($param)->format();
     }
 }

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -547,21 +547,10 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
      */
     private function extractParametersFromReflection(ReflectionMethod $method): array
     {
-        $result = [];
-
-        foreach ($method->getParameters() as $param) {
-            $result[] = new ParameterInfo(
-                name: $param->getName(),
-                type: $param->getType() !== null
-                    ? TypeFormatter::formatReflection($param->getType())
-                    : null,
-                hasDefault: $param->isDefaultValueAvailable(),
-                isVariadic: $param->isVariadic(),
-                isPassedByReference: $param->isPassedByReference(),
-            );
-        }
-
-        return $result;
+        return array_map(
+            ParameterInfo::fromReflection(...),
+            $method->getParameters(),
+        );
     }
 
     /**

--- a/tests/Domain/ParameterInfoTest.php
+++ b/tests/Domain/ParameterInfoTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Domain;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
 
 #[CoversClass(ParameterInfo::class)]
 class ParameterInfoTest extends TestCase
@@ -143,5 +144,89 @@ class ParameterInfoTest extends TestCase
         );
 
         self::assertSame('array &...$args', $param->format());
+    }
+
+    public function testFromReflectionSimple(): void
+    {
+        $fn = function (string $value) {};
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('value', $param->name);
+        self::assertSame('string', $param->type);
+        self::assertFalse($param->hasDefault);
+        self::assertFalse($param->isVariadic);
+        self::assertFalse($param->isPassedByReference);
+    }
+
+    public function testFromReflectionWithDefault(): void
+    {
+        $fn = function (int $count = 10) {};
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('count', $param->name);
+        self::assertSame('int', $param->type);
+        self::assertTrue($param->hasDefault);
+        self::assertFalse($param->isVariadic);
+        self::assertFalse($param->isPassedByReference);
+    }
+
+    public function testFromReflectionVariadic(): void
+    {
+        $fn = function (string ...$args) {};
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('args', $param->name);
+        self::assertSame('string', $param->type);
+        self::assertFalse($param->hasDefault);
+        self::assertTrue($param->isVariadic);
+        self::assertFalse($param->isPassedByReference);
+    }
+
+    public function testFromReflectionByReference(): void
+    {
+        $fn = function (array &$data) {};
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('data', $param->name);
+        self::assertSame('array', $param->type);
+        self::assertFalse($param->hasDefault);
+        self::assertFalse($param->isVariadic);
+        self::assertTrue($param->isPassedByReference);
+    }
+
+    public function testFromReflectionNoType(): void
+    {
+        $fn = function ($untyped) {};
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('untyped', $param->name);
+        self::assertNull($param->type);
+        self::assertFalse($param->hasDefault);
+        self::assertFalse($param->isVariadic);
+        self::assertFalse($param->isPassedByReference);
+    }
+
+    public function testFromReflectionNullable(): void
+    {
+        $fn = function (?string $nullable) {};
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('nullable', $param->name);
+        self::assertSame('?string', $param->type);
+        self::assertFalse($param->hasDefault);
+        self::assertFalse($param->isVariadic);
+        self::assertFalse($param->isPassedByReference);
     }
 }

--- a/tests/Domain/ParameterInfoTest.php
+++ b/tests/Domain/ParameterInfoTest.php
@@ -148,7 +148,8 @@ class ParameterInfoTest extends TestCase
 
     public function testFromReflectionSimple(): void
     {
-        $fn = function (string $value) {};
+        $fn = function (string $value) {
+        };
         $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
 
         $param = ParameterInfo::fromReflection($reflectionParam);
@@ -162,7 +163,8 @@ class ParameterInfoTest extends TestCase
 
     public function testFromReflectionWithDefault(): void
     {
-        $fn = function (int $count = 10) {};
+        $fn = function (int $count = 10) {
+        };
         $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
 
         $param = ParameterInfo::fromReflection($reflectionParam);
@@ -176,7 +178,8 @@ class ParameterInfoTest extends TestCase
 
     public function testFromReflectionVariadic(): void
     {
-        $fn = function (string ...$args) {};
+        $fn = function (string ...$args) {
+        };
         $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
 
         $param = ParameterInfo::fromReflection($reflectionParam);
@@ -190,7 +193,8 @@ class ParameterInfoTest extends TestCase
 
     public function testFromReflectionByReference(): void
     {
-        $fn = function (array &$data) {};
+        $fn = function (array &$data) {
+        };
         $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
 
         $param = ParameterInfo::fromReflection($reflectionParam);
@@ -204,7 +208,8 @@ class ParameterInfoTest extends TestCase
 
     public function testFromReflectionNoType(): void
     {
-        $fn = function ($untyped) {};
+        $fn = function ($untyped) {
+        };
         $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
 
         $param = ParameterInfo::fromReflection($reflectionParam);
@@ -218,7 +223,8 @@ class ParameterInfoTest extends TestCase
 
     public function testFromReflectionNullable(): void
     {
-        $fn = function (?string $nullable) {};
+        $fn = function (?string $nullable) {
+        };
         $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
 
         $param = ParameterInfo::fromReflection($reflectionParam);


### PR DESCRIPTION
## Summary
- Adds `ParameterInfo::fromReflection()` factory method for centralized Reflection parameter extraction
- Updates HoverHandler, SignatureHelpHandler, and DefaultClassInfoFactory to use the new factory
- Eliminates duplicate parameter formatting logic across handlers (-43 lines)

Fixes #144

## Test plan
- [x] All existing tests pass
- [x] New unit tests for fromReflection() covering: simple, default, variadic, by-reference, no-type, nullable

🤖 Generated with [Claude Code](https://claude.ai/code)