### PR TITLE
SymbolResolver: Create ResolvedSymbol interface and implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Firehed\\PhpLsp\\Tests\\": "tests/"
+            "Firehed\\PhpLsp\\Tests\\": "tests/",
+            "Firehed\\PhpLsp\\": "tests/"
         }
     },
     "scripts": {

--- a/src/Domain/ClassInfo.php
+++ b/src/Domain/ClassInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a class, interface, trait, or enum.
  */
-final readonly class ClassInfo
+final readonly class ClassInfo implements Formattable
 {
     /**
      * @param list<ClassName> $interfaces Implemented interfaces
@@ -34,5 +34,44 @@ final readonly class ClassInfo
         public ?string $file,
         public ?int $line,
     ) {
+    }
+
+    /**
+     * Returns a formatted class signature for display.
+     * Example: "final class User extends Entity implements JsonSerializable"
+     */
+    public function format(): string
+    {
+        $parts = [];
+        if ($this->isFinal) {
+            $parts[] = 'final';
+        }
+        if ($this->isAbstract) {
+            $parts[] = 'abstract';
+        }
+        if ($this->isReadonly) {
+            $parts[] = 'readonly';
+        }
+
+        $parts[] = match ($this->kind) {
+            ClassKind::Interface_ => 'interface',
+            ClassKind::Trait_ => 'trait',
+            ClassKind::Enum_ => 'enum',
+            default => 'class',
+        };
+        $parts[] = $this->name->shortName();
+
+        $sig = implode(' ', $parts);
+
+        if ($this->kind === ClassKind::Class_ && $this->parent !== null) {
+            $sig .= ' extends ' . $this->parent->shortName();
+        }
+        if ($this->kind === ClassKind::Interface_ && $this->interfaces !== []) {
+            $sig .= ' extends ' . implode(', ', array_map(fn($n) => $n->shortName(), $this->interfaces));
+        } elseif ($this->interfaces !== []) {
+            $sig .= ' implements ' . implode(', ', array_map(fn($n) => $n->shortName(), $this->interfaces));
+        }
+
+        return $sig;
     }
 }

--- a/src/Domain/FunctionInfo.php
+++ b/src/Domain/FunctionInfo.php
@@ -28,14 +28,17 @@ final readonly class FunctionInfo implements Formattable
 
     public static function fromNode(Stmt\Function_ $node): self
     {
-        $params = array_filter(
-            array_map(ParameterInfo::fromNode(...), $node->params),
-            fn($p) => $p !== null,
-        );
+        $params = [];
+        foreach ($node->params as $position => $param) {
+            $paramInfo = ParameterInfo::fromNode($param, $position);
+            if ($paramInfo !== null) {
+                $params[] = $paramInfo;
+            }
+        }
 
         return new self(
             name: $node->name->toString(),
-            parameters: array_values($params),
+            parameters: $params,
             returnType: TypeFactory::fromNode($node->returnType),
             docblock: $node->getDocComment()?->getText(),
             file: null,

--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 use Firehed\PhpLsp\Utility\TypeFactory;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use ReflectionParameter;
 
 /**
@@ -18,6 +19,8 @@ final readonly class ParameterInfo implements Formattable
         public string $name,
         public ?Type $type,
         public bool $hasDefault,
+        public ?string $defaultValue,
+        public int $position,
         public bool $isVariadic,
         public bool $isPassedByReference,
     ) {
@@ -29,6 +32,7 @@ final readonly class ParameterInfo implements Formattable
      */
     public static function fromNode(
         Param $param,
+        int $position,
         ?string $selfContext = null,
         ?string $parentContext = null,
     ): ?self {
@@ -36,10 +40,18 @@ final readonly class ParameterInfo implements Formattable
             return null;
         }
 
+        $defaultValue = null;
+        if ($param->default !== null) {
+            $printer = new PrettyPrinter();
+            $defaultValue = $printer->prettyPrintExpr($param->default);
+        }
+
         return new self(
             name: $param->var->name,
             type: TypeFactory::fromNode($param->type, $selfContext, $parentContext),
             hasDefault: $param->default !== null,
+            defaultValue: $defaultValue,
+            position: $position,
             isVariadic: $param->variadic,
             isPassedByReference: $param->byRef,
         );
@@ -47,13 +59,31 @@ final readonly class ParameterInfo implements Formattable
 
     public static function fromReflection(ReflectionParameter $param): self
     {
+        $defaultValue = null;
+        if ($param->isDefaultValueAvailable()) {
+            $defaultValue = self::formatReflectionDefault($param->getDefaultValue());
+        }
+
         return new self(
             name: $param->getName(),
             type: TypeFactory::fromReflection($param->getType()),
             hasDefault: $param->isDefaultValueAvailable(),
+            defaultValue: $defaultValue,
+            position: $param->getPosition(),
             isVariadic: $param->isVariadic(),
             isPassedByReference: $param->isPassedByReference(),
         );
+    }
+
+    private static function formatReflectionDefault(mixed $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+        if ($value === []) {
+            return '[]';
+        }
+        return var_export($value, true);
     }
 
     public function format(bool $showDefault = false): string
@@ -70,7 +100,7 @@ final readonly class ParameterInfo implements Formattable
         }
         $str .= '$' . $this->name;
         if ($showDefault && $this->hasDefault && !$this->isVariadic) {
-            $str .= ' = ...';
+            $str .= ' = ' . ($this->defaultValue ?? '...');
         }
         return $str;
     }

--- a/src/Index/Location.php
+++ b/src/Index/Location.php
@@ -16,6 +16,19 @@ final readonly class Location
     }
 
     /**
+     * Creates a Location from a filesystem path and 1-based line number.
+     * Returns null if either argument is null.
+     */
+    public static function fromFileLine(?string $file, ?int $line): ?self
+    {
+        if ($file === null || $line === null) {
+            return null;
+        }
+        $uri = str_starts_with($file, 'file://') ? $file : 'file://' . $file;
+        return new self($uri, $line - 1, 0, $line - 1, 0);
+    }
+
+    /**
      * @return array{
      *   uri: string,
      *   range: array{

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -265,6 +265,8 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
                         name: 'value',
                         type: $scalarTypeInfo,
                         hasDefault: false,
+                        defaultValue: null,
+                        position: 0,
                         isVariadic: false,
                         isPassedByReference: false,
                     ),
@@ -287,6 +289,8 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
                         name: 'value',
                         type: $scalarTypeInfo,
                         hasDefault: false,
+                        defaultValue: null,
+                        position: 0,
                         isVariadic: false,
                         isPassedByReference: false,
                     ),
@@ -309,8 +313,8 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
     private function extractParameters(array $params, ClassName $className, ?ClassName $parentClass): array
     {
         $result = [];
-        foreach ($params as $param) {
-            $info = ParameterInfo::fromNode($param, $className->fqn, $parentClass?->fqn);
+        foreach ($params as $position => $param) {
+            $info = ParameterInfo::fromNode($param, $position, $className->fqn, $parentClass?->fqn);
             if ($info !== null) {
                 $result[] = $info;
             }

--- a/src/Resolution/ResolvedCallable.php
+++ b/src/Resolution/ResolvedCallable.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\Type;
+
+/**
+ * A resolved callable (function or method) with parameter information.
+ */
+interface ResolvedCallable extends ResolvedSymbol
+{
+    /**
+     * @return list<ParameterInfo>
+     */
+    public function getParameters(): array;
+
+    public function getReturnType(): ?Type;
+
+    /**
+     * Returns the parameter at the given 0-based position, or null if out of bounds.
+     */
+    public function getParameterAtPosition(int $position): ?ParameterInfo;
+
+    /**
+     * Returns the parameter with the given name (without $), or null if not found.
+     */
+    public function getParameterByName(string $name): ?ParameterInfo;
+}

--- a/src/Resolution/ResolvedClass.php
+++ b/src/Resolution/ResolvedClass.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * A resolved class, interface, trait, or enum wrapping ClassInfo.
+ */
+final readonly class ResolvedClass implements ResolvedSymbol
+{
+    public function __construct(
+        private ClassInfo $info,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return Location::fromFileLine($this->info->file, $this->info->line);
+    }
+
+    public function getDocumentation(): ?string
+    {
+        if ($this->info->docblock === null) {
+            return null;
+        }
+        return DocblockParser::extractDescription($this->info->docblock);
+    }
+
+    /**
+     * Returns the class name as a Type. This allows class references to be
+     * typed in the same way as other symbols.
+     */
+    public function getType(): Type
+    {
+        return $this->info->name;
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+}

--- a/src/Resolution/ResolvedClass.php
+++ b/src/Resolution/ResolvedClass.php
@@ -6,30 +6,17 @@ namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\Type;
-use Firehed\PhpLsp\Index\Location;
-use Firehed\PhpLsp\Utility\DocblockParser;
 
 /**
  * A resolved class, interface, trait, or enum wrapping ClassInfo.
  */
 final readonly class ResolvedClass implements ResolvedSymbol
 {
+    use ResolvesFromInfo;
+
     public function __construct(
         private ClassInfo $info,
     ) {
-    }
-
-    public function getDefinitionLocation(): ?Location
-    {
-        return Location::fromFileLine($this->info->file, $this->info->line);
-    }
-
-    public function getDocumentation(): ?string
-    {
-        if ($this->info->docblock === null) {
-            return null;
-        }
-        return DocblockParser::extractDescription($this->info->docblock);
     }
 
     /**
@@ -39,10 +26,5 @@ final readonly class ResolvedClass implements ResolvedSymbol
     public function getType(): Type
     {
         return $this->info->name;
-    }
-
-    public function format(): string
-    {
-        return $this->info->format();
     }
 }

--- a/src/Resolution/ResolvedConstant.php
+++ b/src/Resolution/ResolvedConstant.php
@@ -8,40 +8,22 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantInfo;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Index\Location;
-use Firehed\PhpLsp\Utility\DocblockParser;
 
 /**
  * A resolved class constant wrapping ConstantInfo.
  */
 final readonly class ResolvedConstant implements ResolvedMember
 {
+    use ResolvesFromInfo;
+
     public function __construct(
         private ConstantInfo $info,
     ) {
     }
 
-    public function getDefinitionLocation(): ?Location
-    {
-        return Location::fromFileLine($this->info->file, $this->info->line);
-    }
-
-    public function getDocumentation(): ?string
-    {
-        if ($this->info->docblock === null) {
-            return null;
-        }
-        return DocblockParser::extractDescription($this->info->docblock);
-    }
-
     public function getType(): ?Type
     {
         return $this->info->type;
-    }
-
-    public function format(): string
-    {
-        return $this->info->format();
     }
 
     public function getDeclaringClass(): ClassName

--- a/src/Resolution/ResolvedConstant.php
+++ b/src/Resolution/ResolvedConstant.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\ConstantInfo;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * A resolved class constant wrapping ConstantInfo.
+ */
+final readonly class ResolvedConstant implements ResolvedMember
+{
+    public function __construct(
+        private ConstantInfo $info,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return Location::fromFileLine($this->info->file, $this->info->line);
+    }
+
+    public function getDocumentation(): ?string
+    {
+        if ($this->info->docblock === null) {
+            return null;
+        }
+        return DocblockParser::extractDescription($this->info->docblock);
+    }
+
+    public function getType(): ?Type
+    {
+        return $this->info->type;
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+
+    public function getDeclaringClass(): ClassName
+    {
+        return $this->info->declaringClass;
+    }
+
+    public function getVisibility(): Visibility
+    {
+        return $this->info->visibility;
+    }
+
+    public function isStatic(): bool
+    {
+        return true;
+    }
+}

--- a/src/Resolution/ResolvedEnumCase.php
+++ b/src/Resolution/ResolvedEnumCase.php
@@ -7,8 +7,6 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
 use Firehed\PhpLsp\Domain\Type;
-use Firehed\PhpLsp\Index\Location;
-use Firehed\PhpLsp\Utility\DocblockParser;
 
 /**
  * A resolved enum case wrapping EnumCaseInfo.
@@ -19,22 +17,11 @@ use Firehed\PhpLsp\Utility\DocblockParser;
  */
 final readonly class ResolvedEnumCase implements ResolvedSymbol
 {
+    use ResolvesFromInfo;
+
     public function __construct(
         private EnumCaseInfo $info,
     ) {
-    }
-
-    public function getDefinitionLocation(): ?Location
-    {
-        return Location::fromFileLine($this->info->file, $this->info->line);
-    }
-
-    public function getDocumentation(): ?string
-    {
-        if ($this->info->docblock === null) {
-            return null;
-        }
-        return DocblockParser::extractDescription($this->info->docblock);
     }
 
     /**
@@ -43,11 +30,6 @@ final readonly class ResolvedEnumCase implements ResolvedSymbol
     public function getType(): Type
     {
         return $this->info->declaringClass;
-    }
-
-    public function format(): string
-    {
-        return $this->info->format();
     }
 
     /**

--- a/src/Resolution/ResolvedEnumCase.php
+++ b/src/Resolution/ResolvedEnumCase.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * A resolved enum case wrapping EnumCaseInfo.
+ *
+ * Note: Enum cases do not implement ResolvedMember because they don't have
+ * visibility or static modifiers in PHP - they are implicitly public and
+ * static-like by nature.
+ */
+final readonly class ResolvedEnumCase implements ResolvedSymbol
+{
+    public function __construct(
+        private EnumCaseInfo $info,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return Location::fromFileLine($this->info->file, $this->info->line);
+    }
+
+    public function getDocumentation(): ?string
+    {
+        if ($this->info->docblock === null) {
+            return null;
+        }
+        return DocblockParser::extractDescription($this->info->docblock);
+    }
+
+    /**
+     * Returns the declaring enum's ClassName as the type.
+     */
+    public function getType(): Type
+    {
+        return $this->info->declaringClass;
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+
+    /**
+     * Returns the class that declares this enum case.
+     */
+    public function getDeclaringClass(): ClassName
+    {
+        return $this->info->declaringClass;
+    }
+}

--- a/src/Resolution/ResolvedFunction.php
+++ b/src/Resolution/ResolvedFunction.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * A resolved function wrapping FunctionInfo.
+ */
+final readonly class ResolvedFunction implements ResolvedCallable
+{
+    public function __construct(
+        private FunctionInfo $info,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return Location::fromFileLine($this->info->file, $this->info->line);
+    }
+
+    public function getDocumentation(): ?string
+    {
+        if ($this->info->docblock === null) {
+            return null;
+        }
+        return DocblockParser::extractDescription($this->info->docblock);
+    }
+
+    public function getType(): ?Type
+    {
+        return $this->info->returnType;
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+
+    public function getParameters(): array
+    {
+        return $this->info->parameters;
+    }
+
+    public function getReturnType(): ?Type
+    {
+        return $this->info->returnType;
+    }
+
+    public function getParameterAtPosition(int $position): ?ParameterInfo
+    {
+        foreach ($this->info->parameters as $param) {
+            if ($param->position === $position) {
+                return $param;
+            }
+        }
+        return null;
+    }
+
+    public function getParameterByName(string $name): ?ParameterInfo
+    {
+        foreach ($this->info->parameters as $param) {
+            if ($param->name === $name) {
+                return $param;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Resolution/ResolvedFunction.php
+++ b/src/Resolution/ResolvedFunction.php
@@ -7,69 +7,22 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Domain\Type;
-use Firehed\PhpLsp\Index\Location;
-use Firehed\PhpLsp\Utility\DocblockParser;
 
 /**
  * A resolved function wrapping FunctionInfo.
  */
 final readonly class ResolvedFunction implements ResolvedCallable
 {
+    use ResolvesFromInfo;
+    use ResolvesCallableParameters;
+
     public function __construct(
         private FunctionInfo $info,
     ) {
     }
 
-    public function getDefinitionLocation(): ?Location
-    {
-        return Location::fromFileLine($this->info->file, $this->info->line);
-    }
-
-    public function getDocumentation(): ?string
-    {
-        if ($this->info->docblock === null) {
-            return null;
-        }
-        return DocblockParser::extractDescription($this->info->docblock);
-    }
-
     public function getType(): ?Type
     {
         return $this->info->returnType;
-    }
-
-    public function format(): string
-    {
-        return $this->info->format();
-    }
-
-    public function getParameters(): array
-    {
-        return $this->info->parameters;
-    }
-
-    public function getReturnType(): ?Type
-    {
-        return $this->info->returnType;
-    }
-
-    public function getParameterAtPosition(int $position): ?ParameterInfo
-    {
-        foreach ($this->info->parameters as $param) {
-            if ($param->position === $position) {
-                return $param;
-            }
-        }
-        return null;
-    }
-
-    public function getParameterByName(string $name): ?ParameterInfo
-    {
-        foreach ($this->info->parameters as $param) {
-            if ($param->name === $name) {
-                return $param;
-            }
-        }
-        return null;
     }
 }

--- a/src/Resolution/ResolvedMember.php
+++ b/src/Resolution/ResolvedMember.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\Visibility;
+
+/**
+ * A resolved class member (method, property, constant).
+ */
+interface ResolvedMember extends ResolvedSymbol
+{
+    /**
+     * Returns the class that declares this member.
+     */
+    public function getDeclaringClass(): ClassName;
+
+    public function getVisibility(): Visibility;
+
+    public function isStatic(): bool;
+}

--- a/src/Resolution/ResolvedMethod.php
+++ b/src/Resolution/ResolvedMethod.php
@@ -9,40 +9,23 @@ use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Index\Location;
-use Firehed\PhpLsp\Utility\DocblockParser;
 
 /**
  * A resolved method wrapping MethodInfo.
  */
 final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
 {
+    use ResolvesFromInfo;
+    use ResolvesCallableParameters;
+
     public function __construct(
         private MethodInfo $info,
     ) {
     }
 
-    public function getDefinitionLocation(): ?Location
-    {
-        return Location::fromFileLine($this->info->file, $this->info->line);
-    }
-
-    public function getDocumentation(): ?string
-    {
-        if ($this->info->docblock === null) {
-            return null;
-        }
-        return DocblockParser::extractDescription($this->info->docblock);
-    }
-
     public function getType(): ?Type
     {
         return $this->info->returnType;
-    }
-
-    public function format(): string
-    {
-        return $this->info->format();
     }
 
     public function getDeclaringClass(): ClassName
@@ -58,35 +41,5 @@ final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
     public function isStatic(): bool
     {
         return $this->info->isStatic;
-    }
-
-    public function getParameters(): array
-    {
-        return $this->info->parameters;
-    }
-
-    public function getReturnType(): ?Type
-    {
-        return $this->info->returnType;
-    }
-
-    public function getParameterAtPosition(int $position): ?ParameterInfo
-    {
-        foreach ($this->info->parameters as $param) {
-            if ($param->position === $position) {
-                return $param;
-            }
-        }
-        return null;
-    }
-
-    public function getParameterByName(string $name): ?ParameterInfo
-    {
-        foreach ($this->info->parameters as $param) {
-            if ($param->name === $name) {
-                return $param;
-            }
-        }
-        return null;
     }
 }

--- a/src/Resolution/ResolvedMethod.php
+++ b/src/Resolution/ResolvedMethod.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * A resolved method wrapping MethodInfo.
+ */
+final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
+{
+    public function __construct(
+        private MethodInfo $info,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return Location::fromFileLine($this->info->file, $this->info->line);
+    }
+
+    public function getDocumentation(): ?string
+    {
+        if ($this->info->docblock === null) {
+            return null;
+        }
+        return DocblockParser::extractDescription($this->info->docblock);
+    }
+
+    public function getType(): ?Type
+    {
+        return $this->info->returnType;
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+
+    public function getDeclaringClass(): ClassName
+    {
+        return $this->info->declaringClass;
+    }
+
+    public function getVisibility(): Visibility
+    {
+        return $this->info->visibility;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->info->isStatic;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->info->parameters;
+    }
+
+    public function getReturnType(): ?Type
+    {
+        return $this->info->returnType;
+    }
+
+    public function getParameterAtPosition(int $position): ?ParameterInfo
+    {
+        foreach ($this->info->parameters as $param) {
+            if ($param->position === $position) {
+                return $param;
+            }
+        }
+        return null;
+    }
+
+    public function getParameterByName(string $name): ?ParameterInfo
+    {
+        foreach ($this->info->parameters as $param) {
+            if ($param->name === $name) {
+                return $param;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Resolution/ResolvedParameter.php
+++ b/src/Resolution/ResolvedParameter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Index\Location;
+
+/**
+ * A resolved parameter wrapping ParameterInfo.
+ *
+ * Parameters don't have persistent definition locations (they're defined
+ * inline in function/method signatures), so getDefinitionLocation() returns null.
+ */
+final readonly class ResolvedParameter implements ResolvedSymbol
+{
+    public function __construct(
+        private ParameterInfo $info,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return null;
+    }
+
+    public function getDocumentation(): ?string
+    {
+        return null;
+    }
+
+    public function getType(): ?Type
+    {
+        return $this->info->type;
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+}

--- a/src/Resolution/ResolvedProperty.php
+++ b/src/Resolution/ResolvedProperty.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * A resolved property wrapping PropertyInfo.
+ */
+final readonly class ResolvedProperty implements ResolvedMember
+{
+    public function __construct(
+        private PropertyInfo $info,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return Location::fromFileLine($this->info->file, $this->info->line);
+    }
+
+    public function getDocumentation(): ?string
+    {
+        if ($this->info->docblock === null) {
+            return null;
+        }
+        return DocblockParser::extractDescription($this->info->docblock);
+    }
+
+    public function getType(): ?Type
+    {
+        return $this->info->type;
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+
+    public function getDeclaringClass(): ClassName
+    {
+        return $this->info->declaringClass;
+    }
+
+    public function getVisibility(): Visibility
+    {
+        return $this->info->visibility;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->info->isStatic;
+    }
+}

--- a/src/Resolution/ResolvedProperty.php
+++ b/src/Resolution/ResolvedProperty.php
@@ -8,40 +8,22 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\PropertyInfo;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Index\Location;
-use Firehed\PhpLsp\Utility\DocblockParser;
 
 /**
  * A resolved property wrapping PropertyInfo.
  */
 final readonly class ResolvedProperty implements ResolvedMember
 {
+    use ResolvesFromInfo;
+
     public function __construct(
         private PropertyInfo $info,
     ) {
     }
 
-    public function getDefinitionLocation(): ?Location
-    {
-        return Location::fromFileLine($this->info->file, $this->info->line);
-    }
-
-    public function getDocumentation(): ?string
-    {
-        if ($this->info->docblock === null) {
-            return null;
-        }
-        return DocblockParser::extractDescription($this->info->docblock);
-    }
-
     public function getType(): ?Type
     {
         return $this->info->type;
-    }
-
-    public function format(): string
-    {
-        return $this->info->format();
     }
 
     public function getDeclaringClass(): ClassName

--- a/src/Resolution/ResolvedSymbol.php
+++ b/src/Resolution/ResolvedSymbol.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Index\Location;
+
+/**
+ * A resolved symbol represents a code element that has been located and analyzed.
+ * Implementations wrap domain objects (ClassInfo, MethodInfo, etc.) to provide
+ * a uniform interface for handlers.
+ */
+interface ResolvedSymbol
+{
+    /**
+     * Returns the source location where this symbol is defined, or null if unknown.
+     */
+    public function getDefinitionLocation(): ?Location;
+
+    /**
+     * Returns the docblock description (first paragraph), or null if none.
+     */
+    public function getDocumentation(): ?string;
+
+    /**
+     * Returns the symbol's type. For callables, this is the return type.
+     */
+    public function getType(): ?Type;
+
+    /**
+     * Returns a formatted signature suitable for display (e.g., hover tooltips).
+     */
+    public function format(): string;
+}

--- a/src/Resolution/ResolvedVariable.php
+++ b/src/Resolution/ResolvedVariable.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Index\Location;
+
+/**
+ * A resolved variable with its inferred type.
+ *
+ * Variables don't have persistent definition locations (they're assigned
+ * inline), so getDefinitionLocation() always returns null.
+ */
+final readonly class ResolvedVariable implements ResolvedSymbol
+{
+    public function __construct(
+        private string $name,
+        private ?Type $type,
+    ) {
+    }
+
+    public function getDefinitionLocation(): ?Location
+    {
+        return null;
+    }
+
+    public function getDocumentation(): ?string
+    {
+        return null;
+    }
+
+    public function getType(): ?Type
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns the variable signature for display (e.g., "string $name").
+     */
+    public function format(): string
+    {
+        if ($this->type === null) {
+            return '$' . $this->name;
+        }
+        return $this->type->format() . ' $' . $this->name;
+    }
+}

--- a/src/Resolution/ResolvesCallableParameters.php
+++ b/src/Resolution/ResolvesCallableParameters.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\Type;
+
+/**
+ * Provides ResolvedCallable implementations.
+ *
+ * Expects the using class to have a `$this->info` property with `parameters`
+ * (array of ParameterInfo) and `returnType` (?Type) properties.
+ */
+trait ResolvesCallableParameters
+{
+    public function getParameters(): array
+    {
+        return $this->info->parameters;
+    }
+
+    public function getReturnType(): ?Type
+    {
+        return $this->info->returnType;
+    }
+
+    public function getParameterAtPosition(int $position): ?ParameterInfo
+    {
+        foreach ($this->info->parameters as $param) {
+            if ($param->position === $position) {
+                return $param;
+            }
+        }
+        return null;
+    }
+
+    public function getParameterByName(string $name): ?ParameterInfo
+    {
+        foreach ($this->info->parameters as $param) {
+            if ($param->name === $name) {
+                return $param;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Resolution/ResolvesFromInfo.php
+++ b/src/Resolution/ResolvesFromInfo.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * Provides common ResolvedSymbol implementations for classes wrapping Info objects.
+ *
+ * Expects the using class to have a `$this->info` property with `file`, `line`,
+ * `docblock` properties and a `format()` method.
+ */
+trait ResolvesFromInfo
+{
+    public function getDefinitionLocation(): ?Location
+    {
+        return Location::fromFileLine($this->info->file, $this->info->line);
+    }
+
+    public function getDocumentation(): ?string
+    {
+        if ($this->info->docblock === null) {
+            return null;
+        }
+        return DocblockParser::extractDescription($this->info->docblock);
+    }
+
+    public function format(): string
+    {
+        return $this->info->format();
+    }
+}

--- a/tests/Domain/ClassInfoTest.php
+++ b/tests/Domain/ClassInfoTest.php
@@ -73,4 +73,160 @@ class ClassInfoTest extends TestCase
         self::assertNull($class->file);
         self::assertNull($class->line);
     }
+
+    public function testFormatSimpleClass(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\User',
+            kind: ClassKind::Class_,
+        );
+
+        self::assertSame('class User', $class->format());
+    }
+
+    public function testFormatFinalClass(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\User',
+            kind: ClassKind::Class_,
+            isFinal: true,
+        );
+
+        self::assertSame('final class User', $class->format());
+    }
+
+    public function testFormatAbstractClass(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\Entity',
+            kind: ClassKind::Class_,
+            isAbstract: true,
+        );
+
+        self::assertSame('abstract class Entity', $class->format());
+    }
+
+    public function testFormatReadonlyClass(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\Value',
+            kind: ClassKind::Class_,
+            isReadonly: true,
+        );
+
+        self::assertSame('readonly class Value', $class->format());
+    }
+
+    public function testFormatClassWithParent(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\User',
+            kind: ClassKind::Class_,
+            parent: new ClassName('App\\Entity'),
+        );
+
+        self::assertSame('class User extends Entity', $class->format());
+    }
+
+    public function testFormatClassWithInterfaces(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\User',
+            kind: ClassKind::Class_,
+            interfaces: [
+                new ClassName('JsonSerializable'),
+                new ClassName('Stringable'),
+            ],
+        );
+
+        self::assertSame('class User implements JsonSerializable, Stringable', $class->format());
+    }
+
+    public function testFormatClassWithParentAndInterfaces(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\User',
+            kind: ClassKind::Class_,
+            isFinal: true,
+            parent: new ClassName('App\\Entity'),
+            interfaces: [new ClassName('JsonSerializable')],
+        );
+
+        self::assertSame('final class User extends Entity implements JsonSerializable', $class->format());
+    }
+
+    public function testFormatInterface(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\UserInterface',
+            kind: ClassKind::Interface_,
+        );
+
+        self::assertSame('interface UserInterface', $class->format());
+    }
+
+    public function testFormatInterfaceExtendingInterfaces(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\UserInterface',
+            kind: ClassKind::Interface_,
+            interfaces: [
+                new ClassName('JsonSerializable'),
+                new ClassName('Stringable'),
+            ],
+        );
+
+        self::assertSame('interface UserInterface extends JsonSerializable, Stringable', $class->format());
+    }
+
+    public function testFormatTrait(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\LoggerTrait',
+            kind: ClassKind::Trait_,
+        );
+
+        self::assertSame('trait LoggerTrait', $class->format());
+    }
+
+    public function testFormatEnum(): void
+    {
+        $class = $this->createClassInfo(
+            name: 'App\\Status',
+            kind: ClassKind::Enum_,
+        );
+
+        self::assertSame('enum Status', $class->format());
+    }
+
+    /**
+     * @param list<ClassName> $interfaces
+     */
+    private function createClassInfo(
+        string $name,
+        ClassKind $kind,
+        bool $isAbstract = false,
+        bool $isFinal = false,
+        bool $isReadonly = false,
+        ?ClassName $parent = null,
+        array $interfaces = [],
+    ): ClassInfo {
+        return new ClassInfo(
+            name: new ClassName($name),
+            kind: $kind,
+            isAbstract: $isAbstract,
+            isFinal: $isFinal,
+            isReadonly: $isReadonly,
+            parent: $parent,
+            interfaces: $interfaces,
+            traits: [],
+            methods: [],
+            properties: [],
+            constants: [],
+            enumCases: [],
+            docblock: null,
+            file: null,
+            line: null,
+        );
+    }
 }

--- a/tests/Domain/ClassInfoTest.php
+++ b/tests/Domain/ClassInfoTest.php
@@ -77,129 +77,130 @@ class ClassInfoTest extends TestCase
     public function testFormatSimpleClass(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\User',
+            name: \stdClass::class,
             kind: ClassKind::Class_,
         );
 
-        self::assertSame('class User', $class->format());
+        self::assertSame('class stdClass', $class->format());
     }
 
     public function testFormatFinalClass(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\User',
+            name: \stdClass::class,
             kind: ClassKind::Class_,
             isFinal: true,
         );
 
-        self::assertSame('final class User', $class->format());
+        self::assertSame('final class stdClass', $class->format());
     }
 
     public function testFormatAbstractClass(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\Entity',
+            name: \stdClass::class,
             kind: ClassKind::Class_,
             isAbstract: true,
         );
 
-        self::assertSame('abstract class Entity', $class->format());
+        self::assertSame('abstract class stdClass', $class->format());
     }
 
     public function testFormatReadonlyClass(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\Value',
+            name: \stdClass::class,
             kind: ClassKind::Class_,
             isReadonly: true,
         );
 
-        self::assertSame('readonly class Value', $class->format());
+        self::assertSame('readonly class stdClass', $class->format());
     }
 
     public function testFormatClassWithParent(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\User',
+            name: \Exception::class,
             kind: ClassKind::Class_,
-            parent: new ClassName('App\\Entity'),
+            parent: new ClassName(\Error::class),
         );
 
-        self::assertSame('class User extends Entity', $class->format());
+        self::assertSame('class Exception extends Error', $class->format());
     }
 
     public function testFormatClassWithInterfaces(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\User',
+            name: \stdClass::class,
             kind: ClassKind::Class_,
             interfaces: [
-                new ClassName('JsonSerializable'),
-                new ClassName('Stringable'),
+                new ClassName(\JsonSerializable::class),
+                new ClassName(\Stringable::class),
             ],
         );
 
-        self::assertSame('class User implements JsonSerializable, Stringable', $class->format());
+        self::assertSame('class stdClass implements JsonSerializable, Stringable', $class->format());
     }
 
     public function testFormatClassWithParentAndInterfaces(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\User',
+            name: \Exception::class,
             kind: ClassKind::Class_,
             isFinal: true,
-            parent: new ClassName('App\\Entity'),
-            interfaces: [new ClassName('JsonSerializable')],
+            parent: new ClassName(\Error::class),
+            interfaces: [new ClassName(\JsonSerializable::class)],
         );
 
-        self::assertSame('final class User extends Entity implements JsonSerializable', $class->format());
+        self::assertSame('final class Exception extends Error implements JsonSerializable', $class->format());
     }
 
     public function testFormatInterface(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\UserInterface',
+            name: \Stringable::class,
             kind: ClassKind::Interface_,
         );
 
-        self::assertSame('interface UserInterface', $class->format());
+        self::assertSame('interface Stringable', $class->format());
     }
 
     public function testFormatInterfaceExtendingInterfaces(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\UserInterface',
+            name: \Stringable::class,
             kind: ClassKind::Interface_,
             interfaces: [
-                new ClassName('JsonSerializable'),
-                new ClassName('Stringable'),
+                new ClassName(\JsonSerializable::class),
+                new ClassName(\Countable::class),
             ],
         );
 
-        self::assertSame('interface UserInterface extends JsonSerializable, Stringable', $class->format());
+        self::assertSame('interface Stringable extends JsonSerializable, Countable', $class->format());
     }
 
     public function testFormatTrait(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\LoggerTrait',
+            name: \Generator::class,
             kind: ClassKind::Trait_,
         );
 
-        self::assertSame('trait LoggerTrait', $class->format());
+        self::assertSame('trait Generator', $class->format());
     }
 
     public function testFormatEnum(): void
     {
         $class = $this->createClassInfo(
-            name: 'App\\Status',
+            name: ClassKind::class,
             kind: ClassKind::Enum_,
         );
 
-        self::assertSame('enum Status', $class->format());
+        self::assertSame('enum ClassKind', $class->format());
     }
 
     /**
+     * @param class-string $name
      * @param list<ClassName> $interfaces
      */
     private function createClassInfo(

--- a/tests/Domain/FunctionInfoTest.php
+++ b/tests/Domain/FunctionInfoTest.php
@@ -68,7 +68,7 @@ class FunctionInfoTest extends TestCase
         $func = new FunctionInfo(
             name: 'greet',
             parameters: [
-                new ParameterInfo('name', new PrimitiveType('string'), false, false, false),
+                new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
             ],
             returnType: null,
             docblock: null,
@@ -84,8 +84,8 @@ class FunctionInfoTest extends TestCase
         $func = new FunctionInfo(
             name: 'add',
             parameters: [
-                new ParameterInfo('a', new PrimitiveType('int'), false, false, false),
-                new ParameterInfo('b', new PrimitiveType('int'), false, false, false),
+                new ParameterInfo('a', new PrimitiveType('int'), false, null, 0, false, false),
+                new ParameterInfo('b', new PrimitiveType('int'), false, null, 1, false, false),
             ],
             returnType: new PrimitiveType('int'),
             docblock: null,
@@ -101,7 +101,7 @@ class FunctionInfoTest extends TestCase
         $func = new FunctionInfo(
             name: 'sum',
             parameters: [
-                new ParameterInfo('numbers', new PrimitiveType('int'), false, true, false),
+                new ParameterInfo('numbers', new PrimitiveType('int'), false, null, 0, true, false),
             ],
             returnType: new PrimitiveType('int'),
             docblock: null,

--- a/tests/Domain/MethodInfoTest.php
+++ b/tests/Domain/MethodInfoTest.php
@@ -86,7 +86,7 @@ class MethodInfoTest extends TestCase
             isAbstract: false,
             isFinal: false,
             parameters: [
-                new ParameterInfo('name', new PrimitiveType('string'), false, false, false),
+                new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
             ],
             returnType: null,
             docblock: null,
@@ -107,8 +107,8 @@ class MethodInfoTest extends TestCase
             isAbstract: false,
             isFinal: false,
             parameters: [
-                new ParameterInfo('a', new PrimitiveType('int'), false, false, false),
-                new ParameterInfo('b', new PrimitiveType('int'), false, false, false),
+                new ParameterInfo('a', new PrimitiveType('int'), false, null, 0, false, false),
+                new ParameterInfo('b', new PrimitiveType('int'), false, null, 1, false, false),
             ],
             returnType: new PrimitiveType('int'),
             docblock: null,
@@ -129,7 +129,7 @@ class MethodInfoTest extends TestCase
             isAbstract: false,
             isFinal: false,
             parameters: [
-                new ParameterInfo('arrays', new PrimitiveType('array'), false, true, false),
+                new ParameterInfo('arrays', new PrimitiveType('array'), false, null, 0, true, false),
             ],
             returnType: new PrimitiveType('array'),
             docblock: null,
@@ -150,8 +150,8 @@ class MethodInfoTest extends TestCase
             isAbstract: false,
             isFinal: false,
             parameters: [
-                new ParameterInfo('a', new PrimitiveType('mixed'), false, false, true),
-                new ParameterInfo('b', new PrimitiveType('mixed'), false, false, true),
+                new ParameterInfo('a', new PrimitiveType('mixed'), false, null, 0, false, true),
+                new ParameterInfo('b', new PrimitiveType('mixed'), false, null, 1, false, true),
             ],
             returnType: new PrimitiveType('void'),
             docblock: null,

--- a/tests/Domain/ParameterInfoTest.php
+++ b/tests/Domain/ParameterInfoTest.php
@@ -21,6 +21,8 @@ class ParameterInfoTest extends TestCase
             name: 'value',
             type: new PrimitiveType('string'),
             hasDefault: true,
+            defaultValue: "'hello'",
+            position: 0,
             isVariadic: false,
             isPassedByReference: false,
         );
@@ -28,6 +30,8 @@ class ParameterInfoTest extends TestCase
         self::assertSame('value', $param->name);
         self::assertSame('string', $param->type?->format());
         self::assertTrue($param->hasDefault);
+        self::assertSame("'hello'", $param->defaultValue);
+        self::assertSame(0, $param->position);
         self::assertFalse($param->isVariadic);
         self::assertFalse($param->isPassedByReference);
     }
@@ -38,6 +42,8 @@ class ParameterInfoTest extends TestCase
             name: 'args',
             type: null,
             hasDefault: false,
+            defaultValue: null,
+            position: 0,
             isVariadic: true,
             isPassedByReference: false,
         );
@@ -52,6 +58,8 @@ class ParameterInfoTest extends TestCase
             name: 'value',
             type: new PrimitiveType('string'),
             hasDefault: false,
+            defaultValue: null,
+            position: 0,
             isVariadic: false,
             isPassedByReference: false,
         );
@@ -65,6 +73,8 @@ class ParameterInfoTest extends TestCase
             name: 'value',
             type: null,
             hasDefault: false,
+            defaultValue: null,
+            position: 0,
             isVariadic: false,
             isPassedByReference: false,
         );
@@ -78,6 +88,8 @@ class ParameterInfoTest extends TestCase
             name: 'args',
             type: new PrimitiveType('string'),
             hasDefault: false,
+            defaultValue: null,
+            position: 0,
             isVariadic: true,
             isPassedByReference: false,
         );
@@ -91,6 +103,8 @@ class ParameterInfoTest extends TestCase
             name: 'value',
             type: new PrimitiveType('int'),
             hasDefault: true,
+            defaultValue: '10',
+            position: 0,
             isVariadic: false,
             isPassedByReference: false,
         );
@@ -104,6 +118,8 @@ class ParameterInfoTest extends TestCase
             name: 'value',
             type: new PrimitiveType('int'),
             hasDefault: true,
+            defaultValue: null,
+            position: 0,
             isVariadic: false,
             isPassedByReference: false,
         );
@@ -117,6 +133,8 @@ class ParameterInfoTest extends TestCase
             name: 'args',
             type: new PrimitiveType('string'),
             hasDefault: true,
+            defaultValue: '[]',
+            position: 0,
             isVariadic: true,
             isPassedByReference: false,
         );
@@ -130,6 +148,8 @@ class ParameterInfoTest extends TestCase
             name: 'value',
             type: new PrimitiveType('string'),
             hasDefault: false,
+            defaultValue: null,
+            position: 0,
             isVariadic: false,
             isPassedByReference: true,
         );
@@ -143,6 +163,8 @@ class ParameterInfoTest extends TestCase
             name: 'args',
             type: new PrimitiveType('array'),
             hasDefault: false,
+            defaultValue: null,
+            position: 0,
             isVariadic: true,
             isPassedByReference: true,
         );
@@ -158,7 +180,7 @@ class ParameterInfoTest extends TestCase
             type: new Identifier('string'),
         );
 
-        $param = ParameterInfo::fromNode($node);
+        $param = ParameterInfo::fromNode($node, 0);
 
         self::assertNotNull($param);
         self::assertSame('name', $param->name);
@@ -166,6 +188,8 @@ class ParameterInfoTest extends TestCase
         self::assertFalse($param->hasDefault);
         self::assertFalse($param->isVariadic);
         self::assertFalse($param->isPassedByReference);
+        self::assertSame(0, $param->position);
+        self::assertNull($param->defaultValue);
     }
 
     public function testFromReflectionSimple(): void
@@ -191,11 +215,12 @@ class ParameterInfoTest extends TestCase
             type: new Identifier('int'),
         );
 
-        $param = ParameterInfo::fromNode($node);
+        $param = ParameterInfo::fromNode($node, 0);
 
         self::assertNotNull($param);
         self::assertSame('count', $param->name);
         self::assertTrue($param->hasDefault);
+        self::assertSame('0', $param->defaultValue);
     }
 
     public function testFromNodeVariadic(): void
@@ -207,7 +232,7 @@ class ParameterInfoTest extends TestCase
             variadic: true,
         );
 
-        $param = ParameterInfo::fromNode($node);
+        $param = ParameterInfo::fromNode($node, 0);
 
         self::assertNotNull($param);
         self::assertTrue($param->isVariadic);
@@ -222,7 +247,7 @@ class ParameterInfoTest extends TestCase
             byRef: true,
         );
 
-        $param = ParameterInfo::fromNode($node);
+        $param = ParameterInfo::fromNode($node, 0);
 
         self::assertNotNull($param);
         self::assertTrue($param->isPassedByReference);
@@ -236,7 +261,7 @@ class ParameterInfoTest extends TestCase
             type: null,
         );
 
-        $param = ParameterInfo::fromNode($node);
+        $param = ParameterInfo::fromNode($node, 0);
 
         self::assertNotNull($param);
         self::assertNull($param->type);
@@ -251,7 +276,7 @@ class ParameterInfoTest extends TestCase
             type: null,
         );
 
-        $param = ParameterInfo::fromNode($node);
+        $param = ParameterInfo::fromNode($node, 0);
 
         self::assertNull($param);
     }
@@ -329,5 +354,152 @@ class ParameterInfoTest extends TestCase
         self::assertFalse($param->hasDefault);
         self::assertFalse($param->isVariadic);
         self::assertFalse($param->isPassedByReference);
+    }
+
+    public function testPositionField(): void
+    {
+        $param = new ParameterInfo(
+            name: 'second',
+            type: new PrimitiveType('string'),
+            hasDefault: false,
+            defaultValue: null,
+            position: 1,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame(1, $param->position);
+    }
+
+    public function testDefaultValueField(): void
+    {
+        $param = new ParameterInfo(
+            name: 'count',
+            type: new PrimitiveType('int'),
+            hasDefault: true,
+            defaultValue: '42',
+            position: 0,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('42', $param->defaultValue);
+    }
+
+    public function testFormatWithActualDefaultValue(): void
+    {
+        $param = new ParameterInfo(
+            name: 'count',
+            type: new PrimitiveType('int'),
+            hasDefault: true,
+            defaultValue: '42',
+            position: 0,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('int $count = 42', $param->format(showDefault: true));
+    }
+
+    public function testFormatWithNullDefaultValue(): void
+    {
+        $param = new ParameterInfo(
+            name: 'value',
+            type: new PrimitiveType('string'),
+            hasDefault: true,
+            defaultValue: null,
+            position: 0,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        self::assertSame('string $value = ...', $param->format(showDefault: true));
+    }
+
+    public function testFromNodeExtractsDefaultValue(): void
+    {
+        $node = new Param(
+            var: new Variable('count'),
+            default: new Int_(42),
+            type: new Identifier('int'),
+        );
+
+        $param = ParameterInfo::fromNode($node, 0);
+
+        self::assertNotNull($param);
+        self::assertSame('42', $param->defaultValue);
+    }
+
+    public function testFromNodeWithPosition(): void
+    {
+        $node = new Param(
+            var: new Variable('name'),
+            default: null,
+            type: new Identifier('string'),
+        );
+
+        $param = ParameterInfo::fromNode($node, 2);
+
+        self::assertNotNull($param);
+        self::assertSame(2, $param->position);
+    }
+
+    public function testFromReflectionExtractsPosition(): void
+    {
+        $fn = function (string $first, int $second, bool $third) {
+        };
+        $params = (new ReflectionFunction($fn))->getParameters();
+
+        $first = ParameterInfo::fromReflection($params[0]);
+        $second = ParameterInfo::fromReflection($params[1]);
+        $third = ParameterInfo::fromReflection($params[2]);
+
+        self::assertSame(0, $first->position);
+        self::assertSame(1, $second->position);
+        self::assertSame(2, $third->position);
+    }
+
+    public function testFromReflectionExtractsDefaultValue(): void
+    {
+        $fn = function (int $count = 10) {
+        };
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('10', $param->defaultValue);
+    }
+
+    public function testFromReflectionWithStringDefault(): void
+    {
+        $fn = function (string $name = 'default') {
+        };
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame("'default'", $param->defaultValue);
+    }
+
+    public function testFromReflectionWithNullDefault(): void
+    {
+        $fn = function (?string $value = null) {
+        };
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('null', $param->defaultValue);
+    }
+
+    public function testFromReflectionWithArrayDefault(): void
+    {
+        $fn = function (array $items = []) {
+        };
+        $reflectionParam = (new ReflectionFunction($fn))->getParameters()[0];
+
+        $param = ParameterInfo::fromReflection($reflectionParam);
+
+        self::assertSame('[]', $param->defaultValue);
     }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -380,7 +380,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$count = ...', $result['contents']);
+        self::assertStringContainsString('$count = 0', $result['contents']);
         self::assertStringNotContainsString('$name = ...', $result['contents']);
     }
 

--- a/tests/Index/LocationTest.php
+++ b/tests/Index/LocationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Location::class)]
+class LocationTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $location = new Location(
+            uri: 'file:///path/to/file.php',
+            startLine: 10,
+            startCharacter: 5,
+            endLine: 10,
+            endCharacter: 15,
+        );
+
+        self::assertSame('file:///path/to/file.php', $location->uri);
+        self::assertSame(10, $location->startLine);
+        self::assertSame(5, $location->startCharacter);
+        self::assertSame(10, $location->endLine);
+        self::assertSame(15, $location->endCharacter);
+    }
+
+    public function testToLspLocation(): void
+    {
+        $location = new Location(
+            uri: 'file:///path/to/file.php',
+            startLine: 10,
+            startCharacter: 5,
+            endLine: 10,
+            endCharacter: 15,
+        );
+
+        $lsp = $location->toLspLocation();
+
+        self::assertSame('file:///path/to/file.php', $lsp['uri']);
+        self::assertSame(10, $lsp['range']['start']['line']);
+        self::assertSame(5, $lsp['range']['start']['character']);
+        self::assertSame(10, $lsp['range']['end']['line']);
+        self::assertSame(15, $lsp['range']['end']['character']);
+    }
+
+    public function testFromFileLineWithValidPath(): void
+    {
+        $location = Location::fromFileLine('/path/to/file.php', 10);
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+        self::assertSame(9, $location->startLine);
+        self::assertSame(0, $location->startCharacter);
+        self::assertSame(9, $location->endLine);
+        self::assertSame(0, $location->endCharacter);
+    }
+
+    public function testFromFileLineWithAlreadyUri(): void
+    {
+        $location = Location::fromFileLine('file:///already/uri.php', 5);
+
+        self::assertNotNull($location);
+        self::assertSame('file:///already/uri.php', $location->uri);
+        self::assertSame(4, $location->startLine);
+    }
+
+    public function testFromFileLineWithNullFile(): void
+    {
+        $location = Location::fromFileLine(null, 10);
+
+        self::assertNull($location);
+    }
+
+    public function testFromFileLineWithNullLine(): void
+    {
+        $location = Location::fromFileLine('/path/to/file.php', null);
+
+        self::assertNull($location);
+    }
+
+    public function testFromFileLineWithBothNull(): void
+    {
+        $location = Location::fromFileLine(null, null);
+
+        self::assertNull($location);
+    }
+}

--- a/tests/Resolution/ResolvedClassTest.php
+++ b/tests/Resolution/ResolvedClassTest.php
@@ -44,6 +44,13 @@ class ResolvedClassTest extends TestCase
         self::assertSame('A user entity', $resolved->getDocumentation());
     }
 
+    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
+    {
+        $resolved = $this->createResolvedClass(docblock: null);
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
     public function testGetType(): void
     {
         $resolved = $this->createResolvedClass();

--- a/tests/Resolution/ResolvedClassTest.php
+++ b/tests/Resolution/ResolvedClassTest.php
@@ -13,42 +13,23 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ResolvedClass::class)]
 class ResolvedClassTest extends TestCase
 {
+    use ResolvesFromInfoTestTrait;
+
+    protected function createSubjectWithLocation(?string $file, ?int $line): ResolvedSymbol
+    {
+        return $this->createResolvedClass(file: $file, line: $line);
+    }
+
+    protected function createSubjectWithDocblock(?string $docblock): ResolvedSymbol
+    {
+        return $this->createResolvedClass(docblock: $docblock);
+    }
+
     public function testImplementsInterfaces(): void
     {
         $resolved = $this->createResolvedClass();
 
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
-    }
-
-    public function testGetDefinitionLocation(): void
-    {
-        $resolved = $this->createResolvedClass();
-
-        $location = $resolved->getDefinitionLocation();
-
-        self::assertNotNull($location);
-        self::assertSame('file:///path/to/file.php', $location->uri);
-    }
-
-    public function testGetDefinitionLocationReturnsNullWhenFileIsNull(): void
-    {
-        $resolved = $this->createResolvedClass(file: null);
-
-        self::assertNull($resolved->getDefinitionLocation());
-    }
-
-    public function testGetDocumentation(): void
-    {
-        $resolved = $this->createResolvedClass(docblock: "/**\n * A user entity\n */");
-
-        self::assertSame('A user entity', $resolved->getDocumentation());
-    }
-
-    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
-    {
-        $resolved = $this->createResolvedClass(docblock: null);
-
-        self::assertNull($resolved->getDocumentation());
     }
 
     public function testGetType(): void

--- a/tests/Resolution/ResolvedClassTest.php
+++ b/tests/Resolution/ResolvedClassTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\ClassKind;
+use Firehed\PhpLsp\Domain\ClassName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedClass::class)]
+class ResolvedClassTest extends TestCase
+{
+    public function testImplementsInterfaces(): void
+    {
+        $resolved = $this->createResolvedClass();
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+    }
+
+    public function testGetDefinitionLocation(): void
+    {
+        $resolved = $this->createResolvedClass();
+
+        $location = $resolved->getDefinitionLocation();
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+    }
+
+    public function testGetDefinitionLocationReturnsNullWhenFileIsNull(): void
+    {
+        $resolved = $this->createResolvedClass(file: null);
+
+        self::assertNull($resolved->getDefinitionLocation());
+    }
+
+    public function testGetDocumentation(): void
+    {
+        $resolved = $this->createResolvedClass(docblock: "/**\n * A user entity\n */");
+
+        self::assertSame('A user entity', $resolved->getDocumentation());
+    }
+
+    public function testGetType(): void
+    {
+        $resolved = $this->createResolvedClass();
+
+        $type = $resolved->getType();
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(\stdClass::class, $type->fqn);
+    }
+
+    public function testFormat(): void
+    {
+        $resolved = $this->createResolvedClass();
+
+        self::assertSame('class stdClass', $resolved->format());
+    }
+
+    private function createResolvedClass(
+        ?string $file = '/path/to/file.php',
+        ?int $line = 10,
+        ?string $docblock = null,
+    ): ResolvedClass {
+        $classInfo = new ClassInfo(
+            name: new ClassName(\stdClass::class),
+            kind: ClassKind::Class_,
+            isAbstract: false,
+            isFinal: false,
+            isReadonly: false,
+            parent: null,
+            interfaces: [],
+            traits: [],
+            methods: [],
+            properties: [],
+            constants: [],
+            enumCases: [],
+            docblock: $docblock,
+            file: $file,
+            line: $line,
+        );
+
+        return new ResolvedClass($classInfo);
+    }
+}

--- a/tests/Resolution/ResolvedConstantTest.php
+++ b/tests/Resolution/ResolvedConstantTest.php
@@ -15,36 +15,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ResolvedConstant::class)]
 class ResolvedConstantTest extends TestCase
 {
+    use ResolvesFromInfoTestTrait;
+
+    protected function createSubjectWithLocation(?string $file, ?int $line): ResolvedSymbol
+    {
+        return $this->createResolvedConstant(file: $file, line: $line);
+    }
+
+    protected function createSubjectWithDocblock(?string $docblock): ResolvedSymbol
+    {
+        return $this->createResolvedConstant(docblock: $docblock);
+    }
+
     public function testImplementsInterfaces(): void
     {
         $resolved = $this->createResolvedConstant();
 
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
         self::assertInstanceOf(ResolvedMember::class, $resolved);
-    }
-
-    public function testGetDefinitionLocation(): void
-    {
-        $resolved = $this->createResolvedConstant();
-
-        $location = $resolved->getDefinitionLocation();
-
-        self::assertNotNull($location);
-        self::assertSame('file:///path/to/file.php', $location->uri);
-    }
-
-    public function testGetDocumentation(): void
-    {
-        $resolved = $this->createResolvedConstant(docblock: "/**\n * Max retries\n */");
-
-        self::assertSame('Max retries', $resolved->getDocumentation());
-    }
-
-    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
-    {
-        $resolved = $this->createResolvedConstant(docblock: null);
-
-        self::assertNull($resolved->getDocumentation());
     }
 
     public function testGetType(): void
@@ -85,6 +73,8 @@ class ResolvedConstantTest extends TestCase
     }
 
     private function createResolvedConstant(
+        ?string $file = '/path/to/file.php',
+        ?int $line = 10,
         ?string $docblock = null,
         ?PrimitiveType $type = null,
         ?ClassName $declaringClass = null,
@@ -96,8 +86,8 @@ class ResolvedConstantTest extends TestCase
             isFinal: false,
             type: $type ?? new PrimitiveType('int'),
             docblock: $docblock,
-            file: '/path/to/file.php',
-            line: 10,
+            file: $file,
+            line: $line,
             declaringClass: $declaringClass ?? new ClassName(\stdClass::class),
         );
 

--- a/tests/Resolution/ResolvedConstantTest.php
+++ b/tests/Resolution/ResolvedConstantTest.php
@@ -40,6 +40,13 @@ class ResolvedConstantTest extends TestCase
         self::assertSame('Max retries', $resolved->getDocumentation());
     }
 
+    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
+    {
+        $resolved = $this->createResolvedConstant(docblock: null);
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
     public function testGetType(): void
     {
         $type = new PrimitiveType('int');

--- a/tests/Resolution/ResolvedConstantTest.php
+++ b/tests/Resolution/ResolvedConstantTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\ConstantInfo;
+use Firehed\PhpLsp\Domain\ConstantName;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\Visibility;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedConstant::class)]
+class ResolvedConstantTest extends TestCase
+{
+    public function testImplementsInterfaces(): void
+    {
+        $resolved = $this->createResolvedConstant();
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+        self::assertInstanceOf(ResolvedMember::class, $resolved);
+    }
+
+    public function testGetDefinitionLocation(): void
+    {
+        $resolved = $this->createResolvedConstant();
+
+        $location = $resolved->getDefinitionLocation();
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+    }
+
+    public function testGetDocumentation(): void
+    {
+        $resolved = $this->createResolvedConstant(docblock: "/**\n * Max retries\n */");
+
+        self::assertSame('Max retries', $resolved->getDocumentation());
+    }
+
+    public function testGetType(): void
+    {
+        $type = new PrimitiveType('int');
+        $resolved = $this->createResolvedConstant(type: $type);
+
+        self::assertSame($type, $resolved->getType());
+    }
+
+    public function testFormat(): void
+    {
+        $resolved = $this->createResolvedConstant();
+
+        self::assertSame('public const int MAX_RETRIES', $resolved->format());
+    }
+
+    public function testGetDeclaringClass(): void
+    {
+        $className = new ClassName(\stdClass::class);
+        $resolved = $this->createResolvedConstant(declaringClass: $className);
+
+        self::assertSame($className, $resolved->getDeclaringClass());
+    }
+
+    public function testGetVisibility(): void
+    {
+        $resolved = $this->createResolvedConstant(visibility: Visibility::Private);
+
+        self::assertSame(Visibility::Private, $resolved->getVisibility());
+    }
+
+    public function testIsStaticAlwaysTrue(): void
+    {
+        $resolved = $this->createResolvedConstant();
+
+        self::assertTrue($resolved->isStatic());
+    }
+
+    private function createResolvedConstant(
+        ?string $docblock = null,
+        ?PrimitiveType $type = null,
+        ?ClassName $declaringClass = null,
+        Visibility $visibility = Visibility::Public,
+    ): ResolvedConstant {
+        $constantInfo = new ConstantInfo(
+            name: new ConstantName('MAX_RETRIES'),
+            visibility: $visibility,
+            isFinal: false,
+            type: $type ?? new PrimitiveType('int'),
+            docblock: $docblock,
+            file: '/path/to/file.php',
+            line: 10,
+            declaringClass: $declaringClass ?? new ClassName(\stdClass::class),
+        );
+
+        return new ResolvedConstant($constantInfo);
+    }
+}

--- a/tests/Resolution/ResolvedEnumCaseTest.php
+++ b/tests/Resolution/ResolvedEnumCaseTest.php
@@ -38,6 +38,13 @@ class ResolvedEnumCaseTest extends TestCase
         self::assertSame('Active status', $resolved->getDocumentation());
     }
 
+    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
+    {
+        $resolved = $this->createResolvedEnumCase(docblock: null);
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
     public function testGetTypeReturnsDeclaringEnum(): void
     {
         $enumName = new ClassName(ClassKind::class);

--- a/tests/Resolution/ResolvedEnumCaseTest.php
+++ b/tests/Resolution/ResolvedEnumCaseTest.php
@@ -14,35 +14,23 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ResolvedEnumCase::class)]
 class ResolvedEnumCaseTest extends TestCase
 {
+    use ResolvesFromInfoTestTrait;
+
+    protected function createSubjectWithLocation(?string $file, ?int $line): ResolvedSymbol
+    {
+        return $this->createResolvedEnumCase(file: $file, line: $line);
+    }
+
+    protected function createSubjectWithDocblock(?string $docblock): ResolvedSymbol
+    {
+        return $this->createResolvedEnumCase(docblock: $docblock);
+    }
+
     public function testImplementsResolvedSymbol(): void
     {
         $resolved = $this->createResolvedEnumCase();
 
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
-    }
-
-    public function testGetDefinitionLocation(): void
-    {
-        $resolved = $this->createResolvedEnumCase();
-
-        $location = $resolved->getDefinitionLocation();
-
-        self::assertNotNull($location);
-        self::assertSame('file:///path/to/file.php', $location->uri);
-    }
-
-    public function testGetDocumentation(): void
-    {
-        $resolved = $this->createResolvedEnumCase(docblock: "/**\n * Active status\n */");
-
-        self::assertSame('Active status', $resolved->getDocumentation());
-    }
-
-    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
-    {
-        $resolved = $this->createResolvedEnumCase(docblock: null);
-
-        self::assertNull($resolved->getDocumentation());
     }
 
     public function testGetTypeReturnsDeclaringEnum(): void
@@ -72,6 +60,8 @@ class ResolvedEnumCaseTest extends TestCase
     }
 
     private function createResolvedEnumCase(
+        ?string $file = '/path/to/file.php',
+        ?int $line = 10,
         ?string $docblock = null,
         ?ClassName $declaringClass = null,
     ): ResolvedEnumCase {
@@ -79,8 +69,8 @@ class ResolvedEnumCaseTest extends TestCase
             name: new EnumCaseName('Active'),
             backingValue: null,
             docblock: $docblock,
-            file: '/path/to/file.php',
-            line: 10,
+            file: $file,
+            line: $line,
             declaringClass: $declaringClass ?? new ClassName(ClassKind::class),
         );
 

--- a/tests/Resolution/ResolvedEnumCaseTest.php
+++ b/tests/Resolution/ResolvedEnumCaseTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\ClassKind;
+use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\EnumCaseName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedEnumCase::class)]
+class ResolvedEnumCaseTest extends TestCase
+{
+    public function testImplementsResolvedSymbol(): void
+    {
+        $resolved = $this->createResolvedEnumCase();
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+    }
+
+    public function testGetDefinitionLocation(): void
+    {
+        $resolved = $this->createResolvedEnumCase();
+
+        $location = $resolved->getDefinitionLocation();
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+    }
+
+    public function testGetDocumentation(): void
+    {
+        $resolved = $this->createResolvedEnumCase(docblock: "/**\n * Active status\n */");
+
+        self::assertSame('Active status', $resolved->getDocumentation());
+    }
+
+    public function testGetTypeReturnsDeclaringEnum(): void
+    {
+        $enumName = new ClassName(ClassKind::class);
+        $resolved = $this->createResolvedEnumCase(declaringClass: $enumName);
+
+        $type = $resolved->getType();
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame(ClassKind::class, $type->fqn);
+    }
+
+    public function testFormat(): void
+    {
+        $resolved = $this->createResolvedEnumCase();
+
+        self::assertSame('case Active', $resolved->format());
+    }
+
+    public function testGetDeclaringClass(): void
+    {
+        $enumName = new ClassName(ClassKind::class);
+        $resolved = $this->createResolvedEnumCase(declaringClass: $enumName);
+
+        self::assertSame($enumName, $resolved->getDeclaringClass());
+    }
+
+    private function createResolvedEnumCase(
+        ?string $docblock = null,
+        ?ClassName $declaringClass = null,
+    ): ResolvedEnumCase {
+        $caseInfo = new EnumCaseInfo(
+            name: new EnumCaseName('Active'),
+            backingValue: null,
+            docblock: $docblock,
+            file: '/path/to/file.php',
+            line: 10,
+            declaringClass: $declaringClass ?? new ClassName(ClassKind::class),
+        );
+
+        return new ResolvedEnumCase($caseInfo);
+    }
+}

--- a/tests/Resolution/ResolvedFunctionTest.php
+++ b/tests/Resolution/ResolvedFunctionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedFunction::class)]
+class ResolvedFunctionTest extends TestCase
+{
+    public function testImplementsInterfaces(): void
+    {
+        $resolved = $this->createResolvedFunction();
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+        self::assertInstanceOf(ResolvedCallable::class, $resolved);
+    }
+
+    public function testGetDefinitionLocation(): void
+    {
+        $resolved = $this->createResolvedFunction();
+
+        $location = $resolved->getDefinitionLocation();
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+    }
+
+    public function testGetDocumentation(): void
+    {
+        $resolved = $this->createResolvedFunction(docblock: "/**\n * Greets a user\n */");
+
+        self::assertSame('Greets a user', $resolved->getDocumentation());
+    }
+
+    public function testGetType(): void
+    {
+        $returnType = new PrimitiveType('string');
+        $resolved = $this->createResolvedFunction(returnType: $returnType);
+
+        self::assertSame($returnType, $resolved->getType());
+    }
+
+    public function testFormat(): void
+    {
+        $resolved = $this->createResolvedFunction();
+
+        self::assertSame('function greet(): string', $resolved->format());
+    }
+
+    public function testGetParameters(): void
+    {
+        $params = [
+            new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
+        ];
+        $resolved = $this->createResolvedFunction(parameters: $params);
+
+        self::assertSame($params, $resolved->getParameters());
+    }
+
+    public function testGetReturnType(): void
+    {
+        $returnType = new PrimitiveType('int');
+        $resolved = $this->createResolvedFunction(returnType: $returnType);
+
+        self::assertSame($returnType, $resolved->getReturnType());
+    }
+
+    public function testGetParameterAtPosition(): void
+    {
+        $params = [
+            new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
+            new ParameterInfo('age', new PrimitiveType('int'), false, null, 1, false, false),
+        ];
+        $resolved = $this->createResolvedFunction(parameters: $params);
+
+        self::assertSame($params[0], $resolved->getParameterAtPosition(0));
+        self::assertSame($params[1], $resolved->getParameterAtPosition(1));
+        self::assertNull($resolved->getParameterAtPosition(2));
+    }
+
+    public function testGetParameterByName(): void
+    {
+        $params = [
+            new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
+        ];
+        $resolved = $this->createResolvedFunction(parameters: $params);
+
+        self::assertSame($params[0], $resolved->getParameterByName('name'));
+        self::assertNull($resolved->getParameterByName('nonexistent'));
+    }
+
+    /**
+     * @param list<ParameterInfo> $parameters
+     */
+    private function createResolvedFunction(
+        ?string $docblock = null,
+        ?PrimitiveType $returnType = null,
+        array $parameters = [],
+    ): ResolvedFunction {
+        $funcInfo = new FunctionInfo(
+            name: 'greet',
+            parameters: $parameters,
+            returnType: $returnType ?? new PrimitiveType('string'),
+            docblock: $docblock,
+            file: '/path/to/file.php',
+            line: 10,
+        );
+
+        return new ResolvedFunction($funcInfo);
+    }
+}

--- a/tests/Resolution/ResolvedFunctionTest.php
+++ b/tests/Resolution/ResolvedFunctionTest.php
@@ -13,36 +13,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ResolvedFunction::class)]
 class ResolvedFunctionTest extends TestCase
 {
+    use ResolvesFromInfoTestTrait;
+
+    protected function createSubjectWithLocation(?string $file, ?int $line): ResolvedSymbol
+    {
+        return $this->createResolvedFunction(file: $file, line: $line);
+    }
+
+    protected function createSubjectWithDocblock(?string $docblock): ResolvedSymbol
+    {
+        return $this->createResolvedFunction(docblock: $docblock);
+    }
+
     public function testImplementsInterfaces(): void
     {
         $resolved = $this->createResolvedFunction();
 
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
         self::assertInstanceOf(ResolvedCallable::class, $resolved);
-    }
-
-    public function testGetDefinitionLocation(): void
-    {
-        $resolved = $this->createResolvedFunction();
-
-        $location = $resolved->getDefinitionLocation();
-
-        self::assertNotNull($location);
-        self::assertSame('file:///path/to/file.php', $location->uri);
-    }
-
-    public function testGetDocumentation(): void
-    {
-        $resolved = $this->createResolvedFunction(docblock: "/**\n * Greets a user\n */");
-
-        self::assertSame('Greets a user', $resolved->getDocumentation());
-    }
-
-    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
-    {
-        $resolved = $this->createResolvedFunction(docblock: null);
-
-        self::assertNull($resolved->getDocumentation());
     }
 
     public function testGetType(): void
@@ -106,6 +94,8 @@ class ResolvedFunctionTest extends TestCase
      * @param list<ParameterInfo> $parameters
      */
     private function createResolvedFunction(
+        ?string $file = '/path/to/file.php',
+        ?int $line = 10,
         ?string $docblock = null,
         ?PrimitiveType $returnType = null,
         array $parameters = [],
@@ -115,8 +105,8 @@ class ResolvedFunctionTest extends TestCase
             parameters: $parameters,
             returnType: $returnType ?? new PrimitiveType('string'),
             docblock: $docblock,
-            file: '/path/to/file.php',
-            line: 10,
+            file: $file,
+            line: $line,
         );
 
         return new ResolvedFunction($funcInfo);

--- a/tests/Resolution/ResolvedFunctionTest.php
+++ b/tests/Resolution/ResolvedFunctionTest.php
@@ -38,6 +38,13 @@ class ResolvedFunctionTest extends TestCase
         self::assertSame('Greets a user', $resolved->getDocumentation());
     }
 
+    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
+    {
+        $resolved = $this->createResolvedFunction(docblock: null);
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
     public function testGetType(): void
     {
         $returnType = new PrimitiveType('string');

--- a/tests/Resolution/ResolvedMethodTest.php
+++ b/tests/Resolution/ResolvedMethodTest.php
@@ -16,6 +16,18 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ResolvedMethod::class)]
 class ResolvedMethodTest extends TestCase
 {
+    use ResolvesFromInfoTestTrait;
+
+    protected function createSubjectWithLocation(?string $file, ?int $line): ResolvedSymbol
+    {
+        return $this->createResolvedMethod(file: $file, line: $line);
+    }
+
+    protected function createSubjectWithDocblock(?string $docblock): ResolvedSymbol
+    {
+        return $this->createResolvedMethod(docblock: $docblock);
+    }
+
     public function testImplementsInterfaces(): void
     {
         $resolved = $this->createResolvedMethod();
@@ -23,38 +35,6 @@ class ResolvedMethodTest extends TestCase
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
         self::assertInstanceOf(ResolvedMember::class, $resolved);
         self::assertInstanceOf(ResolvedCallable::class, $resolved);
-    }
-
-    public function testGetDefinitionLocation(): void
-    {
-        $resolved = $this->createResolvedMethod(file: '/path/to/file.php', line: 10);
-
-        $location = $resolved->getDefinitionLocation();
-
-        self::assertNotNull($location);
-        self::assertSame('file:///path/to/file.php', $location->uri);
-        self::assertSame(9, $location->startLine);
-    }
-
-    public function testGetDefinitionLocationReturnsNullWhenFileIsNull(): void
-    {
-        $resolved = $this->createResolvedMethod(file: null, line: 10);
-
-        self::assertNull($resolved->getDefinitionLocation());
-    }
-
-    public function testGetDocumentation(): void
-    {
-        $resolved = $this->createResolvedMethod(docblock: "/**\n * Does something\n */");
-
-        self::assertSame('Does something', $resolved->getDocumentation());
-    }
-
-    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
-    {
-        $resolved = $this->createResolvedMethod(docblock: null);
-
-        self::assertNull($resolved->getDocumentation());
     }
 
     public function testGetType(): void

--- a/tests/Resolution/ResolvedMethodTest.php
+++ b/tests/Resolution/ResolvedMethodTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\Visibility;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedMethod::class)]
+class ResolvedMethodTest extends TestCase
+{
+    public function testImplementsInterfaces(): void
+    {
+        $resolved = $this->createResolvedMethod();
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+        self::assertInstanceOf(ResolvedMember::class, $resolved);
+        self::assertInstanceOf(ResolvedCallable::class, $resolved);
+    }
+
+    public function testGetDefinitionLocation(): void
+    {
+        $resolved = $this->createResolvedMethod(file: '/path/to/file.php', line: 10);
+
+        $location = $resolved->getDefinitionLocation();
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+        self::assertSame(9, $location->startLine);
+    }
+
+    public function testGetDefinitionLocationReturnsNullWhenFileIsNull(): void
+    {
+        $resolved = $this->createResolvedMethod(file: null, line: 10);
+
+        self::assertNull($resolved->getDefinitionLocation());
+    }
+
+    public function testGetDocumentation(): void
+    {
+        $resolved = $this->createResolvedMethod(docblock: "/**\n * Does something\n */");
+
+        self::assertSame('Does something', $resolved->getDocumentation());
+    }
+
+    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
+    {
+        $resolved = $this->createResolvedMethod(docblock: null);
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
+    public function testGetType(): void
+    {
+        $returnType = new PrimitiveType('string');
+        $resolved = $this->createResolvedMethod(returnType: $returnType);
+
+        self::assertSame($returnType, $resolved->getType());
+    }
+
+    public function testGetTypeReturnsNullWhenNoReturnType(): void
+    {
+        $resolved = $this->createResolvedMethodWithNullReturnType();
+
+        self::assertNull($resolved->getType());
+    }
+
+    public function testFormat(): void
+    {
+        $resolved = $this->createResolvedMethod();
+
+        self::assertSame('public function doSomething(): string', $resolved->format());
+    }
+
+    public function testGetDeclaringClass(): void
+    {
+        $className = new ClassName(\stdClass::class);
+        $resolved = $this->createResolvedMethod(declaringClass: $className);
+
+        self::assertSame($className, $resolved->getDeclaringClass());
+    }
+
+    public function testGetVisibility(): void
+    {
+        $resolved = $this->createResolvedMethod(visibility: Visibility::Protected);
+
+        self::assertSame(Visibility::Protected, $resolved->getVisibility());
+    }
+
+    public function testIsStatic(): void
+    {
+        $resolved = $this->createResolvedMethod(isStatic: true);
+
+        self::assertTrue($resolved->isStatic());
+    }
+
+    public function testIsStaticFalse(): void
+    {
+        $resolved = $this->createResolvedMethod(isStatic: false);
+
+        self::assertFalse($resolved->isStatic());
+    }
+
+    public function testGetParameters(): void
+    {
+        $params = [
+            new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
+            new ParameterInfo('count', new PrimitiveType('int'), false, null, 1, false, false),
+        ];
+        $resolved = $this->createResolvedMethod(parameters: $params);
+
+        self::assertSame($params, $resolved->getParameters());
+    }
+
+    public function testGetReturnType(): void
+    {
+        $returnType = new PrimitiveType('int');
+        $resolved = $this->createResolvedMethod(returnType: $returnType);
+
+        self::assertSame($returnType, $resolved->getReturnType());
+    }
+
+    public function testGetParameterAtPosition(): void
+    {
+        $params = [
+            new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
+            new ParameterInfo('count', new PrimitiveType('int'), false, null, 1, false, false),
+        ];
+        $resolved = $this->createResolvedMethod(parameters: $params);
+
+        self::assertSame($params[0], $resolved->getParameterAtPosition(0));
+        self::assertSame($params[1], $resolved->getParameterAtPosition(1));
+        self::assertNull($resolved->getParameterAtPosition(2));
+    }
+
+    public function testGetParameterByName(): void
+    {
+        $params = [
+            new ParameterInfo('name', new PrimitiveType('string'), false, null, 0, false, false),
+            new ParameterInfo('count', new PrimitiveType('int'), false, null, 1, false, false),
+        ];
+        $resolved = $this->createResolvedMethod(parameters: $params);
+
+        self::assertSame($params[0], $resolved->getParameterByName('name'));
+        self::assertSame($params[1], $resolved->getParameterByName('count'));
+        self::assertNull($resolved->getParameterByName('nonexistent'));
+    }
+
+    /**
+     * @param list<ParameterInfo> $parameters
+     */
+    private function createResolvedMethod(
+        ?string $file = '/path/to/file.php',
+        ?int $line = 10,
+        ?string $docblock = null,
+        ?PrimitiveType $returnType = null,
+        ?ClassName $declaringClass = null,
+        Visibility $visibility = Visibility::Public,
+        bool $isStatic = false,
+        array $parameters = [],
+    ): ResolvedMethod {
+        $methodInfo = new MethodInfo(
+            name: new MethodName('doSomething'),
+            visibility: $visibility,
+            isStatic: $isStatic,
+            isAbstract: false,
+            isFinal: false,
+            parameters: $parameters,
+            returnType: $returnType ?? new PrimitiveType('string'),
+            docblock: $docblock,
+            file: $file,
+            line: $line,
+            declaringClass: $declaringClass ?? new ClassName(\stdClass::class),
+        );
+
+        return new ResolvedMethod($methodInfo);
+    }
+
+    private function createResolvedMethodWithNullReturnType(): ResolvedMethod
+    {
+        $methodInfo = new MethodInfo(
+            name: new MethodName('doSomething'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [],
+            returnType: null,
+            docblock: null,
+            file: '/path/to/file.php',
+            line: 10,
+            declaringClass: new ClassName(\stdClass::class),
+        );
+
+        return new ResolvedMethod($methodInfo);
+    }
+}

--- a/tests/Resolution/ResolvedParameterTest.php
+++ b/tests/Resolution/ResolvedParameterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedParameter::class)]
+class ResolvedParameterTest extends TestCase
+{
+    public function testImplementsResolvedSymbol(): void
+    {
+        $resolved = $this->createResolvedParameter();
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+    }
+
+    public function testGetDefinitionLocationAlwaysReturnsNull(): void
+    {
+        $resolved = $this->createResolvedParameter();
+
+        self::assertNull($resolved->getDefinitionLocation());
+    }
+
+    public function testGetDocumentationAlwaysReturnsNull(): void
+    {
+        $resolved = $this->createResolvedParameter();
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
+    public function testGetType(): void
+    {
+        $type = new PrimitiveType('string');
+        $resolved = $this->createResolvedParameter(type: $type);
+
+        self::assertSame($type, $resolved->getType());
+    }
+
+    public function testGetTypeReturnsNullWhenUntyped(): void
+    {
+        $paramInfo = new ParameterInfo(
+            name: 'data',
+            type: null,
+            hasDefault: false,
+            defaultValue: null,
+            position: 0,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+        $resolved = new ResolvedParameter($paramInfo);
+
+        self::assertNull($resolved->getType());
+    }
+
+    public function testFormat(): void
+    {
+        $resolved = $this->createResolvedParameter();
+
+        self::assertSame('string $name', $resolved->format());
+    }
+
+    private function createResolvedParameter(?PrimitiveType $type = null): ResolvedParameter
+    {
+        $paramInfo = new ParameterInfo(
+            name: 'name',
+            type: $type ?? new PrimitiveType('string'),
+            hasDefault: false,
+            defaultValue: null,
+            position: 0,
+            isVariadic: false,
+            isPassedByReference: false,
+        );
+
+        return new ResolvedParameter($paramInfo);
+    }
+}

--- a/tests/Resolution/ResolvedPropertyTest.php
+++ b/tests/Resolution/ResolvedPropertyTest.php
@@ -15,44 +15,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ResolvedProperty::class)]
 class ResolvedPropertyTest extends TestCase
 {
+    use ResolvesFromInfoTestTrait;
+
+    protected function createSubjectWithLocation(?string $file, ?int $line): ResolvedSymbol
+    {
+        return $this->createResolvedProperty(file: $file, line: $line);
+    }
+
+    protected function createSubjectWithDocblock(?string $docblock): ResolvedSymbol
+    {
+        return $this->createResolvedProperty(docblock: $docblock);
+    }
+
     public function testImplementsInterfaces(): void
     {
         $resolved = $this->createResolvedProperty();
 
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
         self::assertInstanceOf(ResolvedMember::class, $resolved);
-    }
-
-    public function testGetDefinitionLocation(): void
-    {
-        $resolved = $this->createResolvedProperty(file: '/path/to/file.php', line: 10);
-
-        $location = $resolved->getDefinitionLocation();
-
-        self::assertNotNull($location);
-        self::assertSame('file:///path/to/file.php', $location->uri);
-        self::assertSame(9, $location->startLine);
-    }
-
-    public function testGetDefinitionLocationReturnsNullWhenFileIsNull(): void
-    {
-        $resolved = $this->createResolvedProperty(file: null, line: 10);
-
-        self::assertNull($resolved->getDefinitionLocation());
-    }
-
-    public function testGetDocumentation(): void
-    {
-        $resolved = $this->createResolvedProperty(docblock: "/**\n * The name property\n */");
-
-        self::assertSame('The name property', $resolved->getDocumentation());
-    }
-
-    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
-    {
-        $resolved = $this->createResolvedProperty(docblock: null);
-
-        self::assertNull($resolved->getDocumentation());
     }
 
     public function testGetType(): void

--- a/tests/Resolution/ResolvedPropertyTest.php
+++ b/tests/Resolution/ResolvedPropertyTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedProperty::class)]
+class ResolvedPropertyTest extends TestCase
+{
+    public function testImplementsInterfaces(): void
+    {
+        $resolved = $this->createResolvedProperty();
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+        self::assertInstanceOf(ResolvedMember::class, $resolved);
+    }
+
+    public function testGetDefinitionLocation(): void
+    {
+        $resolved = $this->createResolvedProperty(file: '/path/to/file.php', line: 10);
+
+        $location = $resolved->getDefinitionLocation();
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+        self::assertSame(9, $location->startLine);
+    }
+
+    public function testGetDefinitionLocationReturnsNullWhenFileIsNull(): void
+    {
+        $resolved = $this->createResolvedProperty(file: null, line: 10);
+
+        self::assertNull($resolved->getDefinitionLocation());
+    }
+
+    public function testGetDocumentation(): void
+    {
+        $resolved = $this->createResolvedProperty(docblock: "/**\n * The name property\n */");
+
+        self::assertSame('The name property', $resolved->getDocumentation());
+    }
+
+    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
+    {
+        $resolved = $this->createResolvedProperty(docblock: null);
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
+    public function testGetType(): void
+    {
+        $type = new PrimitiveType('string');
+        $resolved = $this->createResolvedProperty(type: $type);
+
+        self::assertSame($type, $resolved->getType());
+    }
+
+    public function testFormat(): void
+    {
+        $resolved = $this->createResolvedProperty();
+
+        self::assertSame('public string $name', $resolved->format());
+    }
+
+    public function testGetDeclaringClass(): void
+    {
+        $className = new ClassName(\stdClass::class);
+        $resolved = $this->createResolvedProperty(declaringClass: $className);
+
+        self::assertSame($className, $resolved->getDeclaringClass());
+    }
+
+    public function testGetVisibility(): void
+    {
+        $resolved = $this->createResolvedProperty(visibility: Visibility::Private);
+
+        self::assertSame(Visibility::Private, $resolved->getVisibility());
+    }
+
+    public function testIsStatic(): void
+    {
+        $resolved = $this->createResolvedProperty(isStatic: true);
+
+        self::assertTrue($resolved->isStatic());
+    }
+
+    private function createResolvedProperty(
+        ?string $file = '/path/to/file.php',
+        ?int $line = 10,
+        ?string $docblock = null,
+        ?PrimitiveType $type = null,
+        ?ClassName $declaringClass = null,
+        Visibility $visibility = Visibility::Public,
+        bool $isStatic = false,
+    ): ResolvedProperty {
+        $propertyInfo = new PropertyInfo(
+            name: new PropertyName('name'),
+            visibility: $visibility,
+            isStatic: $isStatic,
+            isReadonly: false,
+            isPromoted: false,
+            type: $type ?? new PrimitiveType('string'),
+            docblock: $docblock,
+            file: $file,
+            line: $line,
+            declaringClass: $declaringClass ?? new ClassName(\stdClass::class),
+        );
+
+        return new ResolvedProperty($propertyInfo);
+    }
+}

--- a/tests/Resolution/ResolvedVariableTest.php
+++ b/tests/Resolution/ResolvedVariableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResolvedVariable::class)]
+class ResolvedVariableTest extends TestCase
+{
+    public function testImplementsResolvedSymbol(): void
+    {
+        $resolved = new ResolvedVariable('name', new PrimitiveType('string'));
+
+        self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+    }
+
+    public function testGetDefinitionLocationAlwaysReturnsNull(): void
+    {
+        $resolved = new ResolvedVariable('name', new PrimitiveType('string'));
+
+        self::assertNull($resolved->getDefinitionLocation());
+    }
+
+    public function testGetDocumentationAlwaysReturnsNull(): void
+    {
+        $resolved = new ResolvedVariable('name', new PrimitiveType('string'));
+
+        self::assertNull($resolved->getDocumentation());
+    }
+
+    public function testGetType(): void
+    {
+        $type = new PrimitiveType('string');
+        $resolved = new ResolvedVariable('name', $type);
+
+        self::assertSame($type, $resolved->getType());
+    }
+
+    public function testGetTypeReturnsNullWhenUntyped(): void
+    {
+        $resolved = new ResolvedVariable('data', null);
+
+        self::assertNull($resolved->getType());
+    }
+
+    public function testFormatWithType(): void
+    {
+        $resolved = new ResolvedVariable('name', new PrimitiveType('string'));
+
+        self::assertSame('string $name', $resolved->format());
+    }
+
+    public function testFormatWithoutType(): void
+    {
+        $resolved = new ResolvedVariable('data', null);
+
+        self::assertSame('$data', $resolved->format());
+    }
+}

--- a/tests/Resolution/ResolvesFromInfoTestTrait.php
+++ b/tests/Resolution/ResolvesFromInfoTestTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+/**
+ * Common tests for classes using the ResolvesFromInfo trait.
+ *
+ * Using classes must implement createSubjectWithLocation() and
+ * createSubjectWithDocblock() to provide test subjects.
+ */
+trait ResolvesFromInfoTestTrait
+{
+    abstract protected function createSubjectWithLocation(?string $file, ?int $line): ResolvedSymbol;
+
+    abstract protected function createSubjectWithDocblock(?string $docblock): ResolvedSymbol;
+
+    public function testGetDefinitionLocation(): void
+    {
+        $resolved = $this->createSubjectWithLocation('/path/to/file.php', 10);
+
+        $location = $resolved->getDefinitionLocation();
+
+        self::assertNotNull($location);
+        self::assertSame('file:///path/to/file.php', $location->uri);
+        self::assertSame(9, $location->startLine);
+    }
+
+    public function testGetDefinitionLocationReturnsNullWhenFileIsNull(): void
+    {
+        $resolved = $this->createSubjectWithLocation(null, 10);
+
+        self::assertNull($resolved->getDefinitionLocation());
+    }
+
+    public function testGetDocumentation(): void
+    {
+        $resolved = $this->createSubjectWithDocblock("/**\n * Test description\n */");
+
+        self::assertSame('Test description', $resolved->getDocumentation());
+    }
+
+    public function testGetDocumentationReturnsNullWhenNoDocblock(): void
+    {
+        $resolved = $this->createSubjectWithDocblock(null);
+
+        self::assertNull($resolved->getDocumentation());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #257

- Add `ResolvedSymbol`, `ResolvedMember`, and `ResolvedCallable` interfaces in `src/Resolution/`
- Add 8 implementation classes wrapping existing domain objects
- Add `format()` method to `ClassInfo` (implements `Formattable`)
- Add `position` and `defaultValue` fields to `ParameterInfo`
- Add `Location::fromFileLine()` factory method

## Test plan

- [x] All new code has 100% test coverage
- [x] `composer check` passes (PHPStan + tests + PHPCS)
- [x] Existing tests updated for ParameterInfo signature change

🤖 Generated with [Claude Code](https://claude.ai/code)