### PR TITLE
Fix self/static/parent return type resolution

### DIFF
--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -51,11 +51,27 @@ final class TypeFactory
         }
 
         if ($node instanceof Name) {
+            $name = $node->toString();
+
+            if ($name === 'self' || $name === 'static') {
+                if ($selfContext !== null) {
+                    return new ClassName($selfContext);
+                }
+                return new PrimitiveType($name);
+            }
+
+            if ($name === 'parent') {
+                if ($parentContext !== null) {
+                    return new ClassName($parentContext);
+                }
+                return new PrimitiveType($name);
+            }
+
             $resolvedName = $node->getAttribute('resolvedName');
             /** @var class-string $fqn */
             $fqn = $resolvedName instanceof Name
                 ? $resolvedName->toString()
-                : $node->toString();
+                : $name;
             return new ClassName($fqn);
         }
 

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2010,6 +2010,110 @@ PHP;
         self::assertNotContains('setName', $labels);
     }
 
+    public function testTypedVariableCompletionFromStaticMethodReturningSelf(): void
+    {
+        $code = <<<'PHP'
+<?php
+class SomeClass
+{
+    public static function create(): ?self
+    {
+        return new self();
+    }
+
+    public function doSomething(): void {}
+}
+
+function test(): void
+{
+    $foo = SomeClass::create();
+    $foo->
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            $this->memberResolver,
+            $this->classRepository,
+            new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 10], // After $foo->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        // Static method 'create' should not appear in instance completions
+        self::assertNotContains('create', $labels);
+        self::assertContains('doSomething', $labels);
+    }
+
+    public function testTypedVariableCompletionFromStaticMethodReturningSelfNullsafe(): void
+    {
+        $code = <<<'PHP'
+<?php
+class SomeClass
+{
+    public static function create(): ?self
+    {
+        return new self();
+    }
+
+    public function doSomething(): void {}
+}
+
+function test(): void
+{
+    $foo = SomeClass::create();
+    $foo?->
+}
+PHP;
+        $this->openDocument('file:///test.php', $code);
+
+        $handler = new CompletionHandler(
+            $this->documents,
+            $this->parser,
+            $this->symbolIndex,
+            $this->memberResolver,
+            $this->classRepository,
+            new BasicTypeResolver($this->memberResolver),
+            new CompletionContextResolver(),
+        );
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 14, 'character' => 11], // After $foo?->
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        // Static method 'create' should not appear in instance completions
+        self::assertNotContains('create', $labels);
+        self::assertContains('doSomething', $labels);
+    }
+
     public function testTypedVariableCompletionReturnsEmptyWhenTypeUnknown(): void
     {
         $code = <<<'PHP'

--- a/tests/Repository/DefaultClassInfoFactoryTest.php
+++ b/tests/Repository/DefaultClassInfoFactoryTest.php
@@ -260,6 +260,40 @@ PHP;
         self::assertSame('string', $info->methods['protectedMethod']->returnType?->format());
     }
 
+    public function testFromAstNodeResolvesSelfReturnType(): void
+    {
+        $node = $this->parseClass('<?php class SomeClass {
+            public static function create(): ?self { return new self(); }
+        }');
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertArrayHasKey('create', $info->methods);
+        $returnType = $info->methods['create']->returnType;
+        self::assertNotNull($returnType);
+        self::assertSame('?SomeClass', $returnType->format());
+        $classNames = $returnType->getResolvableClassNames();
+        self::assertCount(1, $classNames);
+        self::assertSame('SomeClass', $classNames[0]->fqn);
+    }
+
+    public function testFromAstNodeResolvesStaticReturnType(): void
+    {
+        $node = $this->parseClass('<?php class Builder {
+            public function build(): static { return $this; }
+        }');
+
+        $info = $this->factory->fromAstNode($node, 'file:///test.php');
+
+        self::assertArrayHasKey('build', $info->methods);
+        $returnType = $info->methods['build']->returnType;
+        self::assertNotNull($returnType);
+        self::assertSame('Builder', $returnType->format());
+        $classNames = $returnType->getResolvableClassNames();
+        self::assertCount(1, $classNames);
+        self::assertSame('Builder', $classNames[0]->fqn);
+    }
+
     public function testFromAstNodeExtractsMethodParameters(): void
     {
         $node = $this->parseClass('<?php class MyClass {

--- a/tests/Utility/TypeFactoryTest.php
+++ b/tests/Utility/TypeFactoryTest.php
@@ -123,6 +123,51 @@ class TypeFactoryTest extends TestCase
         self::assertSame('parent', $type->format());
     }
 
+    public function testFromNodeWithNameSelfAndContextCreatesClassName(): void
+    {
+        $node = new Name('self');
+        $type = TypeFactory::fromNode($node, selfContext: \stdClass::class);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\stdClass::class, $type->fqn);
+    }
+
+    public function testFromNodeWithNameStaticAndContextCreatesClassName(): void
+    {
+        $node = new Name('static');
+        $type = TypeFactory::fromNode($node, selfContext: \ArrayObject::class);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\ArrayObject::class, $type->fqn);
+    }
+
+    public function testFromNodeWithNameParentAndContextCreatesClassName(): void
+    {
+        $node = new Name('parent');
+        $type = TypeFactory::fromNode($node, parentContext: \Throwable::class);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\Throwable::class, $type->fqn);
+    }
+
+    public function testFromNodeWithNameSelfWithoutContextCreatesPrimitiveType(): void
+    {
+        $node = new Name('self');
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('self', $type->format());
+    }
+
+    public function testFromNodeWithNameParentWithoutContextCreatesPrimitiveType(): void
+    {
+        $node = new Name('parent');
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('parent', $type->format());
+    }
+
     public function testFromNodeWithNullableTypeCreatesUnionType(): void
     {
         $node = new NullableType(new Name(\stdClass::class));

--- a/tests/Utility/TypeFactoryTest.php
+++ b/tests/Utility/TypeFactoryTest.php
@@ -168,6 +168,15 @@ class TypeFactoryTest extends TestCase
         self::assertSame('parent', $type->format());
     }
 
+    public function testFromNodeWithNameStaticWithoutContextCreatesPrimitiveType(): void
+    {
+        $node = new Name('static');
+        $type = TypeFactory::fromNode($node);
+
+        self::assertInstanceOf(PrimitiveType::class, $type);
+        self::assertSame('static', $type->format());
+    }
+
     public function testFromNodeWithNullableTypeCreatesUnionType(): void
     {
         $node = new NullableType(new Name(\stdClass::class));


### PR DESCRIPTION
## Summary
- Fix `TypeFactory::fromNode()` to resolve `self`, `static`, and `parent` when they appear as `Name` nodes, not just `Identifier` nodes
- PHP-Parser's `NameResolver` visitor converts these keywords to `Name` nodes in return type contexts, but the previous code only handled the `Identifier` case

Closes #219

## Test plan
- [x] Added `TypeFactoryTest` cases for `Name` nodes with `self`/`static`/`parent`
- [x] Added `DefaultClassInfoFactoryTest` cases for method return types using `self` and `static`
- [x] Added `CompletionHandlerTest` cases for completions on variables assigned from static methods returning `?self` (both `->` and `?->` operators)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)