### PR TITLE
SymbolResolver: Add class/name and variable resolution

### DIFF
--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -532,7 +532,7 @@ final class SymbolResolver
         }
 
         if ($node instanceof Name) {
-            return $this->resolveName($node);
+            return $this->resolveName($node, $ast);
         }
 
         if ($node instanceof Variable) {
@@ -574,8 +574,19 @@ final class SymbolResolver
         return null;
     }
 
-    private function resolveName(Name $node): ?ResolvedSymbol
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveName(Name $node, array $ast): ?ResolvedSymbol
     {
+        $parent = $node->getAttribute('parent');
+
+        // Function call: resolve to ResolvedFunction
+        if ($parent instanceof FuncCall) {
+            return $this->resolveFunctionCall($node, $ast);
+        }
+
+        // Class reference (new, instanceof, static call, type hint, etc.)
         $classNameStr = ScopeFinder::resolveClassName($node);
 
         $classInfo = $this->classRepository->get(new ClassName($classNameStr));
@@ -584,6 +595,28 @@ final class SymbolResolver
         }
 
         return new ResolvedClass($classInfo);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveFunctionCall(Name $node, array $ast): ?ResolvedFunction
+    {
+        $funcName = $node->toString();
+
+        // Try user-defined function first
+        $funcNode = ScopeFinder::findFunction($funcName, $ast);
+        if ($funcNode !== null) {
+            return new ResolvedFunction(FunctionInfo::fromNode($funcNode));
+        }
+
+        // Fall back to built-in function via reflection
+        try {
+            $funcInfo = FunctionInfo::fromReflection(new \ReflectionFunction($funcName));
+            return new ResolvedFunction($funcInfo);
+        } catch (\ReflectionException) {
+            return null;
+        }
     }
 
     /**

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -629,9 +629,54 @@ final class SymbolResolver
             return null;
         }
 
+        // Check if this is a parameter declaration
+        $parent = $node->getAttribute('parent');
+        if ($parent instanceof Node\Param) {
+            return $this->resolveParameter($parent);
+        }
+
         $type = ExpressionTypeResolver::resolveExpressionType($node, $ast, $this->typeResolver);
 
         return new ResolvedVariable($name, $type);
+    }
+
+    private function resolveParameter(Node\Param $param): ?ResolvedParameter
+    {
+        $var = $param->var;
+        if (!$var instanceof Variable || !is_string($var->name)) {
+            return null;
+        }
+
+        $enclosingScope = ScopeFinder::findEnclosingScope($param);
+        if ($enclosingScope === null) {
+            return null;
+        }
+
+        // Find position in parameter list
+        $position = 0;
+        foreach ($enclosingScope->params as $i => $p) {
+            if ($p === $param) {
+                $position = $i;
+                break;
+            }
+        }
+
+        $selfContext = null;
+        $parentContext = null;
+
+        if ($enclosingScope instanceof Stmt\ClassMethod) {
+            $selfContext = ScopeFinder::findEnclosingClassName($enclosingScope);
+            $classInfo = $selfContext !== null
+                ? $this->classRepository->get(new ClassName($selfContext))
+                : null;
+            $parentContext = $classInfo?->parent?->fqn;
+        }
+
+        $paramInfo = \Firehed\PhpLsp\Domain\ParameterInfo::fromNode($param, $position, $selfContext, $parentContext);
+        if ($paramInfo === null) {
+            return null;
+        }
+        return new ResolvedParameter($paramInfo);
     }
 
     /**

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -39,6 +39,7 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\VarLikeIdentifier;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Attribute;
 use PhpParser\Node\Stmt;
 
 /**
@@ -336,22 +337,7 @@ final class SymbolResolver
             return null;
         }
 
-        $functionName = $name->toString();
-
-        // Try user-defined function first
-        $funcNode = ScopeFinder::findFunction($functionName, $ast);
-        if ($funcNode !== null) {
-            $funcInfo = FunctionInfo::fromNode($funcNode);
-            return new ResolvedFunction($funcInfo);
-        }
-
-        // Fall back to built-in function
-        try {
-            $funcInfo = FunctionInfo::fromReflection(new \ReflectionFunction($functionName));
-            return new ResolvedFunction($funcInfo);
-        } catch (\ReflectionException) {
-            return null;
-        }
+        return $this->resolveFunctionByName($name->toString(), $ast);
     }
 
     /**
@@ -607,17 +593,23 @@ final class SymbolResolver
      */
     private function resolveFunctionCall(Name $node, array $ast): ?ResolvedFunction
     {
-        $funcName = $node->toString();
+        return $this->resolveFunctionByName($node->toString(), $ast);
+    }
 
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveFunctionByName(string $functionName, array $ast): ?ResolvedFunction
+    {
         // Try user-defined function first
-        $funcNode = ScopeFinder::findFunction($funcName, $ast);
+        $funcNode = ScopeFinder::findFunction($functionName, $ast);
         if ($funcNode !== null) {
             return new ResolvedFunction(FunctionInfo::fromNode($funcNode));
         }
 
         // Fall back to built-in function via reflection
         try {
-            $funcInfo = FunctionInfo::fromReflection(new \ReflectionFunction($funcName));
+            $funcInfo = FunctionInfo::fromReflection(new \ReflectionFunction($functionName));
             return new ResolvedFunction($funcInfo);
         } catch (\ReflectionException) {
             return null;
@@ -693,6 +685,12 @@ final class SymbolResolver
     {
         // Find the call this arg belongs to
         $call = $arg->getAttribute('parent');
+
+        // Handle attribute named arguments
+        if ($call instanceof Attribute) {
+            return $this->resolveAttributeNamedArgument($node, $call);
+        }
+
         if (
             !$call instanceof FuncCall
             && !$call instanceof MethodCall
@@ -708,6 +706,31 @@ final class SymbolResolver
             return null;
         }
 
+        $paramInfo = $callable->getParameterByName($node->toString());
+        if ($paramInfo === null) {
+            return null;
+        }
+
+        return new ResolvedParameter($paramInfo);
+    }
+
+    private function resolveAttributeNamedArgument(Identifier $node, Attribute $attribute): ?ResolvedParameter
+    {
+        $classNameStr = ScopeFinder::resolveClassName($attribute->name);
+        $className = new ClassName($classNameStr);
+
+        // Resolve constructor of attribute class
+        $methodInfo = $this->memberResolver->findMethod(
+            $className,
+            new MethodName('__construct'),
+            Visibility::Private,
+        );
+
+        if ($methodInfo === null) {
+            return null;
+        }
+
+        $callable = new ResolvedMethod($methodInfo);
         $paramInfo = $callable->getParameterByName($node->toString());
         if ($paramInfo === null) {
             return null;

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -571,6 +571,11 @@ final class SymbolResolver
             return $this->resolveClassConstFetch($parent);
         }
 
+        // Named argument: func(name: value) - cursor on 'name'
+        if ($parent instanceof Node\Arg && $parent->name === $node) {
+            return $this->resolveNamedArgument($node, $parent, $ast);
+        }
+
         return null;
     }
 
@@ -676,6 +681,38 @@ final class SymbolResolver
         if ($paramInfo === null) {
             return null;
         }
+        return new ResolvedParameter($paramInfo);
+    }
+
+    /**
+     * Resolve a named argument to its parameter.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function resolveNamedArgument(Identifier $node, Node\Arg $arg, array $ast): ?ResolvedParameter
+    {
+        // Find the call this arg belongs to
+        $call = $arg->getAttribute('parent');
+        if (
+            !$call instanceof FuncCall
+            && !$call instanceof MethodCall
+            && !$call instanceof NullsafeMethodCall
+            && !$call instanceof StaticCall
+            && !$call instanceof New_
+        ) {
+            return null;
+        }
+
+        $callable = $this->resolveCallable($call, $ast);
+        if ($callable === null) {
+            return null;
+        }
+
+        $paramInfo = $callable->getParameterByName($node->toString());
+        if ($paramInfo === null) {
+            return null;
+        }
+
         return new ResolvedParameter($paramInfo);
     }
 

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -637,17 +637,14 @@ final class SymbolResolver
         return new ResolvedVariable($name, $type);
     }
 
-    private function resolveParameter(Node\Param $param): ?ResolvedParameter
+    private function resolveParameter(Node\Param $param): ResolvedParameter
     {
-        $var = $param->var;
-        if (!$var instanceof Variable || !is_string($var->name)) {
-            return null;
-        }
-
         $enclosingScope = ScopeFinder::findEnclosingScope($param);
+        // @codeCoverageIgnoreStart
         if ($enclosingScope === null) {
-            return null;
+            throw new \LogicException('Param node always has enclosing scope');
         }
+        // @codeCoverageIgnoreEnd
 
         // Find position in parameter list
         $position = 0;
@@ -663,16 +660,21 @@ final class SymbolResolver
 
         if ($enclosingScope instanceof Stmt\ClassMethod) {
             $selfContext = ScopeFinder::findEnclosingClassName($enclosingScope);
-            $classInfo = $selfContext !== null
-                ? $this->classRepository->get(new ClassName($selfContext))
-                : null;
+            // @codeCoverageIgnoreStart
+            if ($selfContext === null) {
+                throw new \LogicException('ClassMethod always has enclosing class');
+            }
+            // @codeCoverageIgnoreEnd
+            $classInfo = $this->classRepository->get(new ClassName($selfContext));
             $parentContext = $classInfo?->parent?->fqn;
         }
 
         $paramInfo = \Firehed\PhpLsp\Domain\ParameterInfo::fromNode($param, $position, $selfContext, $parentContext);
+        // @codeCoverageIgnoreStart
         if ($paramInfo === null) {
-            return null;
+            throw new \LogicException('ParameterInfo::fromNode should not return null for valid Param');
         }
+        // @codeCoverageIgnoreEnd
         return new ResolvedParameter($paramInfo);
     }
 
@@ -691,6 +693,7 @@ final class SymbolResolver
             return $this->resolveAttributeNamedArgument($node, $call);
         }
 
+        // @codeCoverageIgnoreStart
         if (
             !$call instanceof FuncCall
             && !$call instanceof MethodCall
@@ -698,8 +701,9 @@ final class SymbolResolver
             && !$call instanceof StaticCall
             && !$call instanceof New_
         ) {
-            return null;
+            throw new \LogicException('Named arg parent must be a call or attribute');
         }
+        // @codeCoverageIgnoreEnd
 
         $callable = $this->resolveCallable($call, $ast);
         if ($callable === null) {

--- a/tests/Fixtures/SignatureHelp.php
+++ b/tests/Fixtures/SignatureHelp.php
@@ -37,6 +37,8 @@ $user = new User(/*|constructor*/"id", "name", "email@example.com"); //hover:cla
 $priority = Priority::fromScore(/*|static_call*/50);
 $x/*|outside_call*/ = 1;
 $namedArgs = signatureHelpAdd(a: 1, b: /*|named_arg*/2);
+$undefinedNamedArg = undefinedFunction(badArg: 1);
+$wrongNamedArg = signatureHelpAdd(wrongName: 1, b: 2);
 $undefined = undefinedFunction(/*|undefined_func*/1);
 // Edge cases for self/parent outside class
 $selfCall = self::method(/*|self_outside_class*/1);

--- a/tests/Fixtures/SignatureHelp.php
+++ b/tests/Fixtures/SignatureHelp.php
@@ -37,8 +37,8 @@ $user = new User(/*|constructor*/"id", "name", "email@example.com"); //hover:cla
 $priority = Priority::fromScore(/*|static_call*/50);
 $x/*|outside_call*/ = 1;
 $namedArgs = signatureHelpAdd(a: 1, b: /*|named_arg*/2);
-$undefinedNamedArg = undefinedFunction(badArg: 1);
-$wrongNamedArg = signatureHelpAdd(wrongName: 1, b: 2);
+$undefinedNamedArg = undefinedFunction(badArg: 1); //hover:named_arg_undefined_func
+$wrongNamedArg = signatureHelpAdd(a: 1, wrongName: 2); //hover:named_arg_wrong_name
 $undefined = undefinedFunction(/*|undefined_func*/1);
 // Edge cases for self/parent outside class
 $selfCall = self::method(/*|self_outside_class*/1);

--- a/tests/Fixtures/src/Attributes/NoConstructorAttribute.php
+++ b/tests/Fixtures/src/Attributes/NoConstructorAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_ALL)]
+final class NoConstructorAttribute
+{
+}

--- a/tests/Fixtures/src/Attributes/Route.php
+++ b/tests/Fixtures/src/Attributes/Route.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Attributes;
+
+use Attribute;
+
+/**
+ * Defines a route for a controller method.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Route
+{
+    public function __construct(
+        public readonly string $path,
+        public readonly string $method = 'GET',
+    ) {
+    }
+}

--- a/tests/Fixtures/src/Domain/User.php
+++ b/tests/Fixtures/src/Domain/User.php
@@ -243,7 +243,7 @@ class User implements Entity, Person
 
     public function triggerSigBuiltinFunc(): int
     {
-        return strlen(/*|sig_builtin_func*/'test');
+        return strlen(/*|sig_builtin_func*/'test'); //hover:builtin_strlen
     }
 
     public function triggerDynamicMethodCall(): void

--- a/tests/Fixtures/src/Services/ApiController.php
+++ b/tests/Fixtures/src/Services/ApiController.php
@@ -9,7 +9,13 @@ use Fixtures\Attributes\Route;
 class ApiController
 {
     #[Route('/api/users')]
-    public function listUsers(): array //hover:attribute_usage
+    public function listUsers(): array
+    {
+        return [];
+    }
+
+    #[Route(path: '/api/posts', method: 'POST')]
+    public function createPost(): array
     {
         return [];
     }

--- a/tests/Fixtures/src/Services/ApiController.php
+++ b/tests/Fixtures/src/Services/ApiController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Services;
+
+use Fixtures\Attributes\Route;
+
+class ApiController
+{
+    #[Route('/api/users')]
+    public function listUsers(): array //hover:attribute_usage
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/src/Services/ApiController.php
+++ b/tests/Fixtures/src/Services/ApiController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fixtures\Services;
 
+use Fixtures\Attributes\NoConstructorAttribute;
 use Fixtures\Attributes\Route;
 
 class ApiController
@@ -16,6 +17,18 @@ class ApiController
 
     #[Route(path: '/api/posts', method: 'POST')]
     public function createPost(): array
+    {
+        return [];
+    }
+
+    #[Route(wrongParam: '/api/wrong')]
+    public function wrongAttrParam(): array
+    {
+        return [];
+    }
+
+    #[NoConstructorAttribute(someParam: 'value')]
+    public function noConstructorAttr(): array
     {
         return [];
     }

--- a/tests/Fixtures/src/Services/ApiController.php
+++ b/tests/Fixtures/src/Services/ApiController.php
@@ -21,13 +21,13 @@ class ApiController
         return [];
     }
 
-    #[Route(wrongParam: '/api/wrong')]
+    #[Route(wrongParam: '/api/wrong')] //hover:attr_wrong_param
     public function wrongAttrParam(): array
     {
         return [];
     }
 
-    #[NoConstructorAttribute(someParam: 'value')]
+    #[NoConstructorAttribute(someParam: 'value')] //hover:attr_no_constructor
     public function noConstructorAttr(): array
     {
         return [];

--- a/tests/Handler/OpensDocumentsTrait.php
+++ b/tests/Handler/OpensDocumentsTrait.php
@@ -209,31 +209,54 @@ trait OpensDocumentsTrait
         $marker = "//hover:$markerName";
         $lines = explode("\n", $content);
         foreach ($lines as $lineNum => $line) {
-            if (strpos($line, $marker) === false) {
+            $markerPos = strpos($line, $marker);
+            if ($markerPos === false) {
                 continue;
             }
 
+            // Collect all symbol positions, return the rightmost one
+            $candidates = [];
+
+            // Member access: ->method, ?->method, ::method, ::$property
             $symbolMatch = [];
             preg_match_all('/(?:->|\?->|::)\$?([a-zA-Z_][a-zA-Z0-9_]*)/', $line, $symbolMatch, PREG_OFFSET_CAPTURE);
-
-            if (count($symbolMatch[1]) > 0) {
-                $lastMatch = end($symbolMatch[1]);
-                return [
-                    'uri' => $uri,
-                    'line' => $lineNum,
-                    'character' => $lastMatch[1],
-                ];
+            foreach ($symbolMatch[1] as $match) {
+                $candidates[] = $match[1];
             }
 
+            // Function calls: func(
             $funcMatch = [];
             preg_match_all('/\b([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/', $line, $funcMatch, PREG_OFFSET_CAPTURE);
+            foreach ($funcMatch[1] as $match) {
+                $candidates[] = $match[1];
+            }
 
-            if (count($funcMatch[1]) > 0) {
-                $lastMatch = end($funcMatch[1]);
+            // Named arguments: identifier: (but not ::)
+            $beforeMarker = substr($line, 0, $markerPos);
+            $colonPos = strrpos($beforeMarker, ':');
+            if ($colonPos !== false && ($colonPos === 0 || $beforeMarker[$colonPos - 1] !== ':')) {
+                $identEnd = $colonPos;
+                while ($identEnd > 0 && ctype_space($beforeMarker[$identEnd - 1])) {
+                    $identEnd--;
+                }
+                $identStart = $identEnd;
+                while ($identStart > 0) {
+                    $char = $beforeMarker[$identStart - 1];
+                    if (!ctype_alnum($char) && $char !== '_') {
+                        break;
+                    }
+                    $identStart--;
+                }
+                if ($identStart < $identEnd) {
+                    $candidates[] = $identStart;
+                }
+            }
+
+            if ($candidates !== []) {
                 return [
                     'uri' => $uri,
                     'line' => $lineNum,
-                    'character' => $lastMatch[1],
+                    'character' => max($candidates),
                 ];
             }
 

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -261,6 +261,35 @@ final class SymbolResolverTest extends TestCase
         self::assertSame('string', $result->getType()?->format());
     }
 
+    public function testResolvesNamedArgument(): void
+    {
+        $uri = $this->openFixture('SignatureHelp.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        // Find the line with named argument: signatureHelpAdd(a: 1, b: 2)
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        $lineNum = 0;
+        $character = 0;
+        foreach ($lines as $i => $line) {
+            if (str_contains($line, 'signatureHelpAdd(a: 1, b:')) {
+                $lineNum = $i;
+                // Position on 'b' in 'b: 2'
+                $pos = strpos($line, 'b:');
+                assert($pos !== false);
+                $character = $pos;
+                break;
+            }
+        }
+
+        $result = $this->resolver->resolveAtPosition($document, $lineNum, $character);
+
+        self::assertInstanceOf(ResolvedParameter::class, $result);
+        self::assertStringContainsString('b', $result->format());
+        self::assertSame('int', $result->getType()?->format());
+    }
+
     public function testGetAccessibleMembersReturnsMembers(): void
     {
         $this->openFixture('src/Domain/User.php');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -290,6 +290,35 @@ final class SymbolResolverTest extends TestCase
         self::assertSame('int', $result->getType()?->format());
     }
 
+    public function testResolvesAttribute(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $uri = $this->openFixture('src/Services/ApiController.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        // Find the line with the attribute: #[Route('/api/users')]
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        $lineNum = 0;
+        $character = 0;
+        foreach ($lines as $i => $line) {
+            if (str_contains($line, '#[Route(')) {
+                $lineNum = $i;
+                // Position on 'Route' after #[
+                $pos = strpos($line, 'Route');
+                assert($pos !== false);
+                $character = $pos + 2; // Inside the name
+                break;
+            }
+        }
+
+        $result = $this->resolver->resolveAtPosition($document, $lineNum, $character);
+
+        self::assertInstanceOf(ResolvedClass::class, $result);
+        self::assertStringContainsString('Route', $result->format());
+    }
+
     public function testGetAccessibleMembersReturnsMembers(): void
     {
         $this->openFixture('src/Domain/User.php');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -682,6 +682,97 @@ final class SymbolResolverTest extends TestCase
         self::assertNull($result);
     }
 
+    public function testResolveNamedArgOnUndefinedFuncReturnsNull(): void
+    {
+        $uri = $this->openFixture('SignatureHelp.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        foreach ($lines as $lineNum => $line) {
+            if (str_contains($line, 'undefinedFunction(badArg:')) {
+                $pos = strpos($line, 'badArg');
+                assert($pos !== false);
+
+                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
+
+                self::assertNull($result);
+                return;
+            }
+        }
+        self::fail('Test fixture line not found');
+    }
+
+    public function testResolveNamedArgWithWrongNameReturnsNull(): void
+    {
+        $uri = $this->openFixture('SignatureHelp.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        foreach ($lines as $lineNum => $line) {
+            if (str_contains($line, 'signatureHelpAdd(wrongName:')) {
+                // Find 'wrongName:' (with colon) to avoid matching $wrongNamedArg
+                $pos = strpos($line, 'wrongName:');
+                assert($pos !== false);
+
+                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
+
+                self::assertNull($result);
+                return;
+            }
+        }
+        self::fail('Test fixture line not found');
+    }
+
+    public function testResolveAttrNamedArgNoConstructorReturnsNull(): void
+    {
+        $this->openFixture('src/Attributes/NoConstructorAttribute.php');
+        $uri = $this->openFixture('src/Services/ApiController.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        foreach ($lines as $lineNum => $line) {
+            if (str_contains($line, 'NoConstructorAttribute(someParam:')) {
+                $pos = strpos($line, 'someParam');
+                assert($pos !== false);
+
+                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
+
+                self::assertNull($result);
+                return;
+            }
+        }
+        self::fail('Test fixture line not found');
+    }
+
+    public function testResolveAttrNamedArgWrongParamReturnsNull(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $uri = $this->openFixture('src/Services/ApiController.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        foreach ($lines as $lineNum => $line) {
+            if (str_contains($line, 'Route(wrongParam:')) {
+                $pos = strpos($line, 'wrongParam');
+                assert($pos !== false);
+
+                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
+
+                self::assertNull($result);
+                return;
+            }
+        }
+        self::fail('Test fixture line not found');
+    }
+
     public function testGetVariablesInScopeSkipsStatementsAfterCursor(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Domain/User.php', 'before_after');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -24,6 +24,7 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Resolution\CallContext;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
+use Firehed\PhpLsp\Resolution\ResolvedParameter;
 use Firehed\PhpLsp\Resolution\ResolvedVariable;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
@@ -230,6 +231,34 @@ final class SymbolResolverTest extends TestCase
 
         self::assertInstanceOf(ResolvedVariable::class, $result);
         self::assertStringContainsString('typed', $result->format());
+    }
+
+    public function testResolvesParameterDeclaration(): void
+    {
+        $uri = $this->openFixture('src/Domain/User.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        // Find the line with the setName method signature
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        $lineNum = 0;
+        $character = 0;
+        foreach ($lines as $i => $line) {
+            if (str_contains($line, 'public function setName(string $name)')) {
+                $lineNum = $i;
+                $pos = strpos($line, '$name');
+                assert($pos !== false);
+                $character = $pos + 2; // Position inside the variable name
+                break;
+            }
+        }
+
+        $result = $this->resolver->resolveAtPosition($document, $lineNum, $character);
+
+        self::assertInstanceOf(ResolvedParameter::class, $result);
+        self::assertStringContainsString('name', $result->format());
+        self::assertSame('string', $result->getType()?->format());
     }
 
     public function testGetAccessibleMembersReturnsMembers(): void

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -319,6 +319,36 @@ final class SymbolResolverTest extends TestCase
         self::assertStringContainsString('Route', $result->format());
     }
 
+    public function testResolvesNamedArgumentInAttribute(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $uri = $this->openFixture('src/Services/ApiController.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        // Find the line with named argument: #[Route(path: '/api/posts', ...)]
+        $content = $document->getContent();
+        $lines = explode("\n", $content);
+        $lineNum = 0;
+        $character = 0;
+        foreach ($lines as $i => $line) {
+            if (str_contains($line, 'path:')) {
+                $lineNum = $i;
+                // Position on 'path' in 'path:'
+                $pos = strpos($line, 'path');
+                assert($pos !== false);
+                $character = $pos;
+                break;
+            }
+        }
+
+        $result = $this->resolver->resolveAtPosition($document, $lineNum, $character);
+
+        self::assertInstanceOf(ResolvedParameter::class, $result);
+        self::assertStringContainsString('path', $result->format());
+        self::assertSame('string', $result->getType()?->format());
+    }
+
     public function testGetAccessibleMembersReturnsMembers(): void
     {
         $this->openFixture('src/Domain/User.php');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -655,24 +655,42 @@ final class SymbolResolverTest extends TestCase
 
     /**
      * @codeCoverageIgnore
-     * @return iterable<string, array{string, string}>
+     * @return iterable<string, array{string, string, list<string>}>
      */
     public static function resolveAtPositionNullCases(): iterable
     {
-        yield 'nonexistent static property' => ['src/Domain/User.php', 'dynamic_constant'];
-        yield 'unknown class' => ['src/Domain/User.php', 'unknown_class'];
-        yield 'unknown property' => ['src/Domain/User.php', 'unknown_property'];
-        yield 'unknown constant' => ['src/Domain/User.php', 'unknown_constant'];
-        yield 'untyped property' => ['src/Domain/User.php', 'untyped_property'];
-        yield 'method definition name' => ['src/Domain/User.php', 'method_name'];
-        yield 'property declaration' => ['src/Domain/User.php', 'property_declaration'];
-        yield 'self const outside class' => ['SignatureHelp.php', 'self_const_outside'];
-        yield 'self prop outside class' => ['SignatureHelp.php', 'self_prop_outside'];
+        yield 'nonexistent static property' => ['src/Domain/User.php', 'dynamic_constant', []];
+        yield 'unknown class' => ['src/Domain/User.php', 'unknown_class', []];
+        yield 'unknown property' => ['src/Domain/User.php', 'unknown_property', []];
+        yield 'unknown constant' => ['src/Domain/User.php', 'unknown_constant', []];
+        yield 'untyped property' => ['src/Domain/User.php', 'untyped_property', []];
+        yield 'method definition name' => ['src/Domain/User.php', 'method_name', []];
+        yield 'property declaration' => ['src/Domain/User.php', 'property_declaration', []];
+        yield 'self const outside class' => ['SignatureHelp.php', 'self_const_outside', []];
+        yield 'self prop outside class' => ['SignatureHelp.php', 'self_prop_outside', []];
+        yield 'named arg on undefined func' => ['SignatureHelp.php', 'named_arg_undefined_func', []];
+        yield 'named arg with wrong name' => ['SignatureHelp.php', 'named_arg_wrong_name', []];
+        yield 'attr named arg no constructor' => [
+            'src/Services/ApiController.php',
+            'attr_no_constructor',
+            ['src/Attributes/NoConstructorAttribute.php'],
+        ];
+        yield 'attr named arg wrong param' => [
+            'src/Services/ApiController.php',
+            'attr_wrong_param',
+            ['src/Attributes/Route.php'],
+        ];
     }
 
+    /**
+     * @param list<string> $extraFixtures
+     */
     #[DataProvider('resolveAtPositionNullCases')]
-    public function testResolveAtPositionReturnsNull(string $fixture, string $marker): void
+    public function testResolveAtPositionReturnsNull(string $fixture, string $marker, array $extraFixtures): void
     {
+        foreach ($extraFixtures as $extra) {
+            $this->openFixture($extra);
+        }
         $cursor = $this->openFixtureAtHoverMarker($fixture, $marker);
         $document = $this->documents->get($cursor['uri']);
         assert($document !== null);
@@ -680,97 +698,6 @@ final class SymbolResolverTest extends TestCase
         $result = $this->resolver->resolveAtPosition($document, $cursor['line'], $cursor['character']);
 
         self::assertNull($result);
-    }
-
-    public function testResolveNamedArgOnUndefinedFuncReturnsNull(): void
-    {
-        $uri = $this->openFixture('SignatureHelp.php');
-        $document = $this->documents->get($uri);
-        assert($document !== null);
-
-        $content = $document->getContent();
-        $lines = explode("\n", $content);
-        foreach ($lines as $lineNum => $line) {
-            if (str_contains($line, 'undefinedFunction(badArg:')) {
-                $pos = strpos($line, 'badArg');
-                assert($pos !== false);
-
-                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
-
-                self::assertNull($result);
-                return;
-            }
-        }
-        self::fail('Test fixture line not found');
-    }
-
-    public function testResolveNamedArgWithWrongNameReturnsNull(): void
-    {
-        $uri = $this->openFixture('SignatureHelp.php');
-        $document = $this->documents->get($uri);
-        assert($document !== null);
-
-        $content = $document->getContent();
-        $lines = explode("\n", $content);
-        foreach ($lines as $lineNum => $line) {
-            if (str_contains($line, 'signatureHelpAdd(wrongName:')) {
-                // Find 'wrongName:' (with colon) to avoid matching $wrongNamedArg
-                $pos = strpos($line, 'wrongName:');
-                assert($pos !== false);
-
-                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
-
-                self::assertNull($result);
-                return;
-            }
-        }
-        self::fail('Test fixture line not found');
-    }
-
-    public function testResolveAttrNamedArgNoConstructorReturnsNull(): void
-    {
-        $this->openFixture('src/Attributes/NoConstructorAttribute.php');
-        $uri = $this->openFixture('src/Services/ApiController.php');
-        $document = $this->documents->get($uri);
-        assert($document !== null);
-
-        $content = $document->getContent();
-        $lines = explode("\n", $content);
-        foreach ($lines as $lineNum => $line) {
-            if (str_contains($line, 'NoConstructorAttribute(someParam:')) {
-                $pos = strpos($line, 'someParam');
-                assert($pos !== false);
-
-                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
-
-                self::assertNull($result);
-                return;
-            }
-        }
-        self::fail('Test fixture line not found');
-    }
-
-    public function testResolveAttrNamedArgWrongParamReturnsNull(): void
-    {
-        $this->openFixture('src/Attributes/Route.php');
-        $uri = $this->openFixture('src/Services/ApiController.php');
-        $document = $this->documents->get($uri);
-        assert($document !== null);
-
-        $content = $document->getContent();
-        $lines = explode("\n", $content);
-        foreach ($lines as $lineNum => $line) {
-            if (str_contains($line, 'Route(wrongParam:')) {
-                $pos = strpos($line, 'wrongParam');
-                assert($pos !== false);
-
-                $result = $this->resolver->resolveAtPosition($document, $lineNum, $pos);
-
-                self::assertNull($result);
-                return;
-            }
-        }
-        self::fail('Test fixture line not found');
     }
 
     public function testGetVariablesInScopeSkipsStatementsAfterCursor(): void

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -135,6 +135,30 @@ final class SymbolResolverTest extends TestCase
         self::assertStringContainsString('User', $result->format());
     }
 
+    public function testResolvesFunctionCall(): void
+    {
+        $cursor = $this->openFixtureAtHoverMarker('SignatureHelp.php', 'signatureHelpAdd');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $result = $this->resolver->resolveAtPosition($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(ResolvedFunction::class, $result);
+        self::assertStringContainsString('signatureHelpAdd', $result->format());
+    }
+
+    public function testResolvesBuiltinFunctionCall(): void
+    {
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'builtin_strlen');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $result = $this->resolver->resolveAtPosition($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(ResolvedFunction::class, $result);
+        self::assertStringContainsString('strlen', $result->format());
+    }
+
     public function testResolvesPropertyFetch(): void
     {
         $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'manager');


### PR DESCRIPTION
## Summary
Completes SymbolResolver with remaining node types per #259:
- Function calls from Name nodes (user-defined and built-in via reflection)
- Parameter declarations (when cursor is on variable in function signature)
- Named arguments (when cursor is on argument name like `func(name: value)`)
- Attribute names (verified working via existing Name node handling)

## Test plan
- [x] All acceptance criteria from #259 verified
- [x] Unit tests added for each new resolution path
- [x] PHPStan clean
- [x] Test coverage maintained

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)