### PR TITLE
Suggest missing abstract methods when defining methods

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -212,6 +212,13 @@ final class CompletionHandler implements HandlerInterface
             return $this->deduplicateCompletions($items);
         }
 
+        // Method definition context - suggest missing abstract methods from interfaces/abstract parent
+        $methodDefPattern = '/(?:public|private|protected)\s+(?:static\s+)?function\s+(\w*)$/';
+        if (preg_match($methodDefPattern, $textBeforeCursor, $matches) === 1) {
+            $prefix = $matches[1];
+            return $this->getMissingAbstractMethodCompletions($prefix, $ast, $line);
+        }
+
         // After visibility keyword - suggest function, static, readonly, const, or types
         // Must check before general type hint context since both patterns overlap
         if (preg_match('/(?:public|private|protected)\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
@@ -417,6 +424,38 @@ final class CompletionHandler implements HandlerInterface
             false,
             $prefix,
         );
+    }
+
+    /**
+     * Get completions for missing abstract methods from interfaces and abstract parents.
+     *
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function getMissingAbstractMethodCompletions(string $prefix, array $ast, int $line): array
+    {
+        $classNode = ScopeFinder::findClassAtLine($ast, $line);
+        if ($classNode === null) {
+            return [];
+        }
+
+        $classNameStr = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+        if ($classNameStr === null) {
+            return [];
+        }
+
+        /** @var class-string $classNameStr */
+        $className = new ClassName($classNameStr);
+        $unimplementedMethods = $this->memberResolver->getUnimplementedAbstractMethods($className);
+
+        $items = [];
+        foreach ($unimplementedMethods as $method) {
+            if (self::matchesPrefix($method->name->name, $prefix)) {
+                $items[] = $this->formatMethodInfoCompletion($method);
+            }
+        }
+
+        return $items;
     }
 
     /**

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -145,6 +145,79 @@ final class MemberResolver
     }
 
     /**
+     * Get abstract methods from interfaces and parent classes that the class
+     * must implement but hasn't yet.
+     *
+     * @return list<MethodInfo>
+     */
+    public function getUnimplementedAbstractMethods(ClassName $class): array
+    {
+        $classInfo = $this->classes->get($class);
+        if ($classInfo === null) {
+            return [];
+        }
+
+        $implementedMethods = [];
+        foreach ($classInfo->methods as $method) {
+            $implementedMethods[strtolower($method->name->name)] = true;
+        }
+
+        $abstractMethods = [];
+        $seen = [];
+
+        $this->collectAbstractMethods($classInfo, $abstractMethods, $implementedMethods, $seen);
+
+        return array_values($abstractMethods);
+    }
+
+    /**
+     * @param array<string, MethodInfo> $abstractMethods
+     * @param array<string, true> $implementedMethods
+     * @param array<string, true> $seen
+     */
+    private function collectAbstractMethods(
+        ClassInfo $classInfo,
+        array &$abstractMethods,
+        array $implementedMethods,
+        array &$seen,
+    ): void {
+        $fqn = $classInfo->name->fqn;
+        if (array_key_exists($fqn, $seen)) {
+            return;
+        }
+        $seen[$fqn] = true;
+
+        $isInterface = $classInfo->kind === \Firehed\PhpLsp\Domain\ClassKind::Interface_;
+
+        foreach ($classInfo->methods as $method) {
+            $key = strtolower($method->name->name);
+            if (array_key_exists($key, $implementedMethods)) {
+                continue;
+            }
+            if (array_key_exists($key, $abstractMethods)) {
+                continue;
+            }
+            if ($isInterface || $method->isAbstract) {
+                $abstractMethods[$key] = $method;
+            }
+        }
+
+        foreach ($classInfo->interfaces as $interfaceName) {
+            $interfaceInfo = $this->classes->get($interfaceName);
+            if ($interfaceInfo !== null) {
+                $this->collectAbstractMethods($interfaceInfo, $abstractMethods, $implementedMethods, $seen);
+            }
+        }
+
+        if ($classInfo->parent !== null) {
+            $parentInfo = $this->classes->get($classInfo->parent);
+            if ($parentInfo !== null) {
+                $this->collectAbstractMethods($parentInfo, $abstractMethods, $implementedMethods, $seen);
+            }
+        }
+    }
+
+    /**
      * @param array<string, true> $seen
      */
     private function findMethodInHierarchy(

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2897,4 +2897,166 @@ PHP;
         self::assertStringContainsString(': int', $detail);
         self::assertStringContainsString('Adds two numbers', $functionItem['documentation'] ?? '');
     }
+
+    public function testMissingAbstractMethodsFromInterface(): void
+    {
+        // Note: the trailing space after "function " is required for the pattern to match
+        $code = <<<'PHP'
+<?php
+interface MyInterface
+{
+    public function doThing(): void;
+
+    public function useOther(string $var): int;
+}
+
+class Bar implements MyInterface
+{
+    public function d
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                // Line 10: "    public function d" - cursor at position 21 (after 'd')
+                'position' => ['line' => 10, 'character' => 21],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+
+        // With prefix 'd', only doThing should match (not useOther)
+        self::assertContains('doThing', $labels);
+        self::assertNotContains('useOther', $labels);
+    }
+
+    public function testMissingAbstractMethodsFromInterfaceAllMethods(): void
+    {
+        // Use prefix 'd' to trigger method completion, then check both methods appear
+        // (doThing matches 'd', useOther doesn't - we test with empty prefix via concat)
+        $codeBase = <<<'PHP'
+<?php
+interface MyInterface
+{
+    public function doThing(): void;
+
+    public function useOther(string $var): int;
+}
+
+class Bar implements MyInterface
+{
+    public function
+PHP;
+        // Add trailing space explicitly since heredoc may strip trailing whitespace
+        $code = $codeBase . " \n}";
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                // Line 10: "    public function " - cursor at position 20 (after space)
+                'position' => ['line' => 10, 'character' => 20],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+
+        // With no prefix, both methods should appear
+        self::assertContains('doThing', $labels, 'Missing interface method doThing should appear');
+        self::assertContains('useOther', $labels, 'Missing interface method useOther should appear');
+    }
+
+    public function testMissingAbstractMethodsFromAbstractParent(): void
+    {
+        $codeBase = <<<'PHP'
+<?php
+abstract class BaseHandler
+{
+    abstract public function handle(): void;
+
+    public function log(): void {}
+}
+
+class MyHandler extends BaseHandler
+{
+    public function
+PHP;
+        $code = $codeBase . " \n}";
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 20],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+
+        // Abstract method should appear, but not the concrete method
+        self::assertContains('handle', $labels, 'Abstract parent method should appear');
+        self::assertNotContains('log', $labels, 'Concrete parent method should not appear');
+    }
+
+    public function testMissingAbstractMethodsExcludesAlreadyImplemented(): void
+    {
+        $codeBase = <<<'PHP'
+<?php
+interface MyInterface
+{
+    public function methodA(): void;
+    public function methodB(): void;
+    public function methodC(): void;
+}
+
+class Impl implements MyInterface
+{
+    public function methodA(): void {}
+
+    public function
+PHP;
+        $code = $codeBase . " \n}";
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 12, 'character' => 20],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+
+        // methodA is already implemented, should not appear
+        self::assertNotContains('methodA', $labels);
+        // methodB and methodC are not implemented, should appear
+        self::assertContains('methodB', $labels);
+        self::assertContains('methodC', $labels);
+    }
 }


### PR DESCRIPTION
## Summary
- When typing `public function ` inside a class that implements interfaces or extends an abstract class, suggest the unimplemented abstract methods as completions
- Adds `MemberResolver::getUnimplementedAbstractMethods()` to find methods from interfaces and abstract parents that have not been implemented yet
- Methods already implemented in the current class are excluded from suggestions

## Test plan
- [x] Tests for interface method completion
- [x] Tests for abstract parent method completion  
- [x] Tests for excluding already-implemented methods
- [x] Tests for prefix filtering

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)
