### PR TITLE
Fix $this-> completion targeting wrong class in multi-class files

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -159,7 +159,7 @@ final class CompletionHandler implements HandlerInterface
         // $this-> completion
         if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
-            return $this->getThisMemberCompletions($prefix, $ast);
+            return $this->getThisMemberCompletions($prefix, $ast, $line);
         }
 
         // $variable-> completion (typed variables, not $this)
@@ -277,18 +277,17 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getThisMemberCompletions(string $prefix, array $ast): array
+    private function getThisMemberCompletions(string $prefix, array $ast, int $line): array
     {
-        $classNode = $this->findFirstClass($ast);
+        $classNode = ScopeFinder::findClassAtLine($ast, $line);
         if ($classNode === null) {
             return [];
         }
 
         $classNameStr = ScopeFinder::getClassLikeName($classNode);
         if ($classNameStr === null) {
-            // @codeCoverageIgnoreStart
-            throw new \LogicException('Top-level class found without name');
-            // @codeCoverageIgnoreEnd
+            // Anonymous class - no completions available
+            return [];
         }
 
         return $this->getMemberCompletions(
@@ -503,19 +502,6 @@ final class CompletionHandler implements HandlerInterface
 
         // Limit results
         return array_slice($items, 0, 100);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findFirstClass(array $ast): ?Stmt\Class_
-    {
-        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
-            if ($stmt instanceof Stmt\Class_) {
-                return $stmt;
-            }
-        }
-        return null;
     }
 
     /**

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2897,4 +2897,108 @@ PHP;
         self::assertStringContainsString(': int', $detail);
         self::assertStringContainsString('Adds two numbers', $functionItem['documentation'] ?? '');
     }
+
+    public function testThisCompletionTargetsEnclosingClassNotFirstClass(): void
+    {
+        // Issue #173: When multiple classes in file, $this-> should complete
+        // members of the enclosing class, not the first class in the file
+        $code = <<<'PHP'
+<?php
+class ParentClass
+{
+    protected string $inheritedProperty;
+    public function inheritedMethod(): void {}
+}
+
+class ChildClass extends ParentClass
+{
+    private string $ownProperty;
+
+    public function ownMethod(): void {}
+
+    public function test(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+
+        // Should have ChildClass's own members
+        self::assertContains('ownProperty', $labels);
+        self::assertContains('ownMethod', $labels);
+        self::assertContains('test', $labels);
+
+        // Should also have inherited members
+        self::assertContains('inheritedProperty', $labels);
+        self::assertContains('inheritedMethod', $labels);
+    }
+
+    public function testThisCompletionWithUnrelatedClassesInFile(): void
+    {
+        // Two unrelated classes in the same file - cursor in second class
+        // should get its members, not the first class's
+        $code = <<<'PHP'
+<?php
+class FirstClass
+{
+    public string $firstProperty;
+    public function firstMethod(): void {}
+}
+
+class SecondClass
+{
+    public string $secondProperty;
+
+    public function secondMethod(): void {}
+
+    public function test(): void
+    {
+        $this->
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+
+        // Should have SecondClass's members
+        self::assertContains('secondProperty', $labels);
+        self::assertContains('secondMethod', $labels);
+        self::assertContains('test', $labels);
+
+        // Should NOT have FirstClass's members
+        self::assertNotContains('firstProperty', $labels);
+        self::assertNotContains('firstMethod', $labels);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes `$this->` completion targeting the first class in a file instead of the enclosing class
- Uses existing `ScopeFinder::findClassAtLine()` instead of iterating top-level statements
- Removes unused `findFirstClass()` method
- Anonymous classes gracefully return empty completions

Closes #173

🤖 Generated with [Claude Code](https://claude.ai/code)