### PR TITLE
Refactor SignatureHelpHandler to use SymbolResolver

### DIFF
--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -5,30 +5,9 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Domain\MethodInfo;
-use Firehed\PhpLsp\Domain\MethodName;
-use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\Repository\MemberResolver;
-use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
-use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Expr\NullsafeMethodCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
-use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
-use ReflectionException;
-use ReflectionFunction;
+use Firehed\PhpLsp\Resolution\CallContext;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 
 /**
  * @phpstan-type ParameterInfoShape array{label: string, documentation?: string}
@@ -42,9 +21,7 @@ final class SignatureHelpHandler implements HandlerInterface
 {
     public function __construct(
         private readonly DocumentManager $documentManager,
-        private readonly ParserService $parser,
-        private readonly MemberResolver $memberResolver,
-        private readonly MemberAccessResolver $memberAccessResolver,
+        private readonly SymbolResolver $symbolResolver,
     ) {
     }
 
@@ -84,277 +61,39 @@ final class SignatureHelpHandler implements HandlerInterface
             return null;
         }
 
-        $ast = $this->parser->parse($document);
-        if ($ast === null) {
+        $context = $this->symbolResolver->getCallContext($document, $line, $character);
+        if ($context === null) {
             return null;
         }
 
-        $offset = $document->offsetAt($line, $character);
+        return $this->formatSignatureHelp($context);
+    }
 
-        // Find the call expression containing this position
-        $callInfo = $this->findCallAtPosition($ast, $offset);
-        if ($callInfo === null) {
-            return null;
-        }
+    /**
+     * @return array{signatures: list<SignatureInfo>, activeSignature: int, activeParameter: int}
+     */
+    private function formatSignatureHelp(CallContext $context): array
+    {
+        $callable = $context->callable;
+        $params = $callable->getParameters();
 
-        [$callNode, $activeParameter] = $callInfo;
+        $signature = [
+            'label' => $callable->format(),
+            'parameters' => array_map(
+                fn($p) => ['label' => $p->format()],
+                $params,
+            ),
+        ];
 
-        $signature = $this->getSignature($callNode, $ast);
-        if ($signature === null) {
-            return null;
+        $doc = $callable->getDocumentation();
+        if ($doc !== null) {
+            $signature['documentation'] = $doc;
         }
 
         return [
             'signatures' => [$signature],
             'activeSignature' => 0,
-            'activeParameter' => $activeParameter,
+            'activeParameter' => $context->activeParameterIndex,
         ];
-    }
-
-    /**
-     * Find the function/method call at the given position and determine active parameter.
-     *
-     * @param array<Stmt> $ast
-     * @return array{0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_, 1: int}|null
-     */
-    private function findCallAtPosition(array $ast, int $offset): ?array
-    {
-        $finder = new class ($offset) extends NodeVisitorAbstract {
-            /** @var FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|null */
-            public ?Node $found = null;
-            public int $activeParameter = 0;
-
-            public function __construct(private readonly int $offset)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if (
-                    !$node instanceof FuncCall
-                    && !$node instanceof MethodCall
-                    && !$node instanceof NullsafeMethodCall
-                    && !$node instanceof StaticCall
-                    && !$node instanceof New_
-                ) {
-                    return null;
-                }
-
-                $startPos = $node->getStartFilePos();
-                $endPos = $node->getEndFilePos();
-
-                // Check if cursor is within this call
-                if ($startPos <= $this->offset && $this->offset <= $endPos) {
-                    // Determine which parameter the cursor is in
-                    $activeParam = 0;
-                    foreach ($node->args as $i => $arg) {
-                        $argEnd = $arg->getEndFilePos();
-                        if ($this->offset > $argEnd) {
-                            $activeParam = $i + 1;
-                        }
-                    }
-
-                    // Keep the most specific (innermost) call
-                    $this->found = $node;
-                    $this->activeParameter = $activeParam;
-                }
-
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        if ($finder->found === null) {
-            return null;
-        }
-
-        return [$finder->found, $finder->activeParameter];
-    }
-
-    /**
-     * @param FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_ $call
-     * @param array<Stmt> $ast
-     * @return SignatureInfo|null
-     */
-    private function getSignature(Node $call, array $ast): ?array
-    {
-        if ($call instanceof FuncCall) {
-            return $this->getFunctionSignature($call, $ast);
-        }
-
-        if ($call instanceof MethodCall || $call instanceof NullsafeMethodCall) {
-            return $this->getMethodSignature($call, $ast);
-        }
-
-        if ($call instanceof StaticCall) {
-            return $this->getStaticMethodSignature($call);
-        }
-
-        // Must be New_ at this point based on the type hint
-        return $this->getConstructorSignature($call);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     * @return SignatureInfo|null
-     */
-    private function getFunctionSignature(FuncCall $call, array $ast): ?array
-    {
-        $name = $call->name;
-        if (!$name instanceof Name) {
-            return null;
-        }
-
-        $functionName = $name->toString();
-
-        // Try user-defined function first
-        $funcNode = ScopeFinder::findFunction($functionName, $ast);
-        if ($funcNode !== null) {
-            return $this->formatFunctionNodeSignature($funcNode);
-        }
-
-        // Fall back to built-in function
-        try {
-            $funcInfo = FunctionInfo::fromReflection(new ReflectionFunction($functionName));
-            return $this->formatFunctionInfoSignature($funcInfo);
-        } catch (ReflectionException) {
-            return null;
-        }
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     * @return SignatureInfo|null
-     */
-    private function getMethodSignature(MethodCall|NullsafeMethodCall $call, array $ast): ?array
-    {
-        $methodName = $call->name;
-        if (!$methodName instanceof Identifier) {
-            return null;
-        }
-
-        $className = $this->memberAccessResolver->resolveObjectClassName($call->var, $ast);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getMethodSignatureForClass($className->fqn, $methodName->toString());
-    }
-
-    /**
-     * @return SignatureInfo|null
-     */
-    private function getStaticMethodSignature(StaticCall $call): ?array
-    {
-        $methodName = $call->name;
-        if (!$methodName instanceof Identifier) {
-            return null;
-        }
-
-        $class = $call->class;
-        if (!$class instanceof Name) {
-            return null;
-        }
-
-        $className = ScopeFinder::resolveClassNameInContext($class, $call);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getMethodSignatureForClass($className, $methodName->toString());
-    }
-
-    /**
-     * @return SignatureInfo|null
-     */
-    private function getConstructorSignature(New_ $call): ?array
-    {
-        $class = $call->class;
-        if (!$class instanceof Name) {
-            return null;
-        }
-
-        $className = ScopeFinder::resolveClassNameInContext($class, $call);
-        if ($className === null) {
-            return null;
-        }
-
-        return $this->getMethodSignatureForClass($className, '__construct');
-    }
-
-    /**
-     * @param class-string $classNameStr
-     * @return SignatureInfo|null
-     */
-    private function getMethodSignatureForClass(
-        string $classNameStr,
-        string $methodNameStr,
-    ): ?array {
-        $className = new ClassName($classNameStr);
-        $methodName = new MethodName($methodNameStr);
-
-        $methodInfo = $this->memberResolver->findMethod($className, $methodName, Visibility::Private);
-        if ($methodInfo !== null) {
-            return $this->formatMethodInfoSignature($methodInfo);
-        }
-
-        return null;
-    }
-
-
-    /**
-     * @return SignatureInfo
-     */
-    private function formatFunctionNodeSignature(Stmt\Function_ $func): array
-    {
-        $funcInfo = FunctionInfo::fromNode($func);
-        return $this->formatFunctionInfoSignature($funcInfo);
-    }
-
-    /**
-     * @return SignatureInfo
-     */
-    private function formatFunctionInfoSignature(FunctionInfo $func): array
-    {
-        $params = array_map(
-            fn($p) => ['label' => $p->format()],
-            $func->parameters,
-        );
-
-        $result = [
-            'label' => $func->format(),
-            'parameters' => $params,
-        ];
-
-        if ($func->docblock !== null) {
-            $result['documentation'] = DocblockParser::extractDescription($func->docblock);
-        }
-
-        return $result;
-    }
-
-    /**
-     * @return SignatureInfo
-     */
-    private function formatMethodInfoSignature(MethodInfo $method): array
-    {
-        $params = array_map(
-            fn($p) => ['label' => $p->format()],
-            $method->parameters,
-        );
-
-        $result = [
-            'label' => $method->format(),
-            'parameters' => $params,
-        ];
-
-        if ($method->docblock !== null) {
-            $result['documentation'] = DocblockParser::extractDescription($method->docblock);
-        }
-
-        return $result;
     }
 }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -10,7 +10,7 @@ use Firehed\PhpLsp\Resolution\CallContext;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 
 /**
- * @phpstan-type ParameterInfoShape array{label: string, documentation?: string}
+ * @phpstan-type ParameterInfoShape array{label: string}
  * @phpstan-type SignatureInfo array{
  *   label: string,
  *   documentation?: string,

--- a/src/Server.php
+++ b/src/Server.php
@@ -83,9 +83,7 @@ final class Server
         );
         $this->handlers[] = new SignatureHelpHandler(
             $this->documentManager,
-            $parser,
-            $memberResolver,
-            $memberAccessResolver,
+            $symbolResolver,
         );
         $this->handlers[] = new CompletionHandler(
             $this->documentManager,

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -7,16 +7,16 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
-use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -46,11 +46,15 @@ class SignatureHelpHandlerTest extends TestCase
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver);
+        $symbolResolver = new SymbolResolver(
+            $this->parser,
+            $this->classRepository,
+            $this->memberResolver,
+            $typeResolver,
+        );
         $this->handler = new SignatureHelpHandler(
             $this->documents,
-            $this->parser,
-            $this->memberResolver,
-            new MemberAccessResolver($typeResolver),
+            $symbolResolver,
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(


### PR DESCRIPTION
## Summary

- Refactors SignatureHelpHandler to delegate to SymbolResolver instead of implementing its own call/signature resolution logic
- Reduces handler from ~360 LOC to ~99 LOC
- Uses `SymbolResolver::getCallContext()` for call detection and callable resolution

Part of #261 (SignatureHelpHandler only; CompletionHandler will be addressed separately).

## Test plan

- [x] All existing SignatureHelpHandler tests pass (20 tests)
- [x] PHPStan clean
- [x] Full test suite passes (853 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)