### PR TITLE
Add getMemberAccessContext() to SymbolResolver and refactor CompletionHandler

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -6,17 +6,15 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\TypeHintContext;
-use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Resolution\MemberAccessContext;
+use Firehed\PhpLsp\Resolution\MemberAccessKind;
 use Firehed\PhpLsp\Resolution\ResolvedConstant;
 use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
@@ -24,19 +22,7 @@ use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node;
-use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\NullsafeMethodCall;
-use PhpParser\Node\Expr\NullsafePropertyFetch;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
 /**
@@ -86,8 +72,6 @@ final class CompletionHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
-        private readonly ClassRepository $classRepository,
-        private readonly MemberAccessResolver $memberAccessResolver,
         private readonly SymbolResolver $symbolResolver,
     ) {
     }
@@ -170,17 +154,10 @@ final class CompletionHandler implements HandlerInterface
         int $line,
         int $character,
     ): array {
-        $offset = $document->offsetAt($line, $character);
-
-        // AST-based member/static access detection
-        // Use offset - 1 because cursor is after the -> and we want the member access node
-        $nodeFinder = new NodeAtPosition();
-        $node = $nodeFinder->find($ast, $offset > 0 ? $offset - 1 : 0);
-        if ($node !== null) {
-            $result = $this->handleMemberAccessNode($node, $ast, $line);
-            if ($result !== null) {
-                return $result;
-            }
+        // Member/static access via SymbolResolver
+        $memberContext = $this->symbolResolver->getMemberAccessContext($document, $line, $character);
+        if ($memberContext !== null) {
+            return $this->handleMemberAccessContext($memberContext);
         }
 
         // Variable completion ($var)
@@ -260,173 +237,50 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * Handle member/static access detected via AST analysis.
+     * Handle member access context from SymbolResolver.
      *
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>|null
-     */
-    private function handleMemberAccessNode(Node $node, array $ast, int $line): ?array
-    {
-        // Handle identifier/error by checking parent
-        if ($node instanceof Identifier || $node instanceof Node\Expr\Error) {
-            $parent = $node->getAttribute('parent');
-            if ($parent instanceof Node) {
-                $node = $parent;
-            } else {
-                // @codeCoverageIgnoreStart
-                // ParserService always sets parent via NodeConnectingVisitor
-                return null;
-                // @codeCoverageIgnoreEnd
-            }
-        }
-
-        // Member access: $obj->member or $obj?->member
-        if (MemberAccessResolver::isMethodCall($node) || MemberAccessResolver::isPropertyFetch($node)) {
-            /** @var MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node */
-            return $this->handleMemberAccess($node, $ast);
-        }
-
-        // Static access: ClassName::member
-        if ($node instanceof StaticPropertyFetch || $node instanceof StaticCall || $node instanceof ClassConstFetch) {
-            return $this->handleStaticAccess($node, $ast, $line);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function handleMemberAccess(
-        MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node,
-        array $ast,
-    ): array {
-        $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
-
-        $className = $this->memberAccessResolver->resolveObjectClassName($node->var, $ast);
-        if ($className === null) {
-            return [];
-        }
-
-        $isThis = $node->var instanceof Variable && $node->var->name === 'this';
-        $enclosingClassName = ScopeFinder::findEnclosingClassName($node);
-        $isSameClass = $enclosingClassName !== null && $enclosingClassName === $className->fqn;
-        $visibility = ($isThis || $isSameClass) ? Visibility::Private : Visibility::Public;
-
-        $members = $this->symbolResolver->getAccessibleMembers($className, $visibility, staticOnly: false);
+    private function handleMemberAccessContext(MemberAccessContext $context): array
+    {
+        $members = match ($context->kind) {
+            MemberAccessKind::Instance => $this->symbolResolver->getAccessibleMembers(
+                $context->type,
+                $context->minVisibility,
+                staticOnly: false,
+            ),
+            MemberAccessKind::Static => $this->symbolResolver->getAccessibleMembers(
+                $context->type,
+                $context->minVisibility,
+                staticOnly: true,
+            ),
+            MemberAccessKind::Parent => [
+                ...$this->symbolResolver->getAccessibleMembers(
+                    $context->type,
+                    $context->minVisibility,
+                    staticOnly: false,
+                ),
+                ...$this->symbolResolver->getAccessibleMembers(
+                    $context->type,
+                    $context->minVisibility,
+                    staticOnly: true,
+                ),
+            ],
+        };
 
         $items = [];
         foreach ($members as $member) {
-            if (self::matchesPrefix($member->getName()->name, $prefix)) {
-                $items[] = $this->formatResolvedMemberCompletion($member);
-            }
-        }
-
-        return $items;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function handleStaticAccess(
-        StaticPropertyFetch|StaticCall|ClassConstFetch $node,
-        array $ast,
-        int $line,
-    ): array {
-        $class = $node->class;
-        if (!$class instanceof Name) {
-            return [];
-        }
-
-        $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
-        $rawName = $class->toString();
-
-        // parent:: has special completion behavior - only shows parent's methods
-        if ($rawName === 'parent') {
-            return $this->getParentCompletions($prefix, $ast, $line);
-        }
-
-        // For self::, static::, and regular class names, resolve and get completions
-        $className = ScopeFinder::resolveClassNameInContext($class, $node);
-        if ($className === null) {
-            return [];
-        }
-
-        return $this->getStaticCompletions($className, $prefix, $ast, $line);
-    }
-
-    /**
-     * Get completions for parent:: - methods from the parent class.
-     *
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function getParentCompletions(string $prefix, array $ast, int $line): array
-    {
-        $classNode = ScopeFinder::findClassAtLine($ast, $line);
-        if ($classNode === null || $classNode->extends === null) {
-            return [];
-        }
-
-        $parentClassName = ScopeFinder::resolveExtendsName($classNode);
-        assert($parentClassName !== null);
-
-        $className = new ClassName($parentClassName);
-
-        // parent:: can call both instance and static methods
-        $instanceMembers = $this->symbolResolver->getAccessibleMembers(
-            $className,
-            Visibility::Protected,
-            staticOnly: false,
-        );
-        $staticMembers = $this->symbolResolver->getAccessibleMembers(
-            $className,
-            Visibility::Protected,
-            staticOnly: true,
-        );
-
-        $items = [];
-        foreach ([...$instanceMembers, ...$staticMembers] as $member) {
-            if (!$member instanceof ResolvedMethod) {
+            // Parent access only shows methods
+            if ($context->kind === MemberAccessKind::Parent && !$member instanceof ResolvedMethod) {
                 continue;
             }
-            if (self::matchesPrefix($member->getName()->name, $prefix)) {
-                $items[] = $this->formatResolvedMemberCompletion($member);
-            }
-        }
-
-        return $items;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function getStaticCompletions(string $className, string $prefix, array $ast, int $line): array
-    {
-        // Resolve short name to FQCN using imports
-        $resolvedClassName = $this->resolveClassName($className, $ast);
-
-        $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
-        $minVisibility = $this->getMinVisibilityForAccess($enclosingClass, $resolvedClassName);
-
-        $members = $this->symbolResolver->getAccessibleMembers(
-            new ClassName($resolvedClassName),
-            $minVisibility,
-            staticOnly: true,
-        );
-
-        $items = [];
-        foreach ($members as $member) {
-            if (self::matchesPrefix($member->getName()->name, $prefix)) {
+            if (self::matchesPrefix($member->getName()->name, $context->prefix)) {
                 $items[] = $this->formatResolvedMemberCompletion($member);
             }
         }
 
         // ::class magic constant is always available for static access
-        if (self::matchesPrefix('class', $prefix)) {
+        if ($context->kind === MemberAccessKind::Static && self::matchesPrefix('class', $context->prefix)) {
             $items[] = [
                 'label' => 'class',
                 'kind' => self::KIND_CONSTANT,
@@ -435,39 +289,6 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $items;
-    }
-
-    /**
-     * Determine minimum visibility for accessing members of target class from enclosing class.
-     *
-     * @param class-string $targetClassName
-     */
-    private function getMinVisibilityForAccess(?Stmt\Class_ $enclosingClass, string $targetClassName): Visibility
-    {
-        if ($enclosingClass === null) {
-            return Visibility::Public;
-        }
-
-        $enclosingClassName = ScopeFinder::getClassLikeName($enclosingClass);
-        if ($enclosingClassName === null) {
-            return Visibility::Public;
-        }
-
-        if ($enclosingClassName === $targetClassName) {
-            return Visibility::Private;
-        }
-
-        // Check direct extends in AST
-        if (ScopeFinder::resolveExtendsName($enclosingClass) === $targetClassName) {
-            return Visibility::Protected;
-        }
-
-        // Check deeper inheritance via ClassRepository
-        if ($this->classRepository->isSubclassOf(new ClassName($enclosingClassName), new ClassName($targetClassName))) {
-            return Visibility::Protected;
-        }
-
-        return Visibility::Public;
     }
 
     /**
@@ -544,19 +365,6 @@ final class CompletionHandler implements HandlerInterface
             'kind' => self::KIND_FUNCTION,
             'detail' => $funcInfo->format(),
         ], $funcInfo->docblock);
-    }
-
-    /**
-     * Resolve a short class name to its FQCN using use statements.
-     *
-     * @param array<Stmt> $ast
-     * @return class-string
-     */
-    private function resolveClassName(string $shortName, array $ast): string
-    {
-        $imports = $this->getImports($ast);
-        /** @var class-string */
-        return $imports[$shortName] ?? $shortName;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -21,6 +21,12 @@ use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Resolution\ResolvedConstant;
+use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
+use Firehed\PhpLsp\Resolution\ResolvedMember;
+use Firehed\PhpLsp\Resolution\ResolvedMethod;
+use Firehed\PhpLsp\Resolution\ResolvedProperty;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\MemberAccessResolver;
@@ -92,6 +98,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly ClassRepository $classRepository,
         private readonly TypeResolverInterface $typeResolver,
         private readonly MemberAccessResolver $memberAccessResolver,
+        private readonly SymbolResolver $symbolResolver,
     ) {
     }
 
@@ -310,7 +317,19 @@ final class CompletionHandler implements HandlerInterface
         $isSameClass = $enclosingClassName !== null && $enclosingClassName === $className->fqn;
         $visibility = ($isThis || $isSameClass) ? Visibility::Private : Visibility::Public;
 
-        return $this->getMemberCompletions($className, $visibility, false, $prefix);
+        $members = $this->symbolResolver->getAccessibleMembers($className, $visibility, staticOnly: false);
+
+        $items = [];
+        foreach ($members as $member) {
+            if (!$member instanceof ResolvedMember) {
+                continue;
+            }
+            if (self::matchesPrefix($member->getName()->name, $prefix)) {
+                $items[] = $this->formatResolvedMemberCompletion($member);
+            }
+        }
+
+        return $items;
     }
 
     /**
@@ -563,6 +582,35 @@ final class CompletionHandler implements HandlerInterface
             'kind' => self::KIND_ENUM_MEMBER,
             'detail' => $enumCase->format(),
         ], $enumCase->docblock);
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    private function formatResolvedMemberCompletion(ResolvedMember $member): array
+    {
+        $kind = match (true) {
+            $member instanceof ResolvedMethod => self::KIND_METHOD,
+            $member instanceof ResolvedProperty => self::KIND_PROPERTY,
+            $member instanceof ResolvedConstant => self::KIND_CONSTANT,
+            $member instanceof ResolvedEnumCase => self::KIND_ENUM_MEMBER,
+            // @codeCoverageIgnoreStart
+            default => throw new \LogicException('Unexpected member type: ' . $member::class),
+            // @codeCoverageIgnoreEnd
+        };
+
+        $item = [
+            'label' => $member->getName()->name,
+            'kind' => $kind,
+            'detail' => $member->format(),
+        ];
+
+        $doc = $member->getDocumentation();
+        if ($doc !== null) {
+            $item['documentation'] = $doc;
+        }
+
+        return $item;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -169,8 +169,7 @@ final class CompletionHandler implements HandlerInterface
         array $ast,
         int $line,
         int $character,
-    ): array
-    {
+    ): array {
         $offset = $document->offsetAt($line, $character);
 
         // AST-based member/static access detection
@@ -840,5 +839,4 @@ final class CompletionHandler implements HandlerInterface
 
         return $items;
     }
-
 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -373,15 +373,22 @@ final class CompletionHandler implements HandlerInterface
         $parentClassName = ScopeFinder::resolveExtendsName($classNode);
         assert($parentClassName !== null);
 
-        // Get all members (both static and instance) but only include methods
-        $members = $this->symbolResolver->getAccessibleMembers(
-            new ClassName($parentClassName),
+        $className = new ClassName($parentClassName);
+
+        // parent:: can call both instance and static methods
+        $instanceMembers = $this->symbolResolver->getAccessibleMembers(
+            $className,
             Visibility::Protected,
             staticOnly: false,
         );
+        $staticMembers = $this->symbolResolver->getAccessibleMembers(
+            $className,
+            Visibility::Protected,
+            staticOnly: true,
+        );
 
         $items = [];
-        foreach ($members as $member) {
+        foreach ([...$instanceMembers, ...$staticMembers] as $member) {
             if (!$member instanceof ResolvedMethod) {
                 continue;
             }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\Visibility;
@@ -22,11 +23,9 @@ use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
-use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
-use Firehed\PhpLsp\Utility\TypeFactory;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
@@ -39,8 +38,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
 
 /**
  * @phpstan-type CompletionItem array{
@@ -90,7 +87,6 @@ final class CompletionHandler implements HandlerInterface
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
         private readonly ClassRepository $classRepository,
-        private readonly TypeResolverInterface $typeResolver,
         private readonly MemberAccessResolver $memberAccessResolver,
         private readonly SymbolResolver $symbolResolver,
     ) {
@@ -155,7 +151,7 @@ final class CompletionHandler implements HandlerInterface
         $lineText = $document->getLine($line);
         $textBeforeCursor = substr($lineText, 0, $character);
 
-        $items = $this->getCompletionItems($textBeforeCursor, $ast, $line, $offset);
+        $items = $this->getCompletionItems($textBeforeCursor, $document, $ast, $line, $character);
 
         return [
             'isIncomplete' => false,
@@ -167,8 +163,16 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getCompletionItems(string $textBeforeCursor, array $ast, int $line, int $offset): array
+    private function getCompletionItems(
+        string $textBeforeCursor,
+        TextDocument $document,
+        array $ast,
+        int $line,
+        int $character,
+    ): array
     {
+        $offset = $document->offsetAt($line, $character);
+
         // AST-based member/static access detection
         // Use offset - 1 because cursor is after the -> and we want the member access node
         $nodeFinder = new NodeAtPosition();
@@ -183,7 +187,7 @@ final class CompletionHandler implements HandlerInterface
         // Variable completion ($var)
         if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
-            return $this->getVariableCompletions($prefix, $ast, $line);
+            return $this->getVariableCompletions($prefix, $document, $line, $character);
         }
 
         // new ClassName completion - suggest imported classes and indexed instantiable types
@@ -813,43 +817,23 @@ final class CompletionHandler implements HandlerInterface
     /**
      * Get variable completions for the current scope.
      *
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getVariableCompletions(string $prefix, array $ast, int $cursorLine): array
-    {
-        // Find the innermost function/method/closure containing the cursor
-        $enclosingScope = $this->findEnclosingScope($ast, $cursorLine);
-        if ($enclosingScope === null) {
-            return [];
-        }
+    private function getVariableCompletions(
+        string $prefix,
+        TextDocument $document,
+        int $line,
+        int $character,
+    ): array {
+        $variables = $this->symbolResolver->getVariablesInScope($document, $line, $character);
 
-        $inMethod = $enclosingScope instanceof Stmt\ClassMethod;
-        $variables = $this->collectScopeVariables($enclosingScope);
-
-        // Build completion items
         $items = [];
-
-        // Add $this if we're in a method
-        if ($inMethod && self::matchesPrefix('this', $prefix)) {
-            // Use ScopeFinder directly for $this - TypeResolverInterface::resolveVariableType
-            // doesn't handle $this (it only checks parameters, use() vars, and assignments)
-            $classNode = ScopeFinder::findClassAtLine($ast, $cursorLine);
-            $className = $classNode?->namespacedName?->toString() ?? $classNode?->name?->toString();
-            $items[] = [
-                'label' => '$this',
-                'kind' => self::KIND_VARIABLE,
-                'detail' => $className ?? 'self',
-            ];
-        }
-
-        foreach ($variables as $name => $basicType) {
-            if (self::matchesPrefix($name, $prefix)) {
-                $resolvedType = $this->typeResolver->resolveVariableType($name, $enclosingScope, $cursorLine, $ast);
+        foreach ($variables as $variable) {
+            if (self::matchesPrefix($variable->getName(), $prefix)) {
                 $items[] = [
-                    'label' => '$' . $name,
+                    'label' => '$' . $variable->getName(),
                     'kind' => self::KIND_VARIABLE,
-                    'detail' => $resolvedType?->format() ?? $basicType,
+                    'detail' => $variable->getType()?->format() ?? 'mixed',
                 ];
             }
         }
@@ -857,140 +841,4 @@ final class CompletionHandler implements HandlerInterface
         return $items;
     }
 
-    /**
-     * Find the innermost function/method/closure containing the given line.
-     *
-     * @param array<Stmt> $ast
-     */
-    private function findEnclosingScope(
-        array $ast,
-        int $cursorLine,
-    ): Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null {
-        $found = null;
-
-        $visitor = new class ($cursorLine, $found) extends NodeVisitorAbstract {
-            /** @var Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null */
-            public $found = null;
-            private int $cursorLine;
-
-            /**
-             * @param Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction|null $found
-             */
-            public function __construct(int $cursorLine, &$found)
-            {
-                $this->cursorLine = $cursorLine;
-                $this->found = &$found;
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if (
-                    ($node instanceof Stmt\Function_
-                        || $node instanceof Stmt\ClassMethod
-                        || $node instanceof Node\Expr\Closure
-                        || $node instanceof Node\Expr\ArrowFunction)
-                    && ScopeFinder::nodeContainsLine($node, $this->cursorLine)
-                ) {
-                    $this->found = $node;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($visitor);
-        $traverser->traverse($ast);
-
-        return $visitor->found;
-    }
-
-    /**
-     * Collect variables from a function/method/closure scope.
-     *
-     * @return array<string, string> Variable name => type
-     */
-    private function collectScopeVariables(
-        Stmt\Function_|Stmt\ClassMethod|Node\Expr\Closure|Node\Expr\ArrowFunction $scope,
-    ): array {
-        $variables = [];
-
-        // Collect parameters
-        foreach ($scope->params as $param) {
-            if ($param->var instanceof Variable && is_string($param->var->name)) {
-                $variables[$param->var->name] = TypeFactory::fromNode($param->type)?->format() ?? 'mixed';
-            }
-        }
-
-        // Collect use() variables from closures
-        if ($scope instanceof Node\Expr\Closure) {
-            foreach ($scope->uses as $use) {
-                if (is_string($use->var->name)) {
-                    $variables[$use->var->name] = 'mixed';
-                }
-            }
-        }
-
-        // Traverse the scope body to find assignments and foreach variables
-        $stmts = $scope instanceof Node\Expr\ArrowFunction ? [] : ($scope->stmts ?? []);
-
-        $collector = new class ($variables) extends NodeVisitorAbstract {
-            /** @var array<string, string> */
-            public array $variables;
-
-            /**
-             * @param array<string, string> $variables
-             */
-            public function __construct(array &$variables)
-            {
-                $this->variables = &$variables;
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                // Skip nested function scopes
-                if (
-                    $node instanceof Stmt\Function_
-                    || $node instanceof Stmt\ClassMethod
-                    || $node instanceof Node\Expr\Closure
-                    || $node instanceof Node\Expr\ArrowFunction
-                ) {
-                    return NodeTraverser::DONT_TRAVERSE_CHILDREN;
-                }
-
-                // Collect assignments
-                if ($node instanceof Node\Expr\Assign) {
-                    if ($node->var instanceof Variable && is_string($node->var->name)) {
-                        if (!isset($this->variables[$node->var->name])) {
-                            $this->variables[$node->var->name] = 'mixed';
-                        }
-                    }
-                }
-
-                // Collect foreach variables
-                if ($node instanceof Stmt\Foreach_) {
-                    if ($node->valueVar instanceof Variable && is_string($node->valueVar->name)) {
-                        $this->variables[$node->valueVar->name] = 'mixed';
-                    }
-                    if ($node->keyVar instanceof Variable && is_string($node->keyVar->name)) {
-                        $this->variables[$node->keyVar->name] = 'mixed';
-                    }
-                }
-
-                // Collect catch variables
-                if ($node instanceof Stmt\Catch_) {
-                    if ($node->var !== null && is_string($node->var->name)) {
-                        $this->variables[$node->var->name] = 'Exception';
-                    }
-                }
-
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($collector);
-        $traverser->traverse($stmts);
-
-        return $collector->variables;
-    }
 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -318,9 +318,6 @@ final class CompletionHandler implements HandlerInterface
 
         $items = [];
         foreach ($members as $member) {
-            if (!$member instanceof ResolvedMember) {
-                continue;
-            }
             if (self::matchesPrefix($member->getName()->name, $prefix)) {
                 $items[] = $this->formatResolvedMemberCompletion($member);
             }
@@ -416,9 +413,6 @@ final class CompletionHandler implements HandlerInterface
 
         $items = [];
         foreach ($members as $member) {
-            if (!$member instanceof ResolvedMember) {
-                continue;
-            }
             if (self::matchesPrefix($member->getName()->name, $prefix)) {
                 $items[] = $this->formatResolvedMemberCompletion($member);
             }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -9,14 +9,9 @@ use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\ConstantInfo;
-use Firehed\PhpLsp\Domain\EnumCaseInfo;
 use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Domain\MethodInfo;
-use Firehed\PhpLsp\Domain\PropertyInfo as DomainPropertyInfo;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Repository\ClassRepository;
-use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -94,7 +89,6 @@ final class CompletionHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
-        private readonly MemberResolver $memberResolver,
         private readonly ClassRepository $classRepository,
         private readonly TypeResolverInterface $typeResolver,
         private readonly MemberAccessResolver $memberAccessResolver,
@@ -364,66 +358,6 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * Unified method to collect member completions with visibility and static/instance filters.
-     *
-     * @return list<CompletionItem>
-     */
-    private function getMemberCompletions(
-        ClassName $className,
-        Visibility $minVisibility,
-        ?bool $static,
-        string $prefix,
-        bool $includeProperties = true,
-        bool $includeConstants = false,
-        bool $includeEnumCases = false,
-    ): array {
-        $items = [];
-
-        foreach ($this->memberResolver->getMethods($className, $minVisibility, $static) as $method) {
-            if (self::matchesPrefix($method->name->name, $prefix)) {
-                $items[] = $this->formatMethodInfoCompletion($method);
-            }
-        }
-
-        if ($includeProperties) {
-            foreach ($this->memberResolver->getProperties($className, $minVisibility, $static) as $property) {
-                if (self::matchesPrefix($property->name->name, $prefix)) {
-                    $items[] = $this->formatPropertyInfoCompletion($property);
-                }
-            }
-        }
-
-        if ($includeConstants) {
-            foreach ($this->memberResolver->getConstants($className, $minVisibility) as $constant) {
-                if (self::matchesPrefix($constant->name->name, $prefix)) {
-                    $items[] = $this->formatConstantInfoCompletion($constant);
-                }
-            }
-
-            // ::class magic constant is always available for static access
-            if ($static === true || $static === null) {
-                if (self::matchesPrefix('class', $prefix)) {
-                    $items[] = [
-                        'label' => 'class',
-                        'kind' => self::KIND_CONSTANT,
-                        'detail' => 'string (fully qualified class name)',
-                    ];
-                }
-            }
-        }
-
-        if ($includeEnumCases) {
-            foreach ($this->memberResolver->getEnumCases($className) as $enumCase) {
-                if (self::matchesPrefix($enumCase->name->name, $prefix)) {
-                    $items[] = $this->formatEnumCaseInfoCompletion($enumCase);
-                }
-            }
-        }
-
-        return $items;
-    }
-
-    /**
      * Get completions for parent:: - methods from the parent class.
      *
      * @param array<Stmt> $ast
@@ -439,13 +373,24 @@ final class CompletionHandler implements HandlerInterface
         $parentClassName = ScopeFinder::resolveExtendsName($classNode);
         assert($parentClassName !== null);
 
-        return $this->getMemberCompletions(
+        // Get all members (both static and instance) but only include methods
+        $members = $this->symbolResolver->getAccessibleMembers(
             new ClassName($parentClassName),
             Visibility::Protected,
-            null,
-            $prefix,
-            includeProperties: false,
+            staticOnly: false,
         );
+
+        $items = [];
+        foreach ($members as $member) {
+            if (!$member instanceof ResolvedMethod) {
+                continue;
+            }
+            if (self::matchesPrefix($member->getName()->name, $prefix)) {
+                $items[] = $this->formatResolvedMemberCompletion($member);
+            }
+        }
+
+        return $items;
     }
 
     /**
@@ -460,14 +405,32 @@ final class CompletionHandler implements HandlerInterface
         $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
         $minVisibility = $this->getMinVisibilityForAccess($enclosingClass, $resolvedClassName);
 
-        return $this->getMemberCompletions(
+        $members = $this->symbolResolver->getAccessibleMembers(
             new ClassName($resolvedClassName),
             $minVisibility,
-            true,
-            $prefix,
-            includeConstants: true,
-            includeEnumCases: true,
+            staticOnly: true,
         );
+
+        $items = [];
+        foreach ($members as $member) {
+            if (!$member instanceof ResolvedMember) {
+                continue;
+            }
+            if (self::matchesPrefix($member->getName()->name, $prefix)) {
+                $items[] = $this->formatResolvedMemberCompletion($member);
+            }
+        }
+
+        // ::class magic constant is always available for static access
+        if (self::matchesPrefix('class', $prefix)) {
+            $items[] = [
+                'label' => 'class',
+                'kind' => self::KIND_CONSTANT,
+                'detail' => 'string (fully qualified class name)',
+            ];
+        }
+
+        return $items;
     }
 
     /**
@@ -534,54 +497,6 @@ final class CompletionHandler implements HandlerInterface
 
         // Limit results
         return array_slice($items, 0, 100);
-    }
-
-    /**
-     * @return CompletionItem
-     */
-    private function formatMethodInfoCompletion(MethodInfo $method): array
-    {
-        return self::withDocumentation([
-            'label' => $method->name->name,
-            'kind' => self::KIND_METHOD,
-            'detail' => $method->format(),
-        ], $method->docblock);
-    }
-
-    /**
-     * @return CompletionItem
-     */
-    private function formatPropertyInfoCompletion(DomainPropertyInfo $property): array
-    {
-        return self::withDocumentation([
-            'label' => $property->name->name,
-            'kind' => self::KIND_PROPERTY,
-            'detail' => $property->format(),
-        ], $property->docblock);
-    }
-
-    /**
-     * @return CompletionItem
-     */
-    private function formatConstantInfoCompletion(ConstantInfo $constant): array
-    {
-        return self::withDocumentation([
-            'label' => $constant->name->name,
-            'kind' => self::KIND_CONSTANT,
-            'detail' => $constant->format(),
-        ], $constant->docblock);
-    }
-
-    /**
-     * @return CompletionItem
-     */
-    private function formatEnumCaseInfoCompletion(EnumCaseInfo $enumCase): array
-    {
-        return self::withDocumentation([
-            'label' => $enumCase->name->name,
-            'kind' => self::KIND_ENUM_MEMBER,
-            'detail' => $enumCase->format(),
-        ], $enumCase->docblock);
     }
 
     /**

--- a/src/Resolution/MemberAccessContext.php
+++ b/src/Resolution/MemberAccessContext.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\Visibility;
+
+/**
+ * Context for member access completion.
+ * Captures the type being accessed, visibility level, and access kind.
+ */
+final readonly class MemberAccessContext
+{
+    public function __construct(
+        public Type $type,
+        public Visibility $minVisibility,
+        public MemberAccessKind $kind,
+        public string $prefix,
+    ) {
+    }
+}

--- a/src/Resolution/MemberAccessKind.php
+++ b/src/Resolution/MemberAccessKind.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+enum MemberAccessKind
+{
+    case Instance;  // $obj-> or $obj?->
+    case Static;    // Class:: (includes self::, static::)
+    case Parent;    // parent:: (both instance and static methods)
+}

--- a/src/Resolution/ResolvedVariable.php
+++ b/src/Resolution/ResolvedVariable.php
@@ -21,6 +21,11 @@ final readonly class ResolvedVariable implements ResolvedSymbol
     ) {
     }
 
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
     public function getDefinitionLocation(): ?Location
     {
         return null;

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -494,6 +494,38 @@ final class SymbolResolver
                 }
             }
 
+            // Collect foreach variables
+            if ($stmt instanceof Stmt\Foreach_) {
+                if ($stmt->valueVar instanceof Variable && is_string($stmt->valueVar->name)) {
+                    $name = $stmt->valueVar->name;
+                    if (!isset($seen[$name])) {
+                        $type = $this->typeResolver->resolveVariableType($name, $scope, $line, $ast);
+                        $variables[] = new ResolvedVariable($name, $type);
+                        $seen[$name] = true;
+                    }
+                }
+                if ($stmt->keyVar instanceof Variable && is_string($stmt->keyVar->name)) {
+                    $name = $stmt->keyVar->name;
+                    if (!isset($seen[$name])) {
+                        $type = $this->typeResolver->resolveVariableType($name, $scope, $line, $ast);
+                        $variables[] = new ResolvedVariable($name, $type);
+                        $seen[$name] = true;
+                    }
+                }
+            }
+
+            // Collect catch variables
+            if ($stmt instanceof Stmt\Catch_) {
+                if ($stmt->var !== null && is_string($stmt->var->name)) {
+                    $name = $stmt->var->name;
+                    if (!isset($seen[$name])) {
+                        $type = $this->typeResolver->resolveVariableType($name, $scope, $line, $ast);
+                        $variables[] = new ResolvedVariable($name, $type);
+                        $seen[$name] = true;
+                    }
+                }
+            }
+
             // Recursively check nested structures (if/while/etc.)
             if (property_exists($stmt, 'stmts') && is_array($stmt->stmts)) {
                 /** @var array<Stmt|Node> $nestedStmts */

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -205,6 +205,182 @@ final class SymbolResolver
     }
 
     /**
+     * Get member access context at position.
+     * Used by: Completion (after -> or ::)
+     */
+    public function getMemberAccessContext(
+        TextDocument $document,
+        int $line,
+        int $character,
+    ): ?MemberAccessContext {
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('Parser returned null');
+            // @codeCoverageIgnoreEnd
+        }
+
+        $offset = $document->offsetAt($line, $character);
+
+        // Use offset - 1 because cursor is after the -> and we want the member access node
+        $nodeFinder = new NodeAtPosition();
+        $node = $nodeFinder->find($ast, $offset > 0 ? $offset - 1 : 0);
+
+        if ($node === null) {
+            return null;
+        }
+
+        // Handle identifier/error by checking parent
+        if ($node instanceof Identifier || $node instanceof Node\Expr\Error) {
+            $parent = $node->getAttribute('parent');
+            if ($parent instanceof Node) {
+                $node = $parent;
+            } else {
+                return null;
+            }
+        }
+
+        return $this->resolveMemberAccessNode($node, $ast, $line);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveMemberAccessNode(Node $node, array $ast, int $line): ?MemberAccessContext
+    {
+        // Instance access: $obj->member or $obj?->member
+        if (MemberAccessResolver::isMethodCall($node) || MemberAccessResolver::isPropertyFetch($node)) {
+            /** @var MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node */
+            return $this->resolveInstanceAccessContext($node, $ast);
+        }
+
+        // Static access: ClassName::member
+        if ($node instanceof StaticPropertyFetch || $node instanceof StaticCall || $node instanceof ClassConstFetch) {
+            return $this->resolveStaticAccessContext($node, $ast, $line);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveInstanceAccessContext(
+        MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node,
+        array $ast,
+    ): ?MemberAccessContext {
+        $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
+
+        $type = ExpressionTypeResolver::resolveExpressionType($node->var, $ast, $this->typeResolver);
+        if ($type === null) {
+            return null;
+        }
+
+        $isThis = $node->var instanceof Variable && $node->var->name === 'this';
+        $enclosingClassName = ScopeFinder::findEnclosingClassName($node);
+
+        $classNames = $type->getResolvableClassNames();
+        $className = $classNames[0] ?? null;
+        $isSameClass = $enclosingClassName !== null && $className !== null && $enclosingClassName === $className->fqn;
+
+        $visibility = ($isThis || $isSameClass) ? Visibility::Private : Visibility::Public;
+
+        return new MemberAccessContext($type, $visibility, MemberAccessKind::Instance, $prefix);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveStaticAccessContext(
+        StaticPropertyFetch|StaticCall|ClassConstFetch $node,
+        array $ast,
+        int $line,
+    ): ?MemberAccessContext {
+        $class = $node->class;
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
+        $rawName = $class->toString();
+
+        // parent:: has special behavior
+        if ($rawName === 'parent') {
+            return $this->resolveParentAccessContext($ast, $line, $prefix);
+        }
+
+        // For self::, static::, and regular class names
+        $className = ScopeFinder::resolveClassNameInContext($class, $node);
+        if ($className === null) {
+            return null;
+        }
+
+        $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
+        $minVisibility = $this->getMinVisibilityForAccess($enclosingClass, $className);
+
+        return new MemberAccessContext(
+            new ClassName($className),
+            $minVisibility,
+            MemberAccessKind::Static,
+            $prefix,
+        );
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveParentAccessContext(array $ast, int $line, string $prefix): ?MemberAccessContext
+    {
+        $classNode = ScopeFinder::findClassAtLine($ast, $line);
+        if ($classNode === null || $classNode->extends === null) {
+            return null;
+        }
+
+        $parentClassName = ScopeFinder::resolveExtendsName($classNode);
+        assert($parentClassName !== null);
+
+        return new MemberAccessContext(
+            new ClassName($parentClassName),
+            Visibility::Protected,
+            MemberAccessKind::Parent,
+            $prefix,
+        );
+    }
+
+    /**
+     * Determine minimum visibility for accessing members of target class from enclosing class.
+     *
+     * @param class-string $targetClassName
+     */
+    private function getMinVisibilityForAccess(?Stmt\Class_ $enclosingClass, string $targetClassName): Visibility
+    {
+        if ($enclosingClass === null) {
+            return Visibility::Public;
+        }
+
+        $enclosingClassName = ScopeFinder::getClassLikeName($enclosingClass);
+        if ($enclosingClassName === null) {
+            return Visibility::Public;
+        }
+
+        if ($enclosingClassName === $targetClassName) {
+            return Visibility::Private;
+        }
+
+        // Check direct extends in AST
+        if (ScopeFinder::resolveExtendsName($enclosingClass) === $targetClassName) {
+            return Visibility::Protected;
+        }
+
+        // Check deeper inheritance via ClassRepository
+        if ($this->classRepository->isSubclassOf(new ClassName($enclosingClassName), new ClassName($targetClassName))) {
+            return Visibility::Protected;
+        }
+
+        return Visibility::Public;
+    }
+
+    /**
      * Get parameters for active call at position.
      * Used by: SignatureHelp, Completion (named args)
      */

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -106,7 +106,7 @@ final class SymbolResolver
      * For instance access (->): returns methods and properties.
      * For static access (::): also includes constants and enum cases.
      *
-     * @return list<ResolvedSymbol>
+     * @return list<ResolvedMember>
      */
     public function getAccessibleMembers(
         Type $type,
@@ -514,23 +514,26 @@ final class SymbolResolver
                 }
             }
 
-            // Collect catch variables
-            if ($stmt instanceof Stmt\Catch_) {
-                if ($stmt->var !== null && is_string($stmt->var->name)) {
-                    $name = $stmt->var->name;
-                    if (!isset($seen[$name])) {
-                        $type = $this->typeResolver->resolveVariableType($name, $scope, $line, $ast);
-                        $variables[] = new ResolvedVariable($name, $type);
-                        $seen[$name] = true;
-                    }
-                }
-            }
-
             // Recursively check nested structures (if/while/etc.)
             if (property_exists($stmt, 'stmts') && is_array($stmt->stmts)) {
                 /** @var array<Stmt|Node> $nestedStmts */
                 $nestedStmts = $stmt->stmts;
                 $this->collectVariablesFromStatements($nestedStmts, $line, $scope, $ast, $variables, $seen);
+            }
+
+            // Handle try/catch - process catch blocks
+            if ($stmt instanceof Stmt\TryCatch) {
+                foreach ($stmt->catches as $catch) {
+                    if ($catch->var !== null && is_string($catch->var->name)) {
+                        $name = $catch->var->name;
+                        if (!isset($seen[$name])) {
+                            $type = $this->typeResolver->resolveVariableType($name, $scope, $line, $ast);
+                            $variables[] = new ResolvedVariable($name, $type);
+                            $seen[$name] = true;
+                        }
+                    }
+                    $this->collectVariablesFromStatements($catch->stmts, $line, $scope, $ast, $variables, $seen);
+                }
             }
         }
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -90,7 +90,6 @@ final class Server
             $parser,
             $symbolIndex,
             $classRepository,
-            $typeResolver,
             $memberAccessResolver,
             $symbolResolver,
         );

--- a/src/Server.php
+++ b/src/Server.php
@@ -89,8 +89,6 @@ final class Server
             $this->documentManager,
             $parser,
             $symbolIndex,
-            $classRepository,
-            $memberAccessResolver,
             $symbolResolver,
         );
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -89,7 +89,6 @@ final class Server
             $this->documentManager,
             $parser,
             $symbolIndex,
-            $memberResolver,
             $classRepository,
             $typeResolver,
             $memberAccessResolver,

--- a/src/Server.php
+++ b/src/Server.php
@@ -93,6 +93,7 @@ final class Server
             $classRepository,
             $typeResolver,
             $memberAccessResolver,
+            $symbolResolver,
         );
     }
 

--- a/tests/Fixtures/src/Completion/Variables.php
+++ b/tests/Fixtures/src/Completion/Variables.php
@@ -36,4 +36,20 @@ class Variables
             $l/*|closure_local*/
         };
     }
+
+    public function withTryCatch(): void
+    {
+        try {
+            throw new \Exception('test');
+        } catch (\Exception $ex) {
+            $e/*|catch_var*/
+        }
+    }
+
+    public function withForeachKey(): void
+    {
+        foreach (['a' => 1] as $key => $value) {
+            $k/*|foreach_key*/
+        }
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -66,7 +66,6 @@ class CompletionHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->memberResolver,
             $this->classRepository,
             $typeResolver,
             $memberAccessResolver,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -67,7 +67,6 @@ class CompletionHandlerTest extends TestCase
             $this->parser,
             $this->symbolIndex,
             $this->classRepository,
-            $typeResolver,
             $memberAccessResolver,
             $symbolResolver,
         );

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -20,6 +20,7 @@ use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -54,6 +55,12 @@ class CompletionHandlerTest extends TestCase
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver);
         $memberAccessResolver = new MemberAccessResolver($typeResolver);
+        $symbolResolver = new SymbolResolver(
+            $this->parser,
+            $this->classRepository,
+            $this->memberResolver,
+            $typeResolver,
+        );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
         $this->handler = new CompletionHandler(
             $this->documents,
@@ -63,6 +70,7 @@ class CompletionHandlerTest extends TestCase
             $this->classRepository,
             $typeResolver,
             $memberAccessResolver,
+            $symbolResolver,
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1566,6 +1566,18 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('protectedMethod', $labels);
     }
 
+    public function testParentMethodCompletionIncludesStaticMethods(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/InheritanceCompletion.php', 'parent_access');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('staticMethod', $labels);
+        self::assertContains('protectedStaticMethod', $labels);
+    }
+
     public function testParentMethodCompletionReturnsEmptyWhenNoParent(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/NoParent.php', 'parent_no_parent');

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -22,7 +22,6 @@ use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -54,7 +53,6 @@ class CompletionHandlerTest extends TestCase
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver);
-        $memberAccessResolver = new MemberAccessResolver($typeResolver);
         $symbolResolver = new SymbolResolver(
             $this->parser,
             $this->classRepository,
@@ -66,8 +64,6 @@ class CompletionHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $memberAccessResolver,
             $symbolResolver,
         );
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/Resolution/ResolvedVariableTest.php
+++ b/tests/Resolution/ResolvedVariableTest.php
@@ -18,6 +18,13 @@ class ResolvedVariableTest extends TestCase
         self::assertInstanceOf(ResolvedSymbol::class, $resolved);
     }
 
+    public function testGetName(): void
+    {
+        $resolved = new ResolvedVariable('myVar', new PrimitiveType('string'));
+
+        self::assertSame('myVar', $resolved->getName());
+    }
+
     public function testGetDefinitionLocationAlwaysReturnsNull(): void
     {
         $resolved = new ResolvedVariable('name', new PrimitiveType('string'));

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -493,6 +493,43 @@ final class SymbolResolverTest extends TestCase
         self::assertTrue($hasInner, 'Expected $inner variable from nested block');
     }
 
+    public function testGetVariablesInScopeIncludesForeachVariables(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/Variables.php', 'foreach_prefix');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $variables = $this->resolver->getVariablesInScope($document, $cursor['line'], $cursor['character']);
+
+        $names = array_map(fn($v) => $v->getName(), $variables);
+        self::assertContains('item', $names);
+    }
+
+    public function testGetVariablesInScopeIncludesForeachKeyVariable(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/Variables.php', 'foreach_key');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $variables = $this->resolver->getVariablesInScope($document, $cursor['line'], $cursor['character']);
+
+        $names = array_map(fn($v) => $v->getName(), $variables);
+        self::assertContains('key', $names);
+        self::assertContains('value', $names);
+    }
+
+    public function testGetVariablesInScopeIncludesCatchVariable(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/Variables.php', 'catch_var');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $variables = $this->resolver->getVariablesInScope($document, $cursor['line'], $cursor['character']);
+
+        $names = array_map(fn($v) => $v->getName(), $variables);
+        self::assertContains('ex', $names);
+    }
+
     public function testGetCallContextReturnsContext(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Domain/User.php', 'sig_this_call');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -23,6 +23,8 @@ use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Resolution\CallContext;
+use Firehed\PhpLsp\Resolution\MemberAccessContext;
+use Firehed\PhpLsp\Resolution\MemberAccessKind;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedParameter;
 use Firehed\PhpLsp\Resolution\ResolvedVariable;
@@ -783,5 +785,123 @@ final class SymbolResolverTest extends TestCase
         $result = $this->resolver->resolveAtPosition($document, $lineNum, $character);
 
         self::assertNull($result);
+    }
+
+    public function testGetMemberAccessContextForInstanceAccess(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'this_empty');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+        self::assertSame(Visibility::Private, $context->minVisibility);
+        self::assertSame('', $context->prefix);
+    }
+
+    public function testGetMemberAccessContextForInstanceAccessWithPrefix(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'this_prefix');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+        self::assertSame('get', $context->prefix);
+    }
+
+    public function testGetMemberAccessContextForNullsafeAccess(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'nullsafe_this_empty');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+    }
+
+    public function testGetMemberAccessContextForStaticAccess(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticAccess.php', 'self_empty');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        self::assertSame(Visibility::Private, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextForStaticKeyword(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticAccess.php', 'static_keyword');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+    }
+
+    public function testGetMemberAccessContextForParentAccess(): void
+    {
+        $this->openFixture('src/Inheritance/ParentClass.php');
+        $this->openFixture('src/Inheritance/ChildClass.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/InheritanceCompletion.php', 'parent_access');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Parent, $context->kind);
+        self::assertSame(Visibility::Protected, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextForExternalClassStatic(): void
+    {
+        $this->openFixture('src/Inheritance/ParentClass.php');
+        $this->openFixture('src/Inheritance/ChildClass.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/InheritanceCompletion.php', 'parent_class_static');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        // ParentClass is in inheritance chain, so protected is accessible
+        self::assertSame(Visibility::Protected, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextReturnsNullOutsideMemberAccess(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $document = $this->documents->get('file:///fixtures/src/Domain/User.php');
+        assert($document !== null);
+
+        // Position at start of file, not in member access
+        $context = $this->resolver->getMemberAccessContext($document, 0, 0);
+
+        self::assertNull($context);
+    }
+
+    public function testGetMemberAccessContextReturnsNullForNoParent(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/NoParent.php', 'parent_no_parent');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertNull($context);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `getMemberAccessContext()` to SymbolResolver for detecting member access context at cursor position
- Adds `MemberAccessKind` enum (Instance, Static, Parent) and `MemberAccessContext` class
- Refactors CompletionHandler to use the new method, removing ~190 lines and two constructor dependencies

## Changes
- New: `SymbolResolver::getMemberAccessContext()` returns type, visibility, access kind, and prefix
- New: `MemberAccessKind` enum distinguishes instance (`$obj->`), static (`Class::`), and parent (`parent::`) access
- Removed: `handleMemberAccessNode()`, `handleMemberAccess()`, `handleStaticAccess()`, `getParentCompletions()`, `getStaticCompletions()`, `getMinVisibilityForAccess()`, `resolveClassName()` from CompletionHandler
- Removed: `ClassRepository` and `MemberAccessResolver` dependencies from CompletionHandler

## Metrics
- CompletionHandler: 843 → 651 lines (-192)
- Constructor dependencies: 6 → 4

## Test plan
- [x] All existing completion tests pass
- [x] New tests for getMemberAccessContext() cover all access kinds
- [x] PHPStan clean
- [x] PHPCS clean

Progresses on #261.

🤖 Generated with [Claude Code](https://claude.ai/code)