### PR TITLE
Fix method chaining after self::/static:: calls

### DIFF
--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -87,7 +87,10 @@ final class BasicTypeResolver implements TypeResolverInterface
         // Static method call: ClassName::method()
         if ($expr instanceof Expr\StaticCall) {
             if ($expr->class instanceof Node\Name && $expr->name instanceof Node\Identifier) {
-                $className = $expr->class->toString();
+                $className = ScopeFinder::resolveClassNameInContext($expr->class, $expr);
+                if ($className === null) {
+                    return null;
+                }
                 return $this->getMethodReturnType($className, $expr->name->toString());
             }
             return null;

--- a/tests/Fixtures/src/Completion/StaticAccess.php
+++ b/tests/Fixtures/src/Completion/StaticAccess.php
@@ -48,4 +48,24 @@ class StaticAccess
     {
         static::/*|static_keyword*/
     }
+
+    public function getInstanceProp(): string
+    {
+        return $this->instanceProp;
+    }
+
+    public function triggerSelfChain(): void
+    {
+        self::getInstance()->/*|self_chain*/
+    }
+
+    public function triggerStaticChain(): void
+    {
+        static::create()->/*|static_chain*/
+    }
+
+    public function triggerSelfChainPrefix(): void
+    {
+        self::getInstance()->get/*|self_chain_prefix*/
+    }
 }

--- a/tests/Fixtures/src/TypeInference/NewKeywords.php
+++ b/tests/Fixtures/src/TypeInference/NewKeywords.php
@@ -22,4 +22,24 @@ class NewKeywords extends ParentClass
     {
         return new parent();
     }
+
+    public static function getInstance(): self
+    {
+        return new self();
+    }
+
+    public function callSelfStaticMethod(): self
+    {
+        return self::getInstance();
+    }
+
+    public function callStaticStaticMethod(): static
+    {
+        return static::createStatic();
+    }
+
+    public function callParentStaticMethod(): void
+    {
+        parent::staticMethod();
+    }
 }

--- a/tests/Fixtures/src/TypeInference/ParentWithoutExtends.php
+++ b/tests/Fixtures/src/TypeInference/ParentWithoutExtends.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference;
+
+class ParentWithoutExtends
+{
+    public function callParentMethod(): void
+    {
+        $x = parent::method();
+    }
+}

--- a/tests/Fixtures/src/TypeInference/StaticCallOutsideClass.php
+++ b/tests/Fixtures/src/TypeInference/StaticCallOutsideClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference;
+
+function callSelfOutsideClass(): void
+{
+    $x = self::method();
+}
+
+function callParentOutsideClass(): void
+{
+    $x = parent::method();
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1990,4 +1990,43 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('hiddenMethod', $labels);
         self::assertContains('getName', $labels);
     }
+
+    public function testChainCompletionAfterSelfStaticCall(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticAccess.php', 'self_chain');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getInstanceProp', $labels);
+        self::assertContains('instanceProp', $labels);
+    }
+
+    public function testChainCompletionAfterStaticStaticCall(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticAccess.php', 'static_chain');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getInstanceProp', $labels);
+        self::assertContains('instanceProp', $labels);
+    }
+
+    public function testChainCompletionAfterSelfStaticCallWithPrefix(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticAccess.php', 'self_chain_prefix');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getInstanceProp', $labels);
+        self::assertNotContains('instanceProp', $labels);
+    }
 }

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -930,4 +930,71 @@ PHP;
 
         self::assertNull($type);
     }
+
+    public function testResolveSelfStaticCall(): void
+    {
+        $resolver = $this->createResolverWithFixtures();
+        $ast = $this->parseFixture('src/TypeInference/NewKeywords.php');
+        $method = $this->findMethodByName($ast, 'callSelfStaticMethod');
+        $finder = new \PhpParser\NodeFinder();
+        $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
+        assert($staticCall !== null);
+
+        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
+    }
+
+    public function testResolveStaticStaticCall(): void
+    {
+        $resolver = $this->createResolverWithFixtures();
+        $ast = $this->parseFixture('src/TypeInference/NewKeywords.php');
+        $method = $this->findMethodByName($ast, 'callStaticStaticMethod');
+        $finder = new \PhpParser\NodeFinder();
+        $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
+        assert($staticCall !== null);
+
+        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
+    }
+
+    public function testResolveSelfStaticCallOutsideClassReturnsNull(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/StaticCallOutsideClass.php');
+        $func = $this->findFunctionByName($ast, 'callSelfOutsideClass');
+        $finder = new \PhpParser\NodeFinder();
+        $staticCall = $finder->findFirstInstanceOf($func, Expr\StaticCall::class);
+        assert($staticCall !== null);
+
+        $type = $this->resolver->resolveExpressionType($staticCall, $func, $ast);
+
+        self::assertNull($type);
+    }
+
+    public function testResolveParentStaticCallWithoutExtendsReturnsNull(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/ParentWithoutExtends.php');
+        $method = $this->findMethodByName($ast, 'callParentMethod');
+        $finder = new \PhpParser\NodeFinder();
+        $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
+        assert($staticCall !== null);
+
+        $type = $this->resolver->resolveExpressionType($staticCall, $method, $ast);
+
+        self::assertNull($type);
+    }
+
+    private function createResolverWithFixtures(): BasicTypeResolver
+    {
+        $classInfoFactory = new DefaultClassInfoFactory();
+        $locator = new \Firehed\PhpLsp\Index\ComposerClassLocator(__DIR__ . '/../Fixtures');
+        $parser = new ParserService();
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+        $memberResolver = new MemberResolver($classRepository);
+
+        return new BasicTypeResolver($memberResolver);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix type resolution for method chaining after `self::method()` or `static::method()` calls
- `BasicTypeResolver` was passing literal `"self"`/`"static"` to method lookup instead of resolving to actual class name
- Use `ScopeFinder::resolveClassNameInContext` to properly resolve special class names

## Test plan
- Added tests for `self::getInstance()->method()` chaining
- Added tests for `static::create()->method()` chaining
- Added tests for prefix filtering on chained calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)