### PR TITLE
Make TypeResolver and DocumentIndexer required in handlers

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -79,7 +79,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly SymbolIndex $symbolIndex,
         private readonly MemberResolver $memberResolver,
         private readonly ClassRepository $classRepository,
-        private readonly ?TypeResolverInterface $typeResolver = null,
+        private readonly TypeResolverInterface $typeResolver,
     ) {
     }
 
@@ -398,10 +398,6 @@ final class CompletionHandler implements HandlerInterface
         array $ast,
         int $line,
     ): array {
-        if ($this->typeResolver === null) {
-            return [];
-        }
-
         // Find the enclosing scope
         $scope = $this->findEnclosingScope($ast, $line);
         if ($scope === null) {
@@ -889,8 +885,7 @@ final class CompletionHandler implements HandlerInterface
 
         foreach ($variables as $name => $basicType) {
             if (self::matchesPrefix($name, $prefix)) {
-                // Use type resolver if available, fall back to basic type
-                $resolvedType = $this->typeResolver?->resolveVariableType($name, $enclosingScope, $cursorLine, $ast);
+                $resolvedType = $this->typeResolver->resolveVariableType($name, $enclosingScope, $cursorLine, $ast);
                 $items[] = [
                     'label' => '$' . $name,
                     'kind' => self::KIND_VARIABLE,

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -30,7 +30,7 @@ final class DefinitionHandler implements HandlerInterface
         private readonly ParserService $parser,
         private readonly MemberResolver $memberResolver,
         private readonly ClassRepository $classRepository,
-        private readonly ?TypeResolverInterface $typeResolver = null,
+        private readonly TypeResolverInterface $typeResolver,
     ) {
     }
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -42,7 +42,7 @@ final class HoverHandler implements HandlerInterface
         private readonly ParserService $parser,
         private readonly ClassRepository $classRepository,
         private readonly MemberResolver $memberResolver,
-        private readonly ?TypeResolverInterface $typeResolver = null,
+        private readonly TypeResolverInterface $typeResolver,
     ) {
     }
 

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -44,7 +44,7 @@ final class SignatureHelpHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly MemberResolver $memberResolver,
-        private readonly ?TypeResolverInterface $typeResolver = null,
+        private readonly TypeResolverInterface $typeResolver,
     ) {
     }
 

--- a/src/Handler/TextDocumentSyncHandler.php
+++ b/src/Handler/TextDocumentSyncHandler.php
@@ -26,7 +26,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         private readonly ParserService $parser,
         private readonly ClassRepository $classRepository,
         private readonly ClassInfoFactory $classInfoFactory,
-        private readonly ?DocumentIndexer $indexer = null,
+        private readonly DocumentIndexer $indexer,
     ) {
     }
 
@@ -110,7 +110,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         $uri = $textDocument['uri'] ?? '';
         assert(is_string($uri));
 
-        $this->indexer?->remove($uri);
+        $this->indexer->remove($uri);
         $this->classRepository->removeDocument($uri);
         $this->documentManager->close($uri);
 
@@ -127,7 +127,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
             $this->registerDocumentClasses($uri, $ast);
         }
 
-        $this->indexer?->index($document);
+        $this->indexer->index($document);
     }
 
     /**

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -7,8 +7,10 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\Symbol;
+use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -49,18 +51,22 @@ class CompletionHandlerTest extends TestCase
             $this->parser,
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
+        $typeResolver = new BasicTypeResolver($this->memberResolver);
+        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
         $this->handler = new CompletionHandler(
             $this->documents,
             $this->parser,
             $this->symbolIndex,
             $this->memberResolver,
             $this->classRepository,
+            $typeResolver,
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
             $this->parser,
             $this->classRepository,
             $this->classInfoFactory,
+            $indexer,
         );
     }
 
@@ -2479,7 +2485,7 @@ PHP;
         self::assertNotContains('__construct', $labels);
     }
 
-    public function testTypedVariableCompletionReturnsEmptyWithoutTypeResolver(): void
+    public function testTypedVariableCompletionResolvesParameterType(): void
     {
         $code = <<<'PHP'
 <?php
@@ -2495,7 +2501,6 @@ function foo(User $user): void
 PHP;
         $this->openDocument('file:///test.php', $code);
 
-        // Handler without type resolver (uses default from setUp)
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
             'id' => 1,
@@ -2509,8 +2514,8 @@ PHP;
         $result = $this->handler->handle($request);
 
         self::assertIsArray($result);
-        // Without type resolver, no completions for typed variables
-        self::assertEmpty($result['items']);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getName', $labels);
     }
 
     /**

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -7,6 +7,9 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
@@ -48,11 +51,13 @@ class DefinitionHandlerTest extends TestCase
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
         );
+        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
             $this->parser,
             $this->classRepository,
             $classInfoFactory,
+            $indexer,
         );
     }
 

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -46,11 +46,13 @@ class HoverHandlerTest extends TestCase
             $this->parser,
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
+        $typeResolver = new BasicTypeResolver($this->memberResolver);
         $this->handler = new HoverHandler(
             $this->documents,
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
+            $typeResolver,
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -7,6 +7,9 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\HoverHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
@@ -49,11 +52,13 @@ class HoverHandlerTest extends TestCase
             $this->classRepository,
             $this->memberResolver,
         );
+        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
             $this->parser,
             $this->classRepository,
             $this->classInfoFactory,
+            $indexer,
         );
     }
 

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -7,6 +7,9 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
@@ -48,11 +51,13 @@ class SignatureHelpHandlerTest extends TestCase
             $this->memberResolver,
             new BasicTypeResolver($this->memberResolver),
         );
+        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
             $this->parser,
             $this->classRepository,
             $this->classInfoFactory,
+            $indexer,
         );
     }
 

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -7,6 +7,9 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
@@ -31,11 +34,13 @@ class TextDocumentSyncHandlerTest extends TestCase
         $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
         $this->classRepository = new DefaultClassRepository($this->classInfoFactory, $locator, $this->parser);
+        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->handler = new TextDocumentSyncHandler(
             $this->manager,
             $this->parser,
             $this->classRepository,
             $this->classInfoFactory,
+            $indexer,
         );
     }
 


### PR DESCRIPTION
## Summary

- Makes TypeResolver required in HoverHandler, DefinitionHandler, SignatureHelpHandler, CompletionHandler
- Makes DocumentIndexer required in TextDocumentSyncHandler
- Removes dead null-checks and nullsafe calls
- Updates test setups to provide required dependencies
- Updates a test that was testing obsolete 'without TypeResolver' behavior

These dependencies were optional but always provided in production. Making them required simplifies the code and prevents silent failures.

## Test plan

- [x] `composer check` passes

Generated with [Claude Code](https://claude.com/claude-code)