### PR TITLE
Migrate handlers to use Formattable domain objects

### DIFF
--- a/src/Domain/MethodInfo.php
+++ b/src/Domain/MethodInfo.php
@@ -27,10 +27,24 @@ final readonly class MethodInfo implements Formattable
     ) {
     }
 
-    public function format(): string
+    public function format(bool $showDefaults = false): string
     {
-        $params = array_map(fn($p) => $p->format(), $this->parameters);
-        $sig = $this->name->name . '(' . implode(', ', $params) . ')';
+        $parts = [$this->visibility->format()];
+        if ($this->isStatic) {
+            $parts[] = 'static';
+        }
+        if ($this->isAbstract) {
+            $parts[] = 'abstract';
+        }
+        if ($this->isFinal) {
+            $parts[] = 'final';
+        }
+        $parts[] = 'function';
+
+        $params = array_map(fn($p) => $p->format(showDefault: $showDefaults), $this->parameters);
+        $parts[] = $this->name->name . '(' . implode(', ', $params) . ')';
+
+        $sig = implode(' ', $parts);
         if ($this->returnType !== null) {
             $sig .= ': ' . $this->returnType;
         }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantInfo;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
 use Firehed\PhpLsp\Domain\Visibility;
@@ -489,7 +490,7 @@ final class CompletionHandler implements HandlerInterface
             if ($stmt instanceof Stmt\Function_) {
                 $name = $stmt->name->toString();
                 if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = $this->formatCallableCompletion($stmt, self::KIND_FUNCTION, 'function ');
+                    $items[] = $this->formatFunctionCompletion($stmt);
                 }
             }
         }
@@ -527,20 +528,10 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatMethodInfoCompletion(MethodInfo $method): array
     {
-        $params = [];
-        foreach ($method->parameters as $param) {
-            $params[] = $param->format();
-        }
-
-        $detail = $method->name->name . '(' . implode(', ', $params) . ')';
-        if ($method->returnType !== null) {
-            $detail .= ': ' . $method->returnType;
-        }
-
         return self::withDocumentation([
             'label' => $method->name->name,
             'kind' => self::KIND_METHOD,
-            'detail' => $detail,
+            'detail' => $method->format(),
         ], $method->docblock);
     }
 
@@ -549,12 +540,10 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatPropertyInfoCompletion(DomainPropertyInfo $property): array
     {
-        $type = $property->type ?? 'mixed';
-
         return self::withDocumentation([
             'label' => $property->name->name,
             'kind' => self::KIND_PROPERTY,
-            'detail' => $type . ' $' . $property->name->name,
+            'detail' => $property->format(),
         ], $property->docblock);
     }
 
@@ -566,7 +555,7 @@ final class CompletionHandler implements HandlerInterface
         return self::withDocumentation([
             'label' => $constant->name->name,
             'kind' => self::KIND_CONSTANT,
-            'detail' => 'const ' . $constant->name->name,
+            'detail' => $constant->format(),
         ], $constant->docblock);
     }
 
@@ -575,51 +564,25 @@ final class CompletionHandler implements HandlerInterface
      */
     private function formatEnumCaseInfoCompletion(EnumCaseInfo $enumCase): array
     {
-        $detail = 'case ' . $enumCase->name->name;
-        if ($enumCase->backingValue !== null) {
-            $detail .= is_string($enumCase->backingValue)
-                ? " = '" . $enumCase->backingValue . "'"
-                : ' = ' . $enumCase->backingValue;
-        }
-
         return self::withDocumentation([
             'label' => $enumCase->name->name,
             'kind' => self::KIND_ENUM_MEMBER,
-            'detail' => $detail,
+            'detail' => $enumCase->format(),
         ], $enumCase->docblock);
     }
 
     /**
      * @return CompletionItem
      */
-    private function formatCallableCompletion(
-        Stmt\ClassMethod|Stmt\Function_ $callable,
-        int $kind,
-        string $detailPrefix = '',
-    ): array {
-        $params = [];
-        foreach ($callable->params as $param) {
-            $paramStr = '';
-            if ($param->type !== null) {
-                $paramStr .= TypeFormatter::formatNode($param->type) . ' ';
-            }
-            $var = $param->var;
-            if ($var instanceof Variable && is_string($var->name)) {
-                $paramStr .= '$' . $var->name;
-            }
-            $params[] = $paramStr;
-        }
-
-        $detail = $detailPrefix . $callable->name->toString() . '(' . implode(', ', $params) . ')';
-        if ($callable->returnType !== null) {
-            $detail .= ': ' . TypeFormatter::formatNode($callable->returnType);
-        }
+    private function formatFunctionCompletion(Stmt\Function_ $func): array
+    {
+        $funcInfo = FunctionInfo::fromNode($func);
 
         return self::withDocumentation([
-            'label' => $callable->name->toString(),
-            'kind' => $kind,
-            'detail' => $detail,
-        ], $callable->getDocComment()?->getText());
+            'label' => $funcInfo->name,
+            'kind' => self::KIND_FUNCTION,
+            'detail' => $funcInfo->format(),
+        ], $funcInfo->docblock);
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -378,22 +378,7 @@ final class HoverHandler implements HandlerInterface
             $parts[] = DocblockParser::extractDescription($method->docblock);
         }
 
-        $visibility = $method->visibility->format() . ' ';
-        $static = $method->isStatic ? 'static ' : '';
-
-        $params = [];
-        foreach ($method->parameters as $param) {
-            $params[] = $param->format(showDefault: true);
-        }
-
-        $signature = $visibility . $static . 'function ' . $method->name->name
-            . '(' . implode(', ', $params) . ')';
-
-        if ($method->returnType !== null) {
-            $signature .= ': ' . $method->returnType;
-        }
-
-        $parts[] = '```php' . "\n" . $signature . "\n```";
+        $parts[] = '```php' . "\n" . $method->format(showDefaults: true) . "\n```";
 
         return implode("\n\n", $parts);
     }
@@ -406,15 +391,7 @@ final class HoverHandler implements HandlerInterface
             $parts[] = DocblockParser::extractDescription($property->docblock);
         }
 
-        $visibility = $property->visibility->format() . ' ';
-        $static = $property->isStatic ? 'static ' : '';
-        $readonly = $property->isReadonly ? 'readonly ' : '';
-
-        $type = $property->type !== null ? $property->type . ' ' : '';
-
-        $signature = $visibility . $static . $readonly . $type . '$' . $property->name->name;
-
-        $parts[] = '```php' . "\n" . $signature . "\n```";
+        $parts[] = '```php' . "\n" . $property->format() . "\n```";
 
         return implode("\n\n", $parts);
     }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -371,22 +371,13 @@ final class SignatureHelpHandler implements HandlerInterface
      */
     private function formatMethodInfoSignature(MethodInfo $method): array
     {
-        $params = [];
-        $paramLabels = [];
-
-        foreach ($method->parameters as $param) {
-            $paramStr = $param->format();
-            $paramLabels[] = $paramStr;
-            $params[] = ['label' => $paramStr];
-        }
-
-        $label = $method->name->name . '(' . implode(', ', $paramLabels) . ')';
-        if ($method->returnType !== null) {
-            $label .= ': ' . $method->returnType;
-        }
+        $params = array_map(
+            fn($p) => ['label' => $p->format()],
+            $method->parameters,
+        );
 
         $result = [
-            'label' => $label,
+            'label' => $method->format(),
             'parameters' => $params,
         ];
 

--- a/tests/Domain/MethodInfoTest.php
+++ b/tests/Domain/MethodInfoTest.php
@@ -55,7 +55,7 @@ class MethodInfoTest extends TestCase
             declaringClass: new ClassName(self::class),
         );
 
-        self::assertSame('doSomething()', $method->format());
+        self::assertSame('public function doSomething()', $method->format());
     }
 
     public function testFormatWithReturnType(): void
@@ -74,7 +74,7 @@ class MethodInfoTest extends TestCase
             declaringClass: new ClassName(self::class),
         );
 
-        self::assertSame('getName(): string', $method->format());
+        self::assertSame('public function getName(): string', $method->format());
     }
 
     public function testFormatWithParameters(): void
@@ -95,7 +95,7 @@ class MethodInfoTest extends TestCase
             declaringClass: new ClassName(self::class),
         );
 
-        self::assertSame('setName(string $name)', $method->format());
+        self::assertSame('public function setName(string $name)', $method->format());
     }
 
     public function testFormatWithMultipleParametersAndReturnType(): void
@@ -117,7 +117,7 @@ class MethodInfoTest extends TestCase
             declaringClass: new ClassName(self::class),
         );
 
-        self::assertSame('calculate(int $a, int $b): int', $method->format());
+        self::assertSame('public function calculate(int $a, int $b): int', $method->format());
     }
 
     public function testFormatWithVariadicParameter(): void
@@ -138,7 +138,7 @@ class MethodInfoTest extends TestCase
             declaringClass: new ClassName(self::class),
         );
 
-        self::assertSame('merge(array ...$arrays): array', $method->format());
+        self::assertSame('public function merge(array ...$arrays): array', $method->format());
     }
 
     public function testFormatWithReferenceParameter(): void
@@ -160,6 +160,44 @@ class MethodInfoTest extends TestCase
             declaringClass: new ClassName(self::class),
         );
 
-        self::assertSame('swap(mixed &$a, mixed &$b): void', $method->format());
+        self::assertSame('public static function swap(mixed &$a, mixed &$b): void', $method->format());
+    }
+
+    public function testFormatAbstractMethod(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('handle'),
+            visibility: Visibility::Protected,
+            isStatic: false,
+            isAbstract: true,
+            isFinal: false,
+            parameters: [],
+            returnType: 'void',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('protected abstract function handle(): void', $method->format());
+    }
+
+    public function testFormatFinalMethod(): void
+    {
+        $method = new MethodInfo(
+            name: new MethodName('getInstance'),
+            visibility: Visibility::Private,
+            isStatic: true,
+            isAbstract: false,
+            isFinal: true,
+            parameters: [],
+            returnType: 'self',
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+
+        self::assertSame('private static final function getInstance(): self', $method->format());
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2691,4 +2691,56 @@ PHP;
         $labels = array_column($result['items'], 'label');
         self::assertContains('test', $labels);
     }
+
+    public function testUserDefinedFunctionCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+/**
+ * Adds two numbers.
+ */
+function calculateSum(int $a, int $b): int
+{
+    return $a + $b;
+}
+
+$result = calc
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 9, 'character' => 14],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $items = $result['items'];
+        $labels = array_column($items, 'label');
+
+        self::assertContains('calculateSum', $labels, 'calculateSum should be in completions');
+
+        $functionItem = null;
+        foreach ($items as $item) {
+            if ($item['label'] === 'calculateSum') {
+                $functionItem = $item;
+                break;
+            }
+        }
+
+        self::assertNotNull($functionItem);
+        self::assertSame(3, $functionItem['kind'] ?? null); // KIND_FUNCTION
+        $detail = $functionItem['detail'] ?? '';
+        self::assertStringContainsString('function calculateSum', $detail);
+        self::assertStringContainsString('int $a', $detail);
+        self::assertStringContainsString('int $b', $detail);
+        self::assertStringContainsString(': int', $detail);
+        self::assertStringContainsString('Adds two numbers', $functionItem['documentation'] ?? '');
+    }
 }


### PR DESCRIPTION
## Summary
- Updated MethodInfo::format() to include visibility, static/abstract/final modifiers, and `function` keyword
- Added `showDefaults` parameter to MethodInfo::format() for hover use case
- Migrated SignatureHelpHandler to use MethodInfo::format()
- Migrated HoverHandler to use MethodInfo::format() and PropertyInfo::format()
- Migrated CompletionHandler to use format() on MethodInfo, PropertyInfo, ConstantInfo, EnumCaseInfo, and FunctionInfo
- Net -67 lines of handler code

Note: This PR builds on #148 (FunctionInfo factories) and #160 (ParameterInfo::fromReflection) which addressed the function-related items in #147.

Fixes #147

## Test plan
- [x] All existing tests pass
- [x] New tests for abstract and final method formatting

🤖 Generated with [Claude Code](https://claude.ai/code)