### PR TITLE
Return class-string from type resolution utilities

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -376,7 +376,6 @@ final class CompletionHandler implements HandlerInterface
         $parentClassName = ScopeFinder::resolveExtendsName($classNode);
         assert($parentClassName !== null);
 
-        /** @var class-string $parentClassName */
         return $this->getMemberCompletions(
             new ClassName($parentClassName),
             Visibility::Protected,
@@ -431,7 +430,6 @@ final class CompletionHandler implements HandlerInterface
         $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
         $minVisibility = $this->getMinVisibilityForAccess($enclosingClass, $resolvedClassName);
 
-        /** @var class-string $resolvedClassName */
         return $this->getMemberCompletions(
             new ClassName($resolvedClassName),
             $minVisibility,
@@ -444,6 +442,8 @@ final class CompletionHandler implements HandlerInterface
 
     /**
      * Determine minimum visibility for accessing members of target class from enclosing class.
+     *
+     * @param class-string $targetClassName
      */
     private function getMinVisibilityForAccess(?Stmt\Class_ $enclosingClass, string $targetClassName): Visibility
     {
@@ -468,7 +468,6 @@ final class CompletionHandler implements HandlerInterface
 
         // Check deeper inheritance via ClassRepository
         /** @var class-string $enclosingClassName */
-        /** @var class-string $targetClassName */
         if ($this->classRepository->isSubclassOf(new ClassName($enclosingClassName), new ClassName($targetClassName))) {
             return Visibility::Protected;
         }
@@ -588,10 +587,12 @@ final class CompletionHandler implements HandlerInterface
      * Resolve a short class name to its FQCN using use statements.
      *
      * @param array<Stmt> $ast
+     * @return class-string
      */
     private function resolveClassName(string $shortName, array $ast): string
     {
         $imports = $this->getImports($ast);
+        /** @var class-string */
         return $imports[$shortName] ?? $shortName;
     }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -284,14 +284,13 @@ final class CompletionHandler implements HandlerInterface
             return [];
         }
 
-        $classNameStr = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+        $classNameStr = ScopeFinder::getClassLikeName($classNode);
         if ($classNameStr === null) {
             // @codeCoverageIgnoreStart
             throw new \LogicException('Top-level class found without name');
             // @codeCoverageIgnoreEnd
         }
 
-        /** @var class-string $classNameStr */
         return $this->getMemberCompletions(
             new ClassName($classNameStr),
             Visibility::Private,
@@ -451,8 +450,7 @@ final class CompletionHandler implements HandlerInterface
             return Visibility::Public;
         }
 
-        $enclosingClassName = $enclosingClass->namespacedName?->toString()
-            ?? $enclosingClass->name?->toString();
+        $enclosingClassName = ScopeFinder::getClassLikeName($enclosingClass);
         if ($enclosingClassName === null) {
             return Visibility::Public;
         }
@@ -467,7 +465,6 @@ final class CompletionHandler implements HandlerInterface
         }
 
         // Check deeper inheritance via ClassRepository
-        /** @var class-string $enclosingClassName */
         if ($this->classRepository->isSubclassOf(new ClassName($enclosingClassName), new ClassName($targetClassName))) {
             return Visibility::Protected;
         }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -128,9 +128,8 @@ final class DefinitionHandler implements HandlerInterface
      */
     private function handleNameDefinition(Name $node): ?array
     {
-        $symbolName = ScopeFinder::resolveName($node);
+        $symbolName = ScopeFinder::resolveClassName($node);
 
-        /** @var class-string $symbolName */
         $classInfo = $this->classRepository->get(new ClassName($symbolName));
         if ($classInfo === null) {
             return null;
@@ -164,25 +163,23 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        $className = ScopeFinder::resolveName($class);
+        $rawName = $class->toString();
 
         // Handle parent:: - resolve to actual parent class name
-        if ($className === 'parent') {
+        if ($rawName === 'parent') {
             $enclosingClass = ScopeFinder::findEnclosingClassNode($call);
-            if ($enclosingClass instanceof Stmt\Class_ && $enclosingClass->extends !== null) {
-                $className = ScopeFinder::resolveName($enclosingClass->extends);
-            } else {
+            if (!$enclosingClass instanceof Stmt\Class_ || $enclosingClass->extends === null) {
                 return null;
             }
-        }
-
-        // Handle self:: and static:: - resolve to enclosing class
-        if ($className === 'self' || $className === 'static') {
-            $enclosingClassName = ScopeFinder::findEnclosingClassName($call);
-            if ($enclosingClassName === null) {
+            $className = ScopeFinder::resolveClassName($enclosingClass->extends);
+        } elseif ($rawName === 'self' || $rawName === 'static') {
+            // Handle self:: and static:: - resolve to enclosing class
+            $className = ScopeFinder::findEnclosingClassName($call);
+            if ($className === null) {
                 return null;
             }
-            $className = $enclosingClassName;
+        } else {
+            $className = ScopeFinder::resolveClassName($class);
         }
 
         return $this->findMethodDefinition($className, $methodName->toString());
@@ -220,6 +217,7 @@ final class DefinitionHandler implements HandlerInterface
     /**
      * Find the definition of a method in a class.
      *
+     * @param class-string $className
      * @return array{
      *   uri: string,
      *   range: array{
@@ -230,7 +228,6 @@ final class DefinitionHandler implements HandlerInterface
      */
     private function findMethodDefinition(string $className, string $methodName): ?array
     {
-        /** @var class-string $className */
         $methodInfo = $this->memberResolver->findMethod(
             new ClassName($className),
             new MethodName($methodName),

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -170,9 +170,8 @@ final class HoverHandler implements HandlerInterface
 
     private function getClassHover(Name $node): ?string
     {
-        $classNameStr = ScopeFinder::resolveName($node);
+        $classNameStr = ScopeFinder::resolveClassName($node);
 
-        /** @var class-string $classNameStr */
         $classInfo = $this->classRepository->get(new ClassName($classNameStr));
 
         if ($classInfo === null) {
@@ -278,7 +277,7 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = ScopeFinder::resolveName($class);
+        $className = ScopeFinder::resolveClassName($class);
 
         return $this->getMethodHoverForClass($className, $methodName->toString());
     }
@@ -313,14 +312,16 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = ScopeFinder::resolveName($class);
+        $className = ScopeFinder::resolveClassName($class);
 
         return $this->getPropertyHoverForClass($className, $propertyName->toString());
     }
 
+    /**
+     * @param class-string $classNameStr
+     */
     private function getMethodHoverForClass(string $classNameStr, string $methodNameStr): ?string
     {
-        /** @var class-string $classNameStr */
         $className = new ClassName($classNameStr);
         $methodName = new MethodName($methodNameStr);
 
@@ -333,9 +334,11 @@ final class HoverHandler implements HandlerInterface
         return $this->formatMethodHover($methodInfo);
     }
 
+    /**
+     * @param class-string $classNameStr
+     */
     private function getPropertyHoverForClass(string $classNameStr, string $propertyNameStr): ?string
     {
-        /** @var class-string $classNameStr */
         $className = new ClassName($classNameStr);
         $propertyName = new PropertyName($propertyNameStr);
 

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -258,15 +258,16 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        $className = ScopeFinder::resolveName($class);
+        $rawName = $class->toString();
 
         // Handle self/static/parent
-        if ($className === 'self' || $className === 'static' || $className === 'parent') {
-            $enclosingClass = ScopeFinder::findEnclosingClassName($call);
-            if ($enclosingClass === null) {
+        if ($rawName === 'self' || $rawName === 'static' || $rawName === 'parent') {
+            $className = ScopeFinder::findEnclosingClassName($call);
+            if ($className === null) {
                 return null;
             }
-            $className = $enclosingClass;
+        } else {
+            $className = ScopeFinder::resolveClassName($class);
         }
 
         return $this->getMethodSignatureForClass($className, $methodName->toString());
@@ -282,19 +283,19 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        $className = ScopeFinder::resolveName($class);
+        $className = ScopeFinder::resolveClassName($class);
 
         return $this->getMethodSignatureForClass($className, '__construct');
     }
 
     /**
+     * @param class-string $classNameStr
      * @return SignatureInfo|null
      */
     private function getMethodSignatureForClass(
         string $classNameStr,
         string $methodNameStr,
     ): ?array {
-        /** @var class-string $classNameStr */
         $className = new ClassName($classNameStr);
         $methodName = new MethodName($methodNameStr);
 

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -89,14 +89,10 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
             throw new \InvalidArgumentException('Cannot create ClassInfo for anonymous class');
         }
 
-        if (isset($node->namespacedName)) {
-            /** @var class-string */
-            $fqn = $node->namespacedName->toString();
-            return new ClassName($fqn);
-        }
-
         /** @var class-string */
-        $fqn = $node->name->toString();
+        $fqn = isset($node->namespacedName)
+            ? $node->namespacedName->toString()
+            : $node->name->toString();
         return new ClassName($fqn);
     }
 
@@ -130,25 +126,11 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
 
     private function resolveParent(Stmt\ClassLike $node): ?ClassName
     {
-        if (!$node instanceof Stmt\Class_) {
+        if (!$node instanceof Stmt\Class_ || $node->extends === null) {
             return null;
         }
 
-        $extends = $node->extends;
-        if ($extends === null) {
-            return null;
-        }
-
-        $resolved = $extends->getAttribute('resolvedName');
-        if ($resolved instanceof \PhpParser\Node\Name\FullyQualified) {
-            /** @var class-string */
-            $fqn = $resolved->toString();
-            return new ClassName($fqn);
-        }
-
-        /** @var class-string */
-        $fqn = $extends->toString();
-        return new ClassName($fqn);
+        return $this->resolveNameToClassName($node->extends);
     }
 
     /**
@@ -194,14 +176,10 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
     private function resolveNameToClassName(\PhpParser\Node\Name $name): ClassName
     {
         $resolved = $name->getAttribute('resolvedName');
-        if ($resolved instanceof \PhpParser\Node\Name\FullyQualified) {
-            /** @var class-string */
-            $fqn = $resolved->toString();
-            return new ClassName($fqn);
-        }
-
         /** @var class-string */
-        $fqn = $name->toString();
+        $fqn = $resolved instanceof \PhpParser\Node\Name\FullyQualified
+            ? $resolved->toString()
+            : $name->toString();
         return new ClassName($fqn);
     }
 

--- a/src/Utility/ExpressionTypeResolver.php
+++ b/src/Utility/ExpressionTypeResolver.php
@@ -25,6 +25,7 @@ final class ExpressionTypeResolver
      * - Typed variables → delegated to TypeResolver
      *
      * @param array<Stmt> $ast
+     * @return ?class-string
      */
     public static function resolveExpressionType(
         Expr $expr,
@@ -44,6 +45,7 @@ final class ExpressionTypeResolver
             return null;
         }
 
+        /** @var ?class-string */
         return $typeResolver->resolveExpressionType($expr, $scope, $ast);
     }
 }

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -89,6 +89,22 @@ final class ScopeFinder
     }
 
     /**
+     * Get the fully qualified name of a class-like node.
+     *
+     * @return ?class-string
+     */
+    public static function getClassLikeName(Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_ $node): ?string
+    {
+        if ($node->name === null) {
+            return null;
+        }
+        /** @var class-string */
+        return isset($node->namespacedName)
+            ? $node->namespacedName->toString()
+            : $node->name->toString();
+    }
+
+    /**
      * Find the fully qualified name of the enclosing class-like node.
      *
      * Returns the FQN if available, otherwise the short name, or null if not
@@ -99,15 +115,10 @@ final class ScopeFinder
     public static function findEnclosingClassName(Node $node): ?string
     {
         $classNode = self::findEnclosingClassNode($node);
-        if ($classNode === null || $classNode->name === null) {
+        if ($classNode === null) {
             return null;
         }
-
-        $namespacedName = $classNode->namespacedName;
-        /** @var class-string */
-        return $namespacedName instanceof Name
-            ? $namespacedName->toString()
-            : $classNode->name->toString();
+        return self::getClassLikeName($classNode);
     }
 
     /**

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -78,10 +78,23 @@ final class ScopeFinder
     }
 
     /**
+     * Resolve a class Name node to its fully qualified class name.
+     *
+     * @return class-string
+     */
+    public static function resolveClassName(Name $name): string
+    {
+        /** @var class-string */
+        return self::resolveName($name);
+    }
+
+    /**
      * Find the fully qualified name of the enclosing class-like node.
      *
      * Returns the FQN if available, otherwise the short name, or null if not
      * in a class context.
+     *
+     * @return ?class-string
      */
     public static function findEnclosingClassName(Node $node): ?string
     {
@@ -91,21 +104,23 @@ final class ScopeFinder
         }
 
         $namespacedName = $classNode->namespacedName;
-        if ($namespacedName instanceof Name) {
-            return $namespacedName->toString();
-        }
-        return $classNode->name->toString();
+        /** @var class-string */
+        return $namespacedName instanceof Name
+            ? $namespacedName->toString()
+            : $classNode->name->toString();
     }
 
     /**
      * Resolve the parent class name from a class node's extends clause.
+     *
+     * @return ?class-string
      */
     public static function resolveExtendsName(Stmt\Class_ $class): ?string
     {
         if ($class->extends === null) {
             return null;
         }
-        return self::resolveName($class->extends);
+        return self::resolveClassName($class->extends);
     }
 
     /**

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -229,6 +229,42 @@ PHP;
         self::assertStringContainsString('int $n', $result['signatures'][0]['label']);
     }
 
+    public function testSignatureHelpOnSelfStaticMethod(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    public static function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+
+    public function useAdd(): int
+    {
+        return self::add(1, 2);
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/signatureHelp',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 24], // Inside self::add(|1, 2)
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('add', $result['signatures'][0]['label']);
+        self::assertStringContainsString('int $a', $result['signatures'][0]['label']);
+    }
+
     public function testSignatureHelpOnConstructor(): void
     {
         $code = <<<'PHP'

--- a/tests/Repository/DefaultClassInfoFactoryTest.php
+++ b/tests/Repository/DefaultClassInfoFactoryTest.php
@@ -33,6 +33,15 @@ final class DefaultClassInfoFactoryTest extends TestCase
         self::assertSame(ClassKind::Class_, $info->kind);
     }
 
+    public function testFromAstNodeExtractsClassNameWithoutNameResolver(): void
+    {
+        $node = $this->parseClassWithoutNameResolver('<?php class SimpleClass {}');
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertSame('SimpleClass', $info->name->fqn);
+    }
+
     public function testFromAstNodeExtractsInterface(): void
     {
         $node = $this->parseClass('<?php interface MyInterface {}');
@@ -70,6 +79,22 @@ final class DefaultClassInfoFactoryTest extends TestCase
 
         self::assertNotNull($info->parent);
         self::assertSame('App\\Parent_', $info->parent->fqn);
+    }
+
+    public function testFromAstNodeExtractsImportedParentClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App;
+use External\BaseClass;
+class Child extends BaseClass {}
+PHP;
+        $node = $this->parseClass($code);
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertNotNull($info->parent);
+        self::assertSame('External\\BaseClass', $info->parent->fqn);
     }
 
     public function testFromAstNodeExtractsAbstractClass(): void
@@ -481,13 +506,25 @@ final class DefaultClassInfoFactoryTest extends TestCase
 
     private function parseClass(string $code, ?string $className = null): Stmt\ClassLike
     {
+        return $this->parseClassInternal($code, $className, useNameResolver: true);
+    }
+
+    private function parseClassWithoutNameResolver(string $code, ?string $className = null): Stmt\ClassLike
+    {
+        return $this->parseClassInternal($code, $className, useNameResolver: false);
+    }
+
+    private function parseClassInternal(string $code, ?string $className, bool $useNameResolver): Stmt\ClassLike
+    {
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
         $ast = $parser->parse($code);
         assert($ast !== null);
 
-        $traverser = new \PhpParser\NodeTraverser();
-        $traverser->addVisitor(new \PhpParser\NodeVisitor\NameResolver());
-        $ast = $traverser->traverse($ast);
+        if ($useNameResolver) {
+            $traverser = new \PhpParser\NodeTraverser();
+            $traverser->addVisitor(new \PhpParser\NodeVisitor\NameResolver());
+            $ast = $traverser->traverse($ast);
+        }
 
         foreach ($ast as $stmt) {
             if ($stmt instanceof Stmt\Namespace_) {

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -505,4 +505,133 @@ PHP;
         self::assertNotNull($found);
         self::assertSame('helper', $found->name->toString());
     }
+
+    public function testResolveClassNameDelegatesToResolveName(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App;
+use Other\Bar;
+class Foo extends Bar {}
+PHP;
+        $ast = self::parseWithParents($code);
+        $namespace = $ast[0];
+        self::assertInstanceOf(Stmt\Namespace_::class, $namespace);
+        $class = $namespace->stmts[1];
+        self::assertInstanceOf(Stmt\Class_::class, $class);
+        self::assertNotNull($class->extends);
+
+        self::assertSame('Other\Bar', ScopeFinder::resolveClassName($class->extends));
+    }
+
+    public function testGetClassLikeNameReturnsNamespacedName(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Models;
+
+class User {}
+PHP;
+        $ast = self::parseWithParents($code);
+        $namespace = $ast[0];
+        self::assertInstanceOf(Stmt\Namespace_::class, $namespace);
+        $class = $namespace->stmts[0];
+        self::assertInstanceOf(Stmt\Class_::class, $class);
+
+        self::assertSame('App\Models\User', ScopeFinder::getClassLikeName($class));
+    }
+
+    public function testGetClassLikeNameReturnsShortNameWhenNoNamespace(): void
+    {
+        $code = '<?php class MyClass {}';
+        $ast = self::parseWithParents($code);
+        $class = $ast[0];
+        self::assertInstanceOf(Stmt\Class_::class, $class);
+
+        self::assertSame('MyClass', ScopeFinder::getClassLikeName($class));
+    }
+
+    public function testGetClassLikeNameReturnsNullForAnonymousClass(): void
+    {
+        $code = <<<'PHP'
+<?php
+$obj = new class {
+    public function test(): void {}
+};
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $visitor = new class () extends \PhpParser\NodeVisitorAbstract {
+            public ?Stmt\Class_ $found = null;
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Stmt\Class_ && $node->name === null) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        self::assertNotNull($visitor->found);
+        self::assertNull(ScopeFinder::getClassLikeName($visitor->found));
+    }
+
+    public function testGetClassLikeNameWorksWithInterface(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Contracts;
+
+interface Renderable {}
+PHP;
+        $ast = self::parseWithParents($code);
+        $namespace = $ast[0];
+        self::assertInstanceOf(Stmt\Namespace_::class, $namespace);
+        $interface = $namespace->stmts[0];
+        self::assertInstanceOf(Stmt\Interface_::class, $interface);
+
+        self::assertSame('App\Contracts\Renderable', ScopeFinder::getClassLikeName($interface));
+    }
+
+    public function testGetClassLikeNameWorksWithTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Concerns;
+
+trait Loggable {}
+PHP;
+        $ast = self::parseWithParents($code);
+        $namespace = $ast[0];
+        self::assertInstanceOf(Stmt\Namespace_::class, $namespace);
+        $trait = $namespace->stmts[0];
+        self::assertInstanceOf(Stmt\Trait_::class, $trait);
+
+        self::assertSame('App\Concerns\Loggable', ScopeFinder::getClassLikeName($trait));
+    }
+
+    public function testGetClassLikeNameWorksWithEnum(): void
+    {
+        $code = <<<'PHP'
+<?php
+namespace App\Enums;
+
+enum Status: string {
+    case Active = 'active';
+}
+PHP;
+        $ast = self::parseWithParents($code);
+        $namespace = $ast[0];
+        self::assertInstanceOf(Stmt\Namespace_::class, $namespace);
+        $enum = $namespace->stmts[0];
+        self::assertInstanceOf(Stmt\Enum_::class, $enum);
+
+        self::assertSame('App\Enums\Status', ScopeFinder::getClassLikeName($enum));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `@return class-string` to `ScopeFinder::findEnclosingClassName()`, `resolveExtendsName()`, and new `resolveClassName()` / `getClassLikeName()` methods
- Add `@return class-string` to `ExpressionTypeResolver::resolveExpressionType()`
- Update handler methods to accept `@param class-string` where callers now provide it
- Consolidate AST-to-class-string conversions in `DefaultClassInfoFactory`

Reduces inline `@var class-string` assertions from ~20 to 8 irreducible points (consolidated conversion helpers and interface boundaries).

Closes #141

## Test plan

- [x] `composer check` passes (PHPStan, PHPUnit, PHPCS)

🤖 Generated with [Claude Code](https://claude.ai/code)