### PR TITLE
Extract function-finding logic to ScopeFinder

### DIFF
--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -32,8 +32,6 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
 use ReflectionException;
 use ReflectionFunction;
 
@@ -228,32 +226,12 @@ final class HoverHandler implements HandlerInterface
      */
     private function getFunctionHover(string $functionName, array $ast): ?string
     {
-        $finder = new class ($functionName) extends NodeVisitorAbstract {
-            public ?Stmt\Function_ $found = null;
-
-            public function __construct(private readonly string $functionName)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Function_ && $node->name->toString() === $this->functionName) {
-                    $this->found = $node;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        if ($finder->found === null) {
+        $funcNode = ScopeFinder::findFunction($functionName, $ast);
+        if ($funcNode === null) {
             return null;
         }
 
-        return $this->formatFunctionHover($finder->found);
+        return $this->formatFunctionHover($funcNode);
     }
 
     private function formatFunctionHover(Stmt\Function_ $node): string

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -210,7 +210,7 @@ final class SignatureHelpHandler implements HandlerInterface
         $functionName = $name->toString();
 
         // Try user-defined function first
-        $funcNode = $this->findFunctionInAst($functionName, $ast);
+        $funcNode = ScopeFinder::findFunction($functionName, $ast);
         if ($funcNode !== null) {
             return $this->formatFunctionNodeSignature($funcNode);
         }
@@ -306,34 +306,6 @@ final class SignatureHelpHandler implements HandlerInterface
         return null;
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findFunctionInAst(string $functionName, array $ast): ?Stmt\Function_
-    {
-        $finder = new class ($functionName) extends NodeVisitorAbstract {
-            public ?Stmt\Function_ $found = null;
-
-            public function __construct(private readonly string $functionName)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Function_ && $node->name->toString() === $this->functionName) {
-                    $this->found = $node;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        return $finder->found;
-    }
 
     /**
      * @return SignatureInfo

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -168,4 +168,35 @@ final class ScopeFinder
             }
         }
     }
+
+    /**
+     * Find a user-defined function by name in the AST.
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function findFunction(string $functionName, array $ast): ?Stmt\Function_
+    {
+        $visitor = new class ($functionName) extends NodeVisitorAbstract {
+            public ?Stmt\Function_ $found = null;
+
+            public function __construct(private readonly string $functionName)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Function_ && $node->name->toString() === $this->functionName) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->found;
+    }
 }

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -462,4 +462,47 @@ PHP;
         self::assertInstanceOf(Stmt\Class_::class, $statements[1]);
         self::assertSame('Second', $statements[1]->name?->toString());
     }
+
+    public function testFindFunctionReturnsNullWhenNotFound(): void
+    {
+        $code = <<<'PHP'
+<?php
+function other(): void {}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        self::assertNull(ScopeFinder::findFunction('nonexistent', $ast));
+    }
+
+    public function testFindFunctionReturnsMatchingFunction(): void
+    {
+        $code = <<<'PHP'
+<?php
+function first(): void {}
+function second(): int { return 1; }
+function third(): string { return ''; }
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $found = ScopeFinder::findFunction('second', $ast);
+
+        self::assertNotNull($found);
+        self::assertSame('second', $found->name->toString());
+    }
+
+    public function testFindFunctionWorksWithNamespace(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Utils;
+
+function helper(): void {}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $found = ScopeFinder::findFunction('helper', $ast);
+
+        self::assertNotNull($found);
+        self::assertSame('helper', $found->name->toString());
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `ScopeFinder::findFunction()` to find user-defined functions by name in an AST
- Migrates `SignatureHelpHandler` and `HoverHandler` to use the shared utility
- Removes ~50 lines of duplicate code

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)