### PR TITLE
Refactor HoverHandler to use SymbolResolver

### DIFF
--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -5,45 +5,15 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Domain\ClassInfo;
-use Firehed\PhpLsp\Domain\ClassKind;
-use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Domain\MethodInfo;
-use Firehed\PhpLsp\Domain\MethodName;
-use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
-use Firehed\PhpLsp\Domain\PropertyName;
-use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Index\NodeAtPosition;
-use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\Repository\ClassRepository;
-use Firehed\PhpLsp\Repository\MemberResolver;
-use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
-use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\NullsafeMethodCall;
-use PhpParser\Node\Expr\NullsafePropertyFetch;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
-use PhpParser\Node\Stmt;
-use ReflectionException;
-use ReflectionFunction;
+use Firehed\PhpLsp\Resolution\ResolvedSymbol;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 
 final class HoverHandler implements HandlerInterface
 {
     public function __construct(
         private readonly DocumentManager $documentManager,
-        private readonly ParserService $parser,
-        private readonly ClassRepository $classRepository,
-        private readonly MemberResolver $memberResolver,
-        private readonly MemberAccessResolver $memberAccessResolver,
+        private readonly SymbolResolver $symbolResolver,
     ) {
     }
 
@@ -83,329 +53,24 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        $ast = $this->parser->parse($document);
-        if ($ast === null) {
+        $symbol = $this->symbolResolver->resolveAtPosition($document, $line, $character);
+        if ($symbol === null) {
             return null;
         }
 
-        $offset = $document->offsetAt($line, $character);
-        $nodeFinder = new NodeAtPosition();
-        $node = $nodeFinder->find($ast, $offset);
-
-        if ($node === null) {
-            return null;
-        }
-
-        $hoverContent = $this->getHoverContent($node, $ast);
-
-        if ($hoverContent === null) {
-            return null;
-        }
-
-        return ['contents' => $hoverContent];
+        return ['contents' => $this->formatHover($symbol)];
     }
 
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getHoverContent(Node $node, array $ast): ?string
-    {
-        // Name node - could be class reference or function call
-        if ($node instanceof Name) {
-            $parent = $node->getAttribute('parent');
-
-            // Function call: check for user-defined function first, then built-in
-            if ($parent instanceof FuncCall) {
-                $functionHover = $this->getFunctionHover($node->toString(), $ast);
-                if ($functionHover !== null) {
-                    return $functionHover;
-                }
-                return $this->getBuiltinFunctionHover($node->toString());
-            }
-
-            // Static method call: ClassName::method()
-            if ($parent instanceof StaticCall) {
-                return $this->getClassHover($node);
-            }
-
-            // Static property fetch: ClassName::$property
-            if ($parent instanceof StaticPropertyFetch) {
-                return $this->getClassHover($node);
-            }
-
-            // Fall through to class hover for class references
-            return $this->getClassHover($node);
-        }
-
-        // Identifier node - could be method name, property name, or function call
-        if ($node instanceof Identifier) {
-            $parent = $node->getAttribute('parent');
-
-            // Method call: $obj->method() or $obj?->method()
-            if (MemberAccessResolver::isMethodCall($parent)) {
-                /** @var MethodCall|NullsafeMethodCall $parent */
-                return $this->getMethodHover($parent, $ast);
-            }
-
-            // Static method call: ClassName::method()
-            if ($parent instanceof StaticCall) {
-                return $this->getStaticMethodHover($parent);
-            }
-
-            // Property fetch: $obj->property or $obj?->property
-            if (MemberAccessResolver::isPropertyFetch($parent)) {
-                /** @var PropertyFetch|NullsafePropertyFetch $parent */
-                return $this->getPropertyHover($parent, $ast);
-            }
-
-            // Static property fetch: ClassName::$property
-            if ($parent instanceof StaticPropertyFetch) {
-                return $this->getStaticPropertyHover($parent);
-            }
-
-            if ($parent instanceof FuncCall) {
-                return $this->getFunctionHover($node->toString(), $ast);
-            }
-        }
-
-        return null;
-    }
-
-    private function getClassHover(Name $node): ?string
-    {
-        $classNameStr = ScopeFinder::resolveClassName($node);
-
-        $classInfo = $this->classRepository->get(new ClassName($classNameStr));
-
-        if ($classInfo === null) {
-            return null;
-        }
-
-        return $this->formatClassHover($classInfo);
-    }
-
-    private function formatClassHover(ClassInfo $classInfo): string
+    private function formatHover(ResolvedSymbol $symbol): string
     {
         $parts = [];
 
-        // Add docblock if present
-        if ($classInfo->docblock !== null) {
-            $parts[] = DocblockParser::extractDescription($classInfo->docblock);
+        $doc = $symbol->getDocumentation();
+        if ($doc !== null) {
+            $parts[] = $doc;
         }
 
-        // Add signature
-        $keyword = match ($classInfo->kind) {
-            ClassKind::Interface_ => 'interface',
-            ClassKind::Trait_ => 'trait',
-            ClassKind::Enum_ => 'enum',
-            default => 'class',
-        };
-
-        $signature = $keyword . ' ' . $classInfo->name->shortName();
-
-        if ($classInfo->kind === ClassKind::Class_) {
-            if ($classInfo->parent !== null) {
-                $signature .= ' extends ' . $classInfo->parent->shortName();
-            }
-            if ($classInfo->interfaces !== []) {
-                $implements = array_map(fn($n) => $n->shortName(), $classInfo->interfaces);
-                $signature .= ' implements ' . implode(', ', $implements);
-            }
-        }
-
-        if ($classInfo->kind === ClassKind::Interface_ && $classInfo->interfaces !== []) {
-            $extends = array_map(fn($n) => $n->shortName(), $classInfo->interfaces);
-            $signature .= ' extends ' . implode(', ', $extends);
-        }
-
-        $parts[] = '```php' . "\n" . $signature . "\n```";
-
-        return implode("\n\n", $parts);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getFunctionHover(string $functionName, array $ast): ?string
-    {
-        $funcNode = ScopeFinder::findFunction($functionName, $ast);
-        if ($funcNode === null) {
-            return null;
-        }
-
-        return $this->formatFunctionHover($funcNode);
-    }
-
-    private function formatFunctionHover(Stmt\Function_ $node): string
-    {
-        $funcInfo = FunctionInfo::fromNode($node);
-        $parts = [];
-
-        if ($funcInfo->docblock !== null) {
-            $parts[] = DocblockParser::extractDescription($funcInfo->docblock);
-        }
-
-        $parts[] = '```php' . "\n" . $funcInfo->format() . "\n```";
-
-        return implode("\n\n", $parts);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getMethodHover(MethodCall|NullsafeMethodCall $call, array $ast): ?string
-    {
-        $methodName = $call->name;
-        if (!$methodName instanceof Identifier) {
-            return null;
-        }
-
-        $className = $this->memberAccessResolver->resolveObjectClassName($call->var, $ast);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getMethodHoverForClass($className->fqn, $methodName->toString());
-    }
-
-    private function getStaticMethodHover(StaticCall $call): ?string
-    {
-        $methodName = $call->name;
-        if (!$methodName instanceof Identifier) {
-            return null;
-        }
-
-        $class = $call->class;
-        if (!$class instanceof Name) {
-            return null;
-        }
-
-        $className = ScopeFinder::resolveClassNameInContext($class, $call);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getMethodHoverForClass($className, $methodName->toString());
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function getPropertyHover(PropertyFetch|NullsafePropertyFetch $fetch, array $ast): ?string
-    {
-        $propertyName = $fetch->name;
-        if (!$propertyName instanceof Identifier) {
-            return null;
-        }
-
-        $className = $this->memberAccessResolver->resolveObjectClassName($fetch->var, $ast);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getPropertyHoverForClass($className->fqn, $propertyName->toString());
-    }
-
-    private function getStaticPropertyHover(StaticPropertyFetch $fetch): ?string
-    {
-        $propertyName = $fetch->name;
-        if (!$propertyName instanceof Node\VarLikeIdentifier) {
-            return null;
-        }
-
-        $class = $fetch->class;
-        if (!$class instanceof Name) {
-            return null;
-        }
-
-        $className = ScopeFinder::resolveClassNameInContext($class, $fetch);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getPropertyHoverForClass($className, $propertyName->toString());
-    }
-
-    /**
-     * @param class-string $classNameStr
-     */
-    private function getMethodHoverForClass(string $classNameStr, string $methodNameStr): ?string
-    {
-        $className = new ClassName($classNameStr);
-        $methodName = new MethodName($methodNameStr);
-
-        // Hover shows all members regardless of caller context
-        $methodInfo = $this->memberResolver->findMethod($className, $methodName, Visibility::Private);
-        if ($methodInfo === null) {
-            return null;
-        }
-
-        return $this->formatMethodHover($methodInfo);
-    }
-
-    /**
-     * @param class-string $classNameStr
-     */
-    private function getPropertyHoverForClass(string $classNameStr, string $propertyNameStr): ?string
-    {
-        $className = new ClassName($classNameStr);
-        $propertyName = new PropertyName($propertyNameStr);
-
-        // Hover shows all members regardless of caller context
-        $propertyInfo = $this->memberResolver->findProperty($className, $propertyName, Visibility::Private);
-        if ($propertyInfo === null) {
-            return null;
-        }
-
-        return $this->formatPropertyHover($propertyInfo);
-    }
-
-    private function formatMethodHover(MethodInfo $method): string
-    {
-        $parts = [];
-
-        if ($method->docblock !== null) {
-            $parts[] = DocblockParser::extractDescription($method->docblock);
-        }
-
-        $parts[] = '```php' . "\n" . $method->format(showDefaults: true) . "\n```";
-
-        return implode("\n\n", $parts);
-    }
-
-    private function formatPropertyHover(DomainPropertyInfo $property): string
-    {
-        $parts = [];
-
-        if ($property->docblock !== null) {
-            $parts[] = DocblockParser::extractDescription($property->docblock);
-        }
-
-        $parts[] = '```php' . "\n" . $property->format() . "\n```";
-
-        return implode("\n\n", $parts);
-    }
-
-    private function getBuiltinFunctionHover(string $functionName): ?string
-    {
-        try {
-            $reflection = new ReflectionFunction($functionName);
-            return $this->formatReflectionFunction($reflection);
-        } catch (ReflectionException) {
-            return null;
-        }
-    }
-
-    private function formatReflectionFunction(ReflectionFunction $func): string
-    {
-        $funcInfo = FunctionInfo::fromReflection($func);
-        $parts = [];
-
-        if ($funcInfo->docblock !== null) {
-            $parts[] = DocblockParser::extractDescription($funcInfo->docblock);
-        }
-
-        $parts[] = '```php' . "\n" . $funcInfo->format() . "\n```";
+        $parts[] = '```php' . "\n" . $symbol->format() . "\n```";
 
         return implode("\n\n", $parts);
     }

--- a/src/Resolution/ResolvedMethod.php
+++ b/src/Resolution/ResolvedMethod.php
@@ -23,6 +23,11 @@ final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
     ) {
     }
 
+    public function format(): string
+    {
+        return $this->info->format(showDefaults: true);
+    }
+
     public function getType(): ?Type
     {
         return $this->info->returnType;

--- a/src/Server.php
+++ b/src/Server.php
@@ -79,10 +79,7 @@ final class Server
         );
         $this->handlers[] = new HoverHandler(
             $this->documentManager,
-            $parser,
-            $classRepository,
-            $memberResolver,
-            $memberAccessResolver,
+            $symbolResolver,
         );
         $this->handlers[] = new SignatureHelpHandler(
             $this->documentManager,

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -17,8 +17,8 @@ use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -31,7 +31,6 @@ class HoverHandlerTest extends TestCase
     private ParserService $parser;
     private DefaultClassRepository $classRepository;
     private DefaultClassInfoFactory $classInfoFactory;
-    private MemberResolver $memberResolver;
     private HoverHandler $handler;
     private TextDocumentSyncHandler $syncHandler;
 
@@ -46,14 +45,17 @@ class HoverHandlerTest extends TestCase
             $locator,
             $this->parser,
         );
-        $this->memberResolver = new MemberResolver($this->classRepository);
-        $typeResolver = new BasicTypeResolver($this->memberResolver);
-        $this->handler = new HoverHandler(
-            $this->documents,
+        $memberResolver = new MemberResolver($this->classRepository);
+        $typeResolver = new BasicTypeResolver($memberResolver);
+        $symbolResolver = new SymbolResolver(
             $this->parser,
             $this->classRepository,
-            $this->memberResolver,
-            new MemberAccessResolver($typeResolver),
+            $memberResolver,
+            $typeResolver,
+        );
+        $this->handler = new HoverHandler(
+            $this->documents,
+            $symbolResolver,
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(


### PR DESCRIPTION
Closes #260 (HoverHandler portion)

## Summary
- Refactors HoverHandler from ~410 LOC to ~77 LOC by delegating symbol resolution to SymbolResolver
- Removes 14 private resolution/formatting methods now handled by SymbolResolver
- Adds `format()` override to `ResolvedMethod` to show parameter defaults in hover display

## Changes
- `src/Handler/HoverHandler.php` - Simplified to call `SymbolResolver::resolveAtPosition()` and format the result
- `src/Resolution/ResolvedMethod.php` - Override `format()` to pass `showDefaults: true`
- `src/Server.php` - Updated HoverHandler construction to use SymbolResolver
- `tests/Handler/HoverHandlerTest.php` - Updated setUp to construct with SymbolResolver

🤖 Generated with [Claude Code](https://claude.ai/claude-code)