### PR TITLE
Migrate CompletionHandlerTest to fixtures (batch 4)

### DIFF
--- a/tests/Fixtures/src/Mixed/ProceduralWithClass.php
+++ b/tests/Fixtures/src/Mixed/ProceduralWithClass.php
@@ -64,3 +64,8 @@ function triggerDynamicStatic(): void
     $class = 'DateTime';
     $class::/*|dynamic_static*/
 }
+
+function triggerSelfOutsideClass(): void
+{
+    self::/*|self_outside_class*/
+}

--- a/tests/Fixtures/src/Mixed/ProceduralWithClass.php
+++ b/tests/Fixtures/src/Mixed/ProceduralWithClass.php
@@ -69,3 +69,8 @@ function triggerSelfOutsideClass(): void
 {
     self::/*|self_outside_class*/
 }
+
+function triggerThisOutsideClass(): void
+{
+    $this->/*|this_outside_class*/
+}

--- a/tests/Fixtures/src/Mixed/ProceduralWithClass.php
+++ b/tests/Fixtures/src/Mixed/ProceduralWithClass.php
@@ -36,3 +36,20 @@ function triggerStaticAccess(): void
 {
     StaticAccess::/*|standalone_static_access*/
 }
+
+function triggerVarFromStaticCall(): void
+{
+    $obj = StaticAccess::create();
+    $obj->/*|var_from_static_call*/
+}
+
+function triggerVarFromStaticCallNullsafe(): void
+{
+    $obj = StaticAccess::create();
+    $obj?->/*|var_from_static_call_nullsafe*/
+}
+
+function triggerUnknownVar(): void
+{
+    $unknown->/*|unknown_var*/
+}

--- a/tests/Fixtures/src/Mixed/ProceduralWithClass.php
+++ b/tests/Fixtures/src/Mixed/ProceduralWithClass.php
@@ -53,3 +53,14 @@ function triggerUnknownVar(): void
 {
     $unknown->/*|unknown_var*/
 }
+
+function triggerDynamicVar(): void
+{
+    $$dynamic->/*|dynamic_var*/
+}
+
+function triggerDynamicStatic(): void
+{
+    $class = 'DateTime';
+    $class::/*|dynamic_static*/
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1500,36 +1500,9 @@ PHP;
 
     public function testDynamicVariableNameReturnsEmpty(): void
     {
-        $code = <<<'PHP'
-<?php
-function foo(): void
-{
-    $$dynamic->
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'dynamic_var');
 
-        $handler = new CompletionHandler(
-            $this->documents,
-            $this->parser,
-            $this->symbolIndex,
-            $this->memberResolver,
-            $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 3, 'character' => 15], // After $$dynamic->
-            ],
-        ]);
-
-        $result = $handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertEmpty($result['items']);
@@ -1537,37 +1510,9 @@ PHP;
 
     public function testDynamicStaticAccessReturnsEmpty(): void
     {
-        $code = <<<'PHP'
-<?php
-function foo(): void
-{
-    $class = 'DateTime';
-    $class::
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'dynamic_static');
 
-        $handler = new CompletionHandler(
-            $this->documents,
-            $this->parser,
-            $this->symbolIndex,
-            $this->memberResolver,
-            $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 4, 'character' => 12], // After $class::
-            ],
-        ]);
-
-        $result = $handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertEmpty($result['items']);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1765,26 +1765,9 @@ PHP;
 
     public function testSelfCompletionOutsideClassReturnsEmpty(): void
     {
-        $code = <<<'PHP'
-<?php
-function foo(): void
-{
-    self::
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'self_outside_class');
 
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 3, 'character' => 10], // After self::
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1937,23 +1937,9 @@ PHP;
 
     public function testThisCompletionOutsideClassReturnsEmpty(): void
     {
-        $code = <<<'PHP'
-<?php
-$this->
-PHP;
-        $this->openDocument('file:///test.php', $code);
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'this_outside_class');
 
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 1, 'character' => 7],
-            ],
-        ]);
-
-        $result = $this->handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertEmpty($result['items']);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1460,140 +1460,39 @@ PHP;
 
     public function testTypedVariableCompletionFromStaticMethodReturningSelf(): void
     {
-        $code = <<<'PHP'
-<?php
-class SomeClass
-{
-    public static function create(): ?self
-    {
-        return new self();
-    }
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'var_from_static_call');
 
-    public function doSomething(): void {}
-}
-
-function test(): void
-{
-    $foo = SomeClass::create();
-    $foo->
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $handler = new CompletionHandler(
-            $this->documents,
-            $this->parser,
-            $this->symbolIndex,
-            $this->memberResolver,
-            $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 14, 'character' => 10], // After $foo->
-            ],
-        ]);
-
-        $result = $handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);
         $labels = array_column($result['items'], 'label');
         // Static method 'create' should not appear in instance completions
         self::assertNotContains('create', $labels);
-        self::assertContains('doSomething', $labels);
+        // Instance methods should appear
+        self::assertContains('triggerSelfEmpty', $labels);
     }
 
     public function testTypedVariableCompletionFromStaticMethodReturningSelfNullsafe(): void
     {
-        $code = <<<'PHP'
-<?php
-class SomeClass
-{
-    public static function create(): ?self
-    {
-        return new self();
-    }
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'var_from_static_call_nullsafe');
 
-    public function doSomething(): void {}
-}
-
-function test(): void
-{
-    $foo = SomeClass::create();
-    $foo?->
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
-
-        $handler = new CompletionHandler(
-            $this->documents,
-            $this->parser,
-            $this->symbolIndex,
-            $this->memberResolver,
-            $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 14, 'character' => 11], // After $foo?->
-            ],
-        ]);
-
-        $result = $handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertArrayHasKey('items', $result);
         $labels = array_column($result['items'], 'label');
         // Static method 'create' should not appear in instance completions
         self::assertNotContains('create', $labels);
-        self::assertContains('doSomething', $labels);
+        // Instance methods should appear
+        self::assertContains('triggerSelfEmpty', $labels);
     }
 
     public function testTypedVariableCompletionReturnsEmptyWhenTypeUnknown(): void
     {
-        $code = <<<'PHP'
-<?php
-function foo(): void
-{
-    $unknown->
-}
-PHP;
-        $this->openDocument('file:///test.php', $code);
+        $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'unknown_var');
 
-        $handler = new CompletionHandler(
-            $this->documents,
-            $this->parser,
-            $this->symbolIndex,
-            $this->memberResolver,
-            $this->classRepository,
-            new BasicTypeResolver($this->memberResolver),
-            new MemberAccessResolver(new BasicTypeResolver($this->memberResolver)),
-        );
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => 'file:///test.php'],
-                'position' => ['line' => 3, 'character' => 14], // After $unknown->
-            ],
-        ]);
-
-        $result = $handler->handle($request);
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
         self::assertEmpty($result['items']);


### PR DESCRIPTION
## Summary
- Migrate 7 inline PHP tests to use fixtures
- Add markers to `ProceduralWithClass.php` for edge case tests:
  - `var_from_static_call` / `var_from_static_call_nullsafe` - variable from static method return
  - `unknown_var` - unknown variable completion
  - `dynamic_var` / `dynamic_static` - dynamic variable/static access
  - `self_outside_class` / `this_outside_class` - keywords outside class context

Reduced inline PHP blocks from 29 to 22.

Relates to #225

## Test plan
- All tests pass
- PHPStan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)