### PR TITLE
Test hover on trait members (closes #85)

### DIFF
--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -645,6 +645,88 @@ PHP;
         self::assertStringContainsString('Namespaced parent method', $result['contents']);
     }
 
+    public function testHoverOnTraitMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait Greeter
+{
+    /**
+     * Says hello.
+     */
+    public function greet(): void {}
+}
+
+class Foo
+{
+    use Greeter;
+
+    public function test(): void
+    {
+        $this->greet();
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('greet', $result['contents']);
+        self::assertStringContainsString('Says hello', $result['contents']);
+    }
+
+    public function testHoverOnTraitProperty(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait HasName
+{
+    /**
+     * The name value.
+     */
+    protected string $name;
+}
+
+class Person
+{
+    use HasName;
+
+    public function test(): void
+    {
+        $this->name;
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$name', $result['contents']);
+        self::assertStringContainsString('The name value', $result['contents']);
+    }
+
     public function testHoverOnInheritedMethodAcrossNamespaces(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary

- Adds tests verifying that hover on trait methods shows the trait's method signature and documentation
- Adds tests verifying that hover on trait properties shows the trait's property signature and documentation

This confirms that issue #85 is resolved by the current architecture (MemberResolver traverses traits).

## Test plan

- [x] Tests pass locally with `composer phpunit -- --filter "testHoverOnTraitMethod|testHoverOnTraitProperty"`
- [x] `composer check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)