### PR TITLE
Fix new self()/static()/parent() type inference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Structure (all under `tests/Fixtures/src/` with `Fixtures\` namespace):
 - `Traits/`, `Inheritance/`, `Services/` — OOP patterns
 - `Repository/` — Repository pattern examples
 - `Completion/`, `Hover/`, `Definition/`, `SignatureHelp/` — Handler-specific fixtures with cursor markers
+- `TypeInference/` — Type resolver test fixtures
 - `Legacy/` — Code quality variations (docblock-only, untyped)
 - `Mixed/` — Procedural + OOP mixes
 
@@ -159,6 +160,14 @@ $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'this_em
 
 // Build request from cursor position
 $result = $this->handler->handle($this->completionRequestAt($cursor));
+```
+
+`LoadsFixturesTrait` provides fixture loading for unit tests (no handler infrastructure):
+
+```php
+// Load fixture content and parse
+$content = $this->loadFixture('src/TypeInference/NewKeywords.php');
+$ast = $this->parse($content);
 ```
 
 ### Cursor Markers

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFactory;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -41,8 +42,18 @@ final class BasicTypeResolver implements TypeResolverInterface
         // new ClassName()
         if ($expr instanceof Expr\New_) {
             if ($expr->class instanceof Node\Name) {
-                /** @var class-string */
-                $fqn = $expr->class->toString();
+                $name = $expr->class->toString();
+                $fqn = match ($name) {
+                    'self', 'static' => ScopeFinder::findEnclosingClassName($expr),
+                    'parent' => ($classNode = ScopeFinder::findEnclosingClassNode($expr)) instanceof Stmt\Class_
+                        ? ScopeFinder::resolveExtendsName($classNode)
+                        : null,
+                    default => $name,
+                };
+                if ($fqn === null) {
+                    return null;
+                }
+                /** @var class-string $fqn */
                 return new ClassName($fqn);
             }
             return null;
@@ -50,7 +61,7 @@ final class BasicTypeResolver implements TypeResolverInterface
 
         // $this - check before generic variable handling
         if ($expr instanceof Expr\Variable && $expr->name === 'this') {
-            $className = $this->findEnclosingClassName($ast, $scope);
+            $className = ScopeFinder::findEnclosingClassName($expr);
             if ($className === null) {
                 return null;
             }
@@ -290,70 +301,5 @@ final class BasicTypeResolver implements TypeResolverInterface
         }
         $classNames = $type->getResolvableClassNames();
         return $classNames !== [] ? $classNames[0]->fqn : null;
-    }
-
-    /**
-     * Find the class name that contains the given scope.
-     *
-     * @param array<Stmt> $ast
-     */
-    private function findEnclosingClassName(
-        array $ast,
-        Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope,
-    ): ?string {
-        if ($scope === null) {
-            return null;
-        }
-
-        $found = null;
-        $visitor = new class ($scope, $found) extends NodeVisitorAbstract {
-            public ?string $found = null;
-            private ?string $currentClass = null;
-            /** @var Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction */
-            private $targetScope;
-
-            /**
-             * @param Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction $targetScope
-             */
-            public function __construct($targetScope, ?string &$found)
-            {
-                $this->targetScope = $targetScope;
-                $this->found = &$found;
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Class_ && $node->name !== null) {
-                    // namespacedName is only set when NameResolver visitor is used
-                    // and may throw if accessed before initialization
-                    try {
-                        $nsName = $node->namespacedName;
-                        $this->currentClass = $nsName !== null ? $nsName->toString() : $node->name->toString();
-                    } catch (\Error) {
-                        $this->currentClass = $node->name->toString();
-                    }
-                }
-
-                if ($node === $this->targetScope && $this->currentClass !== null) {
-                    $this->found = $this->currentClass;
-                }
-
-                return null;
-            }
-
-            public function leaveNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Class_) {
-                    $this->currentClass = null;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($visitor);
-        $traverser->traverse($ast);
-
-        return $visitor->found;
     }
 }

--- a/tests/Fixtures/src/TypeInference/AnonymousClass.php
+++ b/tests/Fixtures/src/TypeInference/AnonymousClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference;
+
+class AnonymousClass
+{
+    public function getAnonymous(): object
+    {
+        return new class {
+            public function createSelf(): self
+            {
+                return new self();
+            }
+        };
+    }
+}

--- a/tests/Fixtures/src/TypeInference/NewKeywords.php
+++ b/tests/Fixtures/src/TypeInference/NewKeywords.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference;
+
+use Fixtures\Inheritance\ParentClass;
+
+class NewKeywords extends ParentClass
+{
+    public function createSelf(): self
+    {
+        return new self();
+    }
+
+    public static function createStatic(): static
+    {
+        return new static();
+    }
+
+    public function createParent(): ParentClass
+    {
+        return new parent();
+    }
+}

--- a/tests/Fixtures/src/TypeInference/ParentInTrait.php
+++ b/tests/Fixtures/src/TypeInference/ParentInTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference;
+
+trait ParentInTrait
+{
+    public function createFromTrait(): mixed
+    {
+        return new parent();
+    }
+}

--- a/tests/LoadsFixturesTrait.php
+++ b/tests/LoadsFixturesTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests;
+
+/**
+ * Provides fixture file loading for unit tests.
+ *
+ * Use this for tests that need fixture file contents without the full
+ * handler infrastructure (document manager, sync handler, etc.).
+ *
+ * For handler tests, use OpensDocumentsTrait instead.
+ */
+trait LoadsFixturesTrait
+{
+    /**
+     * Load fixture file contents.
+     *
+     * @param string $fixturePath Path relative to tests/Fixtures/
+     */
+    private function loadFixture(string $fixturePath): string
+    {
+        $fullPath = __DIR__ . '/Fixtures/' . $fixturePath;
+        $content = file_get_contents($fullPath);
+        assert($content !== false, "Fixture not found: $fixturePath");
+        return $content;
+    }
+}

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -895,4 +895,17 @@ PHP;
 
         self::assertNull($type);
     }
+
+    public function testResolveNewSelfInAnonymousClassReturnsNull(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/AnonymousClass.php');
+        $method = $this->findMethodByName($ast, 'createSelf');
+        $finder = new \PhpParser\NodeFinder();
+        $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
+        assert($newExpr !== null);
+
+        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+
+        self::assertNull($type);
+    }
 }

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -17,6 +17,7 @@ use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -28,6 +29,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(BasicTypeResolver::class)]
 class BasicTypeResolverTest extends TestCase
 {
+    use LoadsFixturesTrait;
+
     private BasicTypeResolver $resolver;
 
     protected function setUp(): void
@@ -816,5 +819,80 @@ PHP;
             }
         }
         throw new \RuntimeException("Could not find function $name");
+    }
+
+    /**
+     * @return array<Stmt>
+     */
+    private function parseFixture(string $fixturePath): array
+    {
+        return $this->parse($this->loadFixture($fixturePath));
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function findMethodByName(array $ast, string $methodName): Stmt\ClassMethod
+    {
+        $finder = new \PhpParser\NodeFinder();
+        $method = $finder->findFirst($ast, fn($node) =>
+            $node instanceof Stmt\ClassMethod && $node->name->toString() === $methodName);
+        assert($method instanceof Stmt\ClassMethod, "Could not find method $methodName");
+        return $method;
+    }
+
+    public function testResolveNewSelfInClass(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/NewKeywords.php');
+        $method = $this->findMethodByName($ast, 'createSelf');
+        $finder = new \PhpParser\NodeFinder();
+        $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
+        assert($newExpr !== null);
+
+        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
+    }
+
+    public function testResolveNewStaticInClass(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/NewKeywords.php');
+        $method = $this->findMethodByName($ast, 'createStatic');
+        $finder = new \PhpParser\NodeFinder();
+        $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
+        assert($newExpr !== null);
+
+        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
+    }
+
+    public function testResolveNewParentInClass(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/NewKeywords.php');
+        $method = $this->findMethodByName($ast, 'createParent');
+        $finder = new \PhpParser\NodeFinder();
+        $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
+        assert($newExpr !== null);
+
+        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\Inheritance\\ParentClass', $type->fqn);
+    }
+
+    public function testResolveNewParentInTraitReturnsNull(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/ParentInTrait.php');
+        $method = $this->findMethodByName($ast, 'createFromTrait');
+        $finder = new \PhpParser\NodeFinder();
+        $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
+        assert($newExpr !== null);
+
+        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+
+        self::assertNull($type);
     }
 }


### PR DESCRIPTION
## Summary
- Fix type inference for `new self()`, `new static()`, and `new parent()` expressions
- Uses ScopeFinder utilities to properly resolve these keywords to actual class names
- Removes duplicated `findEnclosingClassName` method in favor of existing `ScopeFinder::findEnclosingClassName`

The type resolver was returning the literal string "self" instead of resolving it to the actual enclosing class name. This caused completion to fail for variables assigned from `new self()` expressions.

## Test plan
- [x] All existing tests pass
- [x] PHPStan passes

🤖 Generated with [Claude Code](https://claude.ai/code)