### PR TITLE
Refactor completion context detection to use AST analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ composer phpcs -- -q --report=emacs # run code style checks (PSR-12)
 - `src/Index/` — Symbol indexing and workspace scanning
 - `src/Document/` — Open document management
 - `src/Utility/` — AST helpers (ScopeFinder, TypeFactory, DocblockParser)
+- `src/Completion/` — Completion context detection (CompletionContextResolver)
 - `docs/features/` — Feature status documentation
 
 ## Architecture
@@ -88,7 +89,9 @@ Key methods:
 
 See `docs/features/completion.md` for current capabilities.
 
-Architecture: regex-based context detection in `CompletionHandler`. Determines completion type ($this->, static, new, function) and delegates to internal methods.
+Architecture: `CompletionContextResolver` uses AST analysis to detect member/static access contexts (handles both `->` and `?->` automatically). Regex-based detection remains for other contexts (variables, type hints, keywords).
+
+**Prefer AST-based context detection over regex.** The parser's error recovery produces usable AST even for incomplete code like `$this->`. AST detection handles operator variants (e.g., `->` vs `?->`) automatically without pattern duplication.
 
 ## LSP Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Key methods:
 - **Add factory methods to domain objects** for new construction patterns (e.g., `FunctionInfo::fromNode()`, `FunctionInfo::fromReflection()`).
 - **Check existing utilities before writing AST traversal.** Search `ScopeFinder` and handlers for similar patterns before creating new `NodeVisitorAbstract` implementations. Duplicate traversal logic should be extracted to utilities.
 - **Use `ExpressionTypeResolver` for expression types.** It wraps `TypeResolverInterface` and handles special cases like `$this`. Handlers should use it consistently rather than calling `TypeResolverInterface` directly.
+- **Use `MemberAccessResolver` for member access.** It handles both `->` and `?->` operators and resolves types via the shared utilities. Handlers should use it instead of duplicating type resolution logic.
 - **Use `Type` objects, not strings.** Store and pass types as `Type` instances. Use `TypeFactory` to create them from AST or reflection. Call `format()` only at display time.
 
 ### Remaining Utilities
@@ -75,6 +76,7 @@ Key methods:
 - `DocblockParser` — Extracts description from docblocks
 - `ExpressionTypeResolver` — Resolves expression types (wraps TypeResolverInterface, handles `$this`)
 - `TypeFactory` — Creates Type domain objects from AST nodes and reflection
+- `MemberAccessResolver` — Resolves method calls and property fetches to domain objects; handles both `->` and `?->` operators
 
 ## Development Workflow
 

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -6,8 +6,8 @@ This document tracks the current state of code completion in php-lsp.
 
 | Context | Trigger | What's Suggested | Status |
 |---------|---------|------------------|--------|
-| `$this->` member access | `$this->` or `$this->prefix` | Methods and properties from current class + inherited via reflection | ✅ Working |
-| Typed variable member access | `$user->` | Public methods and properties when type is known (parameter types, `new` expressions) | ✅ Working |
+| `$this->` member access | `$this->` or `$this?->` | Methods and properties from current class + inherited via reflection | ✅ Working |
+| Typed variable member access | `$user->` or `$user?->` | Public methods and properties when type is known (parameter types, `new` expressions) | ✅ Working |
 | Variable completions | `$log` | Local variables, parameters, `$this` in methods | ✅ Working |
 | Static access | `ClassName::` | Static methods, constants, static properties (visibility-aware) | ✅ Working |
 | `new` expression | `new ` | Classes from composer classmap | ✅ Working |
@@ -31,13 +31,16 @@ This document tracks the current state of code completion in php-lsp.
 
 ```
 CompletionHandler
-└── Regex-based context detection in getCompletionItems()
-    ├── $this-> member completions
-    ├── $variable-> typed variable completions (via TypeResolverInterface)
+├── AST-based context detection (via CompletionContextResolver)
+│   ├── $this-> and $this?-> member completions
+│   ├── $variable-> and $variable?-> typed variable completions
+│   ├── ClassName:: static completions
+│   └── self::/static::/parent:: completions
+└── Regex-based fallback for other contexts
     ├── $var variable completions
-    ├── ClassName:: static completions
     ├── new ClassName completions
-    └── Function name completions
+    ├── Type hint completions
+    └── Function/keyword completions
 ```
 
 ## Testing

--- a/src/Completion/CompletionContext.php
+++ b/src/Completion/CompletionContext.php
@@ -12,8 +12,6 @@ enum CompletionContext
     case VariableMember;
     case StaticMember;
     case ParentMember;
-    case Variable;
-    case NewExpression;
     case Unknown;
 
     public static function fromMemberAccess(Expr $var): self

--- a/src/Completion/CompletionContext.php
+++ b/src/Completion/CompletionContext.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use PhpParser\Node\Expr;
+
+enum CompletionContext
+{
+    case ThisMember;
+    case VariableMember;
+    case StaticMember;
+    case ParentMember;
+    case Variable;
+    case NewExpression;
+    case Unknown;
+
+    public static function fromMemberAccess(Expr $var): self
+    {
+        if ($var instanceof Expr\Variable && $var->name === 'this') {
+            return self::ThisMember;
+        }
+        if ($var instanceof Expr\Variable) {
+            return self::VariableMember;
+        }
+        return self::Unknown;
+    }
+}

--- a/src/Completion/CompletionContextResolver.php
+++ b/src/Completion/CompletionContextResolver.php
@@ -13,35 +13,21 @@ use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-/**
- * @phpstan-type MemberAccessResult array{
- *   context: CompletionContext,
- *   var: Expr,
- *   prefix: string,
- * }
- * @phpstan-type StaticAccessResult array{
- *   context: CompletionContext,
- *   class: Name,
- *   prefix: string,
- * }
- * @phpstan-type ContextResult MemberAccessResult|StaticAccessResult|null
- */
 final class CompletionContextResolver
 {
     /**
      * Find completion context at the given offset using AST analysis.
      *
      * @param array<Stmt> $ast
-     * @return ContextResult
      */
-    public function resolve(array $ast, int $offset): ?array
+    public function resolve(array $ast, int $offset): MemberAccessContext|StaticAccessContext|null
     {
         $node = $this->findNodeAtOffset($ast, $offset);
         if ($node === null) {
             return null;
         }
 
-        return $this->analyzeNode($node, $offset);
+        return $this->analyzeNode($node);
     }
 
     /**
@@ -78,10 +64,7 @@ final class CompletionContextResolver
         return $finder->found;
     }
 
-    /**
-     * @return ContextResult
-     */
-    private function analyzeNode(Node $node, int $offset): ?array
+    private function analyzeNode(Node $node): MemberAccessContext|StaticAccessContext|null
     {
         if ($node instanceof Expr\PropertyFetch || $node instanceof Expr\NullsafePropertyFetch) {
             return $this->analyzeMemberAccess($node);
@@ -107,7 +90,7 @@ final class CompletionContextResolver
         if ($node instanceof Identifier || $node instanceof Error) {
             $parent = $node->getAttribute('parent');
             if ($parent instanceof Node) {
-                return $this->analyzeNode($parent, $offset);
+                return $this->analyzeNode($parent);
             }
         }
 
@@ -116,9 +99,8 @@ final class CompletionContextResolver
 
     /**
      * @param Expr\PropertyFetch|Expr\NullsafePropertyFetch|Expr\MethodCall|Expr\NullsafeMethodCall $node
-     * @return MemberAccessResult|null
      */
-    private function analyzeMemberAccess(Expr $node): ?array
+    private function analyzeMemberAccess(Expr $node): ?MemberAccessContext
     {
         $name = $node->name;
         $prefix = '';
@@ -136,19 +118,10 @@ final class CompletionContextResolver
             return null;
         }
 
-        return [
-            'context' => $context,
-            'var' => $node->var,
-            'prefix' => $prefix,
-        ];
+        return new MemberAccessContext($context, $node->var, $prefix);
     }
 
-    /**
-     * @param Node $class
-     * @param Node $name
-     * @return StaticAccessResult|null
-     */
-    private function analyzeStaticAccess(Node $class, Node $name): ?array
+    private function analyzeStaticAccess(Node $class, Node $name): ?StaticAccessContext
     {
         if (!$class instanceof Name) {
             return null;
@@ -168,10 +141,6 @@ final class CompletionContextResolver
             default => CompletionContext::StaticMember,
         };
 
-        return [
-            'context' => $context,
-            'class' => $class,
-            'prefix' => $prefix,
-        ];
+        return new StaticAccessContext($context, $class, $prefix);
     }
 }

--- a/src/Completion/CompletionContextResolver.php
+++ b/src/Completion/CompletionContextResolver.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Error;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @phpstan-type MemberAccessResult array{
+ *   context: CompletionContext,
+ *   var: Expr,
+ *   prefix: string,
+ * }
+ * @phpstan-type StaticAccessResult array{
+ *   context: CompletionContext,
+ *   class: Name,
+ *   prefix: string,
+ * }
+ * @phpstan-type ContextResult MemberAccessResult|StaticAccessResult|null
+ */
+final class CompletionContextResolver
+{
+    /**
+     * Find completion context at the given offset using AST analysis.
+     *
+     * @param array<Stmt> $ast
+     * @return ContextResult
+     */
+    public function resolve(array $ast, int $offset): ?array
+    {
+        $node = $this->findNodeAtOffset($ast, $offset);
+        if ($node === null) {
+            return null;
+        }
+
+        return $this->analyzeNode($node, $offset);
+    }
+
+    /**
+     * @param array<Node> $ast
+     */
+    private function findNodeAtOffset(array $ast, int $offset): ?Node
+    {
+        $finder = new class ($offset) extends NodeVisitorAbstract {
+            public ?Node $found = null;
+
+            public function __construct(private readonly int $offset)
+            {
+            }
+
+            public function enterNode(Node $node): null
+            {
+                $startPos = $node->getStartFilePos();
+                $endPos = $node->getEndFilePos();
+
+                // Allow cursor immediately after node end (endPos + 1)
+                // This handles completion triggers like "$this->|"
+                if ($startPos <= $this->offset && $this->offset <= $endPos + 1) {
+                    $this->found = $node;
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        return $finder->found;
+    }
+
+    /**
+     * @return ContextResult
+     */
+    private function analyzeNode(Node $node, int $offset): ?array
+    {
+        if ($node instanceof Expr\PropertyFetch || $node instanceof Expr\NullsafePropertyFetch) {
+            return $this->analyzeMemberAccess($node);
+        }
+
+        if ($node instanceof Expr\MethodCall || $node instanceof Expr\NullsafeMethodCall) {
+            return $this->analyzeMemberAccess($node);
+        }
+
+        if ($node instanceof Expr\StaticPropertyFetch) {
+            return $this->analyzeStaticAccess($node->class, $node->name);
+        }
+
+        if ($node instanceof Expr\StaticCall) {
+            return $this->analyzeStaticAccess($node->class, $node->name);
+        }
+
+        if ($node instanceof Expr\ClassConstFetch) {
+            return $this->analyzeStaticAccess($node->class, $node->name);
+        }
+
+        // Identifier or Error node - delegate to parent
+        if ($node instanceof Identifier || $node instanceof Error) {
+            $parent = $node->getAttribute('parent');
+            if ($parent instanceof Node) {
+                return $this->analyzeNode($parent, $offset);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Expr\PropertyFetch|Expr\NullsafePropertyFetch|Expr\MethodCall|Expr\NullsafeMethodCall $node
+     * @return MemberAccessResult|null
+     */
+    private function analyzeMemberAccess(Expr $node): ?array
+    {
+        $name = $node->name;
+        $prefix = '';
+
+        if ($name instanceof Identifier) {
+            $prefix = $name->toString();
+        } elseif ($name instanceof Error) {
+            $prefix = '';
+        } else {
+            return null;
+        }
+
+        $context = CompletionContext::fromMemberAccess($node->var);
+        if ($context === CompletionContext::Unknown) {
+            return null;
+        }
+
+        return [
+            'context' => $context,
+            'var' => $node->var,
+            'prefix' => $prefix,
+        ];
+    }
+
+    /**
+     * @param Node $class
+     * @param Node $name
+     * @return StaticAccessResult|null
+     */
+    private function analyzeStaticAccess(Node $class, Node $name): ?array
+    {
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        $prefix = '';
+        if ($name instanceof Identifier) {
+            $prefix = $name->toString();
+        } elseif ($name instanceof Error) {
+            $prefix = '';
+        }
+
+        $rawName = $class->toString();
+        $context = match ($rawName) {
+            'parent' => CompletionContext::ParentMember,
+            'self', 'static' => CompletionContext::StaticMember,
+            default => CompletionContext::StaticMember,
+        };
+
+        return [
+            'context' => $context,
+            'class' => $class,
+            'prefix' => $prefix,
+        ];
+    }
+}

--- a/src/Completion/CompletionContextResolver.php
+++ b/src/Completion/CompletionContextResolver.php
@@ -130,8 +130,6 @@ final class CompletionContextResolver
         $prefix = '';
         if ($name instanceof Identifier) {
             $prefix = $name->toString();
-        } elseif ($name instanceof Error) {
-            $prefix = '';
         }
 
         $rawName = $class->toString();

--- a/src/Completion/MemberAccessContext.php
+++ b/src/Completion/MemberAccessContext.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use PhpParser\Node\Expr;
+
+final class MemberAccessContext
+{
+    public function __construct(
+        public readonly CompletionContext $context,
+        public readonly Expr $var,
+        public readonly string $prefix,
+    ) {
+    }
+}

--- a/src/Completion/StaticAccessContext.php
+++ b/src/Completion/StaticAccessContext.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use PhpParser\Node\Name;
+
+final class StaticAccessContext
+{
+    public function __construct(
+        public readonly CompletionContext $context,
+        public readonly Name $class,
+        public readonly string $prefix,
+    ) {
+    }
+}

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Handler;
 
+use Firehed\PhpLsp\Completion\CompletionContext;
+use Firehed\PhpLsp\Completion\CompletionContextResolver;
 use Firehed\PhpLsp\Completion\ContextDetector;
+use Firehed\PhpLsp\Completion\MemberAccessContext;
+use Firehed\PhpLsp\Completion\StaticAccessContext;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
@@ -73,6 +77,8 @@ final class CompletionHandler implements HandlerInterface
         return $item;
     }
 
+    private readonly CompletionContextResolver $contextResolver;
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
@@ -81,6 +87,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly ClassRepository $classRepository,
         private readonly TypeResolverInterface $typeResolver,
     ) {
+        $this->contextResolver = new CompletionContextResolver();
     }
 
     public function supports(string $method): bool
@@ -142,7 +149,7 @@ final class CompletionHandler implements HandlerInterface
         $lineText = $document->getLine($line);
         $textBeforeCursor = substr($lineText, 0, $character);
 
-        $items = $this->getCompletionItems($textBeforeCursor, $ast, $line);
+        $items = $this->getCompletionItems($textBeforeCursor, $ast, $line, $offset);
 
         return [
             'isIncomplete' => false,
@@ -154,53 +161,19 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getCompletionItems(string $textBeforeCursor, array $ast, int $line): array
+    private function getCompletionItems(string $textBeforeCursor, array $ast, int $line, int $offset): array
     {
-        // $this-> completion
-        if (preg_match('/\$this->(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            return $this->getThisMemberCompletions($prefix, $ast, $line);
-        }
-
-        // $variable-> completion (typed variables, not $this)
-        if (preg_match('/\$(\w+)->(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $variableName = $matches[1];
-            $prefix = $matches[2];
-            return $this->getTypedVariableMemberCompletions($variableName, $prefix, $ast, $line);
+        // AST-based context detection for member/static access
+        // Handles both -> and ?-> automatically
+        $astContext = $this->contextResolver->resolve($ast, $offset);
+        if ($astContext !== null) {
+            return $this->handleAstContext($astContext, $ast, $line);
         }
 
         // Variable completion ($var)
         if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             return $this->getVariableCompletions($prefix, $ast, $line);
-        }
-
-        // self:: and static:: completion - resolve to enclosing class
-        if (preg_match('/\b(?:self|static)::(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $classNode = ScopeFinder::findClassAtLine($ast, $line);
-            if ($classNode !== null) {
-                $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
-                if ($className === null) {
-                    // Anonymous class - no completions available
-                    return [];
-                }
-                $prefix = $matches[1];
-                return $this->getStaticCompletions($className, $prefix, $ast, $line);
-            }
-            return [];
-        }
-
-        // parent:: completion - methods from parent class
-        if (preg_match('/\bparent::(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            return $this->getParentCompletions($prefix, $ast, $line);
-        }
-
-        // ClassName:: completion (static) - also match single : for mid-typing
-        if (preg_match('/([A-Z]\w*)::?(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $className = $matches[1];
-            $prefix = $matches[2];
-            return $this->getStaticCompletions($className, $prefix, $ast, $line);
         }
 
         // new ClassName completion - suggest imported classes and indexed instantiable types
@@ -271,6 +244,80 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return [];
+    }
+
+    /**
+     * Handle completion context detected via AST analysis.
+     *
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function handleAstContext(
+        MemberAccessContext|StaticAccessContext $context,
+        array $ast,
+        int $line,
+    ): array {
+        if ($context instanceof MemberAccessContext) {
+            return $this->handleMemberAccessContext($context, $ast, $line);
+        }
+
+        return $this->handleStaticAccessContext($context, $ast, $line);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function handleMemberAccessContext(MemberAccessContext $context, array $ast, int $line): array
+    {
+        return match ($context->context) {
+            CompletionContext::ThisMember => $this->getThisMemberCompletions($context->prefix, $ast, $line),
+            CompletionContext::VariableMember => $this->handleVariableMemberContext($context, $ast, $line),
+            default => [],
+        };
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function handleVariableMemberContext(MemberAccessContext $context, array $ast, int $line): array
+    {
+        $var = $context->var;
+        if (!$var instanceof Node\Expr\Variable || !is_string($var->name)) {
+            return [];
+        }
+
+        return $this->getTypedVariableMemberCompletions($var->name, $context->prefix, $ast, $line);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function handleStaticAccessContext(StaticAccessContext $context, array $ast, int $line): array
+    {
+        $rawName = $context->class->toString();
+
+        if ($rawName === 'parent') {
+            return $this->getParentCompletions($context->prefix, $ast, $line);
+        }
+
+        if ($rawName === 'self' || $rawName === 'static') {
+            $classNode = ScopeFinder::findClassAtLine($ast, $line);
+            if ($classNode === null) {
+                return [];
+            }
+            $className = $classNode->namespacedName?->toString() ?? $classNode->name?->toString();
+            if ($className === null) {
+                return [];
+            }
+            return $this->getStaticCompletions($className, $context->prefix, $ast, $line);
+        }
+
+        // ClassName:: - resolve via imports
+        $resolvedName = ScopeFinder::resolveClassName($context->class);
+        return $this->getStaticCompletions($resolvedName, $context->prefix, $ast, $line);
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -77,8 +77,6 @@ final class CompletionHandler implements HandlerInterface
         return $item;
     }
 
-    private readonly CompletionContextResolver $contextResolver;
-
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
@@ -86,8 +84,8 @@ final class CompletionHandler implements HandlerInterface
         private readonly MemberResolver $memberResolver,
         private readonly ClassRepository $classRepository,
         private readonly TypeResolverInterface $typeResolver,
+        private readonly CompletionContextResolver $contextResolver,
     ) {
-        $this->contextResolver = new CompletionContextResolver();
     }
 
     public function supports(string $method): bool

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -15,9 +15,10 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
-use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -25,13 +26,16 @@ use PhpParser\Node\Stmt;
 
 final class DefinitionHandler implements HandlerInterface
 {
+    private readonly MemberAccessResolver $memberAccessResolver;
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly MemberResolver $memberResolver,
         private readonly ClassRepository $classRepository,
-        private readonly TypeResolverInterface $typeResolver,
+        TypeResolverInterface $typeResolver,
     ) {
+        $this->memberAccessResolver = new MemberAccessResolver($memberResolver, $typeResolver);
     }
 
     public function supports(string $method): bool
@@ -103,8 +107,9 @@ final class DefinitionHandler implements HandlerInterface
                 return $this->handleStaticMethodDefinition($parent);
             }
 
-            // Instance method call: $obj->method()
-            if ($parent instanceof MethodCall) {
+            // Instance method call: $obj->method() or $obj?->method()
+            if (MemberAccessResolver::isMethodCall($parent)) {
+                /** @var MethodCall|NullsafeMethodCall $parent */
                 return $this->handleInstanceMethodDefinition($parent, $ast);
             }
         }
@@ -186,7 +191,7 @@ final class DefinitionHandler implements HandlerInterface
     }
 
     /**
-     * Handle definition for instance method call: $obj->method()
+     * Handle definition for instance method call: $obj->method() or $obj?->method()
      *
      * @param array<Stmt> $ast
      * @return array{
@@ -197,7 +202,7 @@ final class DefinitionHandler implements HandlerInterface
      *   },
      * }|null
      */
-    private function handleInstanceMethodDefinition(MethodCall $call, array $ast): ?array
+    private function handleInstanceMethodDefinition(MethodCall|NullsafeMethodCall $call, array $ast): ?array
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
@@ -206,13 +211,12 @@ final class DefinitionHandler implements HandlerInterface
             // @codeCoverageIgnoreEnd
         }
 
-        $type = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
-        $classNames = $type?->getResolvableClassNames() ?? [];
-        if ($classNames === []) {
+        $className = $this->memberAccessResolver->resolveObjectClassName($call->var, $ast);
+        if ($className === null) {
             return null;
         }
 
-        return $this->findMethodDefinition($classNames[0]->fqn, $methodName->toString());
+        return $this->findMethodDefinition($className->fqn, $methodName->toString());
     }
 
     /**

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -14,7 +14,6 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
-use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Expr\MethodCall;
@@ -26,16 +25,13 @@ use PhpParser\Node\Stmt;
 
 final class DefinitionHandler implements HandlerInterface
 {
-    private readonly MemberAccessResolver $memberAccessResolver;
-
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly MemberResolver $memberResolver,
         private readonly ClassRepository $classRepository,
-        TypeResolverInterface $typeResolver,
+        private readonly MemberAccessResolver $memberAccessResolver,
     ) {
-        $this->memberAccessResolver = new MemberAccessResolver($typeResolver);
     }
 
     public function supports(string $method): bool

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -35,7 +35,7 @@ final class DefinitionHandler implements HandlerInterface
         private readonly ClassRepository $classRepository,
         TypeResolverInterface $typeResolver,
     ) {
-        $this->memberAccessResolver = new MemberAccessResolver($memberResolver, $typeResolver);
+        $this->memberAccessResolver = new MemberAccessResolver($typeResolver);
     }
 
     public function supports(string $method): bool

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -21,11 +21,13 @@ use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
@@ -37,13 +39,16 @@ use ReflectionFunction;
 
 final class HoverHandler implements HandlerInterface
 {
+    private readonly MemberAccessResolver $memberAccessResolver;
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ClassRepository $classRepository,
         private readonly MemberResolver $memberResolver,
-        private readonly TypeResolverInterface $typeResolver,
+        TypeResolverInterface $typeResolver,
     ) {
+        $this->memberAccessResolver = new MemberAccessResolver($memberResolver, $typeResolver);
     }
 
     public function supports(string $method): bool
@@ -140,8 +145,9 @@ final class HoverHandler implements HandlerInterface
         if ($node instanceof Identifier) {
             $parent = $node->getAttribute('parent');
 
-            // Method call: $obj->method() or $this->method()
-            if ($parent instanceof MethodCall) {
+            // Method call: $obj->method() or $obj?->method()
+            if (MemberAccessResolver::isMethodCall($parent)) {
+                /** @var MethodCall|NullsafeMethodCall $parent */
                 return $this->getMethodHover($parent, $ast);
             }
 
@@ -150,8 +156,9 @@ final class HoverHandler implements HandlerInterface
                 return $this->getStaticMethodHover($parent);
             }
 
-            // Property fetch: $obj->property or $this->property
-            if ($parent instanceof PropertyFetch) {
+            // Property fetch: $obj->property or $obj?->property
+            if (MemberAccessResolver::isPropertyFetch($parent)) {
+                /** @var PropertyFetch|NullsafePropertyFetch $parent */
                 return $this->getPropertyHover($parent, $ast);
             }
 
@@ -250,20 +257,19 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function getMethodHover(MethodCall $call, array $ast): ?string
+    private function getMethodHover(MethodCall|NullsafeMethodCall $call, array $ast): ?string
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
             return null;
         }
 
-        $type = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
-        $classNames = $type?->getResolvableClassNames() ?? [];
-        if ($classNames === []) {
+        $className = $this->memberAccessResolver->resolveObjectClassName($call->var, $ast);
+        if ($className === null) {
             return null;
         }
 
-        return $this->getMethodHoverForClass($classNames[0]->fqn, $methodName->toString());
+        return $this->getMethodHoverForClass($className->fqn, $methodName->toString());
     }
 
     private function getStaticMethodHover(StaticCall $call): ?string
@@ -286,20 +292,19 @@ final class HoverHandler implements HandlerInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function getPropertyHover(PropertyFetch $fetch, array $ast): ?string
+    private function getPropertyHover(PropertyFetch|NullsafePropertyFetch $fetch, array $ast): ?string
     {
         $propertyName = $fetch->name;
         if (!$propertyName instanceof Identifier) {
             return null;
         }
 
-        $type = ExpressionTypeResolver::resolveExpressionType($fetch->var, $ast, $this->typeResolver);
-        $classNames = $type?->getResolvableClassNames() ?? [];
-        if ($classNames === []) {
+        $className = $this->memberAccessResolver->resolveObjectClassName($fetch->var, $ast);
+        if ($className === null) {
             return null;
         }
 
-        return $this->getPropertyHoverForClass($classNames[0]->fqn, $propertyName->toString());
+        return $this->getPropertyHoverForClass($className->fqn, $propertyName->toString());
     }
 
     private function getStaticPropertyHover(StaticPropertyFetch $fetch): ?string

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -48,7 +48,7 @@ final class HoverHandler implements HandlerInterface
         private readonly MemberResolver $memberResolver,
         TypeResolverInterface $typeResolver,
     ) {
-        $this->memberAccessResolver = new MemberAccessResolver($memberResolver, $typeResolver);
+        $this->memberAccessResolver = new MemberAccessResolver($typeResolver);
     }
 
     public function supports(string $method): bool

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -19,7 +19,6 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
-use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -39,16 +38,13 @@ use ReflectionFunction;
 
 final class HoverHandler implements HandlerInterface
 {
-    private readonly MemberAccessResolver $memberAccessResolver;
-
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly ClassRepository $classRepository,
         private readonly MemberResolver $memberResolver,
-        TypeResolverInterface $typeResolver,
+        private readonly MemberAccessResolver $memberAccessResolver,
     ) {
-        $this->memberAccessResolver = new MemberAccessResolver($typeResolver);
     }
 
     public function supports(string $method): bool

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -13,7 +13,6 @@ use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Repository\MemberResolver;
-use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -41,15 +40,12 @@ use ReflectionFunction;
  */
 final class SignatureHelpHandler implements HandlerInterface
 {
-    private readonly MemberAccessResolver $memberAccessResolver;
-
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly MemberResolver $memberResolver,
-        TypeResolverInterface $typeResolver,
+        private readonly MemberAccessResolver $memberAccessResolver,
     ) {
-        $this->memberAccessResolver = new MemberAccessResolver($typeResolver);
     }
 
     public function supports(string $method): bool

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -49,7 +49,7 @@ final class SignatureHelpHandler implements HandlerInterface
         private readonly MemberResolver $memberResolver,
         TypeResolverInterface $typeResolver,
     ) {
-        $this->memberAccessResolver = new MemberAccessResolver($memberResolver, $typeResolver);
+        $this->memberAccessResolver = new MemberAccessResolver($typeResolver);
     }
 
     public function supports(string $method): bool

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -15,12 +15,13 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -40,12 +41,15 @@ use ReflectionFunction;
  */
 final class SignatureHelpHandler implements HandlerInterface
 {
+    private readonly MemberAccessResolver $memberAccessResolver;
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly MemberResolver $memberResolver,
-        private readonly TypeResolverInterface $typeResolver,
+        TypeResolverInterface $typeResolver,
     ) {
+        $this->memberAccessResolver = new MemberAccessResolver($memberResolver, $typeResolver);
     }
 
     public function supports(string $method): bool
@@ -115,12 +119,12 @@ final class SignatureHelpHandler implements HandlerInterface
      * Find the function/method call at the given position and determine active parameter.
      *
      * @param array<Stmt> $ast
-     * @return array{0: FuncCall|MethodCall|StaticCall|New_, 1: int}|null
+     * @return array{0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_, 1: int}|null
      */
     private function findCallAtPosition(array $ast, int $offset): ?array
     {
         $finder = new class ($offset) extends NodeVisitorAbstract {
-            /** @var FuncCall|MethodCall|StaticCall|New_|null */
+            /** @var FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|null */
             public ?Node $found = null;
             public int $activeParameter = 0;
 
@@ -133,6 +137,7 @@ final class SignatureHelpHandler implements HandlerInterface
                 if (
                     !$node instanceof FuncCall
                     && !$node instanceof MethodCall
+                    && !$node instanceof NullsafeMethodCall
                     && !$node instanceof StaticCall
                     && !$node instanceof New_
                 ) {
@@ -174,7 +179,7 @@ final class SignatureHelpHandler implements HandlerInterface
     }
 
     /**
-     * @param FuncCall|MethodCall|StaticCall|New_ $call
+     * @param FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_ $call
      * @param array<Stmt> $ast
      * @return SignatureInfo|null
      */
@@ -184,7 +189,7 @@ final class SignatureHelpHandler implements HandlerInterface
             return $this->getFunctionSignature($call, $ast);
         }
 
-        if ($call instanceof MethodCall) {
+        if ($call instanceof MethodCall || $call instanceof NullsafeMethodCall) {
             return $this->getMethodSignature($call, $ast);
         }
 
@@ -228,20 +233,19 @@ final class SignatureHelpHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return SignatureInfo|null
      */
-    private function getMethodSignature(MethodCall $call, array $ast): ?array
+    private function getMethodSignature(MethodCall|NullsafeMethodCall $call, array $ast): ?array
     {
         $methodName = $call->name;
         if (!$methodName instanceof Identifier) {
             return null;
         }
 
-        $type = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
-        $classNames = $type?->getResolvableClassNames() ?? [];
-        if ($classNames === []) {
+        $className = $this->memberAccessResolver->resolveObjectClassName($call->var, $ast);
+        if ($className === null) {
             return null;
         }
 
-        return $this->getMethodSignatureForClass($classNames[0]->fqn, $methodName->toString());
+        return $this->getMethodSignatureForClass($className->fqn, $methodName->toString());
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -21,6 +21,8 @@ use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Completion\CompletionContextResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
@@ -59,6 +61,8 @@ final class Server
         $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver);
+        $memberAccessResolver = new MemberAccessResolver($typeResolver);
+        $completionContextResolver = new CompletionContextResolver();
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
@@ -74,20 +78,20 @@ final class Server
             $parser,
             $memberResolver,
             $classRepository,
-            $typeResolver,
+            $memberAccessResolver,
         );
         $this->handlers[] = new HoverHandler(
             $this->documentManager,
             $parser,
             $classRepository,
             $memberResolver,
-            $typeResolver,
+            $memberAccessResolver,
         );
         $this->handlers[] = new SignatureHelpHandler(
             $this->documentManager,
             $parser,
             $memberResolver,
-            $typeResolver,
+            $memberAccessResolver,
         );
         $this->handlers[] = new CompletionHandler(
             $this->documentManager,
@@ -96,6 +100,7 @@ final class Server
             $memberResolver,
             $classRepository,
             $typeResolver,
+            $completionContextResolver,
         );
     }
 

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -63,8 +63,8 @@ final class BasicTypeResolver implements TypeResolverInterface
             return $this->resolveVariableType($expr->name, $scope, $expr->getStartLine() - 1, $ast);
         }
 
-        // Method call: $obj->method()
-        if ($expr instanceof Expr\MethodCall) {
+        // Method call: $obj->method() or $obj?->method()
+        if ($expr instanceof Expr\MethodCall || $expr instanceof Expr\NullsafeMethodCall) {
             $objectType = $this->resolveExpressionType($expr->var, $scope, $ast);
             $className = $this->extractClassName($objectType);
             if ($className !== null && $expr->name instanceof Node\Identifier) {
@@ -82,8 +82,8 @@ final class BasicTypeResolver implements TypeResolverInterface
             return null;
         }
 
-        // Property fetch: $obj->property
-        if ($expr instanceof Expr\PropertyFetch) {
+        // Property fetch: $obj->property or $obj?->property
+        if ($expr instanceof Expr\PropertyFetch || $expr instanceof Expr\NullsafePropertyFetch) {
             $objectType = $this->resolveExpressionType($expr->var, $scope, $ast);
             $className = $this->extractClassName($objectType);
             if ($className !== null && $expr->name instanceof Node\Identifier) {

--- a/src/Utility/MemberAccessResolver.php
+++ b/src/Utility/MemberAccessResolver.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\NullsafePropertyFetch;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt;
+
+/**
+ * Resolves member access (method calls and property fetches) to domain objects.
+ * Handles both regular (->) and nullsafe (?->) operators.
+ */
+final class MemberAccessResolver
+{
+    public function __construct(
+        private readonly MemberResolver $memberResolver,
+        private readonly TypeResolverInterface $typeResolver,
+    ) {
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    public function resolveMethodCall(MethodCall|NullsafeMethodCall $call, array $ast): ?MethodInfo
+    {
+        $methodName = $call->name;
+        if (!$methodName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveObjectClassName($call->var, $ast);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->memberResolver->findMethod(
+            $className,
+            new MethodName($methodName->toString()),
+            Visibility::Public,
+        );
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    public function resolvePropertyFetch(PropertyFetch|NullsafePropertyFetch $fetch, array $ast): ?PropertyInfo
+    {
+        $propertyName = $fetch->name;
+        if (!$propertyName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveObjectClassName($fetch->var, $ast);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->memberResolver->findProperty(
+            $className,
+            new PropertyName($propertyName->toString()),
+            Visibility::Public,
+        );
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    public function resolveObjectClassName(Expr $var, array $ast): ?ClassName
+    {
+        $type = ExpressionTypeResolver::resolveExpressionType($var, $ast, $this->typeResolver);
+        $classNames = $type?->getResolvableClassNames() ?? [];
+
+        return $classNames[0] ?? null;
+    }
+
+    public static function isMethodCall(mixed $node): bool
+    {
+        return $node instanceof MethodCall || $node instanceof NullsafeMethodCall;
+    }
+
+    public static function isPropertyFetch(mixed $node): bool
+    {
+        return $node instanceof PropertyFetch || $node instanceof NullsafePropertyFetch;
+    }
+}

--- a/src/Utility/MemberAccessResolver.php
+++ b/src/Utility/MemberAccessResolver.php
@@ -5,19 +5,12 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\MethodInfo;
-use Firehed\PhpLsp\Domain\MethodName;
-use Firehed\PhpLsp\Domain\PropertyInfo;
-use Firehed\PhpLsp\Domain\PropertyName;
-use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 
 /**
@@ -27,53 +20,8 @@ use PhpParser\Node\Stmt;
 final class MemberAccessResolver
 {
     public function __construct(
-        private readonly MemberResolver $memberResolver,
         private readonly TypeResolverInterface $typeResolver,
     ) {
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    public function resolveMethodCall(MethodCall|NullsafeMethodCall $call, array $ast): ?MethodInfo
-    {
-        $methodName = $call->name;
-        if (!$methodName instanceof Identifier) {
-            return null;
-        }
-
-        $className = $this->resolveObjectClassName($call->var, $ast);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->memberResolver->findMethod(
-            $className,
-            new MethodName($methodName->toString()),
-            Visibility::Public,
-        );
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    public function resolvePropertyFetch(PropertyFetch|NullsafePropertyFetch $fetch, array $ast): ?PropertyInfo
-    {
-        $propertyName = $fetch->name;
-        if (!$propertyName instanceof Identifier) {
-            return null;
-        }
-
-        $className = $this->resolveObjectClassName($fetch->var, $ast);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->memberResolver->findProperty(
-            $className,
-            new PropertyName($propertyName->toString()),
-            Visibility::Public,
-        );
     }
 
     /**

--- a/tests/Completion/CompletionContextResolverTest.php
+++ b/tests/Completion/CompletionContextResolverTest.php
@@ -6,18 +6,21 @@ namespace Firehed\PhpLsp\Tests\Completion;
 
 use Firehed\PhpLsp\Completion\CompletionContext;
 use Firehed\PhpLsp\Completion\CompletionContextResolver;
+use Firehed\PhpLsp\Completion\MemberAccessContext;
+use Firehed\PhpLsp\Completion\StaticAccessContext;
 use PhpParser\ErrorHandler;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(CompletionContextResolver::class)]
 #[CoversClass(CompletionContext::class)]
+#[CoversClass(MemberAccessContext::class)]
+#[CoversClass(StaticAccessContext::class)]
 class CompletionContextResolverTest extends TestCase
 {
     private CompletionContextResolver $resolver;
@@ -35,10 +38,10 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::ThisMember, $result['context']);
-        self::assertInstanceOf(Variable::class, $result['var']);
-        self::assertSame('', $result['prefix']);
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::ThisMember, $result->context);
+        self::assertInstanceOf(Variable::class, $result->var);
+        self::assertSame('', $result->prefix);
     }
 
     public function testThisMemberAccessNullsafe(): void
@@ -49,10 +52,10 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::ThisMember, $result['context']);
-        self::assertInstanceOf(Variable::class, $result['var']);
-        self::assertSame('', $result['prefix']);
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::ThisMember, $result->context);
+        self::assertInstanceOf(Variable::class, $result->var);
+        self::assertSame('', $result->prefix);
     }
 
     public function testThisMemberAccessWithPrefix(): void
@@ -63,9 +66,9 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::ThisMember, $result['context']);
-        self::assertSame('get', $result['prefix']);
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::ThisMember, $result->context);
+        self::assertSame('get', $result->prefix);
     }
 
     public function testThisMemberAccessNullsafeWithPrefix(): void
@@ -76,9 +79,9 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::ThisMember, $result['context']);
-        self::assertSame('get', $result['prefix']);
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::ThisMember, $result->context);
+        self::assertSame('get', $result->prefix);
     }
 
     public function testVariableMemberAccessArrow(): void
@@ -89,11 +92,11 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::VariableMember, $result['context']);
-        self::assertInstanceOf(Variable::class, $result['var']);
-        self::assertSame('obj', $result['var']->name);
-        self::assertSame('', $result['prefix']);
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::VariableMember, $result->context);
+        self::assertInstanceOf(Variable::class, $result->var);
+        self::assertSame('obj', $result->var->name);
+        self::assertSame('', $result->prefix);
     }
 
     public function testVariableMemberAccessNullsafe(): void
@@ -104,11 +107,11 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::VariableMember, $result['context']);
-        self::assertInstanceOf(Variable::class, $result['var']);
-        self::assertSame('obj', $result['var']->name);
-        self::assertSame('', $result['prefix']);
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::VariableMember, $result->context);
+        self::assertInstanceOf(Variable::class, $result->var);
+        self::assertSame('obj', $result->var->name);
+        self::assertSame('', $result->prefix);
     }
 
     public function testVariableMemberAccessWithPrefix(): void
@@ -119,10 +122,11 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::VariableMember, $result['context']);
-        self::assertSame('user', $result['var']->name);
-        self::assertSame('getName', $result['prefix']);
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::VariableMember, $result->context);
+        self::assertInstanceOf(Variable::class, $result->var);
+        self::assertSame('user', $result->var->name);
+        self::assertSame('getName', $result->prefix);
     }
 
     public function testStaticAccessSelf(): void
@@ -133,10 +137,9 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::StaticMember, $result['context']);
-        self::assertInstanceOf(Name::class, $result['class']);
-        self::assertSame('self', $result['class']->toString());
+        self::assertInstanceOf(StaticAccessContext::class, $result);
+        self::assertSame(CompletionContext::StaticMember, $result->context);
+        self::assertSame('self', $result->class->toString());
     }
 
     public function testStaticAccessStatic(): void
@@ -147,9 +150,9 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::StaticMember, $result['context']);
-        self::assertSame('static', $result['class']->toString());
+        self::assertInstanceOf(StaticAccessContext::class, $result);
+        self::assertSame(CompletionContext::StaticMember, $result->context);
+        self::assertSame('static', $result->class->toString());
     }
 
     public function testStaticAccessParent(): void
@@ -160,9 +163,9 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::ParentMember, $result['context']);
-        self::assertSame('parent', $result['class']->toString());
+        self::assertInstanceOf(StaticAccessContext::class, $result);
+        self::assertSame(CompletionContext::ParentMember, $result->context);
+        self::assertSame('parent', $result->class->toString());
     }
 
     public function testStaticAccessClassName(): void
@@ -173,9 +176,9 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::StaticMember, $result['context']);
-        self::assertSame('DateTime', $result['class']->toString());
+        self::assertInstanceOf(StaticAccessContext::class, $result);
+        self::assertSame(CompletionContext::StaticMember, $result->context);
+        self::assertSame('DateTime', $result->class->toString());
     }
 
     public function testStaticAccessWithPrefix(): void
@@ -186,9 +189,9 @@ class CompletionContextResolverTest extends TestCase
 
         $result = $this->resolver->resolve($ast, $offset);
 
-        self::assertNotNull($result);
-        self::assertSame(CompletionContext::StaticMember, $result['context']);
-        self::assertSame('create', $result['prefix']);
+        self::assertInstanceOf(StaticAccessContext::class, $result);
+        self::assertSame(CompletionContext::StaticMember, $result->context);
+        self::assertSame('create', $result->prefix);
     }
 
     public function testNoContextForPlainCode(): void
@@ -203,7 +206,7 @@ class CompletionContextResolverTest extends TestCase
     }
 
     /**
-     * @return array<\PhpParser\Node\Stmt>
+     * @return array<Stmt>
      */
     private function parse(string $code): array
     {
@@ -213,6 +216,7 @@ class CompletionContextResolverTest extends TestCase
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new ParentConnectingVisitor());
+        /** @var array<Stmt> */
         return $traverser->traverse($ast);
     }
 }

--- a/tests/Completion/CompletionContextResolverTest.php
+++ b/tests/Completion/CompletionContextResolverTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Completion;
+
+use Firehed\PhpLsp\Completion\CompletionContext;
+use Firehed\PhpLsp\Completion\CompletionContextResolver;
+use PhpParser\ErrorHandler;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CompletionContextResolver::class)]
+#[CoversClass(CompletionContext::class)]
+class CompletionContextResolverTest extends TestCase
+{
+    private CompletionContextResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new CompletionContextResolver();
+    }
+
+    public function testThisMemberAccessArrow(): void
+    {
+        $code = '<?php $this->';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::ThisMember, $result['context']);
+        self::assertInstanceOf(Variable::class, $result['var']);
+        self::assertSame('', $result['prefix']);
+    }
+
+    public function testThisMemberAccessNullsafe(): void
+    {
+        $code = '<?php $this?->';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::ThisMember, $result['context']);
+        self::assertInstanceOf(Variable::class, $result['var']);
+        self::assertSame('', $result['prefix']);
+    }
+
+    public function testThisMemberAccessWithPrefix(): void
+    {
+        $code = '<?php $this->get';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::ThisMember, $result['context']);
+        self::assertSame('get', $result['prefix']);
+    }
+
+    public function testThisMemberAccessNullsafeWithPrefix(): void
+    {
+        $code = '<?php $this?->get';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::ThisMember, $result['context']);
+        self::assertSame('get', $result['prefix']);
+    }
+
+    public function testVariableMemberAccessArrow(): void
+    {
+        $code = '<?php $obj->';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::VariableMember, $result['context']);
+        self::assertInstanceOf(Variable::class, $result['var']);
+        self::assertSame('obj', $result['var']->name);
+        self::assertSame('', $result['prefix']);
+    }
+
+    public function testVariableMemberAccessNullsafe(): void
+    {
+        $code = '<?php $obj?->';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::VariableMember, $result['context']);
+        self::assertInstanceOf(Variable::class, $result['var']);
+        self::assertSame('obj', $result['var']->name);
+        self::assertSame('', $result['prefix']);
+    }
+
+    public function testVariableMemberAccessWithPrefix(): void
+    {
+        $code = '<?php $user->getName';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::VariableMember, $result['context']);
+        self::assertSame('user', $result['var']->name);
+        self::assertSame('getName', $result['prefix']);
+    }
+
+    public function testStaticAccessSelf(): void
+    {
+        $code = '<?php self::';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::StaticMember, $result['context']);
+        self::assertInstanceOf(Name::class, $result['class']);
+        self::assertSame('self', $result['class']->toString());
+    }
+
+    public function testStaticAccessStatic(): void
+    {
+        $code = '<?php static::';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::StaticMember, $result['context']);
+        self::assertSame('static', $result['class']->toString());
+    }
+
+    public function testStaticAccessParent(): void
+    {
+        $code = '<?php parent::';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::ParentMember, $result['context']);
+        self::assertSame('parent', $result['class']->toString());
+    }
+
+    public function testStaticAccessClassName(): void
+    {
+        $code = '<?php DateTime::';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::StaticMember, $result['context']);
+        self::assertSame('DateTime', $result['class']->toString());
+    }
+
+    public function testStaticAccessWithPrefix(): void
+    {
+        $code = '<?php DateTime::create';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNotNull($result);
+        self::assertSame(CompletionContext::StaticMember, $result['context']);
+        self::assertSame('create', $result['prefix']);
+    }
+
+    public function testNoContextForPlainCode(): void
+    {
+        $code = '<?php $x = 1;';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @return array<\PhpParser\Node\Stmt>
+     */
+    private function parse(string $code): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $errorHandler = new ErrorHandler\Collecting();
+        $ast = $parser->parse($code, $errorHandler) ?? [];
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        return $traverser->traverse($ast);
+    }
+}

--- a/tests/Completion/CompletionContextResolverTest.php
+++ b/tests/Completion/CompletionContextResolverTest.php
@@ -235,7 +235,9 @@ class CompletionContextResolverTest extends TestCase
     {
         $code = '<?php $obj->$prop';
         $ast = $this->parse($code);
-        $offset = strlen($code);
+        // Position right after '->' (offset 11), before the dynamic $prop
+        // This ensures PropertyFetch is found, not the Variable node for $prop
+        $offset = 11;
 
         $result = $this->resolver->resolve($ast, $offset);
 
@@ -263,6 +265,32 @@ class CompletionContextResolverTest extends TestCase
         $result = $this->resolver->resolve($ast, $offset);
 
         self::assertNull($result);
+    }
+
+    public function testEmptyAstReturnsNull(): void
+    {
+        $ast = [];
+        $offset = 0;
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNull($result);
+    }
+
+    public function testMethodCallWithPrefix(): void
+    {
+        $code = '<?php $obj->getUser()';
+        $ast = $this->parse($code);
+        // Position cursor inside method name (before parentheses)
+        $pos = strpos($code, 'getUser');
+        self::assertIsInt($pos);
+        $offset = $pos + 3;
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertInstanceOf(MemberAccessContext::class, $result);
+        self::assertSame(CompletionContext::VariableMember, $result->context);
+        self::assertSame('getUser', $result->prefix);
     }
 
     /**

--- a/tests/Completion/CompletionContextResolverTest.php
+++ b/tests/Completion/CompletionContextResolverTest.php
@@ -267,6 +267,17 @@ class CompletionContextResolverTest extends TestCase
         self::assertNull($result);
     }
 
+    public function testDynamicClassStaticPropertyReturnsNull(): void
+    {
+        $code = '<?php $class::$prop';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNull($result);
+    }
+
     public function testEmptyAstReturnsNull(): void
     {
         $ast = [];

--- a/tests/Completion/CompletionContextResolverTest.php
+++ b/tests/Completion/CompletionContextResolverTest.php
@@ -205,6 +205,66 @@ class CompletionContextResolverTest extends TestCase
         self::assertNull($result);
     }
 
+    public function testStaticPropertyFetch(): void
+    {
+        $code = '<?php self::$staticProp';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertInstanceOf(StaticAccessContext::class, $result);
+        self::assertSame(CompletionContext::StaticMember, $result->context);
+        self::assertSame('staticProp', $result->prefix);
+    }
+
+    public function testClassConstFetch(): void
+    {
+        $code = '<?php DateTime::ATOM';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertInstanceOf(StaticAccessContext::class, $result);
+        self::assertSame(CompletionContext::StaticMember, $result->context);
+        self::assertSame('ATOM', $result->prefix);
+    }
+
+    public function testDynamicMemberNameReturnsNull(): void
+    {
+        $code = '<?php $obj->$prop';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNull($result);
+    }
+
+    public function testChainedMethodCallReturnsNull(): void
+    {
+        $code = '<?php $obj->method()->';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        // Returns null because the var is a MethodCall, not a Variable
+        self::assertNull($result);
+    }
+
+    public function testDynamicClassReturnsNull(): void
+    {
+        $code = '<?php $class::method()';
+        $ast = $this->parse($code);
+        $offset = strlen($code);
+
+        $result = $this->resolver->resolve($ast, $offset);
+
+        self::assertNull($result);
+    }
+
     /**
      * @return array<Stmt>
      */

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2041,6 +2041,42 @@ PHP;
         self::assertEmpty($result['items']);
     }
 
+    public function testDynamicVariableNameReturnsEmpty(): void
+    {
+        $code = <<<'PHP'
+<?php
+function foo(): void
+{
+    $$dynamic->
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            $this->memberResolver,
+            $this->classRepository,
+            new BasicTypeResolver($this->memberResolver),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 3, 'character' => 15], // After $$dynamic->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertEmpty($result['items']);
+    }
+
     public function testTypedVariableCompletionIncludesInheritedMembers(): void
     {
         $code = <<<'PHP'

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -3001,4 +3001,114 @@ PHP;
         self::assertNotContains('firstProperty', $labels);
         self::assertNotContains('firstMethod', $labels);
     }
+
+    public function testNullsafeThisMemberCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    public function greet(): string
+    {
+        return "Hello";
+    }
+
+    public function test(): void
+    {
+        $this?->
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 10, 'character' => 16],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('greet', $labels);
+        self::assertContains('test', $labels);
+    }
+
+    public function testNullsafeVariableMemberCompletion(): void
+    {
+        $code = <<<'PHP'
+<?php
+class User
+{
+    public function getName(): string
+    {
+        return 'name';
+    }
+}
+
+function test(?User $user): void
+{
+    $user?->
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 11, 'character' => 12],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getName', $labels);
+    }
+
+    public function testNullsafeThisMemberCompletionWithPrefix(): void
+    {
+        $code = <<<'PHP'
+<?php
+class MyClass
+{
+    public function greet(): string { return "Hello"; }
+    public function goodbye(): string { return "Bye"; }
+    public function test(): void
+    {
+        $this?->gr
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 7, 'character' => 18],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('greet', $labels);
+        self::assertNotContains('goodbye', $labels);
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Completion\CompletionContextResolver;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\DocumentIndexer;
@@ -60,6 +61,7 @@ class CompletionHandlerTest extends TestCase
             $this->memberResolver,
             $this->classRepository,
             $typeResolver,
+            new CompletionContextResolver(),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
@@ -1892,6 +1894,7 @@ PHP;
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
         );
 
         $request = RequestMessage::fromArray([
@@ -1939,6 +1942,7 @@ PHP;
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
         );
 
         $request = RequestMessage::fromArray([
@@ -1984,6 +1988,7 @@ PHP;
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
         );
 
         $request = RequestMessage::fromArray([
@@ -2023,6 +2028,7 @@ PHP;
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
         );
 
         $request = RequestMessage::fromArray([
@@ -2059,6 +2065,7 @@ PHP;
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
         );
 
         $request = RequestMessage::fromArray([
@@ -2095,6 +2102,7 @@ PHP;
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
         );
 
         $request = RequestMessage::fromArray([
@@ -2146,6 +2154,7 @@ PHP;
             $this->memberResolver,
             $this->classRepository,
             new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
         );
 
         $request = RequestMessage::fromArray([

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -17,6 +17,7 @@ use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -44,12 +45,13 @@ class DefinitionHandlerTest extends TestCase
             $this->parser,
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
+        $typeResolver = new BasicTypeResolver($this->memberResolver);
         $this->handler = new DefinitionHandler(
             $this->documents,
             $this->parser,
             $this->memberResolver,
             $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
+            new MemberAccessResolver($typeResolver),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -18,6 +18,7 @@ use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -52,7 +53,7 @@ class HoverHandlerTest extends TestCase
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            $typeResolver,
+            new MemberAccessResolver($typeResolver),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
@@ -379,7 +380,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver($this->memberResolver),
+            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
         );
 
         $request = RequestMessage::fromArray([
@@ -427,7 +428,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver($this->memberResolver),
+            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
         );
 
         $request = RequestMessage::fromArray([
@@ -1031,7 +1032,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver($this->memberResolver),
+            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
         );
 
         $request = RequestMessage::fromArray([
@@ -1066,7 +1067,7 @@ PHP;
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new BasicTypeResolver($this->memberResolver),
+            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
         );
 
         $request = RequestMessage::fromArray([

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -17,6 +17,7 @@ use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -45,11 +46,12 @@ class SignatureHelpHandlerTest extends TestCase
             $this->parser,
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
+        $typeResolver = new BasicTypeResolver($this->memberResolver);
         $this->handler = new SignatureHelpHandler(
             $this->documents,
             $this->parser,
             $this->memberResolver,
-            new BasicTypeResolver($this->memberResolver),
+            new MemberAccessResolver($typeResolver),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -548,6 +548,60 @@ PHP;
         return $finder->found;
     }
 
+    public function testResolveNullsafeMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(?Exception $ex) {
+    $msg = $ex?->getMessage();
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $methodCall = $this->findFirstExprOfType($ast, Expr\NullsafeMethodCall::class);
+
+        $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('string', $type->format());
+    }
+
+    public function testResolveNullsafePropertyFetch(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(?Exception $ex) {
+    $msg = $ex?->message;
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $propertyFetch = $this->findFirstExprOfType($ast, Expr\NullsafePropertyFetch::class);
+
+        // Exception::$message is a protected property - type resolution returns null
+        $type = $this->resolver->resolveExpressionType($propertyFetch, $function, $ast);
+        self::assertNull($type);
+    }
+
+    public function testResolveNullsafeMethodCallChain(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(?Exception $ex) {
+    $prev = $ex?->getPrevious();
+}
+PHP;
+        $ast = $this->parse($code);
+        $function = $this->findFirstStmtOfType($ast, Stmt\Function_::class);
+        $methodCall = $this->findFirstExprOfType($ast, Expr\NullsafeMethodCall::class);
+
+        $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
+
+        // getPrevious returns ?Throwable
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
+    }
+
     /**
      * @param array<Stmt> $ast
      */

--- a/tests/Utility/MemberAccessResolverTest.php
+++ b/tests/Utility/MemberAccessResolverTest.php
@@ -206,6 +206,20 @@ PHP;
         self::assertNull($result);
     }
 
+    public function testUnresolvedVariableTypeReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+$unknown->foo();
+PHP;
+        $ast = $this->parse($code);
+        $call = $this->findFirst($ast, MethodCall::class);
+
+        $result = $this->resolver->resolveMethodCall($call, $ast);
+
+        self::assertNull($result);
+    }
+
     /**
      * @return array<Stmt>
      */

--- a/tests/Utility/MemberAccessResolverTest.php
+++ b/tests/Utility/MemberAccessResolverTest.php
@@ -190,6 +190,22 @@ PHP;
         self::assertNull($result);
     }
 
+    public function testMethodCallOnPrimitiveTypeReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(string $str) {
+    $str->foo();
+}
+PHP;
+        $ast = $this->parse($code);
+        $call = $this->findFirst($ast, MethodCall::class);
+
+        $result = $this->resolver->resolveMethodCall($call, $ast);
+
+        self::assertNull($result);
+    }
+
     /**
      * @return array<Stmt>
      */

--- a/tests/Utility/MemberAccessResolverTest.php
+++ b/tests/Utility/MemberAccessResolverTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\ClassLocator;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Utility\MemberAccessResolver;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\NullsafePropertyFetch;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MemberAccessResolver::class)]
+class MemberAccessResolverTest extends TestCase
+{
+    private MemberAccessResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = self::createStub(ClassLocator::class);
+        $parser = new ParserService();
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+        $memberResolver = new MemberResolver($classRepository);
+        $typeResolver = new BasicTypeResolver($memberResolver);
+
+        $this->resolver = new MemberAccessResolver($memberResolver, $typeResolver);
+    }
+
+    public function testResolveMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(\Exception $e) {
+    $e->getMessage();
+}
+PHP;
+        $ast = $this->parse($code);
+        $call = $this->findFirst($ast, MethodCall::class);
+
+        $result = $this->resolver->resolveMethodCall($call, $ast);
+
+        self::assertInstanceOf(MethodInfo::class, $result);
+        self::assertSame('getMessage', $result->name->name);
+    }
+
+    public function testResolveNullsafeMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(?\Exception $e) {
+    $e?->getMessage();
+}
+PHP;
+        $ast = $this->parse($code);
+        $call = $this->findFirst($ast, NullsafeMethodCall::class);
+
+        $result = $this->resolver->resolveMethodCall($call, $ast);
+
+        self::assertInstanceOf(MethodInfo::class, $result);
+        self::assertSame('getMessage', $result->name->name);
+    }
+
+    public function testResolvePropertyFetch(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(\Exception $e) {
+    $e->message;
+}
+PHP;
+        $ast = $this->parse($code);
+        $fetch = $this->findFirst($ast, PropertyFetch::class);
+
+        // Exception::$message is protected, so null expected with Public visibility
+        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
+
+        self::assertNull($result);
+    }
+
+    public function testResolveNullsafePropertyFetch(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(?\Exception $e) {
+    $e?->message;
+}
+PHP;
+        $ast = $this->parse($code);
+        $fetch = $this->findFirst($ast, NullsafePropertyFetch::class);
+
+        // Exception::$message is protected, so null expected with Public visibility
+        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
+
+        self::assertNull($result);
+    }
+
+    public function testIsMethodCall(): void
+    {
+        self::assertTrue(MemberAccessResolver::isMethodCall(new MethodCall(
+            new \PhpParser\Node\Expr\Variable('x'),
+            'foo'
+        )));
+        self::assertTrue(MemberAccessResolver::isMethodCall(new NullsafeMethodCall(
+            new \PhpParser\Node\Expr\Variable('x'),
+            'foo'
+        )));
+        self::assertFalse(MemberAccessResolver::isMethodCall(new PropertyFetch(
+            new \PhpParser\Node\Expr\Variable('x'),
+            'foo'
+        )));
+    }
+
+    public function testIsPropertyFetch(): void
+    {
+        self::assertTrue(MemberAccessResolver::isPropertyFetch(new PropertyFetch(
+            new \PhpParser\Node\Expr\Variable('x'),
+            'foo'
+        )));
+        self::assertTrue(MemberAccessResolver::isPropertyFetch(new NullsafePropertyFetch(
+            new \PhpParser\Node\Expr\Variable('x'),
+            'foo'
+        )));
+        self::assertFalse(MemberAccessResolver::isPropertyFetch(new MethodCall(
+            new \PhpParser\Node\Expr\Variable('x'),
+            'foo'
+        )));
+    }
+
+    /**
+     * @return array<Stmt>
+     */
+    private function parse(string $code): array
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $ast = $parser->parse($code) ?? [];
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new ParentConnectingVisitor());
+        /** @var array<Stmt> */
+        return $traverser->traverse($ast);
+    }
+
+    /**
+     * @template T of \PhpParser\Node
+     * @param array<Stmt> $ast
+     * @param class-string<T> $type
+     * @return T
+     */
+    private function findFirst(array $ast, string $type): \PhpParser\Node
+    {
+        $found = null;
+        $finder = new class ($type, $found) extends NodeVisitorAbstract {
+            public ?\PhpParser\Node $found = null;
+            /** @var class-string */
+            private string $type;
+
+            /**
+             * @param class-string $type
+             */
+            public function __construct(string $type, ?\PhpParser\Node &$found)
+            {
+                $this->type = $type;
+                $this->found = &$found;
+            }
+
+            public function enterNode(\PhpParser\Node $node): ?int
+            {
+                if ($node instanceof $this->type && $this->found === null) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        if ($finder->found === null) {
+            throw new \RuntimeException("Could not find node of type $type");
+        }
+        assert($finder->found instanceof $type);
+        return $finder->found;
+    }
+}

--- a/tests/Utility/MemberAccessResolverTest.php
+++ b/tests/Utility/MemberAccessResolverTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Utility;
 
-use Firehed\PhpLsp\Domain\MethodInfo;
-use Firehed\PhpLsp\Domain\PropertyInfo;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
@@ -17,10 +15,10 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
-use PhpParser\NodeVisitorAbstract;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -39,10 +37,10 @@ class MemberAccessResolverTest extends TestCase
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver);
 
-        $this->resolver = new MemberAccessResolver($memberResolver, $typeResolver);
+        $this->resolver = new MemberAccessResolver($typeResolver);
     }
 
-    public function testResolveMethodCall(): void
+    public function testResolveObjectClassName(): void
     {
         $code = <<<'PHP'
 <?php
@@ -51,61 +49,24 @@ function test(\Exception $e) {
 }
 PHP;
         $ast = $this->parse($code);
-        $call = $this->findFirst($ast, MethodCall::class);
+        $methodCall = $this->findFirst($ast, MethodCall::class);
 
-        $result = $this->resolver->resolveMethodCall($call, $ast);
+        $result = $this->resolver->resolveObjectClassName($methodCall->var, $ast);
 
-        self::assertInstanceOf(MethodInfo::class, $result);
-        self::assertSame('getMessage', $result->name->name);
+        self::assertNotNull($result);
+        self::assertSame('Exception', $result->fqn);
     }
 
-    public function testResolveNullsafeMethodCall(): void
+    public function testResolveObjectClassNameReturnsNullForUnknownVariable(): void
     {
         $code = <<<'PHP'
 <?php
-function test(?\Exception $e) {
-    $e?->getMessage();
-}
+$unknown->foo();
 PHP;
         $ast = $this->parse($code);
-        $call = $this->findFirst($ast, NullsafeMethodCall::class);
+        $methodCall = $this->findFirst($ast, MethodCall::class);
 
-        $result = $this->resolver->resolveMethodCall($call, $ast);
-
-        self::assertInstanceOf(MethodInfo::class, $result);
-        self::assertSame('getMessage', $result->name->name);
-    }
-
-    public function testResolvePropertyFetch(): void
-    {
-        $code = <<<'PHP'
-<?php
-function test(\Exception $e) {
-    $e->message;
-}
-PHP;
-        $ast = $this->parse($code);
-        $fetch = $this->findFirst($ast, PropertyFetch::class);
-
-        // Exception::$message is protected, so null expected with Public visibility
-        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
-
-        self::assertNull($result);
-    }
-
-    public function testResolveNullsafePropertyFetch(): void
-    {
-        $code = <<<'PHP'
-<?php
-function test(?\Exception $e) {
-    $e?->message;
-}
-PHP;
-        $ast = $this->parse($code);
-        $fetch = $this->findFirst($ast, NullsafePropertyFetch::class);
-
-        // Exception::$message is protected, so null expected with Public visibility
-        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
+        $result = $this->resolver->resolveObjectClassName($methodCall->var, $ast);
 
         self::assertNull($result);
     }
@@ -113,15 +74,15 @@ PHP;
     public function testIsMethodCall(): void
     {
         self::assertTrue(MemberAccessResolver::isMethodCall(new MethodCall(
-            new \PhpParser\Node\Expr\Variable('x'),
+            new Variable('x'),
             'foo'
         )));
         self::assertTrue(MemberAccessResolver::isMethodCall(new NullsafeMethodCall(
-            new \PhpParser\Node\Expr\Variable('x'),
+            new Variable('x'),
             'foo'
         )));
         self::assertFalse(MemberAccessResolver::isMethodCall(new PropertyFetch(
-            new \PhpParser\Node\Expr\Variable('x'),
+            new Variable('x'),
             'foo'
         )));
     }
@@ -129,95 +90,17 @@ PHP;
     public function testIsPropertyFetch(): void
     {
         self::assertTrue(MemberAccessResolver::isPropertyFetch(new PropertyFetch(
-            new \PhpParser\Node\Expr\Variable('x'),
+            new Variable('x'),
             'foo'
         )));
         self::assertTrue(MemberAccessResolver::isPropertyFetch(new NullsafePropertyFetch(
-            new \PhpParser\Node\Expr\Variable('x'),
+            new Variable('x'),
             'foo'
         )));
         self::assertFalse(MemberAccessResolver::isPropertyFetch(new MethodCall(
-            new \PhpParser\Node\Expr\Variable('x'),
+            new Variable('x'),
             'foo'
         )));
-    }
-
-    public function testDynamicMethodNameReturnsNull(): void
-    {
-        $code = <<<'PHP'
-<?php
-function test(\Exception $e, string $method) {
-    $e->$method();
-}
-PHP;
-        $ast = $this->parse($code);
-        $call = $this->findFirst($ast, MethodCall::class);
-
-        $result = $this->resolver->resolveMethodCall($call, $ast);
-
-        self::assertNull($result);
-    }
-
-    public function testDynamicPropertyNameReturnsNull(): void
-    {
-        $code = <<<'PHP'
-<?php
-function test(\Exception $e, string $prop) {
-    $e->$prop;
-}
-PHP;
-        $ast = $this->parse($code);
-        $fetch = $this->findFirst($ast, PropertyFetch::class);
-
-        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
-
-        self::assertNull($result);
-    }
-
-    public function testPrimitiveTypeReturnsNull(): void
-    {
-        $code = <<<'PHP'
-<?php
-function test(string $str) {
-    $str->foo;
-}
-PHP;
-        $ast = $this->parse($code);
-        $fetch = $this->findFirst($ast, PropertyFetch::class);
-
-        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
-
-        self::assertNull($result);
-    }
-
-    public function testMethodCallOnPrimitiveTypeReturnsNull(): void
-    {
-        $code = <<<'PHP'
-<?php
-function test(string $str) {
-    $str->foo();
-}
-PHP;
-        $ast = $this->parse($code);
-        $call = $this->findFirst($ast, MethodCall::class);
-
-        $result = $this->resolver->resolveMethodCall($call, $ast);
-
-        self::assertNull($result);
-    }
-
-    public function testUnresolvedVariableTypeReturnsNull(): void
-    {
-        $code = <<<'PHP'
-<?php
-$unknown->foo();
-PHP;
-        $ast = $this->parse($code);
-        $call = $this->findFirst($ast, MethodCall::class);
-
-        $result = $this->resolver->resolveMethodCall($call, $ast);
-
-        self::assertNull($result);
     }
 
     /**
@@ -242,14 +125,12 @@ PHP;
      */
     private function findFirst(array $ast, string $type): \PhpParser\Node
     {
-        $finder = new class ($type) extends NodeVisitorAbstract {
+        $finder = new class ($type) extends \PhpParser\NodeVisitorAbstract {
             public ?\PhpParser\Node $found = null;
             /** @var class-string */
             private string $type;
 
-            /**
-             * @param class-string $type
-             */
+            /** @param class-string $type */
             public function __construct(string $type)
             {
                 $this->type = $type;

--- a/tests/Utility/MemberAccessResolverTest.php
+++ b/tests/Utility/MemberAccessResolverTest.php
@@ -142,6 +142,54 @@ PHP;
         )));
     }
 
+    public function testDynamicMethodNameReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(\Exception $e, string $method) {
+    $e->$method();
+}
+PHP;
+        $ast = $this->parse($code);
+        $call = $this->findFirst($ast, MethodCall::class);
+
+        $result = $this->resolver->resolveMethodCall($call, $ast);
+
+        self::assertNull($result);
+    }
+
+    public function testDynamicPropertyNameReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(\Exception $e, string $prop) {
+    $e->$prop;
+}
+PHP;
+        $ast = $this->parse($code);
+        $fetch = $this->findFirst($ast, PropertyFetch::class);
+
+        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
+
+        self::assertNull($result);
+    }
+
+    public function testPrimitiveTypeReturnsNull(): void
+    {
+        $code = <<<'PHP'
+<?php
+function test(string $str) {
+    $str->foo;
+}
+PHP;
+        $ast = $this->parse($code);
+        $fetch = $this->findFirst($ast, PropertyFetch::class);
+
+        $result = $this->resolver->resolvePropertyFetch($fetch, $ast);
+
+        self::assertNull($result);
+    }
+
     /**
      * @return array<Stmt>
      */
@@ -164,8 +212,7 @@ PHP;
      */
     private function findFirst(array $ast, string $type): \PhpParser\Node
     {
-        $found = null;
-        $finder = new class ($type, $found) extends NodeVisitorAbstract {
+        $finder = new class ($type) extends NodeVisitorAbstract {
             public ?\PhpParser\Node $found = null;
             /** @var class-string */
             private string $type;
@@ -173,10 +220,9 @@ PHP;
             /**
              * @param class-string $type
              */
-            public function __construct(string $type, ?\PhpParser\Node &$found)
+            public function __construct(string $type)
             {
                 $this->type = $type;
-                $this->found = &$found;
             }
 
             public function enterNode(\PhpParser\Node $node): ?int


### PR DESCRIPTION
## Summary

- Replaces regex-based context detection for member access with AST-based analysis
- Handles both -> and ?-> (nullsafe) operators automatically via node types
- Adds nullsafe operator support to BasicTypeResolver for type chain resolution
- Updates Hover, Definition, and SignatureHelp handlers to support nullsafe operators via MemberAccessResolver

## Changes

**New classes:**
- CompletionContext enum - represents completion context types
- CompletionContextResolver - AST-based context detection
- MemberAccessContext / StaticAccessContext - typed result objects
- MemberAccessResolver - centralizes member access resolution for both -> and ?->

**Modified:**
- CompletionHandler - uses AST detection first, falls back to regex for other contexts
- BasicTypeResolver - handles NullsafeMethodCall and NullsafePropertyFetch
- HoverHandler - uses MemberAccessResolver for nullsafe support
- DefinitionHandler - uses MemberAccessResolver for nullsafe support
- SignatureHelpHandler - uses MemberAccessResolver for nullsafe support

## Test plan

- [x] All existing completion tests pass
- [x] New tests for nullsafe completion
- [x] New tests for CompletionContextResolver
- [x] New tests for MemberAccessResolver
- [x] PHPStan passes

Generated with Claude Code