### PR TITLE
Add property go-to-definition support

### DIFF
--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -18,7 +18,10 @@ use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\NullsafePropertyFetch;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -94,7 +97,7 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        // Check if this is a method name (Identifier) in a method call
+        // Check if this is a method/property name (Identifier) in a member access
         if ($node instanceof Identifier) {
             $parent = $node->getAttribute('parent');
 
@@ -107,6 +110,17 @@ final class DefinitionHandler implements HandlerInterface
             if (MemberAccessResolver::isMethodCall($parent)) {
                 /** @var MethodCall|NullsafeMethodCall $parent */
                 return $this->handleInstanceMethodDefinition($parent, $ast);
+            }
+
+            // Instance property fetch: $obj->property or $obj?->property
+            if (MemberAccessResolver::isPropertyFetch($parent)) {
+                /** @var PropertyFetch|NullsafePropertyFetch $parent */
+                return $this->handleInstancePropertyDefinition($parent, $ast);
+            }
+
+            // Static property fetch: ClassName::$property, self::$property, etc.
+            if ($parent instanceof StaticPropertyFetch) {
+                return $this->handleStaticPropertyDefinition($parent);
             }
         }
 
@@ -229,6 +243,45 @@ final class DefinitionHandler implements HandlerInterface
         }
 
         return $this->createLocationFromFileLine($methodInfo->file, $methodInfo->line);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function handleInstancePropertyDefinition(PropertyFetch|NullsafePropertyFetch $fetch, array $ast): ?array
+    {
+        $propertyInfo = $this->memberAccessResolver->resolvePropertyFetch($fetch, $ast);
+        if ($propertyInfo === null) {
+            return null;
+        }
+
+        return $this->createLocationFromFileLine($propertyInfo->file, $propertyInfo->line);
+    }
+
+    /**
+     * @return array{
+     *   uri: string,
+     *   range: array{
+     *     start: array{line: int, character: int},
+     *     end: array{line: int, character: int},
+     *   },
+     * }|null
+     */
+    private function handleStaticPropertyDefinition(StaticPropertyFetch $fetch): ?array
+    {
+        $propertyInfo = $this->memberAccessResolver->resolveStaticPropertyFetch($fetch);
+        if ($propertyInfo === null) {
+            return null;
+        }
+
+        return $this->createLocationFromFileLine($propertyInfo->file, $propertyInfo->line);
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -12,7 +12,6 @@ use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
-use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -293,37 +292,22 @@ final class HoverHandler implements HandlerInterface
      */
     private function getPropertyHover(PropertyFetch|NullsafePropertyFetch $fetch, array $ast): ?string
     {
-        $propertyName = $fetch->name;
-        if (!$propertyName instanceof Identifier) {
+        $propertyInfo = $this->memberAccessResolver->resolvePropertyFetch($fetch, $ast);
+        if ($propertyInfo === null) {
             return null;
         }
 
-        $className = $this->memberAccessResolver->resolveObjectClassName($fetch->var, $ast);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getPropertyHoverForClass($className->fqn, $propertyName->toString());
+        return $this->formatPropertyHover($propertyInfo);
     }
 
     private function getStaticPropertyHover(StaticPropertyFetch $fetch): ?string
     {
-        $propertyName = $fetch->name;
-        if (!$propertyName instanceof Node\VarLikeIdentifier) {
+        $propertyInfo = $this->memberAccessResolver->resolveStaticPropertyFetch($fetch);
+        if ($propertyInfo === null) {
             return null;
         }
 
-        $class = $fetch->class;
-        if (!$class instanceof Name) {
-            return null;
-        }
-
-        $className = ScopeFinder::resolveClassNameInContext($class, $fetch);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getPropertyHoverForClass($className, $propertyName->toString());
+        return $this->formatPropertyHover($propertyInfo);
     }
 
     /**
@@ -341,23 +325,6 @@ final class HoverHandler implements HandlerInterface
         }
 
         return $this->formatMethodHover($methodInfo);
-    }
-
-    /**
-     * @param class-string $classNameStr
-     */
-    private function getPropertyHoverForClass(string $classNameStr, string $propertyNameStr): ?string
-    {
-        $className = new ClassName($classNameStr);
-        $propertyName = new PropertyName($propertyNameStr);
-
-        // Hover shows all members regardless of caller context
-        $propertyInfo = $this->memberResolver->findProperty($className, $propertyName, Visibility::Private);
-        if ($propertyInfo === null) {
-            return null;
-        }
-
-        return $this->formatPropertyHover($propertyInfo);
     }
 
     private function formatMethodHover(MethodInfo $method): string

--- a/src/Server.php
+++ b/src/Server.php
@@ -60,7 +60,7 @@ final class Server
         $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver);
-        $memberAccessResolver = new MemberAccessResolver($typeResolver);
+        $memberAccessResolver = new MemberAccessResolver($typeResolver, $memberResolver);
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;

--- a/src/Utility/MemberAccessResolver.php
+++ b/src/Utility/MemberAccessResolver.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Utility;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
 /**
@@ -21,6 +28,7 @@ final class MemberAccessResolver
 {
     public function __construct(
         private readonly TypeResolverInterface $typeResolver,
+        private readonly MemberResolver $memberResolver,
     ) {
     }
 
@@ -33,6 +41,52 @@ final class MemberAccessResolver
         $classNames = $type?->getResolvableClassNames() ?? [];
 
         return $classNames[0] ?? null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    public function resolvePropertyFetch(PropertyFetch|NullsafePropertyFetch $fetch, array $ast): ?PropertyInfo
+    {
+        $propertyName = $fetch->name;
+        if (!$propertyName instanceof Identifier) {
+            return null;
+        }
+
+        $className = $this->resolveObjectClassName($fetch->var, $ast);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->memberResolver->findProperty(
+            $className,
+            new PropertyName($propertyName->toString()),
+            Visibility::Private,
+        );
+    }
+
+    public function resolveStaticPropertyFetch(StaticPropertyFetch $fetch): ?PropertyInfo
+    {
+        $propertyName = $fetch->name;
+        if (!$propertyName instanceof Identifier) {
+            return null;
+        }
+
+        $class = $fetch->class;
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        $className = ScopeFinder::resolveClassNameInContext($class, $fetch);
+        if ($className === null) {
+            return null;
+        }
+
+        return $this->memberResolver->findProperty(
+            new ClassName($className),
+            new PropertyName($propertyName->toString()),
+            Visibility::Private,
+        );
     }
 
     public static function isMethodCall(mixed $node): bool

--- a/tests/Fixtures/EdgeCases/DynamicAccess.php
+++ b/tests/Fixtures/EdgeCases/DynamicAccess.php
@@ -16,7 +16,14 @@ class DynamicAccessClass
         $method = 'foo';
         $this->$method(); //hover:dynamic_instance_method
     }
+
+    public function testDynamicInstanceProperty(): void
+    {
+        $prop = 'foo';
+        echo $this->$prop; //hover:dynamic_instance_property
+    }
 }
 
 $class = 'SomeClass';
 $class::method(); //hover:dynamic_class_name
+$class::$staticProp; //hover:dynamic_class_property

--- a/tests/Fixtures/EdgeCases/UnknownTypeProperty.php
+++ b/tests/Fixtures/EdgeCases/UnknownTypeProperty.php
@@ -1,0 +1,11 @@
+<?php
+
+// Edge cases: accessing properties on unknown types.
+// All of these should return null for definition lookup.
+
+namespace Fixtures\EdgeCases;
+
+function accessPropertyOnUntypedParam($obj): void
+{
+    echo $obj->someProperty; //hover:untyped_property
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -53,7 +53,7 @@ class CompletionHandlerTest extends TestCase
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver);
-        $memberAccessResolver = new MemberAccessResolver($typeResolver);
+        $memberAccessResolver = new MemberAccessResolver($typeResolver, $this->memberResolver);
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
         $this->handler = new CompletionHandler(
             $this->documents,

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -51,7 +51,7 @@ class DefinitionHandlerTest extends TestCase
             $this->parser,
             $this->memberResolver,
             $this->classRepository,
-            new MemberAccessResolver($typeResolver),
+            new MemberAccessResolver($typeResolver, $this->memberResolver),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
@@ -538,6 +538,122 @@ class DefinitionHandlerTest extends TestCase
         ]);
 
         $result = $this->handler->handle($request);
+
+        self::assertNull($result);
+    }
+
+    public function testGoToInstancePropertyDefinition(): void
+    {
+        $parentUri = $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ChildClass.php', 'inherited_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($parentUri, $result['uri']);
+        self::assertSame(12, $result['range']['start']['line']);
+    }
+
+    public function testGoToStaticPropertyDefinition(): void
+    {
+        $parentUri = $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ParentClass.php', 'staticProperty');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($parentUri, $result['uri']);
+        self::assertSame(21, $result['range']['start']['line']);
+    }
+
+    public function testGoToSelfStaticPropertyDefinition(): void
+    {
+        $parentUri = $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ChildClass.php', 'self_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($parentUri, $result['uri']);
+        self::assertSame(21, $result['range']['start']['line']);
+    }
+
+    public function testGoToStaticKeywordPropertyDefinition(): void
+    {
+        $parentUri = $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ChildClass.php', 'static_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($parentUri, $result['uri']);
+        self::assertSame(21, $result['range']['start']['line']);
+    }
+
+    public function testGoToParentStaticPropertyDefinition(): void
+    {
+        $parentUri = $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ChildClass.php', 'parent_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($parentUri, $result['uri']);
+        self::assertSame(21, $result['range']['start']['line']);
+    }
+
+    public function testGoToNullsafePropertyDefinition(): void
+    {
+        $userUri = $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'manager_nullsafe');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($userUri, $result['uri']);
+        self::assertSame(28, $result['range']['start']['line']);
+    }
+
+    public function testGoToGrandparentPropertyDefinition(): void
+    {
+        $grandparentUri = $this->openFixture('src/Inheritance/Grandparent.php');
+        $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ChildClass.php', 'grandparent_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($grandparentUri, $result['uri']);
+        self::assertSame(11, $result['range']['start']['line']);
+    }
+
+    public function testGoToOverriddenPropertyDefinition(): void
+    {
+        $this->openFixture('src/Inheritance/ParentClass.php');
+        $childUri = $this->openFixture('src/Inheritance/ChildClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ChildClass.php', 'shared_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($childUri, $result['uri']);
+        self::assertSame(13, $result['range']['start']['line']);
+    }
+
+    public function testReturnsNullForPropertyOnUnknownType(): void
+    {
+        $cursor = $this->openFixtureAtHoverMarker('EdgeCases/UnknownTypeProperty.php', 'untyped_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertNull($result);
+    }
+
+    public function testReturnsNullForBuiltInClassProperty(): void
+    {
+        $cursor = $this->openFixtureAtHoverMarker('src/Hover/BuiltinUsage.php', 'builtin_class_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
 
         self::assertNull($result);
     }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -53,7 +53,7 @@ class HoverHandlerTest extends TestCase
             $this->parser,
             $this->classRepository,
             $this->memberResolver,
-            new MemberAccessResolver($typeResolver),
+            new MemberAccessResolver($typeResolver, $this->memberResolver),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -50,7 +50,7 @@ class SignatureHelpHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->memberResolver,
-            new MemberAccessResolver($typeResolver),
+            new MemberAccessResolver($typeResolver, $this->memberResolver),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/Utility/MemberAccessResolverTest.php
+++ b/tests/Utility/MemberAccessResolverTest.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
@@ -40,7 +41,7 @@ class MemberAccessResolverTest extends TestCase
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver);
 
-        $this->resolver = new MemberAccessResolver($typeResolver);
+        $this->resolver = new MemberAccessResolver($typeResolver, $memberResolver);
     }
 
     public function testResolveObjectClassName(): void
@@ -98,6 +99,53 @@ class MemberAccessResolverTest extends TestCase
         )));
     }
 
+    public function testResolvePropertyFetch(): void
+    {
+        $code = $this->loadFixture('src/TypeInference/BuiltinTypes.php');
+        $ast = $this->parse($code);
+        $propertyFetch = $this->findFirst($ast, NullsafePropertyFetch::class);
+
+        $result = $this->resolver->resolvePropertyFetch($propertyFetch, $ast);
+
+        self::assertNotNull($result);
+        self::assertSame('message', $result->name->name);
+    }
+
+    public function testResolvePropertyFetchReturnsNullForUnknownType(): void
+    {
+        $code = $this->loadFixture('EdgeCases/UnknownTypeProperty.php');
+        $ast = $this->parse($code);
+        $propertyFetch = $this->findFirst($ast, PropertyFetch::class);
+
+        $result = $this->resolver->resolvePropertyFetch($propertyFetch, $ast);
+
+        self::assertNull($result);
+    }
+
+    public function testResolvePropertyFetchReturnsNullForDynamicPropertyName(): void
+    {
+        $code = $this->loadFixture('EdgeCases/DynamicAccess.php');
+        $ast = $this->parse($code);
+        $propertyFetches = $this->findAll($ast, PropertyFetch::class);
+        $dynamicFetch = $propertyFetches[count($propertyFetches) - 1];
+
+        $result = $this->resolver->resolvePropertyFetch($dynamicFetch, $ast);
+
+        self::assertNull($result);
+    }
+
+    public function testResolveStaticPropertyFetchReturnsNullForDynamicClassName(): void
+    {
+        $code = $this->loadFixture('EdgeCases/DynamicAccess.php');
+        $ast = $this->parse($code);
+        $staticFetches = $this->findAll($ast, StaticPropertyFetch::class);
+        $dynamicFetch = $staticFetches[count($staticFetches) - 1];
+
+        $result = $this->resolver->resolveStaticPropertyFetch($dynamicFetch);
+
+        self::assertNull($result);
+    }
+
     /**
      * @return array<Stmt>
      */
@@ -120,35 +168,23 @@ class MemberAccessResolverTest extends TestCase
      */
     private function findFirst(array $ast, string $type): \PhpParser\Node
     {
-        $finder = new class ($type) extends \PhpParser\NodeVisitorAbstract {
-            public ?\PhpParser\Node $found = null;
-            /** @var class-string */
-            private string $type;
-
-            /** @param class-string $type */
-            public function __construct(string $type)
-            {
-                $this->type = $type;
-            }
-
-            public function enterNode(\PhpParser\Node $node): ?int
-            {
-                if ($node instanceof $this->type && $this->found === null) {
-                    $this->found = $node;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        if ($finder->found === null) {
+        $all = $this->findAll($ast, $type);
+        if (count($all) === 0) {
             throw new \RuntimeException("Could not find node of type $type");
         }
-        assert($finder->found instanceof $type);
-        return $finder->found;
+        return $all[0];
+    }
+
+    /**
+     * @template T of \PhpParser\Node
+     * @param array<Stmt> $ast
+     * @param class-string<T> $type
+     * @return list<T>
+     */
+    private function findAll(array $ast, string $type): array
+    {
+        $finder = new \PhpParser\NodeFinder();
+        /** @var list<T> */
+        return $finder->findInstanceOf($ast, $type);
     }
 }


### PR DESCRIPTION
## Summary

- Add go-to-definition support for properties (`$obj->property`, `$obj?->property`, `ClassName::$staticProperty`, `self::$prop`, etc.)
- Extract property resolution into shared `MemberAccessResolver` methods
- Refactor HoverHandler to use the shared resolution, eliminating duplicate code

Closes #190

## Changes

1. **MemberAccessResolver** - Added `resolvePropertyFetch()` and `resolveStaticPropertyFetch()` methods that both handlers now use
2. **DefinitionHandler** - Added property JTD support using the shared resolver
3. **HoverHandler** - Refactored to use the shared resolver (removed ~30 lines of duplicate resolution logic)
4. **Test fixtures** - Added edge case fixtures for dynamic property access

## Notes

This addresses the code smell noted in #253 - property resolution was implemented in HoverHandler but missing from DefinitionHandler. Both handlers now use the same shared utility, preventing this class of bug.

🤖 Generated with [Claude Code](https://claude.ai/code)
