### PR TITLE
Refactor DefinitionHandler to use SymbolResolver

### DIFF
--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -5,32 +5,14 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\MethodName;
-use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Index\Location;
-use Firehed\PhpLsp\Index\NodeAtPosition;
-use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\Repository\ClassRepository;
-use Firehed\PhpLsp\Repository\MemberResolver;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
-use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\NullsafeMethodCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
-use PhpParser\Node\Stmt;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 
 final class DefinitionHandler implements HandlerInterface
 {
     public function __construct(
         private readonly DocumentManager $documentManager,
-        private readonly ParserService $parser,
-        private readonly MemberResolver $memberResolver,
-        private readonly ClassRepository $classRepository,
-        private readonly MemberAccessResolver $memberAccessResolver,
+        private readonly SymbolResolver $symbolResolver,
     ) {
     }
 
@@ -71,184 +53,13 @@ final class DefinitionHandler implements HandlerInterface
             return null;
         }
 
-        // Get the document
         $document = $this->documentManager->get($uri);
         if ($document === null) {
             return null;
         }
 
-        // Parse the document
-        $ast = $this->parser->parse($document);
-        if ($ast === null) {
-            // @codeCoverageIgnoreStart
-            throw new \LogicException('Parser returned null with error-collecting handler');
-            // @codeCoverageIgnoreEnd
-        }
+        $symbol = $this->symbolResolver->resolveAtPosition($document, $line, $character);
 
-        // Find node at position
-        $offset = $document->offsetAt($line, $character);
-        $nodeFinder = new NodeAtPosition();
-        $node = $nodeFinder->find($ast, $offset);
-
-        if ($node === null) {
-            return null;
-        }
-
-        // Check if this is a method name (Identifier) in a method call
-        if ($node instanceof Identifier) {
-            $parent = $node->getAttribute('parent');
-
-            // Static method call: ClassName::method()
-            if ($parent instanceof StaticCall) {
-                return $this->handleStaticMethodDefinition($parent);
-            }
-
-            // Instance method call: $obj->method() or $obj?->method()
-            if (MemberAccessResolver::isMethodCall($parent)) {
-                /** @var MethodCall|NullsafeMethodCall $parent */
-                return $this->handleInstanceMethodDefinition($parent, $ast);
-            }
-        }
-
-        // Class/interface/trait/enum reference
-        if ($node instanceof Name) {
-            return $this->handleNameDefinition($node);
-        }
-
-        return null;
-    }
-
-    /**
-     * @return array{
-     *   uri: string,
-     *   range: array{
-     *     start: array{line: int, character: int},
-     *     end: array{line: int, character: int},
-     *   },
-     * }|null
-     */
-    private function handleNameDefinition(Name $node): ?array
-    {
-        $symbolName = ScopeFinder::resolveClassNameInContext($node, $node);
-        if ($symbolName === null) {
-            return null;
-        }
-
-        $classInfo = $this->classRepository->get(new ClassName($symbolName));
-        if ($classInfo === null) {
-            return null;
-        }
-
-        return $this->createLocationFromFileLine($classInfo->file, $classInfo->line);
-    }
-
-    /**
-     * Handle definition for static method call: ClassName::method()
-     *
-     * @return array{
-     *   uri: string,
-     *   range: array{
-     *     start: array{line: int, character: int},
-     *     end: array{line: int, character: int},
-     *   },
-     * }|null
-     */
-    private function handleStaticMethodDefinition(StaticCall $call): ?array
-    {
-        $methodName = $call->name;
-        if (!$methodName instanceof Identifier) {
-            // @codeCoverageIgnoreStart
-            throw new \LogicException('handleStaticMethodDefinition called with non-Identifier method name');
-            // @codeCoverageIgnoreEnd
-        }
-
-        $class = $call->class;
-        if (!$class instanceof Name) {
-            return null;
-        }
-
-        $className = ScopeFinder::resolveClassNameInContext($class, $call);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->findMethodDefinition($className, $methodName->toString());
-    }
-
-    /**
-     * Handle definition for instance method call: $obj->method() or $obj?->method()
-     *
-     * @param array<Stmt> $ast
-     * @return array{
-     *   uri: string,
-     *   range: array{
-     *     start: array{line: int, character: int},
-     *     end: array{line: int, character: int},
-     *   },
-     * }|null
-     */
-    private function handleInstanceMethodDefinition(MethodCall|NullsafeMethodCall $call, array $ast): ?array
-    {
-        $methodName = $call->name;
-        if (!$methodName instanceof Identifier) {
-            // @codeCoverageIgnoreStart
-            throw new \LogicException('handleInstanceMethodDefinition called with non-Identifier method name');
-            // @codeCoverageIgnoreEnd
-        }
-
-        $className = $this->memberAccessResolver->resolveObjectClassName($call->var, $ast);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->findMethodDefinition($className->fqn, $methodName->toString());
-    }
-
-    /**
-     * Find the definition of a method in a class.
-     *
-     * @param class-string $className
-     * @return array{
-     *   uri: string,
-     *   range: array{
-     *     start: array{line: int, character: int},
-     *     end: array{line: int, character: int},
-     *   },
-     * }|null
-     */
-    private function findMethodDefinition(string $className, string $methodName): ?array
-    {
-        $methodInfo = $this->memberResolver->findMethod(
-            new ClassName($className),
-            new MethodName($methodName),
-            Visibility::Private,
-        );
-
-        if ($methodInfo === null) {
-            return null;
-        }
-
-        return $this->createLocationFromFileLine($methodInfo->file, $methodInfo->line);
-    }
-
-    /**
-     * @return array{
-     *   uri: string,
-     *   range: array{
-     *     start: array{line: int, character: int},
-     *     end: array{line: int, character: int},
-     *   },
-     * }|null
-     */
-    private function createLocationFromFileLine(?string $file, ?int $line): ?array
-    {
-        if ($file === null || $line === null) {
-            return null;
-        }
-
-        $uri = str_starts_with($file, 'file://') ? $file : 'file://' . $file;
-        $location = new Location($uri, $line - 1, 0, $line - 1, 0);
-
-        return $location->toLspLocation();
+        return $symbol?->getDefinitionLocation()?->toLspLocation();
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -20,6 +20,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Protocol\RequestMessage;
@@ -61,6 +62,7 @@ final class Server
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver);
         $memberAccessResolver = new MemberAccessResolver($typeResolver);
+        $symbolResolver = new SymbolResolver($parser, $classRepository, $memberResolver, $typeResolver);
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;
@@ -73,10 +75,7 @@ final class Server
         );
         $this->handlers[] = new DefinitionHandler(
             $this->documentManager,
-            $parser,
-            $memberResolver,
-            $classRepository,
-            $memberAccessResolver,
+            $symbolResolver,
         );
         $this->handlers[] = new HoverHandler(
             $this->documentManager,

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -16,8 +16,8 @@ use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -29,7 +29,6 @@ class DefinitionHandlerTest extends TestCase
     private DocumentManager $documents;
     private ParserService $parser;
     private DefaultClassRepository $classRepository;
-    private MemberResolver $memberResolver;
     private DefinitionHandler $handler;
     private TextDocumentSyncHandler $syncHandler;
 
@@ -44,14 +43,17 @@ class DefinitionHandlerTest extends TestCase
             $locator,
             $this->parser,
         );
-        $this->memberResolver = new MemberResolver($this->classRepository);
-        $typeResolver = new BasicTypeResolver($this->memberResolver);
+        $memberResolver = new MemberResolver($this->classRepository);
+        $typeResolver = new BasicTypeResolver($memberResolver);
+        $symbolResolver = new SymbolResolver(
+            $this->parser,
+            $this->classRepository,
+            $memberResolver,
+            $typeResolver,
+        );
         $this->handler = new DefinitionHandler(
             $this->documents,
-            $this->parser,
-            $this->memberResolver,
-            $this->classRepository,
-            new MemberAccessResolver($typeResolver),
+            $symbolResolver,
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(


### PR DESCRIPTION
Progresses on #260 (DefinitionHandler portion only; HoverHandler will be a separate PR)

## Summary
- Refactors DefinitionHandler from ~250 LOC to ~65 LOC by delegating symbol resolution to SymbolResolver
- Removes 5 private resolution methods that are now handled by SymbolResolver
- Updates Server.php to create and inject SymbolResolver

## Changes
- `src/Handler/DefinitionHandler.php` - Simplified to call `SymbolResolver::resolveAtPosition()` and format the result
- `src/Server.php` - Creates `SymbolResolver` instance and injects it into `DefinitionHandler`
- `tests/Handler/DefinitionHandlerTest.php` - Updated setUp to construct with SymbolResolver

🤖 Generated with [Claude Code](https://claude.ai/claude-code)