### PR TITLE
Change TypeResolverInterface to return Type instead of string

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -402,14 +402,14 @@ final class CompletionHandler implements HandlerInterface
         }
 
         // Resolve the variable's type
-        $classNameStr = $this->typeResolver->resolveVariableType($variableName, $scope, $line, $ast);
-        if ($classNameStr === null) {
+        $type = $this->typeResolver->resolveVariableType($variableName, $scope, $line, $ast);
+        $classNames = $type?->getResolvableClassNames() ?? [];
+        if ($classNames === []) {
             return [];
         }
 
-        /** @var class-string $classNameStr */
         return $this->getMemberCompletions(
-            new ClassName($classNameStr),
+            $classNames[0],
             Visibility::Public,
             false,
             $prefix,
@@ -873,7 +873,7 @@ final class CompletionHandler implements HandlerInterface
                 $items[] = [
                     'label' => '$' . $name,
                     'kind' => self::KIND_VARIABLE,
-                    'detail' => $resolvedType ?? $basicType,
+                    'detail' => $resolvedType?->format() ?? $basicType,
                 ];
             }
         }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -206,12 +206,13 @@ final class DefinitionHandler implements HandlerInterface
             // @codeCoverageIgnoreEnd
         }
 
-        $className = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
-        if ($className === null) {
+        $type = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
+        $classNames = $type?->getResolvableClassNames() ?? [];
+        if ($classNames === []) {
             return null;
         }
 
-        return $this->findMethodDefinition($className, $methodName->toString());
+        return $this->findMethodDefinition($classNames[0]->fqn, $methodName->toString());
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -257,12 +257,13 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
-        if ($className === null) {
+        $type = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
+        $classNames = $type?->getResolvableClassNames() ?? [];
+        if ($classNames === []) {
             return null;
         }
 
-        return $this->getMethodHoverForClass($className, $methodName->toString());
+        return $this->getMethodHoverForClass($classNames[0]->fqn, $methodName->toString());
     }
 
     private function getStaticMethodHover(StaticCall $call): ?string
@@ -292,12 +293,13 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $className = ExpressionTypeResolver::resolveExpressionType($fetch->var, $ast, $this->typeResolver);
-        if ($className === null) {
+        $type = ExpressionTypeResolver::resolveExpressionType($fetch->var, $ast, $this->typeResolver);
+        $classNames = $type?->getResolvableClassNames() ?? [];
+        if ($classNames === []) {
             return null;
         }
 
-        return $this->getPropertyHoverForClass($className, $propertyName->toString());
+        return $this->getPropertyHoverForClass($classNames[0]->fqn, $propertyName->toString());
     }
 
     private function getStaticPropertyHover(StaticPropertyFetch $fetch): ?string

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -235,12 +235,13 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        $className = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
-        if ($className === null) {
+        $type = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
+        $classNames = $type?->getResolvableClassNames() ?? [];
+        if ($classNames === []) {
             return null;
         }
 
-        return $this->getMethodSignatureForClass($className, $methodName->toString());
+        return $this->getMethodSignatureForClass($classNames[0]->fqn, $methodName->toString());
     }
 
     /**

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\TypeInference;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Utility\TypeFactory;
@@ -36,11 +37,13 @@ final class BasicTypeResolver implements TypeResolverInterface
         Expr $expr,
         Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope,
         array $ast,
-    ): ?string {
+    ): ?Type {
         // new ClassName()
         if ($expr instanceof Expr\New_) {
             if ($expr->class instanceof Node\Name) {
-                return $expr->class->toString();
+                /** @var class-string */
+                $fqn = $expr->class->toString();
+                return new ClassName($fqn);
             }
             return null;
         }
@@ -48,7 +51,11 @@ final class BasicTypeResolver implements TypeResolverInterface
         // $this - check before generic variable handling
         if ($expr instanceof Expr\Variable && $expr->name === 'this') {
             $className = $this->findEnclosingClassName($ast, $scope);
-            return $className;
+            if ($className === null) {
+                return null;
+            }
+            /** @var class-string $className */
+            return new ClassName($className);
         }
 
         // Variable reference - delegate to resolveVariableType
@@ -59,8 +66,9 @@ final class BasicTypeResolver implements TypeResolverInterface
         // Method call: $obj->method()
         if ($expr instanceof Expr\MethodCall) {
             $objectType = $this->resolveExpressionType($expr->var, $scope, $ast);
-            if ($objectType !== null && $expr->name instanceof Node\Identifier) {
-                return $this->getMethodReturnType($objectType, $expr->name->toString());
+            $className = $this->extractClassName($objectType);
+            if ($className !== null && $expr->name instanceof Node\Identifier) {
+                return $this->getMethodReturnType($className, $expr->name->toString());
             }
             return null;
         }
@@ -77,8 +85,9 @@ final class BasicTypeResolver implements TypeResolverInterface
         // Property fetch: $obj->property
         if ($expr instanceof Expr\PropertyFetch) {
             $objectType = $this->resolveExpressionType($expr->var, $scope, $ast);
-            if ($objectType !== null && $expr->name instanceof Node\Identifier) {
-                return $this->getPropertyType($objectType, $expr->name->toString());
+            $className = $this->extractClassName($objectType);
+            if ($className !== null && $expr->name instanceof Node\Identifier) {
+                return $this->getPropertyType($className, $expr->name->toString());
             }
             return null;
         }
@@ -107,7 +116,7 @@ final class BasicTypeResolver implements TypeResolverInterface
         Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction $scope,
         int $line,
         array $ast,
-    ): ?string {
+    ): ?Type {
         // Check parameters first
         foreach ($scope->params as $param) {
             if (
@@ -115,9 +124,7 @@ final class BasicTypeResolver implements TypeResolverInterface
                 && is_string($param->var->name)
                 && $param->var->name === $variableName
             ) {
-                $type = TypeFactory::fromNode($param->type);
-                $classNames = $type?->getResolvableClassNames() ?? [];
-                return $classNames !== [] ? $classNames[0]->fqn : null;
+                return TypeFactory::fromNode($param->type);
             }
         }
 
@@ -136,7 +143,7 @@ final class BasicTypeResolver implements TypeResolverInterface
         $stmts = $scope instanceof Expr\ArrowFunction ? [] : ($scope->stmts ?? []);
 
         $visitor = new class ($variableName, $line, $foundType, $this, $scope, $ast) extends NodeVisitorAbstract {
-            public ?string $foundType = null;
+            public ?Type $foundType = null;
             private string $variableName;
             private int $line;
             private BasicTypeResolver $resolver;
@@ -152,7 +159,7 @@ final class BasicTypeResolver implements TypeResolverInterface
             public function __construct(
                 string $variableName,
                 int $line,
-                ?string &$foundType,
+                ?Type &$foundType,
                 BasicTypeResolver $resolver,
                 $scope,
                 array $ast,
@@ -205,7 +212,7 @@ final class BasicTypeResolver implements TypeResolverInterface
         return $visitor->foundType;
     }
 
-    private function getMethodReturnType(string $className, string $methodName): ?string
+    private function getMethodReturnType(string $className, string $methodName): ?Type
     {
         /** @var class-string $className */
         $methodInfo = $this->memberResolver->findMethod(
@@ -214,11 +221,10 @@ final class BasicTypeResolver implements TypeResolverInterface
             Visibility::Public,
         );
 
-        $classNames = $methodInfo?->returnTypeInfo?->getResolvableClassNames() ?? [];
-        return $classNames !== [] ? $classNames[0]->fqn : null;
+        return $methodInfo?->returnTypeInfo;
     }
 
-    private function getPropertyType(string $className, string $propertyName): ?string
+    private function getPropertyType(string $className, string $propertyName): ?Type
     {
         /** @var class-string $className */
         $propertyInfo = $this->memberResolver->findProperty(
@@ -227,7 +233,15 @@ final class BasicTypeResolver implements TypeResolverInterface
             Visibility::Public,
         );
 
-        $classNames = $propertyInfo?->typeInfo?->getResolvableClassNames() ?? [];
+        return $propertyInfo?->typeInfo;
+    }
+
+    private function extractClassName(?Type $type): ?string
+    {
+        if ($type === null) {
+            return null;
+        }
+        $classNames = $type->getResolvableClassNames();
         return $classNames !== [] ? $classNames[0]->fqn : null;
     }
 

--- a/src/TypeInference/TypeResolverInterface.php
+++ b/src/TypeInference/TypeResolverInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\TypeInference;
 
+use Firehed\PhpLsp\Domain\Type;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 
@@ -22,13 +23,12 @@ interface TypeResolverInterface
      * @param Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope
      *        The enclosing scope, if any
      * @param array<Stmt> $ast The full AST for context (class lookups, etc.)
-     * @return string|null The resolved type, or null if unknown
      */
     public function resolveExpressionType(
         Expr $expr,
         Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope,
         array $ast,
-    ): ?string;
+    ): ?Type;
 
     /**
      * Resolve the type of a variable at a given position.
@@ -38,12 +38,11 @@ interface TypeResolverInterface
      *        The enclosing scope
      * @param int $line The line number (0-based) where the variable is used
      * @param array<Stmt> $ast The full AST for context
-     * @return string|null The resolved type, or null if unknown
      */
     public function resolveVariableType(
         string $variableName,
         Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction $scope,
         int $line,
         array $ast,
-    ): ?string;
+    ): ?Type;
 }

--- a/src/Utility/ExpressionTypeResolver.php
+++ b/src/Utility/ExpressionTypeResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Utility;
 
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Variable;
@@ -18,22 +20,25 @@ use PhpParser\Node\Stmt;
 final class ExpressionTypeResolver
 {
     /**
-     * Resolve the class name of an expression.
+     * Resolve the type of an expression.
      *
      * Handles:
      * - $this → enclosing class name
      * - Typed variables → delegated to TypeResolver
      *
      * @param array<Stmt> $ast
-     * @return ?class-string
      */
     public static function resolveExpressionType(
         Expr $expr,
         array $ast,
         ?TypeResolverInterface $typeResolver,
-    ): ?string {
+    ): ?Type {
         if ($expr instanceof Variable && $expr->name === 'this') {
-            return ScopeFinder::findEnclosingClassName($expr);
+            $className = ScopeFinder::findEnclosingClassName($expr);
+            if ($className === null) {
+                return null;
+            }
+            return new ClassName($className);
         }
 
         if ($typeResolver === null) {
@@ -45,7 +50,6 @@ final class ExpressionTypeResolver
             return null;
         }
 
-        /** @var ?class-string */
         return $typeResolver->resolveExpressionType($expr, $scope, $ast);
     }
 }

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\TypeInference;
 
+use DateTime;
+use DateTimeImmutable;
+use Exception;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\UnionType;
 use Firehed\PhpLsp\Parser\ParserService;
+use Throwable;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
@@ -42,7 +49,8 @@ class BasicTypeResolverTest extends TestCase
 
         $type = $this->resolver->resolveExpressionType($expr, null, $ast);
 
-        self::assertSame('DateTime', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(DateTime::class, $type->fqn);
     }
 
     public function testResolveParameterType(): void
@@ -58,7 +66,8 @@ PHP;
 
         $type = $this->resolver->resolveVariableType('dt', $function, 2, $ast);
 
-        self::assertSame('DateTime', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(DateTime::class, $type->fqn);
     }
 
     public function testResolveAssignmentFromNew(): void
@@ -75,7 +84,8 @@ PHP;
 
         $type = $this->resolver->resolveVariableType('x', $function, 3, $ast);
 
-        self::assertSame('DateTime', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(DateTime::class, $type->fqn);
     }
 
     public function testResolveMethodReturnTypeResolvesObjectType(): void
@@ -96,12 +106,13 @@ PHP;
 
         // The object type is resolved, even if method return type isn't
         $objectType = $this->resolver->resolveExpressionType($methodCall->var, $function, $ast);
-        self::assertSame('DateTime', $objectType);
+        self::assertInstanceOf(ClassName::class, $objectType);
+        self::assertSame(DateTime::class, $objectType->fqn);
     }
 
-    public function testResolveMethodReturnTypePrimitiveReturnsNull(): void
+    public function testResolveMethodReturnTypePrimitive(): void
     {
-        // Exception::getMessage() has return type string - not a class, so null
+        // Exception::getMessage() has return type string
         $code = <<<'PHP'
 <?php
 function test() {
@@ -115,7 +126,8 @@ PHP;
 
         $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
 
-        self::assertNull($type);
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('string', $type->format());
     }
 
     public function testResolveMethodReturnTypeReturnsNullForUnknownMethod(): void
@@ -136,9 +148,9 @@ PHP;
         self::assertNull($type);
     }
 
-    public function testResolveMethodReturnTypeIntReturnsNull(): void
+    public function testResolveMethodReturnTypeInt(): void
     {
-        // Exception::getLine() returns int - not a class, so null
+        // Exception::getLine() returns int
         $code = <<<'PHP'
 <?php
 function test() {
@@ -152,7 +164,8 @@ PHP;
 
         $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
 
-        self::assertNull($type);
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('int', $type->format());
     }
 
     public function testResolvePropertyTypeReturnsNullForUnknownClass(): void
@@ -186,7 +199,8 @@ PHP;
 
         $type = $this->resolver->resolveExpressionType($clone, $function, $ast);
 
-        self::assertSame('DateTime', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(DateTime::class, $type->fqn);
     }
 
     public function testResolveTernaryExpression(): void
@@ -203,7 +217,8 @@ PHP;
 
         $type = $this->resolver->resolveExpressionType($ternary, $function, $ast);
 
-        self::assertSame('DateTime', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(DateTime::class, $type->fqn);
     }
 
     public function testResolveNullCoalesceExpression(): void
@@ -220,8 +235,9 @@ PHP;
 
         $type = $this->resolver->resolveExpressionType($coalesce, $function, $ast);
 
-        // The left side is ?DateTime parameter, returns DateTime class
-        self::assertSame('DateTime', $type);
+        // The left side is ?DateTime|null, full UnionType returned
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
     }
 
     public function testResolveThisInClassMethod(): void
@@ -240,7 +256,8 @@ PHP;
 
         $type = $this->resolver->resolveExpressionType($thisVar, $method, $ast);
 
-        self::assertSame('MyClass', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('MyClass', $type->fqn);
     }
 
     public function testResolveNullableParameterType(): void
@@ -256,8 +273,12 @@ PHP;
 
         $type = $this->resolver->resolveVariableType('dt', $function, 2, $ast);
 
-        // Returns the class name, stripped of nullable
-        self::assertSame('DateTime', $type);
+        // Returns full UnionType with DateTime|null
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
+        $classNames = $type->getResolvableClassNames();
+        self::assertCount(1, $classNames);
+        self::assertSame(DateTime::class, $classNames[0]->fqn);
     }
 
     public function testResolveUnionParameterType(): void
@@ -273,8 +294,12 @@ PHP;
 
         $type = $this->resolver->resolveVariableType('dt', $function, 2, $ast);
 
-        // Returns the first class from the union
-        self::assertSame('DateTime', $type);
+        // Returns full UnionType with both classes
+        self::assertInstanceOf(UnionType::class, $type);
+        $classNames = $type->getResolvableClassNames();
+        self::assertCount(2, $classNames);
+        self::assertSame(DateTime::class, $classNames[0]->fqn);
+        self::assertSame(DateTimeImmutable::class, $classNames[1]->fqn);
     }
 
     public function testResolveUnknownVariableReturnsNull(): void
@@ -306,7 +331,8 @@ PHP;
 
         $type = $this->resolver->resolveVariableType('dt', $closure, 2, $ast);
 
-        self::assertSame('DateTime', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(DateTime::class, $type->fqn);
     }
 
     public function testResolveArrowFunctionParameter(): void
@@ -317,7 +343,8 @@ PHP;
 
         $type = $this->resolver->resolveVariableType('dt', $arrow, 0, $ast);
 
-        self::assertSame('DateTime', $type);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(DateTime::class, $type->fqn);
     }
 
     public function testResolveNullableMethodReturnType(): void
@@ -336,8 +363,12 @@ PHP;
 
         $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
 
-        // Returns the class name, stripped of nullable
-        self::assertSame('Throwable', $type);
+        // Returns full nullable type
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
+        $classNames = $type->getResolvableClassNames();
+        self::assertCount(1, $classNames);
+        self::assertSame(Throwable::class, $classNames[0]->fqn);
     }
 
     public function testChainWithNullableIntermediate(): void
@@ -384,14 +415,18 @@ PHP;
         $getMessageCall = $finder->methodCalls[0];
         $getPreviousCall = $finder->methodCalls[1];
 
-        // Verify getPrevious() returns Throwable (class extracted from ?Throwable)
+        // getPrevious() returns ?Throwable as a UnionType
         $prevType = $this->resolver->resolveExpressionType($getPreviousCall, $function, $ast);
-        self::assertSame('Throwable', $prevType);
+        self::assertInstanceOf(UnionType::class, $prevType);
+        self::assertTrue($prevType->isNullable());
+        $classNames = $prevType->getResolvableClassNames();
+        self::assertCount(1, $classNames);
+        self::assertSame(Throwable::class, $classNames[0]->fqn);
 
-        // getMessage() returns string (null for class-based resolution)
-        // The chain works because getPrevious() resolved to Throwable
+        // getMessage() returns string as PrimitiveType
         $msgType = $this->resolver->resolveExpressionType($getMessageCall, $function, $ast);
-        self::assertNull($msgType);
+        self::assertInstanceOf(PrimitiveType::class, $msgType);
+        self::assertSame('string', $msgType->format());
     }
 
     /**

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -185,6 +185,42 @@ PHP;
         self::assertNull($type);
     }
 
+    public function testResolveThisInFunctionReturnsNull(): void
+    {
+        // $this used in a function (not a method) - findEnclosingClassName returns null
+        $code = <<<'PHP'
+<?php
+function test() {
+    $x = $this;
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $thisVar = $this->findThisVariable($ast);
+
+        $type = $this->resolver->resolveExpressionType($thisVar, $function, $ast);
+
+        self::assertNull($type);
+    }
+
+    public function testResolveMethodCallOnUnresolvedTypeReturnsNull(): void
+    {
+        // Method call on a variable whose type can't be resolved
+        $code = <<<'PHP'
+<?php
+function test() {
+    $result = $unknown->someMethod();
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $methodCall = $this->findFirstExprOfType($ast, Expr\MethodCall::class);
+
+        $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
+
+        self::assertNull($type);
+    }
+
     public function testResolveCloneExpression(): void
     {
         $code = <<<'PHP'

--- a/tests/Utility/ExpressionTypeResolverTest.php
+++ b/tests/Utility/ExpressionTypeResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Utility;
 
+use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,7 +33,8 @@ PHP;
         self::assertNotNull($thisNode);
         $result = ExpressionTypeResolver::resolveExpressionType($thisNode, $ast, null);
 
-        self::assertSame('App\Models\User', $result);
+        self::assertInstanceOf(ClassName::class, $result);
+        self::assertSame('App\Models\User', $result->fqn);
     }
 
     public function testResolveExpressionTypeReturnsNullForThisOutsideClass(): void
@@ -70,11 +72,13 @@ PHP;
         $typeResolver = $this->createMock(TypeResolverInterface::class);
         $typeResolver->expects(self::once())
             ->method('resolveExpressionType')
-            ->willReturn('App\Models\User');
+            // @phpstan-ignore argument.type (test class doesn't exist)
+            ->willReturn(new ClassName('App\Models\User'));
 
         $result = ExpressionTypeResolver::resolveExpressionType($userNode, $ast, $typeResolver);
 
-        self::assertSame('App\Models\User', $result);
+        self::assertInstanceOf(ClassName::class, $result);
+        self::assertSame('App\Models\User', $result->fqn);
     }
 
     public function testResolveExpressionTypeReturnsNullWithoutTypeResolver(): void


### PR DESCRIPTION
## Summary
- Change `TypeResolverInterface` return types from `?string` to `?Type`
- Update `BasicTypeResolver` to return full Type objects instead of extracting class names
- Update `ExpressionTypeResolver` wrapper to return `?Type`
- Update all handler call sites to extract class names from Type objects

This preserves full type information (including nullability) for callers, enabling future null-safety diagnostics.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)