### PR TITLE
Extract constant types via reflection

### DIFF
--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -583,7 +583,7 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
                 name: new ConstantName($name),
                 visibility: $this->visibilityFromReflectionConstant($constant),
                 isFinal: $constant->isFinal(),
-                type: null,
+                type: TypeFactory::fromReflection($constant->getType()),
                 docblock: $constant->getDocComment() !== false ? $constant->getDocComment() : null,
                 file: $class->getFileName() !== false ? $class->getFileName() : null,
                 line: null,

--- a/tests/Repository/DefaultClassInfoFactoryTest.php
+++ b/tests/Repository/DefaultClassInfoFactoryTest.php
@@ -343,6 +343,7 @@ PHP;
 
         self::assertSame(Visibility::Protected, $info->constants['PROTECTED_CONST']->visibility);
         self::assertSame(Visibility::Private, $info->constants['PRIVATE_CONST']->visibility);
+        self::assertNull($info->constants['PRIVATE_CONST']->type);
     }
 
     public function testFromAstNodeExtractsDocblock(): void

--- a/tests/Repository/DefaultClassInfoFactoryTest.php
+++ b/tests/Repository/DefaultClassInfoFactoryTest.php
@@ -484,6 +484,16 @@ PHP;
         self::assertSame(Visibility::Public, $info->constants['TEST_CONST']->visibility);
     }
 
+    public function testFromReflectionExtractsTypedConstants(): void
+    {
+        $reflection = new ReflectionClass(TestClass::class);
+
+        $info = $this->factory->fromReflection($reflection);
+
+        self::assertArrayHasKey('TYPED_CONST', $info->constants);
+        self::assertSame('string', $info->constants['TYPED_CONST']->type?->format());
+    }
+
     public function testFromReflectionExtractsInterfaces(): void
     {
         $reflection = new ReflectionClass(ClassWithInterface::class);

--- a/tests/Repository/TestClass.php
+++ b/tests/Repository/TestClass.php
@@ -9,6 +9,7 @@ class TestClass
     use TestTrait;
 
     public const TEST_CONST = 'value';
+    public const string TYPED_CONST = 'typed';
 
     public string $publicProp;
 


### PR DESCRIPTION
## Summary

- Use `TypeFactory::fromReflection($constant->getType())` instead of hardcoding `type: null` in `extractConstantsFromReflection()`
- Typed constants (PHP 8.3+) in built-in/vendor classes now have their types extracted correctly

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)