### PR TITLE
Test inherited member completion (closes #95)

### DIFF
--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -185,6 +185,44 @@ PHP;
         self::assertContains('age', $labels);
     }
 
+    public function testThisCompletionIncludesInheritedMembers(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyException extends \Exception
+{
+    private string $ownProperty;
+
+    public function test(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Own members
+        self::assertContains('ownProperty', $labels);
+        self::assertContains('test', $labels);
+        // Inherited members from Exception
+        self::assertContains('getMessage', $labels);
+        self::assertContains('getCode', $labels);
+    }
+
     public function testStaticMethodCompletion(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary

- Adds E2E test verifying that `$this->` completion includes both own members and inherited members from parent classes

This confirms that issue #95 is resolved by the current architecture.

## Test plan

- [x] Test passes locally with `composer phpunit -- --filter testThisCompletionIncludesInheritedMembers`
- [x] `composer check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)