### PR TITLE
Fix $this variable completion to show actual class name

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -876,7 +876,10 @@ final class CompletionHandler implements HandlerInterface
 
         // Add $this if we're in a method
         if ($inMethod && self::matchesPrefix('this', $prefix)) {
-            $className = $this->typeResolver?->resolveVariableType('this', $enclosingScope, $cursorLine, $ast);
+            // Use ScopeFinder directly for $this - TypeResolverInterface::resolveVariableType
+            // doesn't handle $this (it only checks parameters, use() vars, and assignments)
+            $classNode = ScopeFinder::findClassAtLine($ast, $cursorLine);
+            $className = $classNode?->namespacedName?->toString() ?? $classNode?->name?->toString();
             $items[] = [
                 'label' => '$this',
                 'kind' => self::KIND_VARIABLE,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1356,6 +1356,65 @@ PHP;
         self::assertContains('$this', $labels);
     }
 
+    public function testVariableCompletionThisShowsClassName(): void
+    {
+        $code = '<?php class MyClass { public function bar() { $t; } }';
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 48], // After $t
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $thisItems = array_filter($result['items'], fn($item) => $item['label'] === '$this');
+        self::assertNotEmpty($thisItems);
+        $thisItem = reset($thisItems);
+        self::assertSame('MyClass', $thisItem['detail'] ?? null);
+    }
+
+    public function testVariableCompletionThisShowsNamespacedClassName(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class User
+{
+    public function getName(): void
+    {
+        $t
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 10], // After $t
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $thisItems = array_filter($result['items'], fn($item) => $item['label'] === '$this');
+        self::assertNotEmpty($thisItems);
+        $thisItem = reset($thisItems);
+        self::assertSame('App\Models\User', $thisItem['detail'] ?? null);
+    }
+
     public function testVariableCompletionWorksInClosures(): void
     {
         $code = '<?php $fn = function ($param) { $localVar = 1; $l; };';


### PR DESCRIPTION
## Summary
- Fixed bug where `$this` variable completion showed `'self'` instead of the actual class name
- Root cause: `TypeResolverInterface::resolveVariableType()` does not handle `$this` (only checks parameters, use() vars, and assignments)
- Fix uses `ScopeFinder::findClassAtLine()` directly to get the enclosing class name

## Per Issue #168 Analysis
CompletionHandler does NOT need `ExpressionTypeResolver` injection because:
- `$this->` member completions are already handled separately via `getThisMemberCompletions()`
- `$variable->` member completions correctly use `resolveVariableType()` for non-`$this` variables
- `$this` in variable list now uses `ScopeFinder::findClassAtLine()` directly with a comment explaining why

Closes #168