### PR TITLE
Migrate BasicTypeResolver to use MemberResolver

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -54,11 +54,11 @@ final class Server
         $symbolIndex = new SymbolIndex();
         $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
         $classLocator = new ComposerClassLocator($projectRoot);
-        $typeResolver = new BasicTypeResolver();
 
         $classInfoFactory = new DefaultClassInfoFactory();
         $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
         $memberResolver = new MemberResolver($classRepository);
+        $typeResolver = new BasicTypeResolver($memberResolver);
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\TypeInference;
 
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Utility\TypeFormatter;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use Firehed\PhpLsp\Utility\ReflectionHelper;
-use Firehed\PhpLsp\Utility\TypeFormatter;
-use ReflectionNamedType;
 
 /**
  * Basic type resolver using simple heuristics.
@@ -25,6 +28,10 @@ use ReflectionNamedType;
  */
 final class BasicTypeResolver implements TypeResolverInterface
 {
+    public function __construct(
+        private readonly MemberResolver $memberResolver,
+    ) {
+    }
     public function resolveExpressionType(
         Expr $expr,
         Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope,
@@ -198,30 +205,26 @@ final class BasicTypeResolver implements TypeResolverInterface
 
     private function getMethodReturnType(string $className, string $methodName): ?string
     {
-        $reflection = ReflectionHelper::getClass($className);
-        if ($reflection === null || !$reflection->hasMethod($methodName)) {
-            return null;
-        }
-        $method = $reflection->getMethod($methodName);
-        $returnType = $method->getReturnType();
-        if (!$returnType instanceof ReflectionNamedType) {
-            return null;
-        }
-        return $returnType->getName();
+        /** @var class-string $className */
+        $methodInfo = $this->memberResolver->findMethod(
+            new ClassName($className),
+            new MethodName($methodName),
+            Visibility::Public,
+        );
+
+        return $methodInfo?->returnType;
     }
 
     private function getPropertyType(string $className, string $propertyName): ?string
     {
-        $reflection = ReflectionHelper::getClass($className);
-        if ($reflection === null || !$reflection->hasProperty($propertyName)) {
-            return null;
-        }
-        $property = $reflection->getProperty($propertyName);
-        $type = $property->getType();
-        if (!$type instanceof ReflectionNamedType) {
-            return null;
-        }
-        return $type->getName();
+        /** @var class-string $className */
+        $propertyInfo = $this->memberResolver->findProperty(
+            new ClassName($className),
+            new PropertyName($propertyName),
+            Visibility::Public,
+        );
+
+        return $propertyInfo?->type;
     }
 
     /**

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1743,7 +1743,7 @@ PHP;
             $this->symbolIndex,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -1790,7 +1790,7 @@ PHP;
             $this->symbolIndex,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -1835,7 +1835,7 @@ PHP;
             $this->symbolIndex,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -1874,7 +1874,7 @@ PHP;
             $this->symbolIndex,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -1910,7 +1910,7 @@ PHP;
             $this->symbolIndex,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -1961,7 +1961,7 @@ PHP;
             $this->symbolIndex,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -46,7 +46,7 @@ class DefinitionHandlerTest extends TestCase
             $this->parser,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -372,7 +372,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -420,7 +420,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -906,7 +906,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([
@@ -941,7 +941,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
 
         $request = RequestMessage::fromArray([

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -46,7 +46,7 @@ class SignatureHelpHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->memberResolver,
-            new BasicTypeResolver(),
+            new BasicTypeResolver($this->memberResolver),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -99,18 +99,77 @@ PHP;
         self::assertSame('DateTime', $objectType);
     }
 
-    public function testResolveStaticMethodCallExtractsClassName(): void
+    public function testResolveMethodReturnType(): void
     {
-        // Note: Static method return type resolution depends on reflection,
-        // which may not have return types for built-in classes.
-        // This test verifies the class name is correctly extracted from the call.
-        $code = '<?php $result = DateTime::createFromFormat("Y-m-d", "2024-01-01");';
+        // Exception::getMessage() has return type string
+        $code = <<<'PHP'
+<?php
+function test() {
+    $ex = new Exception();
+    $result = $ex->getMessage();
+}
+PHP;
         $ast = $this->parse($code);
-        $staticCall = $this->findFirstExprOfType($ast, Expr\StaticCall::class);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $methodCall = $this->findFirstExprOfType($ast, Expr\MethodCall::class);
 
-        // Verify we can at least extract the class name from the static call
-        self::assertInstanceOf(Name::class, $staticCall->class);
-        self::assertSame('DateTime', $staticCall->class->toString());
+        $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
+
+        self::assertSame('string', $type);
+    }
+
+    public function testResolveMethodReturnTypeReturnsNullForUnknownMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test() {
+    $ex = new Exception();
+    $result = $ex->nonExistentMethod();
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $methodCall = $this->findFirstExprOfType($ast, Expr\MethodCall::class);
+
+        $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
+
+        self::assertNull($type);
+    }
+
+    public function testResolveMethodReturnTypeInt(): void
+    {
+        // Exception::getLine() returns int
+        $code = <<<'PHP'
+<?php
+function test() {
+    $ex = new Exception();
+    $result = $ex->getLine();
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $methodCall = $this->findFirstExprOfType($ast, Expr\MethodCall::class);
+
+        $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
+
+        self::assertSame('int', $type);
+    }
+
+    public function testResolvePropertyTypeReturnsNullForUnknownClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(UnknownClass $obj) {
+    $result = $obj->name;
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $propertyFetch = $this->findFirstExprOfType($ast, Expr\PropertyFetch::class);
+
+        $type = $this->resolver->resolveExpressionType($propertyFetch, $function, $ast);
+
+        self::assertNull($type);
     }
 
     public function testResolveCloneExpression(): void

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\TypeInference;
 
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\ClassLocator;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -20,7 +25,13 @@ class BasicTypeResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->resolver = new BasicTypeResolver();
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $parser = new ParserService();
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+        $memberResolver = new MemberResolver($classRepository);
+
+        $this->resolver = new BasicTypeResolver($memberResolver);
     }
 
     public function testResolveNewExpression(): void


### PR DESCRIPTION
## Summary

Resolves #143

- Adds `MemberResolver` as a constructor dependency to `BasicTypeResolver`
- Replaces `ReflectionHelper::getClass()` calls with `MemberResolver::findMethod()` and `MemberResolver::findProperty()`
- Removes the `ReflectionHelper` dependency from `BasicTypeResolver`

This unblocks #121 (Phase 5: Remove deprecated code) by removing the last usage of ReflectionHelper from non-deprecated code.

## Test plan

- [x] All existing tests pass with the new dependency injection
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.ai/code)