### PR TITLE
Generalize findClassAtLine to findClassLikeAtLine

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -178,16 +178,12 @@ final class CompletionHandler implements HandlerInterface
         // self:: and static:: completion - resolve to enclosing class
         if (preg_match('/\b(?:self|static)::(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $classNode = ScopeFinder::findClassLikeAtLine($ast, $line);
-            if ($classNode !== null) {
-                $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
-                if ($className === null) {
-                    // Anonymous class - no completions available
-                    return [];
-                }
-                $prefix = $matches[1];
-                return $this->getStaticCompletions($className, $prefix, $ast, $line);
+            $className = $classNode !== null ? ScopeFinder::getClassLikeName($classNode) : null;
+            if ($className === null) {
+                return [];
             }
-            return [];
+            $prefix = $matches[1];
+            return $this->getStaticCompletions($className, $prefix, $ast, $line);
         }
 
         // parent:: completion - methods from parent class
@@ -861,10 +857,8 @@ final class CompletionHandler implements HandlerInterface
 
         // Add $this if we're in a method
         if ($inMethod && self::matchesPrefix('this', $prefix)) {
-            // Use ScopeFinder directly for $this - TypeResolverInterface::resolveVariableType
-            // doesn't handle $this (it only checks parameters, use() vars, and assignments)
             $classNode = ScopeFinder::findClassLikeAtLine($ast, $cursorLine);
-            $className = $classNode?->namespacedName?->toString() ?? $classNode?->name?->toString();
+            $className = $classNode !== null ? ScopeFinder::getClassLikeName($classNode) : null;
             $items[] = [
                 'label' => '$this',
                 'kind' => self::KIND_VARIABLE,

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -177,7 +177,7 @@ final class CompletionHandler implements HandlerInterface
 
         // self:: and static:: completion - resolve to enclosing class
         if (preg_match('/\b(?:self|static)::(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $classNode = ScopeFinder::findClassAtLine($ast, $line);
+            $classNode = ScopeFinder::findClassLikeAtLine($ast, $line);
             if ($classNode !== null) {
                 $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
                 if ($className === null) {
@@ -279,7 +279,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getThisMemberCompletions(string $prefix, array $ast, int $line): array
     {
-        $classNode = ScopeFinder::findClassAtLine($ast, $line);
+        $classNode = ScopeFinder::findClassLikeAtLine($ast, $line);
         if ($classNode === null) {
             return [];
         }
@@ -366,8 +366,8 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getParentCompletions(string $prefix, array $ast, int $line): array
     {
-        $classNode = ScopeFinder::findClassAtLine($ast, $line);
-        if ($classNode === null || $classNode->extends === null) {
+        $classNode = ScopeFinder::findClassLikeAtLine($ast, $line);
+        if (!$classNode instanceof Stmt\Class_ || $classNode->extends === null) {
             return [];
         }
 
@@ -425,7 +425,7 @@ final class CompletionHandler implements HandlerInterface
         // Resolve short name to FQCN using imports
         $resolvedClassName = $this->resolveClassName($className, $ast);
 
-        $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
+        $enclosingClass = ScopeFinder::findClassLikeAtLine($ast, $line);
         $minVisibility = $this->getMinVisibilityForAccess($enclosingClass, $resolvedClassName);
 
         return $this->getMemberCompletions(
@@ -443,13 +443,15 @@ final class CompletionHandler implements HandlerInterface
      *
      * @param class-string $targetClassName
      */
-    private function getMinVisibilityForAccess(?Stmt\Class_ $enclosingClass, string $targetClassName): Visibility
-    {
-        if ($enclosingClass === null) {
+    private function getMinVisibilityForAccess(
+        Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $enclosingClassLike,
+        string $targetClassName,
+    ): Visibility {
+        if ($enclosingClassLike === null) {
             return Visibility::Public;
         }
 
-        $enclosingClassName = ScopeFinder::getClassLikeName($enclosingClass);
+        $enclosingClassName = ScopeFinder::getClassLikeName($enclosingClassLike);
         if ($enclosingClassName === null) {
             return Visibility::Public;
         }
@@ -458,8 +460,11 @@ final class CompletionHandler implements HandlerInterface
             return Visibility::Private;
         }
 
-        // Check direct extends in AST
-        if (ScopeFinder::resolveExtendsName($enclosingClass) === $targetClassName) {
+        // Check direct extends in AST (only classes have extends)
+        if (
+            $enclosingClassLike instanceof Stmt\Class_
+            && ScopeFinder::resolveExtendsName($enclosingClassLike) === $targetClassName
+        ) {
             return Visibility::Protected;
         }
 
@@ -858,7 +863,7 @@ final class CompletionHandler implements HandlerInterface
         if ($inMethod && self::matchesPrefix('this', $prefix)) {
             // Use ScopeFinder directly for $this - TypeResolverInterface::resolveVariableType
             // doesn't handle $this (it only checks parameters, use() vars, and assignments)
-            $classNode = ScopeFinder::findClassAtLine($ast, $cursorLine);
+            $classNode = ScopeFinder::findClassLikeAtLine($ast, $cursorLine);
             $className = $classNode?->namespacedName?->toString() ?? $classNode?->name?->toString();
             $items[] = [
                 'label' => '$this',

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -149,14 +149,16 @@ final class ScopeFinder
     }
 
     /**
-     * Find the class containing the given line (0-indexed).
+     * Find the class-like (class, interface, trait, enum) containing the given line (0-indexed).
      *
      * @param array<Stmt> $ast
      */
-    public static function findClassAtLine(array $ast, int $line): ?Stmt\Class_
-    {
+    public static function findClassLikeAtLine(
+        array $ast,
+        int $line,
+    ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
         $visitor = new class ($line) extends NodeVisitorAbstract {
-            public ?Stmt\Class_ $found = null;
+            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
 
             public function __construct(private readonly int $line)
             {
@@ -164,7 +166,13 @@ final class ScopeFinder
 
             public function enterNode(Node $node): ?int
             {
-                if ($node instanceof Stmt\Class_ && ScopeFinder::nodeContainsLine($node, $this->line)) {
+                if (
+                    ($node instanceof Stmt\Class_
+                        || $node instanceof Stmt\Interface_
+                        || $node instanceof Stmt\Trait_
+                        || $node instanceof Stmt\Enum_)
+                    && ScopeFinder::nodeContainsLine($node, $this->line)
+                ) {
                     $this->found = $node;
                 }
                 return null;

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2742,6 +2742,85 @@ PHP;
         self::assertEmpty($result['items']);
     }
 
+    public function testThisCompletionInTrait(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    private string $traitProperty;
+
+    public function traitMethod(): void {}
+
+    public function test(): void {
+        $this->
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+
+        self::assertContains('traitProperty', $labels);
+        self::assertContains('traitMethod', $labels);
+        self::assertContains('test', $labels);
+    }
+
+    public function testThisCompletionInEnum(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status: string {
+    case Active = 'active';
+    case Inactive = 'inactive';
+
+    public function label(): string {
+        return match($this) {
+            self::Active => 'Active',
+            self::Inactive => 'Inactive',
+        };
+    }
+
+    public function test(): void {
+        $this->
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 13, 'character' => 15],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+
+        self::assertContains('label', $labels);
+        self::assertContains('test', $labels);
+    }
+
     public function testStaticCompletionFromAnonymousClassContext(): void
     {
         $code = <<<'PHP'

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -356,6 +356,7 @@ PHP;
 
         $trait = ScopeFinder::findClassLikeAtLine($ast, 2);
         self::assertInstanceOf(Stmt\Trait_::class, $trait);
+        self::assertNotNull($trait->name);
         self::assertSame('MyTrait', $trait->name->toString());
     }
 
@@ -371,6 +372,7 @@ PHP;
 
         $enum = ScopeFinder::findClassLikeAtLine($ast, 2);
         self::assertInstanceOf(Stmt\Enum_::class, $enum);
+        self::assertNotNull($enum->name);
         self::assertSame('Status', $enum->name->toString());
     }
 

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -326,7 +326,7 @@ PHP;
         self::assertFalse(ScopeFinder::nodeContainsLine($classNode, 10));
     }
 
-    public function testFindClassAtLineReturnsClassContainingLine(): void
+    public function testFindClassLikeAtLineReturnsClassContainingLine(): void
     {
         $code = <<<'PHP'
 <?php
@@ -339,12 +339,42 @@ PHP;
         $ast = self::parseWithParents($code);
 
         // Line 4 (0-indexed) is inside Second class
-        $class = ScopeFinder::findClassAtLine($ast, 4);
-        self::assertNotNull($class);
+        $class = ScopeFinder::findClassLikeAtLine($ast, 4);
+        self::assertInstanceOf(Stmt\Class_::class, $class);
         self::assertSame('Second', $class->name?->toString());
     }
 
-    public function testFindClassAtLineReturnsNullWhenNotInClass(): void
+    public function testFindClassLikeAtLineReturnsTraitContainingLine(): void
+    {
+        $code = <<<'PHP'
+<?php
+trait MyTrait {
+    public function test(): void {}
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $trait = ScopeFinder::findClassLikeAtLine($ast, 2);
+        self::assertInstanceOf(Stmt\Trait_::class, $trait);
+        self::assertSame('MyTrait', $trait->name->toString());
+    }
+
+    public function testFindClassLikeAtLineReturnsEnumContainingLine(): void
+    {
+        $code = <<<'PHP'
+<?php
+enum Status: string {
+    case Active = 'active';
+}
+PHP;
+        $ast = self::parseWithParents($code);
+
+        $enum = ScopeFinder::findClassLikeAtLine($ast, 2);
+        self::assertInstanceOf(Stmt\Enum_::class, $enum);
+        self::assertSame('Status', $enum->name->toString());
+    }
+
+    public function testFindClassLikeAtLineReturnsNullWhenNotInClassLike(): void
     {
         $code = <<<'PHP'
 <?php
@@ -355,7 +385,7 @@ PHP;
         $ast = self::parseWithParents($code);
 
         // Line 3 (0-indexed) is after the class
-        $class = ScopeFinder::findClassAtLine($ast, 3);
+        $class = ScopeFinder::findClassLikeAtLine($ast, 3);
         self::assertNull($class);
     }
 


### PR DESCRIPTION
## Summary

- Renames `findClassAtLine` to `findClassLikeAtLine` returning `Class_|Interface_|Trait_|Enum_|null`
- Matches the return type of `findEnclosingClassNode` for consistency
- Updates all callers in CompletionHandler
- Adds completion tests verifying `$this->` works in traits and enums

Closes #187

## Test plan
- [x] New ScopeFinder tests for trait and enum lookup
- [x] New CompletionHandler tests for `$this->` in traits and enums
- [x] All existing tests pass