### PR TITLE
Fix trait static return type resolution

### DIFF
--- a/src/Domain/ClassName.php
+++ b/src/Domain/ClassName.php
@@ -61,7 +61,7 @@ final readonly class ClassName implements Type
         return strcasecmp($this->fqn, $other->fqn) === 0;
     }
 
-    public function resolveLateBound(string $callingClass): Type
+    public function resolveLateBound(string $callingClass, bool $declaringClassIsTrait = false): Type
     {
         return $this;
     }

--- a/src/Domain/ClassName.php
+++ b/src/Domain/ClassName.php
@@ -60,4 +60,9 @@ final readonly class ClassName implements Type
     {
         return strcasecmp($this->fqn, $other->fqn) === 0;
     }
+
+    public function resolveLateBound(string $callingClass): Type
+    {
+        return $this;
+    }
 }

--- a/src/Domain/IntersectionType.php
+++ b/src/Domain/IntersectionType.php
@@ -14,14 +14,6 @@ final readonly class IntersectionType implements Type
     ) {
     }
 
-    /**
-     * @return list<Type>
-     */
-    public function getMembers(): array
-    {
-        return $this->members;
-    }
-
     public function format(): string
     {
         $parts = array_map(

--- a/src/Domain/IntersectionType.php
+++ b/src/Domain/IntersectionType.php
@@ -37,10 +37,10 @@ final readonly class IntersectionType implements Type
         return false;
     }
 
-    public function resolveLateBound(string $callingClass): Type
+    public function resolveLateBound(string $callingClass, bool $declaringClassIsTrait = false): Type
     {
         $resolved = array_map(
-            fn (Type $member) => $member->resolveLateBound($callingClass),
+            fn (Type $member) => $member->resolveLateBound($callingClass, $declaringClassIsTrait),
             $this->members,
         );
         return new self($resolved);

--- a/src/Domain/IntersectionType.php
+++ b/src/Domain/IntersectionType.php
@@ -14,6 +14,14 @@ final readonly class IntersectionType implements Type
     ) {
     }
 
+    /**
+     * @return list<Type>
+     */
+    public function getMembers(): array
+    {
+        return $this->members;
+    }
+
     public function format(): string
     {
         $parts = array_map(

--- a/src/Domain/IntersectionType.php
+++ b/src/Domain/IntersectionType.php
@@ -44,4 +44,13 @@ final readonly class IntersectionType implements Type
     {
         return false;
     }
+
+    public function resolveLateBound(string $callingClass): Type
+    {
+        $resolved = array_map(
+            fn (Type $member) => $member->resolveLateBound($callingClass),
+            $this->members,
+        );
+        return new self($resolved);
+    }
 }

--- a/src/Domain/LateBindingKeyword.php
+++ b/src/Domain/LateBindingKeyword.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+enum LateBindingKeyword: string
+{
+    case Self = 'self';
+    case Static = 'static';
+    case Parent = 'parent';
+}

--- a/src/Domain/LateStaticType.php
+++ b/src/Domain/LateStaticType.php
@@ -31,15 +31,11 @@ final class LateStaticType implements Type
         return false;
     }
 
-    /**
-     * @param class-string $callingClass The class from which the method was called
-     * @param class-string|null $callingParent The parent of the calling class (for parent::)
-     */
-    public function resolve(string $callingClass, ?string $callingParent = null): ClassName
+    public function resolveLateBound(string $callingClass): Type
     {
         return match ($this->keyword) {
             LateBindingKeyword::Self, LateBindingKeyword::Static => new ClassName($callingClass),
-            LateBindingKeyword::Parent => new ClassName($callingParent ?? $this->declaringClass->fqn),
+            LateBindingKeyword::Parent => new ClassName($this->declaringClass->fqn),
         };
     }
 }

--- a/src/Domain/LateStaticType.php
+++ b/src/Domain/LateStaticType.php
@@ -8,14 +8,14 @@ namespace Firehed\PhpLsp\Domain;
 final class LateStaticType implements Type
 {
     public function __construct(
-        public readonly string $keyword,
+        public readonly LateBindingKeyword $keyword,
         public readonly ClassName $declaringClass,
     ) {
     }
 
     public function format(): string
     {
-        return $this->keyword;
+        return $this->keyword->value;
     }
 
     /**
@@ -37,14 +37,9 @@ final class LateStaticType implements Type
      */
     public function resolve(string $callingClass, ?string $callingParent = null): ClassName
     {
-        // Both `self` and `static` resolve to callingClass. This is correct for traits (where
-        // self binds to the using class) and pragmatic for inheritance (avoids tracking origin).
         return match ($this->keyword) {
-            'self', 'static' => new ClassName($callingClass),
-            'parent' => new ClassName($callingParent ?? $this->declaringClass->fqn),
-            // @codeCoverageIgnoreStart
-            default => throw new \LogicException("Invalid late-binding keyword: {$this->keyword}"),
-            // @codeCoverageIgnoreEnd
+            LateBindingKeyword::Self, LateBindingKeyword::Static => new ClassName($callingClass),
+            LateBindingKeyword::Parent => new ClassName($callingParent ?? $this->declaringClass->fqn),
         };
     }
 }

--- a/src/Domain/LateStaticType.php
+++ b/src/Domain/LateStaticType.php
@@ -4,13 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
-/**
- * Represents a late-static-binding type (static, self, or parent).
- *
- * These types are not resolved at parse time because they depend on the
- * calling context. For example, a trait method returning `static` should
- * resolve to the class using the trait, not the trait itself.
- */
+/** Represents a late-static-binding type (static, self, or parent). */
 final class LateStaticType implements Type
 {
     public function __construct(
@@ -38,16 +32,19 @@ final class LateStaticType implements Type
     }
 
     /**
-     * Resolve this late-binding type to an actual class name.
-     *
      * @param class-string $callingClass The class from which the method was called
      * @param class-string|null $callingParent The parent of the calling class (for parent::)
      */
     public function resolve(string $callingClass, ?string $callingParent = null): ClassName
     {
+        // Both `self` and `static` resolve to callingClass. This is correct for traits (where
+        // self binds to the using class) and pragmatic for inheritance (avoids tracking origin).
         return match ($this->keyword) {
+            'self', 'static' => new ClassName($callingClass),
             'parent' => new ClassName($callingParent ?? $this->declaringClass->fqn),
-            default => new ClassName($callingClass),
+            // @codeCoverageIgnoreStart
+            default => throw new \LogicException("Invalid late-binding keyword: {$this->keyword}"),
+            // @codeCoverageIgnoreEnd
         };
     }
 }

--- a/src/Domain/LateStaticType.php
+++ b/src/Domain/LateStaticType.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Represents a late-static-binding type (static, self, or parent).
+ *
+ * These types are not resolved at parse time because they depend on the
+ * calling context. For example, a trait method returning `static` should
+ * resolve to the class using the trait, not the trait itself.
+ */
+final class LateStaticType implements Type
+{
+    public function __construct(
+        public readonly string $keyword,
+        public readonly ClassName $declaringClass,
+    ) {
+    }
+
+    public function format(): string
+    {
+        return $this->keyword;
+    }
+
+    /**
+     * @return list<ClassName>
+     */
+    public function getResolvableClassNames(): array
+    {
+        return [$this->declaringClass];
+    }
+
+    public function isNullable(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Resolve this late-binding type to an actual class name.
+     *
+     * @param class-string $callingClass The class from which the method was called
+     * @param class-string|null $callingParent The parent of the calling class (for parent::)
+     */
+    public function resolve(string $callingClass, ?string $callingParent = null): ClassName
+    {
+        return match ($this->keyword) {
+            'parent' => new ClassName($callingParent ?? $this->declaringClass->fqn),
+            default => new ClassName($callingClass),
+        };
+    }
+}

--- a/src/Domain/LateStaticType.php
+++ b/src/Domain/LateStaticType.php
@@ -31,11 +31,14 @@ final class LateStaticType implements Type
         return false;
     }
 
-    public function resolveLateBound(string $callingClass): Type
+    public function resolveLateBound(string $callingClass, bool $declaringClassIsTrait = false): Type
     {
         return match ($this->keyword) {
-            LateBindingKeyword::Self, LateBindingKeyword::Static => new ClassName($callingClass),
-            LateBindingKeyword::Parent => new ClassName($this->declaringClass->fqn),
+            LateBindingKeyword::Self => $declaringClassIsTrait
+                ? new ClassName($callingClass)
+                : $this->declaringClass,
+            LateBindingKeyword::Static => new ClassName($callingClass),
+            LateBindingKeyword::Parent => $this->declaringClass,
         };
     }
 }

--- a/src/Domain/PrimitiveType.php
+++ b/src/Domain/PrimitiveType.php
@@ -33,4 +33,9 @@ final readonly class PrimitiveType implements Type
     {
         return $this->name === 'null';
     }
+
+    public function resolveLateBound(string $callingClass): Type
+    {
+        return $this;
+    }
 }

--- a/src/Domain/PrimitiveType.php
+++ b/src/Domain/PrimitiveType.php
@@ -34,7 +34,7 @@ final readonly class PrimitiveType implements Type
         return $this->name === 'null';
     }
 
-    public function resolveLateBound(string $callingClass): Type
+    public function resolveLateBound(string $callingClass, bool $declaringClassIsTrait = false): Type
     {
         return $this;
     }

--- a/src/Domain/Type.php
+++ b/src/Domain/Type.php
@@ -12,4 +12,11 @@ interface Type extends Formattable
     public function getResolvableClassNames(): array;
 
     public function isNullable(): bool;
+
+    /**
+     * Resolve late-bound types (static/self/parent) to concrete types.
+     *
+     * @param class-string $callingClass
+     */
+    public function resolveLateBound(string $callingClass): Type;
 }

--- a/src/Domain/Type.php
+++ b/src/Domain/Type.php
@@ -16,7 +16,13 @@ interface Type extends Formattable
     /**
      * Resolve late-bound types (static/self/parent) to concrete types.
      *
-     * @param class-string $callingClass
+     * In PHP, `self` in traits resolves to the class using the trait, not the
+     * trait itself. This differs from `self` in regular classes, which resolves
+     * to the declaring class. The `$declaringClassIsTrait` parameter allows
+     * callers to distinguish these cases at resolution time.
+     *
+     * @param class-string $callingClass The class the method was called on
+     * @param bool $declaringClassIsTrait Whether the method was declared in a trait
      */
-    public function resolveLateBound(string $callingClass): Type;
+    public function resolveLateBound(string $callingClass, bool $declaringClassIsTrait = false): Type;
 }

--- a/src/Domain/UnionType.php
+++ b/src/Domain/UnionType.php
@@ -14,14 +14,6 @@ final readonly class UnionType implements Type
     ) {
     }
 
-    /**
-     * @return list<Type>
-     */
-    public function getMembers(): array
-    {
-        return $this->members;
-    }
-
     public function format(): string
     {
         // Format 2-member nullable unions as ?T instead of T|null

--- a/src/Domain/UnionType.php
+++ b/src/Domain/UnionType.php
@@ -53,10 +53,10 @@ final readonly class UnionType implements Type
         return false;
     }
 
-    public function resolveLateBound(string $callingClass): Type
+    public function resolveLateBound(string $callingClass, bool $declaringClassIsTrait = false): Type
     {
         $resolved = array_map(
-            fn (Type $member) => $member->resolveLateBound($callingClass),
+            fn (Type $member) => $member->resolveLateBound($callingClass, $declaringClassIsTrait),
             $this->members,
         );
         return new self($resolved);

--- a/src/Domain/UnionType.php
+++ b/src/Domain/UnionType.php
@@ -14,6 +14,14 @@ final readonly class UnionType implements Type
     ) {
     }
 
+    /**
+     * @return list<Type>
+     */
+    public function getMembers(): array
+    {
+        return $this->members;
+    }
+
     public function format(): string
     {
         // Format 2-member nullable unions as ?T instead of T|null

--- a/src/Domain/UnionType.php
+++ b/src/Domain/UnionType.php
@@ -60,4 +60,13 @@ final readonly class UnionType implements Type
         }
         return false;
     }
+
+    public function resolveLateBound(string $callingClass): Type
+    {
+        $resolved = array_map(
+            fn (Type $member) => $member->resolveLateBound($callingClass),
+            $this->members,
+        );
+        return new self($resolved);
+    }
 }

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -210,6 +210,7 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
                     $stmt->returnType,
                     $className->fqn,
                     $parentClass?->fqn,
+                    preserveLateBinding: true,
                 ),
                 docblock: $stmt->getDocComment()?->getText(),
                 file: $filePath,

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Repository;
 
 use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantInfo;
 use Firehed\PhpLsp\Domain\ConstantName;
@@ -72,6 +73,11 @@ final class MemberResolver
     {
         $classInfo = $this->classes->get($class);
         return $classInfo?->enumCases[$case->name] ?? null;
+    }
+
+    public function isTraitClass(ClassName $class): bool
+    {
+        return $this->classes->get($class)?->kind === ClassKind::Trait_;
     }
 
     /**

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\TypeInference;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\IntersectionType;
 use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\UnionType;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -255,13 +257,59 @@ final class BasicTypeResolver implements TypeResolverInterface
         );
 
         $returnType = $methodInfo?->returnType;
-
-        // Resolve late-binding types (static, self, parent) to the calling class
-        if ($returnType instanceof LateStaticType) {
-            return $returnType->resolve($className);
+        if ($returnType === null) {
+            return null;
         }
 
-        return $returnType;
+        return $this->resolveLateBoundType($returnType, $className);
+    }
+
+    /**
+     * Recursively resolve LateStaticType within composite types (UnionType, IntersectionType).
+     *
+     * @param class-string $callingClass
+     */
+    private function resolveLateBoundType(Type $type, string $callingClass): Type
+    {
+        if ($type instanceof LateStaticType) {
+            return $type->resolve($callingClass);
+        }
+
+        if ($type instanceof UnionType) {
+            return $this->resolveUnionMembers($type, $callingClass);
+        }
+
+        if ($type instanceof IntersectionType) {
+            return $this->resolveIntersectionMembers($type, $callingClass);
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param class-string $callingClass
+     */
+    private function resolveUnionMembers(UnionType $type, string $callingClass): UnionType
+    {
+        $resolved = array_map(
+            fn (Type $member) => $this->resolveLateBoundType($member, $callingClass),
+            $type->getMembers(),
+        );
+
+        return new UnionType($resolved);
+    }
+
+    /**
+     * @param class-string $callingClass
+     */
+    private function resolveIntersectionMembers(IntersectionType $type, string $callingClass): IntersectionType
+    {
+        $resolved = array_map(
+            fn (Type $member) => $this->resolveLateBoundType($member, $callingClass),
+            $type->getMembers(),
+        );
+
+        return new IntersectionType($resolved);
     }
 
     private function getPropertyType(string $className, string $propertyName): ?Type

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\TypeInference;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
@@ -253,7 +254,14 @@ final class BasicTypeResolver implements TypeResolverInterface
             Visibility::Private,
         );
 
-        return $methodInfo?->returnType;
+        $returnType = $methodInfo?->returnType;
+
+        // Resolve late-binding types (static, self, parent) to the calling class
+        if ($returnType instanceof LateStaticType) {
+            return $returnType->resolve($className);
+        }
+
+        return $returnType;
     }
 
     private function getPropertyType(string $className, string $propertyName): ?Type

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -253,7 +253,13 @@ final class BasicTypeResolver implements TypeResolverInterface
             Visibility::Private,
         );
 
-        return $methodInfo?->returnType?->resolveLateBound($className);
+        if ($methodInfo === null) {
+            return null;
+        }
+
+        $isFromTrait = $this->memberResolver->isTraitClass($methodInfo->declaringClass);
+
+        return $methodInfo->returnType?->resolveLateBound($className, $isFromTrait);
     }
 
     private function getPropertyType(string $className, string $propertyName): ?Type

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\TypeInference;
 
 use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\IntersectionType;
-use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
-use Firehed\PhpLsp\Domain\UnionType;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -256,60 +253,7 @@ final class BasicTypeResolver implements TypeResolverInterface
             Visibility::Private,
         );
 
-        $returnType = $methodInfo?->returnType;
-        if ($returnType === null) {
-            return null;
-        }
-
-        return $this->resolveLateBoundType($returnType, $className);
-    }
-
-    /**
-     * Recursively resolve LateStaticType within composite types (UnionType, IntersectionType).
-     *
-     * @param class-string $callingClass
-     */
-    private function resolveLateBoundType(Type $type, string $callingClass): Type
-    {
-        if ($type instanceof LateStaticType) {
-            return $type->resolve($callingClass);
-        }
-
-        if ($type instanceof UnionType) {
-            return $this->resolveUnionMembers($type, $callingClass);
-        }
-
-        if ($type instanceof IntersectionType) {
-            return $this->resolveIntersectionMembers($type, $callingClass);
-        }
-
-        return $type;
-    }
-
-    /**
-     * @param class-string $callingClass
-     */
-    private function resolveUnionMembers(UnionType $type, string $callingClass): UnionType
-    {
-        $resolved = array_map(
-            fn (Type $member) => $this->resolveLateBoundType($member, $callingClass),
-            $type->getMembers(),
-        );
-
-        return new UnionType($resolved);
-    }
-
-    /**
-     * @param class-string $callingClass
-     */
-    private function resolveIntersectionMembers(IntersectionType $type, string $callingClass): IntersectionType
-    {
-        $resolved = array_map(
-            fn (Type $member) => $this->resolveLateBoundType($member, $callingClass),
-            $type->getMembers(),
-        );
-
-        return new IntersectionType($resolved);
+        return $methodInfo?->returnType?->resolveLateBound($className);
     }
 
     private function getPropertyType(string $className, string $propertyName): ?Type

--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\IntersectionType;
+use Firehed\PhpLsp\Domain\LateBindingKeyword;
 use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\Type;
@@ -59,7 +60,7 @@ final class TypeFactory
             if ($name === 'self' || $name === 'static') {
                 if ($selfContext !== null) {
                     if ($preserveLateBinding) {
-                        return new LateStaticType($name, new ClassName($selfContext));
+                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($selfContext));
                     }
                     return new ClassName($selfContext);
                 }
@@ -69,7 +70,7 @@ final class TypeFactory
             if ($name === 'parent') {
                 if ($parentContext !== null) {
                     if ($preserveLateBinding) {
-                        return new LateStaticType($name, new ClassName($parentContext));
+                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($parentContext));
                     }
                     return new ClassName($parentContext);
                 }
@@ -90,7 +91,7 @@ final class TypeFactory
             if ($name === 'self' || $name === 'static') {
                 if ($selfContext !== null) {
                     if ($preserveLateBinding) {
-                        return new LateStaticType($name, new ClassName($selfContext));
+                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($selfContext));
                     }
                     return new ClassName($selfContext);
                 }
@@ -100,7 +101,7 @@ final class TypeFactory
             if ($name === 'parent') {
                 if ($parentContext !== null) {
                     if ($preserveLateBinding) {
-                        return new LateStaticType($name, new ClassName($parentContext));
+                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($parentContext));
                     }
                     return new ClassName($parentContext);
                 }

--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\IntersectionType;
+use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\UnionType;
@@ -40,11 +41,13 @@ final class TypeFactory
     /**
      * @param class-string|null $selfContext
      * @param class-string|null $parentContext
+     * @param bool $preserveLateBinding If true, returns LateStaticType for static/self/parent
      */
     public static function fromNode(
         ?Node $node,
         ?string $selfContext = null,
         ?string $parentContext = null,
+        bool $preserveLateBinding = false,
     ): ?Type {
         if ($node === null) {
             return null;
@@ -55,6 +58,9 @@ final class TypeFactory
 
             if ($name === 'self' || $name === 'static') {
                 if ($selfContext !== null) {
+                    if ($preserveLateBinding) {
+                        return new LateStaticType($name, new ClassName($selfContext));
+                    }
                     return new ClassName($selfContext);
                 }
                 return new PrimitiveType($name);
@@ -62,6 +68,9 @@ final class TypeFactory
 
             if ($name === 'parent') {
                 if ($parentContext !== null) {
+                    if ($preserveLateBinding) {
+                        return new LateStaticType($name, new ClassName($parentContext));
+                    }
                     return new ClassName($parentContext);
                 }
                 return new PrimitiveType($name);
@@ -80,6 +89,9 @@ final class TypeFactory
 
             if ($name === 'self' || $name === 'static') {
                 if ($selfContext !== null) {
+                    if ($preserveLateBinding) {
+                        return new LateStaticType($name, new ClassName($selfContext));
+                    }
                     return new ClassName($selfContext);
                 }
                 return new PrimitiveType($name);
@@ -87,6 +99,9 @@ final class TypeFactory
 
             if ($name === 'parent') {
                 if ($parentContext !== null) {
+                    if ($preserveLateBinding) {
+                        return new LateStaticType($name, new ClassName($parentContext));
+                    }
                     return new ClassName($parentContext);
                 }
                 return new PrimitiveType($name);
@@ -102,7 +117,7 @@ final class TypeFactory
         }
 
         if ($node instanceof Node\NullableType) {
-            $inner = self::fromNode($node->type, $selfContext, $parentContext);
+            $inner = self::fromNode($node->type, $selfContext, $parentContext, $preserveLateBinding);
             // @codeCoverageIgnoreStart
             if ($inner === null) {
                 throw new LogicException('NullableType inner type resolved to null');
@@ -112,16 +127,14 @@ final class TypeFactory
         }
 
         if ($node instanceof Node\UnionType) {
-            $members = array_values(array_filter(
-                array_map(fn (Node $n) => self::fromNode($n, $selfContext, $parentContext), $node->types),
-            ));
+            $mapper = fn (Node $n) => self::fromNode($n, $selfContext, $parentContext, $preserveLateBinding);
+            $members = array_values(array_filter(array_map($mapper, $node->types)));
             return new UnionType($members);
         }
 
         if ($node instanceof Node\IntersectionType) {
-            $members = array_values(array_filter(
-                array_map(fn (Node $n) => self::fromNode($n, $selfContext, $parentContext), $node->types),
-            ));
+            $mapper = fn (Node $n) => self::fromNode($n, $selfContext, $parentContext, $preserveLateBinding);
+            $members = array_values(array_filter(array_map($mapper, $node->types)));
             return new IntersectionType($members);
         }
 

--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -95,16 +95,12 @@ final class TypeFactory
             return new UnionType([$inner, new PrimitiveType('null')]);
         }
 
-        if ($node instanceof Node\UnionType) {
+        if ($node instanceof Node\UnionType || $node instanceof Node\IntersectionType) {
             $mapper = fn (Node $n) => self::fromNode($n, $selfContext, $parentContext, $preserveLateBinding);
             $members = array_values(array_filter(array_map($mapper, $node->types)));
-            return new UnionType($members);
-        }
-
-        if ($node instanceof Node\IntersectionType) {
-            $mapper = fn (Node $n) => self::fromNode($n, $selfContext, $parentContext, $preserveLateBinding);
-            $members = array_values(array_filter(array_map($mapper, $node->types)));
-            return new IntersectionType($members);
+            return $node instanceof Node\UnionType
+                ? new UnionType($members)
+                : new IntersectionType($members);
         }
 
         // @codeCoverageIgnoreStart

--- a/src/Utility/TypeFactory.php
+++ b/src/Utility/TypeFactory.php
@@ -54,58 +54,26 @@ final class TypeFactory
             return null;
         }
 
-        if ($node instanceof Name) {
+        if ($node instanceof Name || $node instanceof Identifier) {
             $name = $node->toString();
 
-            if ($name === 'self' || $name === 'static') {
-                if ($selfContext !== null) {
-                    if ($preserveLateBinding) {
-                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($selfContext));
-                    }
-                    return new ClassName($selfContext);
-                }
-                return new PrimitiveType($name);
+            $lateBindingType = self::tryLateBindingType(
+                $name,
+                $selfContext,
+                $parentContext,
+                $preserveLateBinding,
+            );
+            if ($lateBindingType !== null) {
+                return $lateBindingType;
             }
 
-            if ($name === 'parent') {
-                if ($parentContext !== null) {
-                    if ($preserveLateBinding) {
-                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($parentContext));
-                    }
-                    return new ClassName($parentContext);
-                }
-                return new PrimitiveType($name);
-            }
-
-            $resolvedName = $node->getAttribute('resolvedName');
-            /** @var class-string $fqn */
-            $fqn = $resolvedName instanceof Name
-                ? $resolvedName->toString()
-                : $name;
-            return new ClassName($fqn);
-        }
-
-        if ($node instanceof Identifier) {
-            $name = $node->toString();
-
-            if ($name === 'self' || $name === 'static') {
-                if ($selfContext !== null) {
-                    if ($preserveLateBinding) {
-                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($selfContext));
-                    }
-                    return new ClassName($selfContext);
-                }
-                return new PrimitiveType($name);
-            }
-
-            if ($name === 'parent') {
-                if ($parentContext !== null) {
-                    if ($preserveLateBinding) {
-                        return new LateStaticType(LateBindingKeyword::from($name), new ClassName($parentContext));
-                    }
-                    return new ClassName($parentContext);
-                }
-                return new PrimitiveType($name);
+            if ($node instanceof Name) {
+                $resolvedName = $node->getAttribute('resolvedName');
+                /** @var class-string $fqn */
+                $fqn = $resolvedName instanceof Name
+                    ? $resolvedName->toString()
+                    : $name;
+                return new ClassName($fqn);
             }
 
             if (in_array($name, self::PRIMITIVES, true)) {
@@ -186,5 +154,36 @@ final class TypeFactory
         // @codeCoverageIgnoreStart
         throw new LogicException('Unexpected ReflectionType: ' . $type::class);
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * @param class-string|null $selfContext
+     * @param class-string|null $parentContext
+     */
+    private static function tryLateBindingType(
+        string $name,
+        ?string $selfContext,
+        ?string $parentContext,
+        bool $preserveLateBinding,
+    ): ?Type {
+        $keyword = LateBindingKeyword::tryFrom($name);
+        if ($keyword === null) {
+            return null;
+        }
+
+        $context = match ($keyword) {
+            LateBindingKeyword::Self, LateBindingKeyword::Static => $selfContext,
+            LateBindingKeyword::Parent => $parentContext,
+        };
+
+        if ($context === null) {
+            return new PrimitiveType($name);
+        }
+
+        if ($preserveLateBinding) {
+            return new LateStaticType($keyword, new ClassName($context));
+        }
+
+        return new ClassName($context);
     }
 }

--- a/tests/Domain/ClassNameTest.php
+++ b/tests/Domain/ClassNameTest.php
@@ -77,4 +77,10 @@ class ClassNameTest extends TestCase
         $cn = new ClassName(\stdClass::class);
         self::assertFalse($cn->isNullable());
     }
+
+    public function testResolveLateBoundReturnsSelf(): void
+    {
+        $cn = new ClassName(\stdClass::class);
+        self::assertSame($cn, $cn->resolveLateBound(\ArrayIterator::class));
+    }
 }

--- a/tests/Domain/IntersectionTypeTest.php
+++ b/tests/Domain/IntersectionTypeTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(IntersectionType::class)]
+#[CoversClass(LateStaticType::class)]
 class IntersectionTypeTest extends TestCase
 {
     public function testFormatJoinsWithAmpersand(): void
@@ -43,13 +44,13 @@ class IntersectionTypeTest extends TestCase
     public function testResolveLateBoundResolvesMembers(): void
     {
         $type = new IntersectionType([
-            new ClassName(\Iterator::class),
+            new LateStaticType(LateBindingKeyword::Static, new ClassName(\Traversable::class)),
             new ClassName(\Countable::class),
         ]);
 
         $resolved = $type->resolveLateBound(\ArrayIterator::class);
 
         self::assertInstanceOf(IntersectionType::class, $resolved);
-        self::assertSame('Iterator&Countable', $resolved->format());
+        self::assertSame('ArrayIterator&Countable', $resolved->format());
     }
 }

--- a/tests/Domain/IntersectionTypeTest.php
+++ b/tests/Domain/IntersectionTypeTest.php
@@ -50,4 +50,20 @@ class IntersectionTypeTest extends TestCase
 
         self::assertSame($members, $type->getMembers());
     }
+
+    public function testResolveLateBoundResolvesMembers(): void
+    {
+        $type = new IntersectionType([
+            new ClassName(\Iterator::class),
+            new ClassName(\Countable::class),
+        ]);
+
+        $resolved = $type->resolveLateBound(\ArrayIterator::class);
+
+        self::assertInstanceOf(IntersectionType::class, $resolved);
+        $members = $resolved->getMembers();
+        self::assertCount(2, $members);
+        self::assertInstanceOf(ClassName::class, $members[0]);
+        self::assertSame(\Iterator::class, $members[0]->fqn);
+    }
 }

--- a/tests/Domain/IntersectionTypeTest.php
+++ b/tests/Domain/IntersectionTypeTest.php
@@ -40,17 +40,6 @@ class IntersectionTypeTest extends TestCase
         self::assertFalse($type->isNullable());
     }
 
-    public function testGetMembersReturnsMembers(): void
-    {
-        $members = [
-            new ClassName(\Iterator::class),
-            new ClassName(\Countable::class),
-        ];
-        $type = new IntersectionType($members);
-
-        self::assertSame($members, $type->getMembers());
-    }
-
     public function testResolveLateBoundResolvesMembers(): void
     {
         $type = new IntersectionType([
@@ -61,9 +50,6 @@ class IntersectionTypeTest extends TestCase
         $resolved = $type->resolveLateBound(\ArrayIterator::class);
 
         self::assertInstanceOf(IntersectionType::class, $resolved);
-        $members = $resolved->getMembers();
-        self::assertCount(2, $members);
-        self::assertInstanceOf(ClassName::class, $members[0]);
-        self::assertSame(\Iterator::class, $members[0]->fqn);
+        self::assertSame('Iterator&Countable', $resolved->format());
     }
 }

--- a/tests/Domain/IntersectionTypeTest.php
+++ b/tests/Domain/IntersectionTypeTest.php
@@ -39,4 +39,15 @@ class IntersectionTypeTest extends TestCase
         ]);
         self::assertFalse($type->isNullable());
     }
+
+    public function testGetMembersReturnsMembers(): void
+    {
+        $members = [
+            new ClassName(\Iterator::class),
+            new ClassName(\Countable::class),
+        ];
+        $type = new IntersectionType($members);
+
+        self::assertSame($members, $type->getMembers());
+    }
 }

--- a/tests/Domain/LateStaticTypeTest.php
+++ b/tests/Domain/LateStaticTypeTest.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Domain;
 
 use ArrayIterator;
-use Countable;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\LateBindingKeyword;
 use Firehed\PhpLsp\Domain\LateStaticType;
-use IteratorAggregate;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Traversable;
@@ -41,39 +39,33 @@ class LateStaticTypeTest extends TestCase
         self::assertFalse($type->isNullable());
     }
 
-    public function testResolveStaticReturnsCallingClass(): void
+    public function testResolveLateBoundStaticReturnsCallingClass(): void
     {
         $type = new LateStaticType(LateBindingKeyword::Static, new ClassName(Traversable::class));
 
-        $resolved = $type->resolve(ArrayIterator::class);
+        $resolved = $type->resolveLateBound(ArrayIterator::class);
 
+        self::assertInstanceOf(ClassName::class, $resolved);
         self::assertSame(ArrayIterator::class, $resolved->fqn);
     }
 
-    public function testResolveSelfReturnsCallingClass(): void
+    public function testResolveLateBoundSelfReturnsCallingClass(): void
     {
         $type = new LateStaticType(LateBindingKeyword::Self, new ClassName(Traversable::class));
 
-        $resolved = $type->resolve(ArrayIterator::class);
+        $resolved = $type->resolveLateBound(ArrayIterator::class);
 
+        self::assertInstanceOf(ClassName::class, $resolved);
         self::assertSame(ArrayIterator::class, $resolved->fqn);
     }
 
-    public function testResolveParentReturnsCallingParent(): void
+    public function testResolveLateBoundParentReturnsDeclaringClass(): void
     {
         $type = new LateStaticType(LateBindingKeyword::Parent, new ClassName(Traversable::class));
 
-        $resolved = $type->resolve(ArrayIterator::class, IteratorAggregate::class);
+        $resolved = $type->resolveLateBound(ArrayIterator::class);
 
-        self::assertSame(IteratorAggregate::class, $resolved->fqn);
-    }
-
-    public function testResolveParentFallsBackToDeclaringClass(): void
-    {
-        $type = new LateStaticType(LateBindingKeyword::Parent, new ClassName(Traversable::class));
-
-        $resolved = $type->resolve(ArrayIterator::class, null);
-
+        self::assertInstanceOf(ClassName::class, $resolved);
         self::assertSame(Traversable::class, $resolved->fqn);
     }
 }

--- a/tests/Domain/LateStaticTypeTest.php
+++ b/tests/Domain/LateStaticTypeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Domain;
+
+use ArrayIterator;
+use Countable;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\LateStaticType;
+use IteratorAggregate;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Traversable;
+
+#[CoversClass(LateStaticType::class)]
+class LateStaticTypeTest extends TestCase
+{
+    public function testFormatReturnsKeyword(): void
+    {
+        $type = new LateStaticType('static', new ClassName(Traversable::class));
+
+        self::assertSame('static', $type->format());
+    }
+
+    public function testGetResolvableClassNamesReturnsDeclaringClass(): void
+    {
+        $type = new LateStaticType('static', new ClassName(Traversable::class));
+
+        $classNames = $type->getResolvableClassNames();
+
+        self::assertCount(1, $classNames);
+        self::assertSame(Traversable::class, $classNames[0]->fqn);
+    }
+
+    public function testIsNullableReturnsFalse(): void
+    {
+        $type = new LateStaticType('static', new ClassName(Traversable::class));
+
+        self::assertFalse($type->isNullable());
+    }
+
+    public function testResolveStaticReturnsCallingClass(): void
+    {
+        $type = new LateStaticType('static', new ClassName(Traversable::class));
+
+        $resolved = $type->resolve(ArrayIterator::class);
+
+        self::assertSame(ArrayIterator::class, $resolved->fqn);
+    }
+
+    public function testResolveSelfReturnsCallingClass(): void
+    {
+        $type = new LateStaticType('self', new ClassName(Traversable::class));
+
+        $resolved = $type->resolve(ArrayIterator::class);
+
+        self::assertSame(ArrayIterator::class, $resolved->fqn);
+    }
+
+    public function testResolveParentReturnsCallingParent(): void
+    {
+        $type = new LateStaticType('parent', new ClassName(Traversable::class));
+
+        $resolved = $type->resolve(ArrayIterator::class, IteratorAggregate::class);
+
+        self::assertSame(IteratorAggregate::class, $resolved->fqn);
+    }
+
+    public function testResolveParentFallsBackToDeclaringClass(): void
+    {
+        $type = new LateStaticType('parent', new ClassName(Traversable::class));
+
+        $resolved = $type->resolve(ArrayIterator::class, null);
+
+        self::assertSame(Traversable::class, $resolved->fqn);
+    }
+}

--- a/tests/Domain/LateStaticTypeTest.php
+++ b/tests/Domain/LateStaticTypeTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Domain;
 use ArrayIterator;
 use Countable;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\LateBindingKeyword;
 use Firehed\PhpLsp\Domain\LateStaticType;
 use IteratorAggregate;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -18,14 +19,14 @@ class LateStaticTypeTest extends TestCase
 {
     public function testFormatReturnsKeyword(): void
     {
-        $type = new LateStaticType('static', new ClassName(Traversable::class));
+        $type = new LateStaticType(LateBindingKeyword::Static, new ClassName(Traversable::class));
 
         self::assertSame('static', $type->format());
     }
 
     public function testGetResolvableClassNamesReturnsDeclaringClass(): void
     {
-        $type = new LateStaticType('static', new ClassName(Traversable::class));
+        $type = new LateStaticType(LateBindingKeyword::Static, new ClassName(Traversable::class));
 
         $classNames = $type->getResolvableClassNames();
 
@@ -35,14 +36,14 @@ class LateStaticTypeTest extends TestCase
 
     public function testIsNullableReturnsFalse(): void
     {
-        $type = new LateStaticType('static', new ClassName(Traversable::class));
+        $type = new LateStaticType(LateBindingKeyword::Static, new ClassName(Traversable::class));
 
         self::assertFalse($type->isNullable());
     }
 
     public function testResolveStaticReturnsCallingClass(): void
     {
-        $type = new LateStaticType('static', new ClassName(Traversable::class));
+        $type = new LateStaticType(LateBindingKeyword::Static, new ClassName(Traversable::class));
 
         $resolved = $type->resolve(ArrayIterator::class);
 
@@ -51,7 +52,7 @@ class LateStaticTypeTest extends TestCase
 
     public function testResolveSelfReturnsCallingClass(): void
     {
-        $type = new LateStaticType('self', new ClassName(Traversable::class));
+        $type = new LateStaticType(LateBindingKeyword::Self, new ClassName(Traversable::class));
 
         $resolved = $type->resolve(ArrayIterator::class);
 
@@ -60,7 +61,7 @@ class LateStaticTypeTest extends TestCase
 
     public function testResolveParentReturnsCallingParent(): void
     {
-        $type = new LateStaticType('parent', new ClassName(Traversable::class));
+        $type = new LateStaticType(LateBindingKeyword::Parent, new ClassName(Traversable::class));
 
         $resolved = $type->resolve(ArrayIterator::class, IteratorAggregate::class);
 
@@ -69,7 +70,7 @@ class LateStaticTypeTest extends TestCase
 
     public function testResolveParentFallsBackToDeclaringClass(): void
     {
-        $type = new LateStaticType('parent', new ClassName(Traversable::class));
+        $type = new LateStaticType(LateBindingKeyword::Parent, new ClassName(Traversable::class));
 
         $resolved = $type->resolve(ArrayIterator::class, null);
 

--- a/tests/Domain/LateStaticTypeTest.php
+++ b/tests/Domain/LateStaticTypeTest.php
@@ -49,11 +49,20 @@ class LateStaticTypeTest extends TestCase
         self::assertSame(ArrayIterator::class, $resolved->fqn);
     }
 
-    public function testResolveLateBoundSelfReturnsCallingClass(): void
+    public function testResolveLateBoundSelfReturnsDeclaringClassForRegularClass(): void
     {
         $type = new LateStaticType(LateBindingKeyword::Self, new ClassName(Traversable::class));
 
-        $resolved = $type->resolveLateBound(ArrayIterator::class);
+        $resolved = $type->resolveLateBound(ArrayIterator::class, declaringClassIsTrait: false);
+
+        self::assertSame($type->declaringClass, $resolved);
+    }
+
+    public function testResolveLateBoundSelfReturnsCallingClassForTrait(): void
+    {
+        $type = new LateStaticType(LateBindingKeyword::Self, new ClassName(Traversable::class));
+
+        $resolved = $type->resolveLateBound(ArrayIterator::class, declaringClassIsTrait: true);
 
         self::assertInstanceOf(ClassName::class, $resolved);
         self::assertSame(ArrayIterator::class, $resolved->fqn);
@@ -65,7 +74,6 @@ class LateStaticTypeTest extends TestCase
 
         $resolved = $type->resolveLateBound(ArrayIterator::class);
 
-        self::assertInstanceOf(ClassName::class, $resolved);
-        self::assertSame(Traversable::class, $resolved->fqn);
+        self::assertSame($type->declaringClass, $resolved);
     }
 }

--- a/tests/Domain/PrimitiveTypeTest.php
+++ b/tests/Domain/PrimitiveTypeTest.php
@@ -33,4 +33,10 @@ class PrimitiveTypeTest extends TestCase
         $type = new PrimitiveType('string');
         self::assertFalse($type->isNullable());
     }
+
+    public function testResolveLateBoundReturnsSelf(): void
+    {
+        $type = new PrimitiveType('string');
+        self::assertSame($type, $type->resolveLateBound(\ArrayIterator::class));
+    }
 }

--- a/tests/Domain/UnionTypeTest.php
+++ b/tests/Domain/UnionTypeTest.php
@@ -95,4 +95,15 @@ class UnionTypeTest extends TestCase
         ]);
         self::assertFalse($type->isNullable());
     }
+
+    public function testGetMembersReturnsMembers(): void
+    {
+        $members = [
+            new ClassName(\Iterator::class),
+            new ClassName(\Countable::class),
+        ];
+        $type = new UnionType($members);
+
+        self::assertSame($members, $type->getMembers());
+    }
 }

--- a/tests/Domain/UnionTypeTest.php
+++ b/tests/Domain/UnionTypeTest.php
@@ -96,17 +96,6 @@ class UnionTypeTest extends TestCase
         self::assertFalse($type->isNullable());
     }
 
-    public function testGetMembersReturnsMembers(): void
-    {
-        $members = [
-            new ClassName(\Iterator::class),
-            new ClassName(\Countable::class),
-        ];
-        $type = new UnionType($members);
-
-        self::assertSame($members, $type->getMembers());
-    }
-
     public function testResolveLateBoundResolvesMembers(): void
     {
         $type = new UnionType([
@@ -117,10 +106,9 @@ class UnionTypeTest extends TestCase
         $resolved = $type->resolveLateBound(\ArrayIterator::class);
 
         self::assertInstanceOf(UnionType::class, $resolved);
-        $members = $resolved->getMembers();
-        self::assertCount(2, $members);
-        self::assertInstanceOf(ClassName::class, $members[0]);
-        self::assertSame(\ArrayIterator::class, $members[0]->fqn);
-        self::assertInstanceOf(PrimitiveType::class, $members[1]);
+        self::assertSame('?ArrayIterator', $resolved->format());
+        $classNames = $resolved->getResolvableClassNames();
+        self::assertCount(1, $classNames);
+        self::assertSame(\ArrayIterator::class, $classNames[0]->fqn);
     }
 }

--- a/tests/Domain/UnionTypeTest.php
+++ b/tests/Domain/UnionTypeTest.php
@@ -106,4 +106,21 @@ class UnionTypeTest extends TestCase
 
         self::assertSame($members, $type->getMembers());
     }
+
+    public function testResolveLateBoundResolvesMembers(): void
+    {
+        $type = new UnionType([
+            new LateStaticType(LateBindingKeyword::Static, new ClassName(\Traversable::class)),
+            new PrimitiveType('null'),
+        ]);
+
+        $resolved = $type->resolveLateBound(\ArrayIterator::class);
+
+        self::assertInstanceOf(UnionType::class, $resolved);
+        $members = $resolved->getMembers();
+        self::assertCount(2, $members);
+        self::assertInstanceOf(ClassName::class, $members[0]);
+        self::assertSame(\ArrayIterator::class, $members[0]->fqn);
+        self::assertInstanceOf(PrimitiveType::class, $members[1]);
+    }
 }

--- a/tests/Fixtures/src/Traits/ConcreteService.php
+++ b/tests/Fixtures/src/Traits/ConcreteService.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Traits;
+
+class ConcreteService
+{
+    use SingletonTrait;
+
+    public string $serviceName = 'concrete';
+
+    public function getServiceName(): string
+    {
+        return $this->serviceName;
+    }
+}

--- a/tests/Fixtures/src/Traits/SingletonTrait.php
+++ b/tests/Fixtures/src/Traits/SingletonTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Traits;
+
+trait SingletonTrait
+{
+    private static ?self $instance = null;
+
+    public static function instance(): static
+    {
+        if (self::$instance === null) {
+            self::$instance = new static();
+        }
+        return self::$instance;
+    }
+
+    public static function getInstance(): self
+    {
+        return static::instance();
+    }
+}

--- a/tests/Fixtures/src/Traits/SingletonTrait.php
+++ b/tests/Fixtures/src/Traits/SingletonTrait.php
@@ -20,4 +20,9 @@ trait SingletonTrait
     {
         return static::instance();
     }
+
+    public static function tryInstance(): ?static
+    {
+        return self::$instance;
+    }
 }

--- a/tests/Fixtures/src/TypeInference/IntersectionReturn.php
+++ b/tests/Fixtures/src/TypeInference/IntersectionReturn.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference;
+
+use ArrayIterator;
+use Countable;
+use Iterator;
+
+class IntersectionReturn
+{
+    public static function getIterableCounter(): Iterator&Countable
+    {
+        return new ArrayIterator([]);
+    }
+}

--- a/tests/Fixtures/src/TypeInference/TraitStaticReturn.php
+++ b/tests/Fixtures/src/TypeInference/TraitStaticReturn.php
@@ -17,4 +17,9 @@ class TraitStaticReturn
     {
         return ConcreteService::instance()->getServiceName();
     }
+
+    public function callNullableTraitStaticMethod(): ?ConcreteService
+    {
+        return ConcreteService::tryInstance();
+    }
 }

--- a/tests/Fixtures/src/TypeInference/TraitStaticReturn.php
+++ b/tests/Fixtures/src/TypeInference/TraitStaticReturn.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference;
+
+use Fixtures\Traits\ConcreteService;
+
+class TraitStaticReturn
+{
+    public function callTraitStaticMethod(): ConcreteService
+    {
+        return ConcreteService::instance();
+    }
+
+    public function chainAfterTraitStaticMethod(): string
+    {
+        return ConcreteService::instance()->getServiceName();
+    }
+}

--- a/tests/Repository/DefaultClassInfoFactoryTest.php
+++ b/tests/Repository/DefaultClassInfoFactoryTest.php
@@ -260,7 +260,7 @@ PHP;
         self::assertSame('string', $info->methods['protectedMethod']->returnType?->format());
     }
 
-    public function testFromAstNodeResolvesSelfReturnType(): void
+    public function testFromAstNodePreservesLateStaticSelfReturnType(): void
     {
         $node = $this->parseClass('<?php class SomeClass {
             public static function create(): ?self { return new self(); }
@@ -271,13 +271,15 @@ PHP;
         self::assertArrayHasKey('create', $info->methods);
         $returnType = $info->methods['create']->returnType;
         self::assertNotNull($returnType);
-        self::assertSame('?SomeClass', $returnType->format());
+        // Late-binding types preserve the keyword for display
+        self::assertSame('?self', $returnType->format());
+        // But still resolve to the declaring class for lookups
         $classNames = $returnType->getResolvableClassNames();
         self::assertCount(1, $classNames);
         self::assertSame('SomeClass', $classNames[0]->fqn);
     }
 
-    public function testFromAstNodeResolvesStaticReturnType(): void
+    public function testFromAstNodePreservesLateStaticStaticReturnType(): void
     {
         $node = $this->parseClass('<?php class Builder {
             public function build(): static { return $this; }
@@ -288,7 +290,9 @@ PHP;
         self::assertArrayHasKey('build', $info->methods);
         $returnType = $info->methods['build']->returnType;
         self::assertNotNull($returnType);
-        self::assertSame('Builder', $returnType->format());
+        // Late-binding types preserve the keyword for display
+        self::assertSame('static', $returnType->format());
+        // But still resolve to the declaring class for lookups
         $classNames = $returnType->getResolvableClassNames();
         self::assertCount(1, $classNames);
         self::assertSame('Builder', $classNames[0]->fqn);

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -1218,6 +1218,42 @@ final class MemberResolverTest extends TestCase
         self::assertContains($interfaceConst, $result);
     }
 
+    public function testIsTraitClassReturnsTrueForTrait(): void
+    {
+        $traitName = new ClassName(self::fakeClass());
+        $traitInfo = $this->createClassInfo($traitName, ClassKind::Trait_);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($traitInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        self::assertTrue($resolver->isTraitClass($traitName));
+    }
+
+    public function testIsTraitClassReturnsFalseForClass(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $classInfo = $this->createClassInfo($className, ClassKind::Class_);
+
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        self::assertFalse($resolver->isTraitClass($className));
+    }
+
+    public function testIsTraitClassReturnsFalseForUnknownClass(): void
+    {
+        $repo = self::createStub(ClassRepository::class);
+        $repo->method('get')->willReturn(null);
+
+        $resolver = new MemberResolver($repo);
+
+        self::assertFalse($resolver->isTraitClass(new ClassName(self::fakeClass())));
+    }
+
     /**
      * @return class-string
      */

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -987,6 +987,23 @@ PHP;
         self::assertNull($type);
     }
 
+    public function testResolveTraitStaticReturnTypeToCallingClass(): void
+    {
+        $resolver = $this->createResolverWithFixtures();
+        $ast = $this->parseFixture('src/TypeInference/TraitStaticReturn.php');
+        $method = $this->findMethodByName($ast, 'callTraitStaticMethod');
+        $finder = new \PhpParser\NodeFinder();
+        $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
+        assert($staticCall !== null);
+
+        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+
+        // The trait method returns `static`, which should resolve to ConcreteService
+        // (the class the method was called on), not SingletonTrait (where it's defined)
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\Traits\\ConcreteService', $type->fqn);
+    }
+
     private function createResolverWithFixtures(): BasicTypeResolver
     {
         $classInfoFactory = new DefaultClassInfoFactory();

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -9,6 +9,7 @@ use DateTimeImmutable;
 use Exception;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\IntersectionType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\UnionType;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -1042,6 +1043,28 @@ PHP;
         // `self` in trait resolves to the using class
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\Traits\\ConcreteService', $type->fqn);
+    }
+
+    public function testResolveIntersectionReturnType(): void
+    {
+        $resolver = $this->createResolverWithFixtures();
+        $ast = $this->parseFixture('src/TypeInference/IntersectionReturn.php');
+        $method = $this->findMethodByName($ast, 'getIterableCounter');
+
+        $type = $resolver->resolveExpressionType(
+            new Expr\StaticCall(
+                new Name\FullyQualified('Fixtures\\TypeInference\\IntersectionReturn'),
+                'getIterableCounter',
+            ),
+            $method,
+            $ast,
+        );
+
+        self::assertInstanceOf(IntersectionType::class, $type);
+        $classNames = $type->getResolvableClassNames();
+        self::assertCount(2, $classNames);
+        self::assertSame('Iterator', $classNames[0]->fqn);
+        self::assertSame('Countable', $classNames[1]->fqn);
     }
 
     private function createResolverWithFixtures(): BasicTypeResolver

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -1004,6 +1004,46 @@ PHP;
         self::assertSame('Fixtures\\Traits\\ConcreteService', $type->fqn);
     }
 
+    public function testResolveNullableTraitStaticReturnTypeToCallingClass(): void
+    {
+        $resolver = $this->createResolverWithFixtures();
+        $ast = $this->parseFixture('src/TypeInference/TraitStaticReturn.php');
+        $method = $this->findMethodByName($ast, 'callNullableTraitStaticMethod');
+        $finder = new \PhpParser\NodeFinder();
+        $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
+        assert($staticCall !== null);
+
+        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+
+        // The trait method returns `?static`, which should resolve to ?ConcreteService
+        self::assertInstanceOf(UnionType::class, $type);
+        self::assertTrue($type->isNullable());
+        $classNames = $type->getResolvableClassNames();
+        self::assertCount(1, $classNames);
+        self::assertSame('Fixtures\\Traits\\ConcreteService', $classNames[0]->fqn);
+    }
+
+    public function testResolveTraitSelfReturnTypeToCallingClass(): void
+    {
+        $resolver = $this->createResolverWithFixtures();
+        $ast = $this->parseFixture('src/TypeInference/TraitStaticReturn.php');
+        // getInstance() returns `self`, testing that self in traits resolves to the using class
+        $method = $this->findMethodByName($ast, 'callTraitStaticMethod');
+
+        $type = $resolver->resolveExpressionType(
+            new Expr\StaticCall(
+                new Name\FullyQualified('Fixtures\\Traits\\ConcreteService'),
+                'getInstance',
+            ),
+            $method,
+            $ast,
+        );
+
+        // `self` in trait resolves to the using class
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\Traits\\ConcreteService', $type->fqn);
+    }
+
     private function createResolverWithFixtures(): BasicTypeResolver
     {
         $classInfoFactory = new DefaultClassInfoFactory();

--- a/tests/Utility/TypeFactoryTest.php
+++ b/tests/Utility/TypeFactoryTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\IntersectionType;
+use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\UnionType;
 use PhpParser\Node\Identifier;
@@ -114,6 +115,36 @@ class TypeFactoryTest extends TestCase
         self::assertSame('self', $type->format());
     }
 
+    public function testFromNodeWithIdentifierSelfAndPreserveLateBindingCreatesLateStaticType(): void
+    {
+        $node = new Identifier('self');
+        $type = TypeFactory::fromNode($node, selfContext: \stdClass::class, preserveLateBinding: true);
+
+        self::assertInstanceOf(LateStaticType::class, $type);
+        self::assertSame('self', $type->keyword);
+        self::assertSame(\stdClass::class, $type->declaringClass->fqn);
+    }
+
+    public function testFromNodeWithIdentifierStaticAndPreserveLateBindingCreatesLateStaticType(): void
+    {
+        $node = new Identifier('static');
+        $type = TypeFactory::fromNode($node, selfContext: \ArrayObject::class, preserveLateBinding: true);
+
+        self::assertInstanceOf(LateStaticType::class, $type);
+        self::assertSame('static', $type->keyword);
+        self::assertSame(\ArrayObject::class, $type->declaringClass->fqn);
+    }
+
+    public function testFromNodeWithIdentifierParentAndPreserveLateBindingCreatesLateStaticType(): void
+    {
+        $node = new Identifier('parent');
+        $type = TypeFactory::fromNode($node, parentContext: \Throwable::class, preserveLateBinding: true);
+
+        self::assertInstanceOf(LateStaticType::class, $type);
+        self::assertSame('parent', $type->keyword);
+        self::assertSame(\Throwable::class, $type->declaringClass->fqn);
+    }
+
     public function testFromNodeWithParentWithoutContextCreatesPrimitiveType(): void
     {
         $node = new Identifier('parent');
@@ -157,6 +188,36 @@ class TypeFactoryTest extends TestCase
 
         self::assertInstanceOf(PrimitiveType::class, $type);
         self::assertSame('self', $type->format());
+    }
+
+    public function testFromNodeWithNameSelfAndPreserveLateBindingCreatesLateStaticType(): void
+    {
+        $node = new Name('self');
+        $type = TypeFactory::fromNode($node, selfContext: \stdClass::class, preserveLateBinding: true);
+
+        self::assertInstanceOf(LateStaticType::class, $type);
+        self::assertSame('self', $type->keyword);
+        self::assertSame(\stdClass::class, $type->declaringClass->fqn);
+    }
+
+    public function testFromNodeWithNameStaticAndPreserveLateBindingCreatesLateStaticType(): void
+    {
+        $node = new Name('static');
+        $type = TypeFactory::fromNode($node, selfContext: \ArrayObject::class, preserveLateBinding: true);
+
+        self::assertInstanceOf(LateStaticType::class, $type);
+        self::assertSame('static', $type->keyword);
+        self::assertSame(\ArrayObject::class, $type->declaringClass->fqn);
+    }
+
+    public function testFromNodeWithNameParentAndPreserveLateBindingCreatesLateStaticType(): void
+    {
+        $node = new Name('parent');
+        $type = TypeFactory::fromNode($node, parentContext: \Throwable::class, preserveLateBinding: true);
+
+        self::assertInstanceOf(LateStaticType::class, $type);
+        self::assertSame('parent', $type->keyword);
+        self::assertSame(\Throwable::class, $type->declaringClass->fqn);
     }
 
     public function testFromNodeWithNameParentWithoutContextCreatesPrimitiveType(): void

--- a/tests/Utility/TypeFactoryTest.php
+++ b/tests/Utility/TypeFactoryTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\IntersectionType;
+use Firehed\PhpLsp\Domain\LateBindingKeyword;
 use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\UnionType;
@@ -121,7 +122,7 @@ class TypeFactoryTest extends TestCase
         $type = TypeFactory::fromNode($node, selfContext: \stdClass::class, preserveLateBinding: true);
 
         self::assertInstanceOf(LateStaticType::class, $type);
-        self::assertSame('self', $type->keyword);
+        self::assertSame(LateBindingKeyword::Self, $type->keyword);
         self::assertSame(\stdClass::class, $type->declaringClass->fqn);
     }
 
@@ -131,7 +132,7 @@ class TypeFactoryTest extends TestCase
         $type = TypeFactory::fromNode($node, selfContext: \ArrayObject::class, preserveLateBinding: true);
 
         self::assertInstanceOf(LateStaticType::class, $type);
-        self::assertSame('static', $type->keyword);
+        self::assertSame(LateBindingKeyword::Static, $type->keyword);
         self::assertSame(\ArrayObject::class, $type->declaringClass->fqn);
     }
 
@@ -141,7 +142,7 @@ class TypeFactoryTest extends TestCase
         $type = TypeFactory::fromNode($node, parentContext: \Throwable::class, preserveLateBinding: true);
 
         self::assertInstanceOf(LateStaticType::class, $type);
-        self::assertSame('parent', $type->keyword);
+        self::assertSame(LateBindingKeyword::Parent, $type->keyword);
         self::assertSame(\Throwable::class, $type->declaringClass->fqn);
     }
 
@@ -196,7 +197,7 @@ class TypeFactoryTest extends TestCase
         $type = TypeFactory::fromNode($node, selfContext: \stdClass::class, preserveLateBinding: true);
 
         self::assertInstanceOf(LateStaticType::class, $type);
-        self::assertSame('self', $type->keyword);
+        self::assertSame(LateBindingKeyword::Self, $type->keyword);
         self::assertSame(\stdClass::class, $type->declaringClass->fqn);
     }
 
@@ -206,7 +207,7 @@ class TypeFactoryTest extends TestCase
         $type = TypeFactory::fromNode($node, selfContext: \ArrayObject::class, preserveLateBinding: true);
 
         self::assertInstanceOf(LateStaticType::class, $type);
-        self::assertSame('static', $type->keyword);
+        self::assertSame(LateBindingKeyword::Static, $type->keyword);
         self::assertSame(\ArrayObject::class, $type->declaringClass->fqn);
     }
 
@@ -216,7 +217,7 @@ class TypeFactoryTest extends TestCase
         $type = TypeFactory::fromNode($node, parentContext: \Throwable::class, preserveLateBinding: true);
 
         self::assertInstanceOf(LateStaticType::class, $type);
-        self::assertSame('parent', $type->keyword);
+        self::assertSame(LateBindingKeyword::Parent, $type->keyword);
         self::assertSame(\Throwable::class, $type->declaringClass->fqn);
     }
 


### PR DESCRIPTION
## Summary

Adds `LateStaticType` to represent late-binding types (`static`/`self`/`parent`) and defers resolution to lookup time, correctly handling PHP semantics:

- **`static`** → Always resolves to the calling class (late static binding)
- **`self`** → Resolves to the declaring class for regular classes (lexical binding), or the using class for traits
- **`parent`** → Resolves to the parent of the declaring class

This fixes trait methods with `static`/`self` return types resolving to the calling class instead of the trait:

```php
trait SingletonTrait {
    public static function instance(): static { ... }
}

class Concrete {
    use SingletonTrait;
}

// Before: Concrete::instance() resolved to SingletonTrait
// After: Concrete::instance() resolves to Concrete
```

### Implementation

- `LateStaticType` stores the keyword and declaring class, deferring resolution
- `MemberResolver::isTraitClass()` detects trait-declared methods
- `BasicTypeResolver::getMethodReturnType()` passes trait context to `resolveLateBound()`
- `TypeFactory` refactored to deduplicate union/intersection handling

### Known Limitation

When a trait is used by class `A` and `B extends A`, calling `B::traitMethod()` where the method returns `self` will resolve to `B` instead of `A`. This is because we detect the method came from a trait but don't track which class originally incorporated it. Fixing this would require propagating the "using class" through the inheritance hierarchy, which is significantly more complex. The current behavior matches `static` semantics in this edge case.

## Test plan

- Unit tests for `LateStaticType` (all keywords, trait vs non-trait)
- Unit tests for `MemberResolver::isTraitClass()`
- Integration tests for trait `static`/`self`/`?static` return type resolution
- Updated `DefaultClassInfoFactoryTest` for late-binding preservation

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
