### PR TITLE
Add ClassRepository::isSubclassOf() and migrate CompletionHandler

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
 use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
@@ -21,7 +22,6 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\ReflectionHelper;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
@@ -78,6 +78,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
         private readonly MemberResolver $memberResolver,
+        private readonly ClassRepository $classRepository,
         private readonly ?TypeResolverInterface $typeResolver = null,
     ) {
     }
@@ -469,8 +470,10 @@ final class CompletionHandler implements HandlerInterface
             return Visibility::Protected;
         }
 
-        // Check deeper inheritance via reflection
-        if (ReflectionHelper::getClass($enclosingClassName)?->isSubclassOf($targetClassName) === true) {
+        // Check deeper inheritance via ClassRepository
+        /** @var class-string $enclosingClassName */
+        /** @var class-string $targetClassName */
+        if ($this->classRepository->isSubclassOf(new ClassName($enclosingClassName), new ClassName($targetClassName))) {
             return Visibility::Protected;
         }
 

--- a/src/Repository/ClassRepository.php
+++ b/src/Repository/ClassRepository.php
@@ -30,4 +30,12 @@ interface ClassRepository
      * Remove all classes associated with a closed document.
      */
     public function removeDocument(string $uri): void;
+
+    /**
+     * Check if a class is a subclass of another.
+     *
+     * Traverses the parent chain and implemented interfaces.
+     * Returns false if the classes are the same or unrelated.
+     */
+    public function isSubclassOf(ClassName $class, ClassName $potentialParent): bool;
 }

--- a/src/Repository/DefaultClassRepository.php
+++ b/src/Repository/DefaultClassRepository.php
@@ -136,6 +136,57 @@ final class DefaultClassRepository implements ClassRepository
         }
     }
 
+    public function isSubclassOf(ClassName $class, ClassName $potentialParent): bool
+    {
+        $classInfo = $this->get($class);
+        if ($classInfo === null) {
+            return false;
+        }
+
+        $targetKey = $this->normalizeKey($potentialParent->fqn);
+        $visited = [$this->normalizeKey($class->fqn) => true];
+
+        return $this->checkInheritance($classInfo, $targetKey, $visited);
+    }
+
+    /**
+     * @param array<string, true> $visited
+     */
+    private function checkInheritance(ClassInfo $classInfo, string $targetKey, array &$visited): bool
+    {
+        // Check parent
+        if ($classInfo->parent !== null) {
+            $parentKey = $this->normalizeKey($classInfo->parent->fqn);
+            if ($parentKey === $targetKey) {
+                return true;
+            }
+            if (!array_key_exists($parentKey, $visited)) {
+                $visited[$parentKey] = true;
+                $parentInfo = $this->get($classInfo->parent);
+                if ($parentInfo !== null && $this->checkInheritance($parentInfo, $targetKey, $visited)) {
+                    return true;
+                }
+            }
+        }
+
+        // Check interfaces
+        foreach ($classInfo->interfaces as $interface) {
+            $interfaceKey = $this->normalizeKey($interface->fqn);
+            if ($interfaceKey === $targetKey) {
+                return true;
+            }
+            if (!array_key_exists($interfaceKey, $visited)) {
+                $visited[$interfaceKey] = true;
+                $interfaceInfo = $this->get($interface);
+                if ($interfaceInfo !== null && $this->checkInheritance($interfaceInfo, $targetKey, $visited)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private function normalizeKey(string $fqn): string
     {
         return strtolower(ltrim($fqn, '\\'));

--- a/src/Server.php
+++ b/src/Server.php
@@ -94,6 +94,7 @@ final class Server
             $parser,
             $symbolIndex,
             $memberResolver,
+            $classRepository,
             $typeResolver,
         );
     }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -54,6 +54,7 @@ class CompletionHandlerTest extends TestCase
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
+            $this->classRepository,
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
@@ -1741,6 +1742,7 @@ PHP;
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
+            $this->classRepository,
             new BasicTypeResolver(),
         );
 
@@ -1787,6 +1789,7 @@ PHP;
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
+            $this->classRepository,
             new BasicTypeResolver(),
         );
 
@@ -1831,6 +1834,7 @@ PHP;
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
+            $this->classRepository,
             new BasicTypeResolver(),
         );
 
@@ -1869,6 +1873,7 @@ PHP;
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
+            $this->classRepository,
             new BasicTypeResolver(),
         );
 
@@ -1904,6 +1909,7 @@ PHP;
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
+            $this->classRepository,
             new BasicTypeResolver(),
         );
 
@@ -1954,6 +1960,7 @@ PHP;
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
+            $this->classRepository,
             new BasicTypeResolver(),
         );
 

--- a/tests/Repository/DefaultClassRepositoryTest.php
+++ b/tests/Repository/DefaultClassRepositoryTest.php
@@ -263,7 +263,11 @@ final class DefaultClassRepositoryTest extends TestCase
     {
         $repo = $this->createRepoWithClasses([
             $this->createClassInfoWithInterfaces('App\\MyClass', ['App\\ChildInterface']),
-            $this->createClassInfoWithInterfaces('App\\ChildInterface', ['App\\ParentInterface'], ClassKind::Interface_),
+            $this->createClassInfoWithInterfaces(
+                'App\\ChildInterface',
+                ['App\\ParentInterface'],
+                ClassKind::Interface_,
+            ),
             $this->createClassInfoForTest('App\\ParentInterface', ClassKind::Interface_),
         ]);
 

--- a/tests/Repository/DefaultClassRepositoryTest.php
+++ b/tests/Repository/DefaultClassRepositoryTest.php
@@ -219,14 +219,188 @@ final class DefaultClassRepositoryTest extends TestCase
         self::assertSame($documentInfo, $result);
     }
 
+    public function testIsSubclassOfDirectParent(): void
+    {
+        $repo = $this->createRepoWithClasses([
+            $this->createClassInfoWithParent('App\\Child', 'App\\Parent'),
+            $this->createClassInfo('App\\Parent'),
+        ]);
+
+        /** @var class-string $child */
+        $child = 'App\\Child';
+        /** @var class-string $parent */
+        $parent = 'App\\Parent';
+
+        self::assertTrue($repo->isSubclassOf(new ClassName($child), new ClassName($parent)));
+    }
+
+    public function testIsSubclassOfTransitiveParent(): void
+    {
+        $repo = $this->createRepoWithClasses([
+            $this->createClassInfoWithParent('App\\Grandchild', 'App\\Child'),
+            $this->createClassInfoWithParent('App\\Child', 'App\\Parent'),
+            $this->createClassInfo('App\\Parent'),
+        ]);
+
+        /** @var class-string $grandchild */
+        $grandchild = 'App\\Grandchild';
+        /** @var class-string $parent */
+        $parent = 'App\\Parent';
+
+        self::assertTrue($repo->isSubclassOf(new ClassName($grandchild), new ClassName($parent)));
+    }
+
+    public function testIsSubclassOfImplementedInterface(): void
+    {
+        $repo = $this->createRepoWithClasses([
+            $this->createClassInfoWithInterfaces('App\\MyClass', ['App\\MyInterface']),
+            $this->createClassInfo('App\\MyInterface', ClassKind::Interface_),
+        ]);
+
+        /** @var class-string $class */
+        $class = 'App\\MyClass';
+        /** @var class-string $interface */
+        $interface = 'App\\MyInterface';
+
+        self::assertTrue($repo->isSubclassOf(new ClassName($class), new ClassName($interface)));
+    }
+
+    public function testIsSubclassOfInheritedInterface(): void
+    {
+        $repo = $this->createRepoWithClasses([
+            $this->createClassInfoWithInterfaces('App\\MyClass', ['App\\ChildInterface']),
+            $this->createClassInfoWithInterfaces('App\\ChildInterface', ['App\\ParentInterface'], ClassKind::Interface_),
+            $this->createClassInfo('App\\ParentInterface', ClassKind::Interface_),
+        ]);
+
+        /** @var class-string $class */
+        $class = 'App\\MyClass';
+        /** @var class-string $interface */
+        $interface = 'App\\ParentInterface';
+
+        self::assertTrue($repo->isSubclassOf(new ClassName($class), new ClassName($interface)));
+    }
+
+    public function testIsSubclassOfReturnsFalseForUnrelatedClasses(): void
+    {
+        $repo = $this->createRepoWithClasses([
+            $this->createClassInfo('App\\ClassA'),
+            $this->createClassInfo('App\\ClassB'),
+        ]);
+
+        /** @var class-string $a */
+        $a = 'App\\ClassA';
+        /** @var class-string $b */
+        $b = 'App\\ClassB';
+
+        self::assertFalse($repo->isSubclassOf(new ClassName($a), new ClassName($b)));
+    }
+
+    public function testIsSubclassOfReturnsFalseForSameClass(): void
+    {
+        $repo = $this->createRepoWithClasses([
+            $this->createClassInfo('App\\MyClass'),
+        ]);
+
+        /** @var class-string $class */
+        $class = 'App\\MyClass';
+
+        self::assertFalse($repo->isSubclassOf(new ClassName($class), new ClassName($class)));
+    }
+
+    public function testIsSubclassOfReturnsFalseForUnknownClass(): void
+    {
+        $factory = self::createStub(ClassInfoFactory::class);
+        $locator = self::createStub(ClassLocator::class);
+        $locator->method('locate')->willReturn(null);
+        $parser = new ParserService();
+
+        $repo = new DefaultClassRepository($factory, $locator, $parser);
+
+        /** @var class-string $unknown */
+        $unknown = 'App\\Unknown';
+        /** @var class-string $other */
+        $other = 'App\\Other';
+
+        self::assertFalse($repo->isSubclassOf(new ClassName($unknown), new ClassName($other)));
+    }
+
+    /**
+     * @param list<ClassInfo> $classes
+     */
+    private function createRepoWithClasses(array $classes): DefaultClassRepository
+    {
+        $factory = self::createStub(ClassInfoFactory::class);
+        $locator = self::createStub(ClassLocator::class);
+        $parser = new ParserService();
+
+        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo->updateDocument('file:///test.php', $classes);
+
+        return $repo;
+    }
+
     /**
      * @param class-string $fqn
+     * @param class-string $parentFqn
      */
-    private function createClassInfo(string $fqn): ClassInfo
+    private function createClassInfoWithParent(string $fqn, string $parentFqn): ClassInfo
     {
         return new ClassInfo(
             name: new ClassName($fqn),
             kind: ClassKind::Class_,
+            isAbstract: false,
+            isFinal: false,
+            isReadonly: false,
+            parent: new ClassName($parentFqn),
+            interfaces: [],
+            traits: [],
+            methods: [],
+            properties: [],
+            constants: [],
+            enumCases: [],
+            docblock: null,
+            file: null,
+            line: null,
+        );
+    }
+
+    /**
+     * @param class-string $fqn
+     * @param list<class-string> $interfaceFqns
+     */
+    private function createClassInfoWithInterfaces(
+        string $fqn,
+        array $interfaceFqns,
+        ClassKind $kind = ClassKind::Class_,
+    ): ClassInfo {
+        return new ClassInfo(
+            name: new ClassName($fqn),
+            kind: $kind,
+            isAbstract: false,
+            isFinal: false,
+            isReadonly: false,
+            parent: null,
+            interfaces: array_map(fn($i) => new ClassName($i), $interfaceFqns),
+            traits: [],
+            methods: [],
+            properties: [],
+            constants: [],
+            enumCases: [],
+            docblock: null,
+            file: null,
+            line: null,
+        );
+    }
+
+    /**
+     * @param class-string $fqn
+     */
+    private function createClassInfo(string $fqn, ClassKind $kind = ClassKind::Class_): ClassInfo
+    {
+        return new ClassInfo(
+            name: new ClassName($fqn),
+            kind: $kind,
             isAbstract: false,
             isFinal: false,
             isReadonly: false,

--- a/tests/Repository/DefaultClassRepositoryTest.php
+++ b/tests/Repository/DefaultClassRepositoryTest.php
@@ -223,15 +223,13 @@ final class DefaultClassRepositoryTest extends TestCase
     {
         $repo = $this->createRepoWithClasses([
             $this->createClassInfoWithParent('App\\Child', 'App\\Parent'),
-            $this->createClassInfo('App\\Parent'),
+            $this->createClassInfoForTest('App\\Parent'),
         ]);
 
-        /** @var class-string $child */
-        $child = 'App\\Child';
-        /** @var class-string $parent */
-        $parent = 'App\\Parent';
-
-        self::assertTrue($repo->isSubclassOf(new ClassName($child), new ClassName($parent)));
+        self::assertTrue($repo->isSubclassOf(
+            new ClassName('App\\Child'), // @phpstan-ignore argument.type
+            new ClassName('App\\Parent'), // @phpstan-ignore argument.type
+        ));
     }
 
     public function testIsSubclassOfTransitiveParent(): void
@@ -239,30 +237,26 @@ final class DefaultClassRepositoryTest extends TestCase
         $repo = $this->createRepoWithClasses([
             $this->createClassInfoWithParent('App\\Grandchild', 'App\\Child'),
             $this->createClassInfoWithParent('App\\Child', 'App\\Parent'),
-            $this->createClassInfo('App\\Parent'),
+            $this->createClassInfoForTest('App\\Parent'),
         ]);
 
-        /** @var class-string $grandchild */
-        $grandchild = 'App\\Grandchild';
-        /** @var class-string $parent */
-        $parent = 'App\\Parent';
-
-        self::assertTrue($repo->isSubclassOf(new ClassName($grandchild), new ClassName($parent)));
+        self::assertTrue($repo->isSubclassOf(
+            new ClassName('App\\Grandchild'), // @phpstan-ignore argument.type
+            new ClassName('App\\Parent'), // @phpstan-ignore argument.type
+        ));
     }
 
     public function testIsSubclassOfImplementedInterface(): void
     {
         $repo = $this->createRepoWithClasses([
             $this->createClassInfoWithInterfaces('App\\MyClass', ['App\\MyInterface']),
-            $this->createClassInfo('App\\MyInterface', ClassKind::Interface_),
+            $this->createClassInfoForTest('App\\MyInterface', ClassKind::Interface_),
         ]);
 
-        /** @var class-string $class */
-        $class = 'App\\MyClass';
-        /** @var class-string $interface */
-        $interface = 'App\\MyInterface';
-
-        self::assertTrue($repo->isSubclassOf(new ClassName($class), new ClassName($interface)));
+        self::assertTrue($repo->isSubclassOf(
+            new ClassName('App\\MyClass'), // @phpstan-ignore argument.type
+            new ClassName('App\\MyInterface'), // @phpstan-ignore argument.type
+        ));
     }
 
     public function testIsSubclassOfInheritedInterface(): void
@@ -270,42 +264,38 @@ final class DefaultClassRepositoryTest extends TestCase
         $repo = $this->createRepoWithClasses([
             $this->createClassInfoWithInterfaces('App\\MyClass', ['App\\ChildInterface']),
             $this->createClassInfoWithInterfaces('App\\ChildInterface', ['App\\ParentInterface'], ClassKind::Interface_),
-            $this->createClassInfo('App\\ParentInterface', ClassKind::Interface_),
+            $this->createClassInfoForTest('App\\ParentInterface', ClassKind::Interface_),
         ]);
 
-        /** @var class-string $class */
-        $class = 'App\\MyClass';
-        /** @var class-string $interface */
-        $interface = 'App\\ParentInterface';
-
-        self::assertTrue($repo->isSubclassOf(new ClassName($class), new ClassName($interface)));
+        self::assertTrue($repo->isSubclassOf(
+            new ClassName('App\\MyClass'), // @phpstan-ignore argument.type
+            new ClassName('App\\ParentInterface'), // @phpstan-ignore argument.type
+        ));
     }
 
     public function testIsSubclassOfReturnsFalseForUnrelatedClasses(): void
     {
         $repo = $this->createRepoWithClasses([
-            $this->createClassInfo('App\\ClassA'),
-            $this->createClassInfo('App\\ClassB'),
+            $this->createClassInfoForTest('App\\ClassA'),
+            $this->createClassInfoForTest('App\\ClassB'),
         ]);
 
-        /** @var class-string $a */
-        $a = 'App\\ClassA';
-        /** @var class-string $b */
-        $b = 'App\\ClassB';
-
-        self::assertFalse($repo->isSubclassOf(new ClassName($a), new ClassName($b)));
+        self::assertFalse($repo->isSubclassOf(
+            new ClassName('App\\ClassA'), // @phpstan-ignore argument.type
+            new ClassName('App\\ClassB'), // @phpstan-ignore argument.type
+        ));
     }
 
     public function testIsSubclassOfReturnsFalseForSameClass(): void
     {
         $repo = $this->createRepoWithClasses([
-            $this->createClassInfo('App\\MyClass'),
+            $this->createClassInfoForTest('App\\MyClass'),
         ]);
 
-        /** @var class-string $class */
-        $class = 'App\\MyClass';
-
-        self::assertFalse($repo->isSubclassOf(new ClassName($class), new ClassName($class)));
+        self::assertFalse($repo->isSubclassOf(
+            new ClassName('App\\MyClass'), // @phpstan-ignore argument.type
+            new ClassName('App\\MyClass'), // @phpstan-ignore argument.type
+        ));
     }
 
     public function testIsSubclassOfReturnsFalseForUnknownClass(): void
@@ -317,12 +307,10 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $repo = new DefaultClassRepository($factory, $locator, $parser);
 
-        /** @var class-string $unknown */
-        $unknown = 'App\\Unknown';
-        /** @var class-string $other */
-        $other = 'App\\Other';
-
-        self::assertFalse($repo->isSubclassOf(new ClassName($unknown), new ClassName($other)));
+        self::assertFalse($repo->isSubclassOf(
+            new ClassName('App\\Unknown'), // @phpstan-ignore argument.type
+            new ClassName('App\\Other'), // @phpstan-ignore argument.type
+        ));
     }
 
     /**
@@ -340,19 +328,15 @@ final class DefaultClassRepositoryTest extends TestCase
         return $repo;
     }
 
-    /**
-     * @param class-string $fqn
-     * @param class-string $parentFqn
-     */
     private function createClassInfoWithParent(string $fqn, string $parentFqn): ClassInfo
     {
         return new ClassInfo(
-            name: new ClassName($fqn),
+            name: new ClassName($fqn), // @phpstan-ignore argument.type
             kind: ClassKind::Class_,
             isAbstract: false,
             isFinal: false,
             isReadonly: false,
-            parent: new ClassName($parentFqn),
+            parent: new ClassName($parentFqn), // @phpstan-ignore argument.type
             interfaces: [],
             traits: [],
             methods: [],
@@ -366,8 +350,7 @@ final class DefaultClassRepositoryTest extends TestCase
     }
 
     /**
-     * @param class-string $fqn
-     * @param list<class-string> $interfaceFqns
+     * @param list<string> $interfaceFqns
      */
     private function createClassInfoWithInterfaces(
         string $fqn,
@@ -375,13 +358,34 @@ final class DefaultClassRepositoryTest extends TestCase
         ClassKind $kind = ClassKind::Class_,
     ): ClassInfo {
         return new ClassInfo(
-            name: new ClassName($fqn),
+            name: new ClassName($fqn), // @phpstan-ignore argument.type
             kind: $kind,
             isAbstract: false,
             isFinal: false,
             isReadonly: false,
             parent: null,
-            interfaces: array_map(fn($i) => new ClassName($i), $interfaceFqns),
+            interfaces: array_map(fn($i) => new ClassName($i), $interfaceFqns), // @phpstan-ignore argument.type
+            traits: [],
+            methods: [],
+            properties: [],
+            constants: [],
+            enumCases: [],
+            docblock: null,
+            file: null,
+            line: null,
+        );
+    }
+
+    private function createClassInfoForTest(string $fqn, ClassKind $kind = ClassKind::Class_): ClassInfo
+    {
+        return new ClassInfo(
+            name: new ClassName($fqn), // @phpstan-ignore argument.type
+            kind: $kind,
+            isAbstract: false,
+            isFinal: false,
+            isReadonly: false,
+            parent: null,
+            interfaces: [],
             traits: [],
             methods: [],
             properties: [],


### PR DESCRIPTION
## Summary

Resolves #142

- Adds `ClassRepository::isSubclassOf()` method to check inheritance relationships via ClassRepository
- Migrates `CompletionHandler` visibility detection to use the new method instead of `ReflectionHelper::getClass()->isSubclassOf()`
- Removes `ReflectionHelper` dependency from `CompletionHandler`

This unblocks #121 (Phase 5: Remove deprecated code) by removing one usage of ReflectionHelper.

## Test plan

- [x] Tests added for isSubclassOf covering direct parents, transitive inheritance, interfaces, and inherited interfaces
- [x] Existing completion tests pass with the new dependency

🤖 Generated with [Claude Code](https://claude.ai/code)