### PR TITLE
Migrate CompletionHandlerTest to fixtures (batch 3)

### DIFF
--- a/tests/Fixtures/src/Completion/ChainCompletion.php
+++ b/tests/Fixtures/src/Completion/ChainCompletion.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\User;
+
+class ChainCompletion
+{
+    private User $user;
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function triggerPropertyChain(): void
+    {
+        $this->user->/*|property_chain*/
+    }
+
+    public function triggerMethodChain(): void
+    {
+        $this->getUser()->/*|method_chain*/
+    }
+
+    public function triggerMultiLevelChain(): void
+    {
+        $this->getUser()->getName()->/*|multi_level_chain*/
+    }
+}

--- a/tests/Fixtures/src/Completion/ChainCompletion.php
+++ b/tests/Fixtures/src/Completion/ChainCompletion.php
@@ -9,6 +9,7 @@ use Fixtures\Domain\User;
 class ChainCompletion
 {
     private User $user;
+    private ?User $nullableUser;
 
     public function getUser(): User
     {
@@ -28,5 +29,10 @@ class ChainCompletion
     public function triggerMultiLevelChain(): void
     {
         $this->getUser()->getName()->/*|multi_level_chain*/
+    }
+
+    public function triggerNullsafePropertyChain(): void
+    {
+        $this->nullableUser?->/*|nullsafe_property_chain*/
     }
 }

--- a/tests/Fixtures/src/Completion/ExternalAccess.php
+++ b/tests/Fixtures/src/Completion/ExternalAccess.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+class ExternalAccess
+{
+    public function accessMethodAccess(MethodAccess $obj): void
+    {
+        $obj->/*|external_method_access*/
+    }
+}

--- a/tests/Fixtures/src/Completion/MethodAccess.php
+++ b/tests/Fixtures/src/Completion/MethodAccess.php
@@ -32,6 +32,14 @@ class MethodAccess
         return $this->active;
     }
 
+    private function secretMethod(): void
+    {
+    }
+
+    protected function hiddenMethod(): void
+    {
+    }
+
     public function triggerThisEmpty(): void
     {
         $this->/*|this_empty*/

--- a/tests/Fixtures/src/Mixed/ProceduralWithClass.php
+++ b/tests/Fixtures/src/Mixed/ProceduralWithClass.php
@@ -2,6 +2,9 @@
 
 namespace Fixtures\Mixed;
 
+use Fixtures\Completion\MethodAccess;
+use Fixtures\Completion\StaticAccess;
+
 $config = [
     'debug' => true,
     'version' => '1.0.0',
@@ -23,3 +26,13 @@ class Helper
 
 $helper = new Helper();
 echo Helper::formatName('John', 'Doe');
+
+function processMethodAccess(MethodAccess $obj): void
+{
+    $obj->/*|standalone_function_access*/
+}
+
+function triggerStaticAccess(): void
+{
+    StaticAccess::/*|standalone_static_access*/
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1734,6 +1734,39 @@ PHP;
         self::assertNotContains('hiddenMethod', $labels);
     }
 
+    public function testStandaloneFunctionAccessExcludesNonPublicMembers(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'standalone_function_access');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Public members should be included
+        self::assertContains('active', $labels);
+        self::assertContains('getName', $labels);
+        // Non-public members should be excluded (no enclosing class context)
+        self::assertNotContains('name', $labels);
+        self::assertNotContains('secretMethod', $labels);
+    }
+
+    public function testStandaloneFunctionStaticAccessExcludesNonPublicMembers(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'standalone_static_access');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Public static members should be included
+        self::assertContains('create', $labels);
+        self::assertContains('NAME', $labels);
+        // Non-public members should be excluded (no enclosing class context)
+        self::assertNotContains('INTERNAL', $labels);
+        self::assertNotContains('SECRET', $labels);
+        self::assertNotContains('reset', $labels);
+    }
+
     public function testSelfConstantCompletion(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/StaticAccess.php', 'self_empty');

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1427,7 +1427,7 @@ PHP;
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);
         $labels = array_column($result['items'], 'label');
-        // Same class access - all members visible
+        // Members available via typed parameter
         self::assertContains('getName', $labels);
         self::assertContains('setName', $labels);
         self::assertContains('active', $labels);
@@ -1727,9 +1727,11 @@ PHP;
         self::assertContains('active', $labels);
         self::assertContains('getName', $labels);
         self::assertContains('getCount', $labels);
-        // Protected and private properties should be excluded
+        // Protected and private members should be excluded
         self::assertNotContains('name', $labels);
         self::assertNotContains('count', $labels);
+        self::assertNotContains('secretMethod', $labels);
+        self::assertNotContains('hiddenMethod', $labels);
     }
 
     public function testSelfConstantCompletion(): void
@@ -2388,6 +2390,17 @@ PHP;
         self::assertArrayHasKey('items', $result);
         $labels = array_column($result['items'], 'label');
         self::assertContains('getName', $labels);
+    }
+
+    public function testChainCompletionOnPrimitiveReturnsEmpty(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/ChainCompletion.php', 'multi_level_chain');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        self::assertSame([], $result['items']);
     }
 
     public function testChainCompletionMultiLevel(): void

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -144,75 +144,26 @@ class CompletionHandlerTest extends TestCase
 
     public function testStaticMethodCompletion(): void
     {
-        $code = <<<'PHP'
-<?php
-class Math
-{
-    public static function add(int $a, int $b): int
-    {
-        return $a + $b;
-    }
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticCaller.php', 'external_static');
 
-    public static function multiply(int $a, int $b): int
-    {
-        return $a * $b;
-    }
-}
-
-$result = Math::
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 14, 'character' => 16], // After Math::
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         $labels = array_column($result['items'], 'label');
-        self::assertContains('add', $labels);
-        self::assertContains('multiply', $labels);
-        // ::class magic constant should always be suggested
+        self::assertContains('create', $labels);
+        self::assertContains('getInstance', $labels);
         self::assertContains('class', $labels);
     }
 
     public function testClassConstantCompletion(): void
     {
-        $code = <<<'PHP'
-<?php
-class Status
-{
-    public const ACTIVE = 'active';
-    public const INACTIVE = 'inactive';
-}
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticCaller.php', 'external_static');
 
-$status = Status::
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 7, 'character' => 18],
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         $labels = array_column($result['items'], 'label');
-        self::assertContains('ACTIVE', $labels);
-        self::assertContains('INACTIVE', $labels);
+        self::assertContains('NAME', $labels);
     }
 
     public function testStaticCompletionResolvesImportedClassName(): void

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2543,33 +2543,9 @@ PHP;
 
     public function testChainCompletionNullsafePropertyChain(): void
     {
-        $code = <<<'PHP'
-<?php
-class User {
-    public function getName(): string { return ''; }
-}
+        $cursor = $this->openFixtureAtCursor('src/Completion/ChainCompletion.php', 'nullsafe_property_chain');
 
-class Service {
-    private ?User $user;
-
-    public function test(): void {
-        $this->user?->
-    }
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 9, 'character' => 22],
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1420,50 +1420,17 @@ PHP;
 
     public function testTypedVariableCompletionFromParameter(): void
     {
-        $code = <<<'PHP'
-<?php
-class User
-{
-    public string $name;
-    public function getName(): string { return $this->name; }
-    public function setName(string $name): void { $this->name = $name; }
-}
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'param_access');
 
-function processUser(User $user): void
-{
-    $user->
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $handler = new CompletionHandler(
-            $this->documents,
-            $this->parser,
-            $this->symbolIndex,
-            $this->memberResolver,
-            $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 10, 'character' => 11], // After $user->
-            ],
-        ]);
-
-        $result = $handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);
         $labels = array_column($result['items'], 'label');
-        self::assertContains('name', $labels);
+        // Same class access - all members visible
         self::assertContains('getName', $labels);
         self::assertContains('setName', $labels);
+        self::assertContains('active', $labels);
     }
 
     public function testTypedVariableCompletionFromNewExpression(): void

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2632,37 +2632,16 @@ PHP;
 
     public function testSameClassVisibilityShowsPrivateMembers(): void
     {
-        $code = <<<'PHP'
-<?php
-class Foo {
-    private function secret(): void {}
-    protected function hidden(): void {}
-    public function visible(): void {}
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'param_access');
 
-    public function test(Foo $other): void {
-        $other->
-    }
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 7, 'character' => 16],
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);
         $labels = array_column($result['items'], 'label');
-        self::assertContains('secret', $labels);
-        self::assertContains('hidden', $labels);
-        self::assertContains('visible', $labels);
+        // Same-class access shows all visibility levels
+        self::assertContains('secretMethod', $labels);
+        self::assertContains('hiddenMethod', $labels);
+        self::assertContains('getName', $labels);
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2368,33 +2368,9 @@ PHP;
 
     public function testChainCompletionPropertyChain(): void
     {
-        $code = <<<'PHP'
-<?php
-class User {
-    public function getName(): string { return ''; }
-}
+        $cursor = $this->openFixtureAtCursor('src/Completion/ChainCompletion.php', 'property_chain');
 
-class Service {
-    private User $user;
-
-    public function test(): void {
-        $this->user->
-    }
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 9, 'character' => 21],
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);
@@ -2404,33 +2380,9 @@ PHP;
 
     public function testChainCompletionMethodChain(): void
     {
-        $code = <<<'PHP'
-<?php
-class User {
-    public function getName(): string { return ''; }
-}
+        $cursor = $this->openFixtureAtCursor('src/Completion/ChainCompletion.php', 'method_chain');
 
-class Service {
-    public function getUser(): User { return new User(); }
-
-    public function test(): void {
-        $this->getUser()->
-    }
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 9, 'character' => 26],
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1717,58 +1717,19 @@ PHP;
 
     public function testTypedVariableCompletionExcludesNonPublicMembers(): void
     {
-        $code = <<<'PHP'
-<?php
-class User
-{
-    public string $name;
-    protected string $email;
-    private string $password;
+        $cursor = $this->openFixtureAtCursor('src/Completion/ExternalAccess.php', 'external_method_access');
 
-    public function getName(): string { return $this->name; }
-    protected function getEmail(): string { return $this->email; }
-    private function getPassword(): string { return $this->password; }
-}
-
-function foo(User $user): void
-{
-    $user->
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $handler = new CompletionHandler(
-            $this->documents,
-            $this->parser,
-            $this->symbolIndex,
-            $this->memberResolver,
-            $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 14, 'character' => 11], // After $user->
-            ],
-        ]);
-
-        $result = $handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         $labels = array_column($result['items'], 'label');
         // Public members should be included
-        self::assertContains('name', $labels);
+        self::assertContains('active', $labels);
         self::assertContains('getName', $labels);
-        // Protected and private members should be excluded
-        self::assertNotContains('email', $labels);
-        self::assertNotContains('password', $labels);
-        self::assertNotContains('getEmail', $labels);
-        self::assertNotContains('getPassword', $labels);
+        self::assertContains('getCount', $labels);
+        // Protected and private properties should be excluded
+        self::assertNotContains('name', $labels);
+        self::assertNotContains('count', $labels);
     }
 
     public function testSelfConstantCompletion(): void


### PR DESCRIPTION
## Summary
- Migrate 6 inline PHP tests to use fixtures
- Add `ExternalAccess.php` fixture for external visibility testing
- Add `ChainCompletion.php` fixture for method/property chain completion
- Add private/protected methods to `MethodAccess.php` for same-class visibility testing

Reduced inline PHP blocks from 34 to 29.

Relates to #225

## Test plan
- All tests pass
- PHPStan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)