### PR TITLE
Add getName() to ResolvedMember interface

### DIFF
--- a/src/Resolution/ResolvedConstant.php
+++ b/src/Resolution/ResolvedConstant.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantInfo;
+use Firehed\PhpLsp\Domain\ConstantName;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 
@@ -29,6 +30,11 @@ final readonly class ResolvedConstant implements ResolvedMember
     public function getDeclaringClass(): ClassName
     {
         return $this->info->declaringClass;
+    }
+
+    public function getName(): ConstantName
+    {
+        return $this->info->name;
     }
 
     public function getVisibility(): Visibility

--- a/src/Resolution/ResolvedEnumCase.php
+++ b/src/Resolution/ResolvedEnumCase.php
@@ -6,16 +6,16 @@ namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
+use Firehed\PhpLsp\Domain\EnumCaseName;
 use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\Visibility;
 
 /**
  * A resolved enum case wrapping EnumCaseInfo.
  *
- * Note: Enum cases do not implement ResolvedMember because they don't have
- * visibility or static modifiers in PHP - they are implicitly public and
- * static-like by nature.
+ * Enum cases are effectively singleton constants: implicitly public and static.
  */
-final readonly class ResolvedEnumCase implements ResolvedSymbol
+final readonly class ResolvedEnumCase implements ResolvedMember
 {
     use ResolvesFromInfo;
 
@@ -24,19 +24,28 @@ final readonly class ResolvedEnumCase implements ResolvedSymbol
     ) {
     }
 
-    /**
-     * Returns the declaring enum's ClassName as the type.
-     */
+    public function getDeclaringClass(): ClassName
+    {
+        return $this->info->declaringClass;
+    }
+
+    public function getName(): EnumCaseName
+    {
+        return $this->info->name;
+    }
+
     public function getType(): Type
     {
         return $this->info->declaringClass;
     }
 
-    /**
-     * Returns the class that declares this enum case.
-     */
-    public function getDeclaringClass(): ClassName
+    public function getVisibility(): Visibility
     {
-        return $this->info->declaringClass;
+        return Visibility::Public;
+    }
+
+    public function isStatic(): bool
+    {
+        return true;
     }
 }

--- a/src/Resolution/ResolvedMember.php
+++ b/src/Resolution/ResolvedMember.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\ConstantName;
+use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Visibility;
 
 /**
- * A resolved class member (method, property, constant).
+ * A resolved class member (method, property, constant, enum case).
  */
 interface ResolvedMember extends ResolvedSymbol
 {
@@ -16,6 +20,8 @@ interface ResolvedMember extends ResolvedSymbol
      * Returns the class that declares this member.
      */
     public function getDeclaringClass(): ClassName;
+
+    public function getName(): MethodName|PropertyName|ConstantName|EnumCaseName;
 
     public function getVisibility(): Visibility;
 

--- a/src/Resolution/ResolvedMethod.php
+++ b/src/Resolution/ResolvedMethod.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\MethodInfo;
+use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
@@ -36,6 +37,11 @@ final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
     public function getDeclaringClass(): ClassName
     {
         return $this->info->declaringClass;
+    }
+
+    public function getName(): MethodName
+    {
+        return $this->info->name;
     }
 
     public function getVisibility(): Visibility

--- a/src/Resolution/ResolvedProperty.php
+++ b/src/Resolution/ResolvedProperty.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\PropertyInfo;
+use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 
@@ -29,6 +30,11 @@ final readonly class ResolvedProperty implements ResolvedMember
     public function getDeclaringClass(): ClassName
     {
         return $this->info->declaringClass;
+    }
+
+    public function getName(): PropertyName
+    {
+        return $this->info->name;
     }
 
     public function getVisibility(): Visibility

--- a/tests/Resolution/ResolvedConstantTest.php
+++ b/tests/Resolution/ResolvedConstantTest.php
@@ -58,6 +58,16 @@ class ResolvedConstantTest extends TestCase
         self::assertSame($className, $resolved->getDeclaringClass());
     }
 
+    public function testGetName(): void
+    {
+        $resolved = $this->createResolvedConstant();
+
+        $name = $resolved->getName();
+
+        self::assertInstanceOf(ConstantName::class, $name);
+        self::assertSame('MAX_RETRIES', $name->name);
+    }
+
     public function testGetVisibility(): void
     {
         $resolved = $this->createResolvedConstant(visibility: Visibility::Private);

--- a/tests/Resolution/ResolvedEnumCaseTest.php
+++ b/tests/Resolution/ResolvedEnumCaseTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
 use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\Visibility;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -26,11 +27,12 @@ class ResolvedEnumCaseTest extends TestCase
         return $this->createResolvedEnumCase(docblock: $docblock);
     }
 
-    public function testImplementsResolvedSymbol(): void
+    public function testImplementsInterfaces(): void
     {
         $resolved = $this->createResolvedEnumCase();
 
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
+        self::assertInstanceOf(ResolvedMember::class, $resolved);
     }
 
     public function testGetTypeReturnsDeclaringEnum(): void
@@ -57,6 +59,30 @@ class ResolvedEnumCaseTest extends TestCase
         $resolved = $this->createResolvedEnumCase(declaringClass: $enumName);
 
         self::assertSame($enumName, $resolved->getDeclaringClass());
+    }
+
+    public function testGetName(): void
+    {
+        $resolved = $this->createResolvedEnumCase();
+
+        $name = $resolved->getName();
+
+        self::assertInstanceOf(EnumCaseName::class, $name);
+        self::assertSame('Active', $name->name);
+    }
+
+    public function testGetVisibilityAlwaysPublic(): void
+    {
+        $resolved = $this->createResolvedEnumCase();
+
+        self::assertSame(Visibility::Public, $resolved->getVisibility());
+    }
+
+    public function testIsStaticAlwaysTrue(): void
+    {
+        $resolved = $this->createResolvedEnumCase();
+
+        self::assertTrue($resolved->isStatic());
     }
 
     private function createResolvedEnumCase(

--- a/tests/Resolution/ResolvedMethodTest.php
+++ b/tests/Resolution/ResolvedMethodTest.php
@@ -67,6 +67,16 @@ class ResolvedMethodTest extends TestCase
         self::assertSame($className, $resolved->getDeclaringClass());
     }
 
+    public function testGetName(): void
+    {
+        $resolved = $this->createResolvedMethod();
+
+        $name = $resolved->getName();
+
+        self::assertInstanceOf(MethodName::class, $name);
+        self::assertSame('doSomething', $name->name);
+    }
+
     public function testGetVisibility(): void
     {
         $resolved = $this->createResolvedMethod(visibility: Visibility::Protected);

--- a/tests/Resolution/ResolvedPropertyTest.php
+++ b/tests/Resolution/ResolvedPropertyTest.php
@@ -58,6 +58,16 @@ class ResolvedPropertyTest extends TestCase
         self::assertSame($className, $resolved->getDeclaringClass());
     }
 
+    public function testGetName(): void
+    {
+        $resolved = $this->createResolvedProperty();
+
+        $name = $resolved->getName();
+
+        self::assertInstanceOf(PropertyName::class, $name);
+        self::assertSame('name', $name->name);
+    }
+
     public function testGetVisibility(): void
     {
         $resolved = $this->createResolvedProperty(visibility: Visibility::Private);


### PR DESCRIPTION
Closes #277

## Summary

- Adds `getName()` method to `ResolvedMember` interface with union return type `MethodName|PropertyName|ConstantName|EnumCaseName`
- Implements `getName()` in all four resolved member classes

## Notable change

`ResolvedEnumCase` now implements `ResolvedMember` instead of just `ResolvedSymbol`. Enum cases are effectively singleton constants (implicitly public and static), so this is semantically correct. The class now implements `getVisibility()` (returns `Visibility::Public`) and `isStatic()` (returns `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)