### PR TITLE
Add FunctionInfo factories and migrate handlers

### DIFF
--- a/src/Domain/FunctionInfo.php
+++ b/src/Domain/FunctionInfo.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
+use Firehed\PhpLsp\Utility\TypeFormatter;
+use PhpParser\Node\Stmt;
+use ReflectionFunction;
+
 /**
  * Metadata about a standalone function.
  */
@@ -20,6 +24,48 @@ final readonly class FunctionInfo implements Formattable
         public ?string $file,
         public ?int $line,
     ) {
+    }
+
+    public static function fromNode(Stmt\Function_ $node): self
+    {
+        $params = array_filter(
+            array_map(ParameterInfo::fromNode(...), $node->params),
+            fn($p) => $p !== null,
+        );
+
+        return new self(
+            name: $node->name->toString(),
+            parameters: array_values($params),
+            returnType: $node->returnType !== null
+                ? TypeFormatter::formatNode($node->returnType)
+                : null,
+            docblock: $node->getDocComment()?->getText(),
+            file: null,
+            line: $node->getStartLine(),
+        );
+    }
+
+    public static function fromReflection(ReflectionFunction $func): self
+    {
+        return new self(
+            name: $func->getName(),
+            parameters: array_map(
+                ParameterInfo::fromReflection(...),
+                $func->getParameters(),
+            ),
+            returnType: $func->getReturnType() !== null
+                ? TypeFormatter::formatReflection($func->getReturnType())
+                : null,
+            docblock: $func->getDocComment() !== false
+                ? $func->getDocComment()
+                : null,
+            file: $func->getFileName() !== false
+                ? $func->getFileName()
+                : null,
+            line: $func->getStartLine() !== false
+                ? $func->getStartLine()
+                : null,
+        );
     }
 
     public function format(): string

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -8,9 +8,9 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
-use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Visibility;
@@ -23,7 +23,6 @@ use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
-use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -259,35 +258,14 @@ final class HoverHandler implements HandlerInterface
 
     private function formatFunctionHover(Stmt\Function_ $node): string
     {
+        $funcInfo = FunctionInfo::fromNode($node);
         $parts = [];
 
-        // Add docblock if present
-        $docComment = $node->getDocComment();
-        if ($docComment !== null) {
-            $parts[] = DocblockParser::extractDescription($docComment->getText());
+        if ($funcInfo->docblock !== null) {
+            $parts[] = DocblockParser::extractDescription($funcInfo->docblock);
         }
 
-        // Build signature
-        $params = [];
-        foreach ($node->params as $param) {
-            $paramStr = '';
-            if ($param->type !== null) {
-                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
-            }
-            $var = $param->var;
-            if ($var instanceof Node\Expr\Variable && is_string($var->name)) {
-                $paramStr .= '$' . $var->name;
-            }
-            $params[] = $paramStr;
-        }
-
-        $signature = 'function ' . $node->name->toString() . '(' . implode(', ', $params) . ')';
-
-        if ($node->returnType !== null) {
-            $signature .= ': ' . TypeFormatter::formatNode($node->returnType);
-        }
-
-        $parts[] = '```php' . "\n" . $signature . "\n```";
+        $parts[] = '```php' . "\n" . $funcInfo->format() . "\n```";
 
         return implode("\n\n", $parts);
     }
@@ -453,26 +431,14 @@ final class HoverHandler implements HandlerInterface
 
     private function formatReflectionFunction(ReflectionFunction $func): string
     {
+        $funcInfo = FunctionInfo::fromReflection($func);
         $parts = [];
 
-        $docComment = $func->getDocComment();
-        if ($docComment !== false) {
-            $parts[] = DocblockParser::extractDescription($docComment);
+        if ($funcInfo->docblock !== null) {
+            $parts[] = DocblockParser::extractDescription($funcInfo->docblock);
         }
 
-        $params = array_map(
-            fn($p) => ParameterInfo::fromReflection($p)->format(showDefault: true),
-            $func->getParameters(),
-        );
-
-        $signature = 'function ' . $func->getName() . '(' . implode(', ', $params) . ')';
-
-        $returnType = $func->getReturnType();
-        if ($returnType !== null) {
-            $signature .= ': ' . TypeFormatter::formatReflection($returnType);
-        }
-
-        $parts[] = '```php' . "\n" . $signature . "\n```";
+        $parts[] = '```php' . "\n" . $funcInfo->format() . "\n```";
 
         return implode("\n\n", $parts);
     }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -6,9 +6,9 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
-use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
@@ -17,13 +17,11 @@ use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
-use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -31,9 +29,6 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use ReflectionException;
 use ReflectionFunction;
-use ReflectionFunctionAbstract;
-use ReflectionMethod;
-use ReflectionParameter;
 
 /**
  * @phpstan-type ParameterInfoShape array{label: string, documentation?: string}
@@ -222,8 +217,8 @@ final class SignatureHelpHandler implements HandlerInterface
 
         // Fall back to built-in function
         try {
-            $reflection = new ReflectionFunction($functionName);
-            return $this->formatReflectionSignature($reflection);
+            $funcInfo = FunctionInfo::fromReflection(new ReflectionFunction($functionName));
+            return $this->formatFunctionInfoSignature($funcInfo);
         } catch (ReflectionException) {
             return null;
         }
@@ -345,35 +340,27 @@ final class SignatureHelpHandler implements HandlerInterface
      */
     private function formatFunctionNodeSignature(Stmt\Function_ $func): array
     {
-        $params = [];
-        $paramLabels = [];
+        $funcInfo = FunctionInfo::fromNode($func);
+        return $this->formatFunctionInfoSignature($funcInfo);
+    }
 
-        foreach ($func->params as $param) {
-            $paramStr = '';
-            if ($param->type !== null) {
-                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
-            }
-            $var = $param->var;
-            if ($var instanceof Variable && is_string($var->name)) {
-                $paramStr .= '$' . $var->name;
-            }
-            $paramLabels[] = $paramStr;
-            $params[] = ['label' => $paramStr];
-        }
-
-        $label = 'function ' . $func->name->toString() . '(' . implode(', ', $paramLabels) . ')';
-        if ($func->returnType !== null) {
-            $label .= ': ' . TypeFormatter::formatNode($func->returnType);
-        }
+    /**
+     * @return SignatureInfo
+     */
+    private function formatFunctionInfoSignature(FunctionInfo $func): array
+    {
+        $params = array_map(
+            fn($p) => ['label' => $p->format()],
+            $func->parameters,
+        );
 
         $result = [
-            'label' => $label,
+            'label' => $func->format(),
             'parameters' => $params,
         ];
 
-        $docComment = $func->getDocComment();
-        if ($docComment !== null) {
-            $result['documentation'] = DocblockParser::extractDescription($docComment->getText());
+        if ($func->docblock !== null) {
+            $result['documentation'] = DocblockParser::extractDescription($func->docblock);
         }
 
         return $result;
@@ -408,48 +395,5 @@ final class SignatureHelpHandler implements HandlerInterface
         }
 
         return $result;
-    }
-
-    /**
-     * @return SignatureInfo
-     */
-    private function formatReflectionSignature(ReflectionFunctionAbstract $func): array
-    {
-        $params = [];
-        $paramLabels = [];
-
-        foreach ($func->getParameters() as $param) {
-            $paramStr = $this->formatReflectionParameter($param);
-            $paramLabels[] = $paramStr;
-            $params[] = ['label' => $paramStr];
-        }
-
-        $name = $func instanceof ReflectionMethod
-            ? $func->getName()
-            : 'function ' . $func->getName();
-
-        $label = $name . '(' . implode(', ', $paramLabels) . ')';
-
-        $returnType = $func->getReturnType();
-        if ($returnType !== null) {
-            $label .= ': ' . TypeFormatter::formatReflection($returnType);
-        }
-
-        $result = [
-            'label' => $label,
-            'parameters' => $params,
-        ];
-
-        $docComment = $func->getDocComment();
-        if ($docComment !== false) {
-            $result['documentation'] = DocblockParser::extractDescription($docComment);
-        }
-
-        return $result;
-    }
-
-    private function formatReflectionParameter(ReflectionParameter $param): string
-    {
-        return ParameterInfo::fromReflection($param)->format();
     }
 }

--- a/tests/Domain/Fixtures/documented_function.php
+++ b/tests/Domain/Fixtures/documented_function.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * A test function with documentation.
+ */
+function testDocumentedFunction(): void
+{
+}

--- a/tests/Domain/FunctionInfoTest.php
+++ b/tests/Domain/FunctionInfoTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
 
 #[CoversClass(FunctionInfo::class)]
 class FunctionInfoTest extends TestCase
@@ -104,5 +109,128 @@ class FunctionInfoTest extends TestCase
         );
 
         self::assertSame('function sum(int ...$numbers): int', $func->format());
+    }
+
+    public function testFromNodeSimple(): void
+    {
+        $node = new Stmt\Function_(
+            name: new Identifier('myFunc'),
+            subNodes: [
+                'params' => [],
+                'returnType' => null,
+            ],
+        );
+
+        $func = FunctionInfo::fromNode($node);
+
+        self::assertSame('myFunc', $func->name);
+        self::assertSame([], $func->parameters);
+        self::assertNull($func->returnType);
+        self::assertNull($func->docblock);
+    }
+
+    public function testFromNodeWithParams(): void
+    {
+        $node = new Stmt\Function_(
+            name: new Identifier('greet'),
+            subNodes: [
+                'params' => [
+                    new Param(
+                        var: new Variable('name'),
+                        type: new Identifier('string'),
+                    ),
+                ],
+                'returnType' => new Identifier('void'),
+            ],
+        );
+
+        $func = FunctionInfo::fromNode($node);
+
+        self::assertSame('greet', $func->name);
+        self::assertCount(1, $func->parameters);
+        self::assertSame('name', $func->parameters[0]->name);
+        self::assertSame('string', $func->parameters[0]->type);
+        self::assertSame('void', $func->returnType);
+    }
+
+    public function testFromNodeWithMultipleParams(): void
+    {
+        $node = new Stmt\Function_(
+            name: new Identifier('add'),
+            subNodes: [
+                'params' => [
+                    new Param(
+                        var: new Variable('a'),
+                        type: new Identifier('int'),
+                    ),
+                    new Param(
+                        var: new Variable('b'),
+                        type: new Identifier('int'),
+                    ),
+                ],
+                'returnType' => new Identifier('int'),
+            ],
+        );
+
+        $func = FunctionInfo::fromNode($node);
+
+        self::assertSame('add', $func->name);
+        self::assertCount(2, $func->parameters);
+        self::assertSame('int', $func->returnType);
+    }
+
+    public function testFromReflectionSimple(): void
+    {
+        $fn = function () {
+        };
+        $reflection = new ReflectionFunction($fn);
+
+        $func = FunctionInfo::fromReflection($reflection);
+
+        self::assertSame([], $func->parameters);
+        self::assertNull($func->returnType);
+    }
+
+    public function testFromReflectionWithParams(): void
+    {
+        $fn = function (string $name): void {
+        };
+        $reflection = new ReflectionFunction($fn);
+
+        $func = FunctionInfo::fromReflection($reflection);
+
+        self::assertCount(1, $func->parameters);
+        self::assertSame('name', $func->parameters[0]->name);
+        self::assertSame('string', $func->parameters[0]->type);
+        self::assertSame('void', $func->returnType);
+    }
+
+    public function testFromReflectionWithMultipleParams(): void
+    {
+        $fn = function (int $a, int $b): int {
+            return $a + $b;
+        };
+        $reflection = new ReflectionFunction($fn);
+
+        $func = FunctionInfo::fromReflection($reflection);
+
+        self::assertCount(2, $func->parameters);
+        self::assertSame('a', $func->parameters[0]->name);
+        self::assertSame('b', $func->parameters[1]->name);
+        self::assertSame('int', $func->returnType);
+    }
+
+    public function testFromReflectionVariadic(): void
+    {
+        $fn = function (int ...$numbers): int {
+            return array_sum($numbers);
+        };
+        $reflection = new ReflectionFunction($fn);
+
+        $func = FunctionInfo::fromReflection($reflection);
+
+        self::assertCount(1, $func->parameters);
+        self::assertTrue($func->parameters[0]->isVariadic);
+        self::assertSame('int', $func->returnType);
     }
 }

--- a/tests/Domain/FunctionInfoTest.php
+++ b/tests/Domain/FunctionInfoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
+use PhpParser\Comment\Doc;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
@@ -179,6 +180,24 @@ class FunctionInfoTest extends TestCase
         self::assertSame('int', $func->returnType);
     }
 
+    public function testFromNodeWithDocblock(): void
+    {
+        $node = new Stmt\Function_(
+            name: new Identifier('documented'),
+            subNodes: [
+                'params' => [],
+                'returnType' => null,
+            ],
+            attributes: [
+                'comments' => [new Doc('/** This function does something. */')],
+            ],
+        );
+
+        $func = FunctionInfo::fromNode($node);
+
+        self::assertSame('/** This function does something. */', $func->docblock);
+    }
+
     public function testFromReflectionSimple(): void
     {
         $fn = function () {
@@ -232,5 +251,15 @@ class FunctionInfoTest extends TestCase
         self::assertCount(1, $func->parameters);
         self::assertTrue($func->parameters[0]->isVariadic);
         self::assertSame('int', $func->returnType);
+    }
+
+    public function testFromReflectionWithDocblock(): void
+    {
+        require_once __DIR__ . '/Fixtures/documented_function.php';
+        $reflection = new ReflectionFunction('testDocumentedFunction');
+
+        $func = FunctionInfo::fromReflection($reflection);
+
+        self::assertSame("/**\n * A test function with documentation.\n */", $func->docblock);
     }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -178,6 +178,7 @@ PHP;
         self::assertIsArray($result);
         self::assertStringContainsString('add', $result['contents']);
         self::assertStringContainsString('int', $result['contents']);
+        self::assertStringContainsString('Adds two numbers together', $result['contents']);
     }
 
     public function testHoverOnMethod(): void

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -281,6 +281,33 @@ PHP;
         self::assertStringContainsString('sort', $result['contents']);
     }
 
+    public function testHoverOnExternalFunctionWithDocblock(): void
+    {
+        require_once __DIR__ . '/../Domain/Fixtures/documented_function.php';
+
+        $code = <<<'PHP'
+<?php
+testDocumentedFunction();
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 1, 'character' => 5],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('testDocumentedFunction', $result['contents']);
+        self::assertStringContainsString('A test function with documentation', $result['contents']);
+    }
+
     public function testHoverOnStaticMethod(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
- Adds `FunctionInfo::fromNode()` and `FunctionInfo::fromReflection()` factory methods
- Updates HoverHandler and SignatureHelpHandler to use the factories
- Consolidates 4 duplicate signature-building methods into one (`FunctionInfo::format()`)
- Net -49 lines of production code

Fixes #148

## Test plan
- [x] All existing tests pass
- [x] New unit tests for fromNode() and fromReflection()

🤖 Generated with [Claude Code](https://claude.ai/code)