### PR TITLE
Initialize ClassLoader without polluting autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         }
     },
     "autoload-dev": {
+        "psr-0": {
+            "Psr0": "tests/Fixtures/Autoload/"
+        },
         "psr-4": {
             "Firehed\\PhpLsp\\Tests\\": "tests/"
         },

--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -14,14 +14,40 @@ final class ComposerClassLocator implements ClassLocator
 
     public function __construct(string $projectRoot)
     {
-        $autoloadFile = rtrim($projectRoot, '/') . '/vendor/autoload.php';
+        $composerDir = rtrim($projectRoot, '/') . '/vendor/composer';
 
-        if (file_exists($autoloadFile)) {
-            $loader = require $autoloadFile;
-            if ($loader instanceof ClassLoader) {
-                $this->loader = $loader;
+        if (!is_dir($composerDir)) {
+            return;
+        }
+
+        $loader = new ClassLoader();
+
+        $psr4File = $composerDir . '/autoload_psr4.php';
+        if (file_exists($psr4File)) {
+            /** @var array<string, list<string>> $psr4 */
+            $psr4 = require $psr4File;
+            foreach ($psr4 as $namespace => $paths) {
+                $loader->setPsr4($namespace, $paths);
             }
         }
+
+        $psr0File = $composerDir . '/autoload_namespaces.php';
+        if (file_exists($psr0File)) {
+            /** @var array<string, list<string>> $psr0 */
+            $psr0 = require $psr0File;
+            foreach ($psr0 as $namespace => $paths) {
+                $loader->set($namespace, $paths);
+            }
+        }
+
+        $classmapFile = $composerDir . '/autoload_classmap.php';
+        if (file_exists($classmapFile)) {
+            /** @var array<class-string, string> $classmap */
+            $classmap = require $classmapFile;
+            $loader->addClassMap($classmap);
+        }
+
+        $this->loader = $loader;
     }
 
     public function locate(ClassName $name): ?string

--- a/tests/Fixtures/Autoload/Psr0/Psr0Fixture.php
+++ b/tests/Fixtures/Autoload/Psr0/Psr0Fixture.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr0;
+
+class Psr0Fixture
+{
+}

--- a/tests/Index/ComposerClassLocatorTest.php
+++ b/tests/Index/ComposerClassLocatorTest.php
@@ -53,6 +53,16 @@ final class ComposerClassLocatorTest extends TestCase
         self::assertStringContainsString('phpunit/phpunit', $path);
     }
 
+    public function testLocateClassFromPsr0(): void
+    {
+        $locator = new ComposerClassLocator(self::PROJECT_ROOT);
+
+        $path = $locator->locateClass(\Psr0\Psr0Fixture::class);
+
+        self::assertNotNull($path);
+        self::assertStringEndsWith('tests/Fixtures/Autoload/Psr0/Psr0Fixture.php', $path);
+    }
+
     public function testDoesNotRegisterAutoloader(): void
     {
         $autoloadersBefore = spl_autoload_functions();

--- a/tests/Index/ComposerClassLocatorTest.php
+++ b/tests/Index/ComposerClassLocatorTest.php
@@ -52,4 +52,28 @@ final class ComposerClassLocatorTest extends TestCase
         self::assertNotNull($path);
         self::assertStringContainsString('phpunit/phpunit', $path);
     }
+
+    public function testDoesNotRegisterAutoloader(): void
+    {
+        $autoloadersBefore = spl_autoload_functions();
+
+        new ComposerClassLocator(self::PROJECT_ROOT);
+
+        $autoloadersAfter = spl_autoload_functions();
+
+        self::assertSame(
+            count($autoloadersBefore),
+            count($autoloadersAfter),
+            'ComposerClassLocator should not register additional autoloaders',
+        );
+    }
+
+    public function testMissingComposerDirectoryReturnsNull(): void
+    {
+        $locator = new ComposerClassLocator('/nonexistent/path');
+
+        $path = $locator->locateClass(TestCase::class);
+
+        self::assertNull($path);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes silent LSP failures on projects with incompatible `nikic/php-parser` versions
- `ComposerClassLocator` now instantiates `ClassLoader` directly from autoload data files instead of requiring `vendor/autoload.php`
- This prevents the target project's autoloader from being registered, avoiding dependency version conflicts

## Problem

When the LSP opened files in a project using an older version of `nikic/php-parser`, the parser would crash with errors like `Undefined constant PhpParser\Node\Expr\Cast\String_::KIND_STRING`. This happened because `require vendor/autoload.php` registers the target project's autoloader, polluting the LSP's class loading with incompatible versions.

## Solution

Instead of requiring `autoload.php`, we now:
1. Read `autoload_psr4.php`, `autoload_namespaces.php` (PSR-0), and `autoload_classmap.php` directly
2. Configure a fresh `ClassLoader` instance with this data
3. Use `findFile()` for lookups without registering any autoloaders

## Test plan

- [x] Existing tests pass
- [x] New test verifies no autoloaders are registered (`spl_autoload_functions()` count unchanged)
- [x] New test verifies graceful handling of missing composer directory
- [x] Manually verified fix resolves the original issue on the affected project

Fixes #180
