### PR TITLE
Add TypeFactory for AST and Reflection types

### DIFF
--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -36,17 +36,15 @@ final class TypeFactory
         'false',
     ];
 
-    private const CONTEXTUAL = [
-        'self',
-        'static',
-        'parent',
-    ];
-
     /**
-     * @param class-string|null $classContext
+     * @param class-string|null $selfContext
+     * @param class-string|null $parentContext
      */
-    public static function fromNode(?Node $node, ?string $classContext = null): ?Type
-    {
+    public static function fromNode(
+        ?Node $node,
+        ?string $selfContext = null,
+        ?string $parentContext = null,
+    ): ?Type {
         if ($node === null) {
             return null;
         }
@@ -60,11 +58,21 @@ final class TypeFactory
         if ($node instanceof Identifier) {
             $name = $node->toString();
 
-            if (in_array($name, self::CONTEXTUAL, true) && $classContext !== null) {
-                return new ClassName($classContext);
+            if ($name === 'self' || $name === 'static') {
+                if ($selfContext !== null) {
+                    return new ClassName($selfContext);
+                }
+                return new PrimitiveType($name);
             }
 
-            if (in_array($name, self::PRIMITIVES, true) || in_array($name, self::CONTEXTUAL, true)) {
+            if ($name === 'parent') {
+                if ($parentContext !== null) {
+                    return new ClassName($parentContext);
+                }
+                return new PrimitiveType($name);
+            }
+
+            if (in_array($name, self::PRIMITIVES, true)) {
                 return new PrimitiveType($name);
             }
 
@@ -73,7 +81,7 @@ final class TypeFactory
         }
 
         if ($node instanceof Node\NullableType) {
-            $inner = self::fromNode($node->type, $classContext);
+            $inner = self::fromNode($node->type, $selfContext, $parentContext);
             if ($inner === null) {
                 return null;
             }
@@ -82,14 +90,14 @@ final class TypeFactory
 
         if ($node instanceof Node\UnionType) {
             $members = array_values(array_filter(
-                array_map(fn (Node $n) => self::fromNode($n, $classContext), $node->types),
+                array_map(fn (Node $n) => self::fromNode($n, $selfContext, $parentContext), $node->types),
             ));
             return new UnionType($members);
         }
 
         if ($node instanceof Node\IntersectionType) {
             $members = array_values(array_filter(
-                array_map(fn (Node $n) => self::fromNode($n, $classContext), $node->types),
+                array_map(fn (Node $n) => self::fromNode($n, $selfContext, $parentContext), $node->types),
             ));
             return new IntersectionType($members);
         }

--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Domain\IntersectionType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\UnionType;
+use LogicException;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -79,15 +80,18 @@ final class TypeFactory
                 return new PrimitiveType($name);
             }
 
-            /** @var class-string $name */
-            return new ClassName($name);
+            // @codeCoverageIgnoreStart
+            throw new LogicException("Unexpected Identifier in type context: $name");
+            // @codeCoverageIgnoreEnd
         }
 
         if ($node instanceof Node\NullableType) {
             $inner = self::fromNode($node->type, $selfContext, $parentContext);
+            // @codeCoverageIgnoreStart
             if ($inner === null) {
-                return null;
+                throw new LogicException('NullableType inner type resolved to null');
             }
+            // @codeCoverageIgnoreEnd
             return new UnionType([$inner, new PrimitiveType('null')]);
         }
 
@@ -105,7 +109,9 @@ final class TypeFactory
             return new IntersectionType($members);
         }
 
-        return null;
+        // @codeCoverageIgnoreStart
+        throw new LogicException('Unexpected node type: ' . $node::class);
+        // @codeCoverageIgnoreEnd
     }
 
     public static function fromReflection(?ReflectionType $type): ?Type
@@ -147,6 +153,8 @@ final class TypeFactory
             return new IntersectionType($members);
         }
 
-        return null;
+        // @codeCoverageIgnoreStart
+        throw new LogicException('Unexpected ReflectionType: ' . $type::class);
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\IntersectionType;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\UnionType;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+final class TypeFactory
+{
+    private const PRIMITIVES = [
+        'string',
+        'int',
+        'float',
+        'bool',
+        'array',
+        'object',
+        'callable',
+        'iterable',
+        'void',
+        'never',
+        'mixed',
+        'null',
+        'true',
+        'false',
+    ];
+
+    private const CONTEXTUAL = [
+        'self',
+        'static',
+        'parent',
+    ];
+
+    /**
+     * @param class-string|null $classContext
+     */
+    public static function fromNode(?Node $node, ?string $classContext = null): ?Type
+    {
+        if ($node === null) {
+            return null;
+        }
+
+        if ($node instanceof Name) {
+            /** @var class-string $fqn */
+            $fqn = $node->toString();
+            return new ClassName($fqn);
+        }
+
+        if ($node instanceof Identifier) {
+            $name = $node->toString();
+
+            if (in_array($name, self::CONTEXTUAL, true) && $classContext !== null) {
+                return new ClassName($classContext);
+            }
+
+            if (in_array($name, self::PRIMITIVES, true) || in_array($name, self::CONTEXTUAL, true)) {
+                return new PrimitiveType($name);
+            }
+
+            /** @var class-string $name */
+            return new ClassName($name);
+        }
+
+        if ($node instanceof Node\NullableType) {
+            $inner = self::fromNode($node->type, $classContext);
+            if ($inner === null) {
+                return null;
+            }
+            return new UnionType([$inner, new PrimitiveType('null')]);
+        }
+
+        if ($node instanceof Node\UnionType) {
+            $members = array_values(array_filter(
+                array_map(fn (Node $n) => self::fromNode($n, $classContext), $node->types),
+            ));
+            return new UnionType($members);
+        }
+
+        if ($node instanceof Node\IntersectionType) {
+            $members = array_values(array_filter(
+                array_map(fn (Node $n) => self::fromNode($n, $classContext), $node->types),
+            ));
+            return new IntersectionType($members);
+        }
+
+        return null;
+    }
+
+    public static function fromReflection(?ReflectionType $type): ?Type
+    {
+        if ($type === null) {
+            return null;
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            $name = $type->getName();
+
+            if ($type->isBuiltin()) {
+                $primitive = new PrimitiveType($name);
+                if ($type->allowsNull() && $name !== 'null' && $name !== 'mixed') {
+                    return new UnionType([$primitive, new PrimitiveType('null')]);
+                }
+                return $primitive;
+            }
+
+            /** @var class-string $name */
+            $className = new ClassName($name);
+            if ($type->allowsNull()) {
+                return new UnionType([$className, new PrimitiveType('null')]);
+            }
+            return $className;
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            $members = array_values(array_filter(
+                array_map(self::fromReflection(...), $type->getTypes()),
+            ));
+            return new UnionType($members);
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            $members = array_values(array_filter(
+                array_map(self::fromReflection(...), $type->getTypes()),
+            ));
+            return new IntersectionType($members);
+        }
+
+        return null;
+    }
+}

--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -50,8 +50,11 @@ final class TypeFactory
         }
 
         if ($node instanceof Name) {
+            $resolvedName = $node->getAttribute('resolvedName');
             /** @var class-string $fqn */
-            $fqn = $node->toString();
+            $fqn = $resolvedName instanceof Name
+                ? $resolvedName->toString()
+                : $node->toString();
             return new ClassName($fqn);
         }
 

--- a/tests/Utility/TypeFactoryTest.php
+++ b/tests/Utility/TypeFactoryTest.php
@@ -71,7 +71,7 @@ class TypeFactoryTest extends TestCase
     public function testFromNodeWithSelfAndContextCreatesClassName(): void
     {
         $node = new Identifier('self');
-        $type = TypeFactory::fromNode($node, \stdClass::class);
+        $type = TypeFactory::fromNode($node, selfContext: \stdClass::class);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(\stdClass::class, $type->fqn);
@@ -80,10 +80,19 @@ class TypeFactoryTest extends TestCase
     public function testFromNodeWithStaticAndContextCreatesClassName(): void
     {
         $node = new Identifier('static');
-        $type = TypeFactory::fromNode($node, \ArrayObject::class);
+        $type = TypeFactory::fromNode($node, selfContext: \ArrayObject::class);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(\ArrayObject::class, $type->fqn);
+    }
+
+    public function testFromNodeWithParentAndContextCreatesClassName(): void
+    {
+        $node = new Identifier('parent');
+        $type = TypeFactory::fromNode($node, parentContext: \Throwable::class);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\Throwable::class, $type->fqn);
     }
 
     public function testFromNodeWithSelfWithoutContextCreatesPrimitiveType(): void

--- a/tests/Utility/TypeFactoryTest.php
+++ b/tests/Utility/TypeFactoryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\IntersectionType;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\UnionType;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType as AstIntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\UnionType as AstUnionType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionMethod;
+
+#[CoversClass(TypeFactory::class)]
+class TypeFactoryTest extends TestCase
+{
+    public function testFromNodeWithNullReturnsNull(): void
+    {
+        self::assertNull(TypeFactory::fromNode(null));
+    }
+
+    public function testFromNodeWithNameCreatesClassName(): void
+    {
+        $node = new Name(\stdClass::class);
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\stdClass::class, $type->fqn);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     * @codeCoverageIgnore
+     */
+    public static function primitiveProvider(): iterable
+    {
+        yield 'string' => ['string'];
+        yield 'int' => ['int'];
+        yield 'float' => ['float'];
+        yield 'bool' => ['bool'];
+        yield 'array' => ['array'];
+        yield 'object' => ['object'];
+        yield 'callable' => ['callable'];
+        yield 'iterable' => ['iterable'];
+        yield 'void' => ['void'];
+        yield 'never' => ['never'];
+        yield 'mixed' => ['mixed'];
+        yield 'null' => ['null'];
+        yield 'true' => ['true'];
+        yield 'false' => ['false'];
+    }
+
+    #[DataProvider('primitiveProvider')]
+    public function testFromNodeWithPrimitiveIdentifierCreatesPrimitiveType(string $name): void
+    {
+        $node = new Identifier($name);
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame($name, $type->format());
+    }
+
+    public function testFromNodeWithSelfAndContextCreatesClassName(): void
+    {
+        $node = new Identifier('self');
+        $type = TypeFactory::fromNode($node, \stdClass::class);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\stdClass::class, $type->fqn);
+    }
+
+    public function testFromNodeWithStaticAndContextCreatesClassName(): void
+    {
+        $node = new Identifier('static');
+        $type = TypeFactory::fromNode($node, \ArrayObject::class);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\ArrayObject::class, $type->fqn);
+    }
+
+    public function testFromNodeWithSelfWithoutContextCreatesPrimitiveType(): void
+    {
+        $node = new Identifier('self');
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('self', $type->format());
+    }
+
+    public function testFromNodeWithNullableTypeCreatesUnionType(): void
+    {
+        $node = new NullableType(new Name(\stdClass::class));
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
+        self::assertSame('stdClass|null', $type->format());
+    }
+
+    public function testFromNodeWithUnionTypeCreatesUnionType(): void
+    {
+        $node = new AstUnionType([
+            new Name(\Iterator::class),
+            new Name(\Countable::class),
+        ]);
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertSame('Iterator|Countable', $type->format());
+    }
+
+    public function testFromNodeWithIntersectionTypeCreatesIntersectionType(): void
+    {
+        $node = new AstIntersectionType([
+            new Name(\Iterator::class),
+            new Name(\Countable::class),
+        ]);
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(IntersectionType::class, $type);
+        self::assertSame('Iterator&Countable', $type->format());
+    }
+
+    public function testFromNodeWithDnfType(): void
+    {
+        $node = new AstUnionType([
+            new AstIntersectionType([
+                new Name(\Iterator::class),
+                new Name(\Countable::class),
+            ]),
+            new Identifier('null'),
+        ]);
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertSame('(Iterator&Countable)|null', $type->format());
+        self::assertTrue($type->isNullable());
+    }
+
+    public function testFromReflectionWithNullReturnsNull(): void
+    {
+        self::assertNull(TypeFactory::fromReflection(null));
+    }
+
+    public function testFromReflectionWithBuiltinCreatesPrimitiveType(): void
+    {
+        $func = new ReflectionFunction(fn (): string => '');
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('string', $type->format());
+    }
+
+    public function testFromReflectionWithClassCreatesClassName(): void
+    {
+        $func = new ReflectionFunction(fn (): \stdClass => new \stdClass());
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\stdClass::class, $type->fqn);
+    }
+
+    public function testFromReflectionWithNullableCreatesUnionType(): void
+    {
+        $func = new ReflectionFunction(fn (): ?\stdClass => null);
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
+        self::assertSame('stdClass|null', $type->format());
+    }
+
+    public function testFromReflectionWithUnionCreatesUnionType(): void
+    {
+        $func = new ReflectionFunction(fn (): \Iterator|\Countable => new \ArrayIterator());
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertSame('Iterator|Countable', $type->format());
+    }
+
+    public function testFromReflectionWithIntersectionCreatesIntersectionType(): void
+    {
+        $func = new ReflectionFunction(fn (): \Iterator&\Countable => new \ArrayIterator());
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(IntersectionType::class, $type);
+        self::assertSame('Iterator&Countable', $type->format());
+    }
+
+    public function testFromReflectionWithMixedDoesNotWrapInUnion(): void
+    {
+        $func = new ReflectionFunction(fn (): mixed => null);
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('mixed', $type->format());
+    }
+
+    public function testFromReflectionWithNullDoesNotWrapInUnion(): void
+    {
+        $func = new ReflectionFunction(fn (): null => null);
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('null', $type->format());
+    }
+}

--- a/tests/Utility/TypeFactoryTest.php
+++ b/tests/Utility/TypeFactoryTest.php
@@ -36,6 +36,16 @@ class TypeFactoryTest extends TestCase
         self::assertSame(\stdClass::class, $type->fqn);
     }
 
+    public function testFromNodeWithNameUsesResolvedName(): void
+    {
+        $node = new Name('User');
+        $node->setAttribute('resolvedName', new Name('App\\Models\\User'));
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('App\\Models\\User', $type->fqn);
+    }
+
     /**
      * @return iterable<string, array{string}>
      * @codeCoverageIgnore
@@ -104,6 +114,15 @@ class TypeFactoryTest extends TestCase
         self::assertSame('self', $type->format());
     }
 
+    public function testFromNodeWithParentWithoutContextCreatesPrimitiveType(): void
+    {
+        $node = new Identifier('parent');
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('parent', $type->format());
+    }
+
     public function testFromNodeWithNullableTypeCreatesUnionType(): void
     {
         $node = new NullableType(new Name(\stdClass::class));
@@ -166,6 +185,16 @@ class TypeFactoryTest extends TestCase
 
         self::assertInstanceOf(PrimitiveType::class, $type);
         self::assertSame('string', $type->format());
+    }
+
+    public function testFromReflectionWithNullableBuiltinCreatesUnionType(): void
+    {
+        $func = new ReflectionFunction(fn (): ?string => null);
+        $type = TypeFactory::fromReflection($func->getReturnType());
+
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
+        self::assertSame('string|null', $type->format());
     }
 
     public function testFromReflectionWithClassCreatesClassName(): void


### PR DESCRIPTION
## Summary

- Add `TypeFactory` utility class with `fromNode()` and `fromReflection()` methods
- `fromNode()` constructs Type domain objects from PHP-Parser AST nodes
- `fromReflection()` constructs Type domain objects from PHP's ReflectionType
- Separate `selfContext` and `parentContext` parameters allow callers to resolve `self`/`static` and `parent` respectively

## Test plan

- [x] `fromNode` with `null` returns `null`
- [x] `fromNode` with `Name` creates `ClassName`
- [x] `fromNode` with primitive `Identifier` creates `PrimitiveType`
- [x] `fromNode` with `self`/`static` + `selfContext` creates `ClassName`
- [x] `fromNode` with `parent` + `parentContext` creates `ClassName`
- [x] `fromNode` with `self` without context creates `PrimitiveType` (deferred)
- [x] `fromNode` with `NullableType` creates `UnionType`
- [x] `fromNode` with `UnionType`/`IntersectionType` creates corresponding types
- [x] DNF types construct correctly
- [x] `fromReflection` handles all ReflectionType variants
- [x] `mixed` and `null` types don't get wrapped in union

Closes #196

🤖 Generated with [Claude Code](https://claude.ai/code)