### PR TITLE
Add null-safe operator tests and fix type resolution visibility

### DIFF
--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -218,7 +218,7 @@ final class BasicTypeResolver implements TypeResolverInterface
         $methodInfo = $this->memberResolver->findMethod(
             new ClassName($className),
             new MethodName($methodName),
-            Visibility::Public,
+            Visibility::Private,
         );
 
         return $methodInfo?->returnType;
@@ -230,7 +230,7 @@ final class BasicTypeResolver implements TypeResolverInterface
         $propertyInfo = $this->memberResolver->findProperty(
             new ClassName($className),
             new PropertyName($propertyName),
-            Visibility::Public,
+            Visibility::Private,
         );
 
         return $propertyInfo?->type;

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -887,4 +887,75 @@ PHP;
         self::assertSame('file:///MyClass.php', $result['uri']);
         self::assertSame(2, $result['range']['start']['line']);
     }
+
+    public function testGoToNullsafeMethodDefinition(): void
+    {
+        $classCode = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {}
+}
+PHP;
+        $this->openDocument('file:///MyClass.php', $classCode);
+
+        $usageCode = <<<'PHP'
+<?php
+function test(?MyClass $obj): void {
+    $obj?->myMethod();
+}
+PHP;
+        $this->openDocument('file:///usage.php', $usageCode);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 2, 'character' => 13], // On "myMethod"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
+
+    public function testGoToNullsafeMethodDefinitionViaAssignment(): void
+    {
+        $classCode = <<<'PHP'
+<?php
+class MyClass {
+    public function myMethod(): void {}
+}
+PHP;
+        $this->openDocument('file:///MyClass.php', $classCode);
+
+        $usageCode = <<<'PHP'
+<?php
+function test(): void {
+    $obj = rand() ? new MyClass() : null;
+    $obj?->myMethod();
+}
+PHP;
+        $this->openDocument('file:///usage.php', $usageCode);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/definition',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///usage.php'],
+                'position' => ['line' => 3, 'character' => 13], // On "myMethod"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertSame('file:///MyClass.php', $result['uri']);
+        self::assertSame(2, $result['range']['start']['line']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -1171,7 +1171,7 @@ class Calculator
 
 class Container
 {
-    public ?Calculator $calc;
+    private ?Calculator $calc;
 
     public function test(): void
     {
@@ -1212,7 +1212,7 @@ class Person
 
 class Container
 {
-    public ?Person $person;
+    private ?Person $person;
 
     public function test(): string
     {

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -1277,4 +1277,97 @@ PHP;
         self::assertStringContainsString('add', $result['contents']);
         self::assertStringContainsString('Adds two numbers', $result['contents']);
     }
+
+    public function testHoverOnNullsafeProtectedPropertyMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Divides two numbers.
+     */
+    public function divide(int $a, int $b): float
+    {
+        return $a / $b;
+    }
+}
+
+class Container
+{
+    protected ?Calculator $calc;
+
+    public function test(): void
+    {
+        $this->calc?->divide(10, 2);
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 18, 'character' => 23], // On "divide"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('divide', $result['contents']);
+        self::assertStringContainsString('Divides two numbers', $result['contents']);
+    }
+
+    public function testHoverOnChainedNullsafeMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Inner
+{
+    /**
+     * Returns the value.
+     */
+    public function getValue(): int
+    {
+        return 42;
+    }
+}
+
+class Middle
+{
+    public ?Inner $inner;
+}
+
+class Outer
+{
+    private ?Middle $middle;
+
+    public function test(): void
+    {
+        $this->middle?->inner?->getValue();
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 23, 'character' => 33], // On "getValue"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('getValue', $result['contents']);
+        self::assertStringContainsString('Returns the value', $result['contents']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -1153,4 +1153,136 @@ PHP;
         self::assertStringContainsString('$prefix = ...', $result['contents']);
         self::assertStringNotContainsString('$name = ...', $result['contents']);
     }
+
+    public function testHoverOnNullsafeMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Multiplies two numbers.
+     */
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+}
+
+class Container
+{
+    public ?Calculator $calc;
+
+    public function test(): void
+    {
+        $this->calc?->multiply(2, 3);
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 18, 'character' => 23], // On "multiply"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('multiply', $result['contents']);
+        self::assertStringContainsString('Multiplies two numbers', $result['contents']);
+    }
+
+    public function testHoverOnNullsafePropertyFetch(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Person
+{
+    /**
+     * The person's full name.
+     */
+    public string $name;
+}
+
+class Container
+{
+    public ?Person $person;
+
+    public function test(): string
+    {
+        return $this->person?->name ?? 'Unknown';
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 15, 'character' => 32], // On "name"
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$name', $result['contents']);
+        self::assertStringContainsString('string', $result['contents']);
+    }
+
+    public function testHoverOnNullsafeTypedVariableMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Adds two numbers.
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+
+function useCalculator(?Calculator $calc): void
+{
+    $calc?->add(1, 2);
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $handlerWithResolver = new HoverHandler(
+            $this->documents,
+            $this->parser,
+            $this->classRepository,
+            $this->memberResolver,
+            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/hover',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 13], // On "add"
+            ],
+        ]);
+
+        $result = $handlerWithResolver->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('add', $result['contents']);
+        self::assertStringContainsString('Adds two numbers', $result['contents']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -1261,14 +1261,6 @@ function useCalculator(?Calculator $calc): void
 PHP;
         $this->openDocument('file:///test.php', $code);
 
-        $handlerWithResolver = new HoverHandler(
-            $this->documents,
-            $this->parser,
-            $this->classRepository,
-            $this->memberResolver,
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
             'id' => 1,
@@ -1279,7 +1271,7 @@ PHP;
             ],
         ]);
 
-        $result = $handlerWithResolver->handle($request);
+        $result = $this->handler->handle($request);
 
         self::assertIsArray($result);
         self::assertStringContainsString('add', $result['contents']);

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -397,4 +397,87 @@ PHP;
         self::assertStringContainsString('greet', $result['signatures'][0]['label']);
         self::assertStringContainsString('Greets a person', $result['signatures'][0]['documentation'] ?? '');
     }
+
+    public function testSignatureHelpOnNullsafeMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Multiplies two numbers.
+     */
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+}
+
+class Container
+{
+    public ?Calculator $calc;
+
+    public function test(): void
+    {
+        $this->calc?->multiply(2, 3);
+    }
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/signatureHelp',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 18, 'character' => 31], // Inside multiply(|2, 3)
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('multiply', $result['signatures'][0]['label']);
+        self::assertStringContainsString('Multiplies two numbers', $result['signatures'][0]['documentation'] ?? '');
+    }
+
+    public function testSignatureHelpOnNullsafeTypedVariableMethodCall(): void
+    {
+        $code = <<<'PHP'
+<?php
+class Calculator
+{
+    /**
+     * Adds two numbers.
+     */
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+
+function useCalculator(?Calculator $calc): void
+{
+    $calc?->add(1, 2);
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/signatureHelp',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 17], // Inside add(|1, 2)
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('add', $result['signatures'][0]['label']);
+        self::assertStringContainsString('Adds two numbers', $result['signatures'][0]['documentation'] ?? '');
+    }
 }

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -415,7 +415,7 @@ class Calculator
 
 class Container
 {
-    public ?Calculator $calc;
+    private ?Calculator $calc;
 
     public function test(): void
     {


### PR DESCRIPTION
Closes #193

## Summary

- Add tests for null-safe operator (`?->`) across Hover, Definition, and SignatureHelp handlers
- Fix bug in `BasicTypeResolver` where type resolution through property chains failed for private/protected properties

## Changes

**Bug fix:** `BasicTypeResolver::getPropertyType()` and `getMethodReturnType()` were using `Visibility::Public`, which prevented type resolution through private property chains like `$this->calc?->method()`. Changed to `Visibility::Private` since type inference should resolve types regardless of visibility—visibility enforcement belongs in completion filtering, not type resolution.

**Tests added:**
- `HoverHandlerTest`: nullsafe method call, nullsafe property fetch, nullsafe typed variable method call, protected property, chained nullsafe
- `DefinitionHandlerTest`: nullsafe method definition, nullsafe method via assignment
- `SignatureHelpHandlerTest`: nullsafe method call, nullsafe typed variable method call

## Scope

Nullsafe (`?->`) now has full parity with `->`:
- Hover ✅
- Definition ✅
- SignatureHelp ✅
- Completion ✅ (for contexts where `->` works)

Remaining completion gaps (chains, self/static return types) affect both operators equally and are tracked in #11 and #219.

## Test plan

- [x] All existing tests pass
- [x] New nullsafe operator tests pass
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)