### PR TITLE
Fix self/parent parameter type resolution

### DIFF
--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -136,6 +136,16 @@ final class BasicTypeResolver implements TypeResolverInterface
         int $line,
         array $ast,
     ): ?Type {
+        // Determine class context for self/static/parent resolution
+        $selfContext = ScopeFinder::findEnclosingClassName($scope);
+        $parentContext = null;
+        if ($selfContext !== null) {
+            $classNode = ScopeFinder::findEnclosingClassNode($scope);
+            if ($classNode instanceof Stmt\Class_) {
+                $parentContext = ScopeFinder::resolveExtendsName($classNode);
+            }
+        }
+
         // Check parameters first
         foreach ($scope->params as $param) {
             if (
@@ -143,7 +153,7 @@ final class BasicTypeResolver implements TypeResolverInterface
                 && is_string($param->var->name)
                 && $param->var->name === $variableName
             ) {
-                return TypeFactory::fromNode($param->type);
+                return TypeFactory::fromNode($param->type, $selfContext, $parentContext);
             }
         }
 

--- a/tests/Fixtures/src/Inheritance/ChildClass.php
+++ b/tests/Fixtures/src/Inheritance/ChildClass.php
@@ -23,4 +23,9 @@ class ChildClass extends ParentClass
     {
         ParentClass::/*|direct_parent_static*/
     }
+
+    public function withParentParam(parent $obj): void
+    {
+        $x = $obj;
+    }
 }

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -73,6 +73,28 @@ PHP;
         self::assertSame(DateTime::class, $type->fqn);
     }
 
+    public function testResolveParameterTypeSelf(): void
+    {
+        $ast = $this->parseFixture('src/Completion/MethodAccess.php');
+        $method = $this->findMethodByName($ast, 'withParameter');
+
+        $type = $this->resolver->resolveVariableType('param', $method, $method->getStartLine(), $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\Completion\\MethodAccess', $type->fqn);
+    }
+
+    public function testResolveParameterTypeParent(): void
+    {
+        $ast = $this->parseFixture('src/Inheritance/ChildClass.php');
+        $method = $this->findMethodByName($ast, 'withParentParam');
+
+        $type = $this->resolver->resolveVariableType('obj', $method, $method->getStartLine(), $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\Inheritance\\ParentClass', $type->fqn);
+    }
+
     public function testResolveAssignmentFromNew(): void
     {
         $code = <<<'PHP'


### PR DESCRIPTION
## Summary
- Fix `BasicTypeResolver::resolveVariableType()` to pass class context to `TypeFactory::fromNode()` when resolving parameter types
- When a parameter is typed as `self` or `parent`, the type was incorrectly returned as `PrimitiveType` instead of being resolved to the actual class name
- This was causing completion to fail for variables typed with `self` parameter types (e.g., `public function foo(self $obj) { $obj->| }`)

## Test plan
- Added tests for `self` and `parent` parameter type resolution
- Tests use existing fixtures (`MethodAccess.php` and `ChildClass.php`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)