### PR TITLE
Refactor CompletionHandler to use SymbolResolver

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -6,17 +6,16 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\TypeHintContext;
-use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Resolution\MemberAccessContext;
+use Firehed\PhpLsp\Resolution\MemberAccessKind;
+use Firehed\PhpLsp\Resolution\MemberFilter;
 use Firehed\PhpLsp\Resolution\ResolvedConstant;
 use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
@@ -24,19 +23,7 @@ use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\MemberAccessResolver;
 use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node;
-use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\NullsafeMethodCall;
-use PhpParser\Node\Expr\NullsafePropertyFetch;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
 /**
@@ -86,8 +73,6 @@ final class CompletionHandler implements HandlerInterface
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
         private readonly SymbolIndex $symbolIndex,
-        private readonly ClassRepository $classRepository,
-        private readonly MemberAccessResolver $memberAccessResolver,
         private readonly SymbolResolver $symbolResolver,
     ) {
     }
@@ -170,17 +155,10 @@ final class CompletionHandler implements HandlerInterface
         int $line,
         int $character,
     ): array {
-        $offset = $document->offsetAt($line, $character);
-
-        // AST-based member/static access detection
-        // Use offset - 1 because cursor is after the -> and we want the member access node
-        $nodeFinder = new NodeAtPosition();
-        $node = $nodeFinder->find($ast, $offset > 0 ? $offset - 1 : 0);
-        if ($node !== null) {
-            $result = $this->handleMemberAccessNode($node, $ast, $line);
-            if ($result !== null) {
-                return $result;
-            }
+        // Member/static access via SymbolResolver
+        $memberContext = $this->symbolResolver->getMemberAccessContext($document, $line, $character);
+        if ($memberContext !== null) {
+            return $this->handleMemberAccessContext($memberContext);
         }
 
         // Variable completion ($var)
@@ -260,173 +238,40 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * Handle member/static access detected via AST analysis.
-     *
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>|null
-     */
-    private function handleMemberAccessNode(Node $node, array $ast, int $line): ?array
-    {
-        // Handle identifier/error by checking parent
-        if ($node instanceof Identifier || $node instanceof Node\Expr\Error) {
-            $parent = $node->getAttribute('parent');
-            if ($parent instanceof Node) {
-                $node = $parent;
-            } else {
-                // @codeCoverageIgnoreStart
-                // ParserService always sets parent via NodeConnectingVisitor
-                return null;
-                // @codeCoverageIgnoreEnd
-            }
-        }
-
-        // Member access: $obj->member or $obj?->member
-        if (MemberAccessResolver::isMethodCall($node) || MemberAccessResolver::isPropertyFetch($node)) {
-            /** @var MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node */
-            return $this->handleMemberAccess($node, $ast);
-        }
-
-        // Static access: ClassName::member
-        if ($node instanceof StaticPropertyFetch || $node instanceof StaticCall || $node instanceof ClassConstFetch) {
-            return $this->handleStaticAccess($node, $ast, $line);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function handleMemberAccess(
-        MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node,
-        array $ast,
-    ): array {
-        $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
-
-        $className = $this->memberAccessResolver->resolveObjectClassName($node->var, $ast);
-        if ($className === null) {
+    private function handleMemberAccessContext(MemberAccessContext $context): array
+    {
+        $classNames = $context->type->getResolvableClassNames();
+        if ($classNames === []) {
             return [];
         }
-
-        $isThis = $node->var instanceof Variable && $node->var->name === 'this';
-        $enclosingClassName = ScopeFinder::findEnclosingClassName($node);
-        $isSameClass = $enclosingClassName !== null && $enclosingClassName === $className->fqn;
-        $visibility = ($isThis || $isSameClass) ? Visibility::Private : Visibility::Public;
-
-        $members = $this->symbolResolver->getAccessibleMembers($className, $visibility, staticOnly: false);
 
         $items = [];
-        foreach ($members as $member) {
-            if (self::matchesPrefix($member->getName()->name, $prefix)) {
-                $items[] = $this->formatResolvedMemberCompletion($member);
+        $filter = match ($context->kind) {
+            MemberAccessKind::Instance => MemberFilter::Instance,
+            MemberAccessKind::Static => MemberFilter::Static,
+            MemberAccessKind::Parent => MemberFilter::All,
+        };
+
+        foreach ($classNames as $className) {
+            $members = $this->symbolResolver->getAccessibleMembers(
+                $className,
+                $context->minVisibility,
+                $filter,
+            );
+
+            foreach ($members as $member) {
+                if ($context->kind === MemberAccessKind::Parent && !$member instanceof ResolvedMethod) {
+                    continue;
+                }
+                if (self::matchesPrefix($member->getName()->name, $context->prefix)) {
+                    $items[] = $this->formatResolvedMemberCompletion($member);
+                }
             }
         }
 
-        return $items;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function handleStaticAccess(
-        StaticPropertyFetch|StaticCall|ClassConstFetch $node,
-        array $ast,
-        int $line,
-    ): array {
-        $class = $node->class;
-        if (!$class instanceof Name) {
-            return [];
-        }
-
-        $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
-        $rawName = $class->toString();
-
-        // parent:: has special completion behavior - only shows parent's methods
-        if ($rawName === 'parent') {
-            return $this->getParentCompletions($prefix, $ast, $line);
-        }
-
-        // For self::, static::, and regular class names, resolve and get completions
-        $className = ScopeFinder::resolveClassNameInContext($class, $node);
-        if ($className === null) {
-            return [];
-        }
-
-        return $this->getStaticCompletions($className, $prefix, $ast, $line);
-    }
-
-    /**
-     * Get completions for parent:: - methods from the parent class.
-     *
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function getParentCompletions(string $prefix, array $ast, int $line): array
-    {
-        $classNode = ScopeFinder::findClassAtLine($ast, $line);
-        if ($classNode === null || $classNode->extends === null) {
-            return [];
-        }
-
-        $parentClassName = ScopeFinder::resolveExtendsName($classNode);
-        assert($parentClassName !== null);
-
-        $className = new ClassName($parentClassName);
-
-        // parent:: can call both instance and static methods
-        $instanceMembers = $this->symbolResolver->getAccessibleMembers(
-            $className,
-            Visibility::Protected,
-            staticOnly: false,
-        );
-        $staticMembers = $this->symbolResolver->getAccessibleMembers(
-            $className,
-            Visibility::Protected,
-            staticOnly: true,
-        );
-
-        $items = [];
-        foreach ([...$instanceMembers, ...$staticMembers] as $member) {
-            if (!$member instanceof ResolvedMethod) {
-                continue;
-            }
-            if (self::matchesPrefix($member->getName()->name, $prefix)) {
-                $items[] = $this->formatResolvedMemberCompletion($member);
-            }
-        }
-
-        return $items;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function getStaticCompletions(string $className, string $prefix, array $ast, int $line): array
-    {
-        // Resolve short name to FQCN using imports
-        $resolvedClassName = $this->resolveClassName($className, $ast);
-
-        $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
-        $minVisibility = $this->getMinVisibilityForAccess($enclosingClass, $resolvedClassName);
-
-        $members = $this->symbolResolver->getAccessibleMembers(
-            new ClassName($resolvedClassName),
-            $minVisibility,
-            staticOnly: true,
-        );
-
-        $items = [];
-        foreach ($members as $member) {
-            if (self::matchesPrefix($member->getName()->name, $prefix)) {
-                $items[] = $this->formatResolvedMemberCompletion($member);
-            }
-        }
-
-        // ::class magic constant is always available for static access
-        if (self::matchesPrefix('class', $prefix)) {
+        if ($context->kind === MemberAccessKind::Static && self::matchesPrefix('class', $context->prefix)) {
             $items[] = [
                 'label' => 'class',
                 'kind' => self::KIND_CONSTANT,
@@ -435,39 +280,6 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $items;
-    }
-
-    /**
-     * Determine minimum visibility for accessing members of target class from enclosing class.
-     *
-     * @param class-string $targetClassName
-     */
-    private function getMinVisibilityForAccess(?Stmt\Class_ $enclosingClass, string $targetClassName): Visibility
-    {
-        if ($enclosingClass === null) {
-            return Visibility::Public;
-        }
-
-        $enclosingClassName = ScopeFinder::getClassLikeName($enclosingClass);
-        if ($enclosingClassName === null) {
-            return Visibility::Public;
-        }
-
-        if ($enclosingClassName === $targetClassName) {
-            return Visibility::Private;
-        }
-
-        // Check direct extends in AST
-        if (ScopeFinder::resolveExtendsName($enclosingClass) === $targetClassName) {
-            return Visibility::Protected;
-        }
-
-        // Check deeper inheritance via ClassRepository
-        if ($this->classRepository->isSubclassOf(new ClassName($enclosingClassName), new ClassName($targetClassName))) {
-            return Visibility::Protected;
-        }
-
-        return Visibility::Public;
     }
 
     /**
@@ -544,19 +356,6 @@ final class CompletionHandler implements HandlerInterface
             'kind' => self::KIND_FUNCTION,
             'detail' => $funcInfo->format(),
         ], $funcInfo->docblock);
-    }
-
-    /**
-     * Resolve a short class name to its FQCN using use statements.
-     *
-     * @param array<Stmt> $ast
-     * @return class-string
-     */
-    private function resolveClassName(string $shortName, array $ast): string
-    {
-        $imports = $this->getImports($ast);
-        /** @var class-string */
-        return $imports[$shortName] ?? $shortName;
     }
 
     /**

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -16,6 +16,7 @@ use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyInfo;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Resolution\MemberFilter;
 
 /**
  * Resolves class members with inheritance traversal.
@@ -86,7 +87,7 @@ final class MemberResolver
     public function getMethods(
         ClassName $class,
         Visibility $minVisibility,
-        ?bool $static = null,
+        MemberFilter $filter = MemberFilter::All,
     ): array {
         $classInfo = $this->classes->get($class);
         if ($classInfo === null) {
@@ -95,7 +96,7 @@ final class MemberResolver
 
         $methods = [];
         $seen = [];
-        $this->collectMethods($classInfo, $minVisibility, $static, $methods, $seen, true);
+        $this->collectMethods($classInfo, $minVisibility, $filter, $methods, $seen, true);
 
         return array_values($methods);
     }
@@ -106,7 +107,7 @@ final class MemberResolver
     public function getProperties(
         ClassName $class,
         Visibility $minVisibility,
-        ?bool $static = null,
+        MemberFilter $filter = MemberFilter::All,
     ): array {
         $classInfo = $this->classes->get($class);
         if ($classInfo === null) {
@@ -115,7 +116,7 @@ final class MemberResolver
 
         $properties = [];
         $seen = [];
-        $this->collectProperties($classInfo, $minVisibility, $static, $properties, $seen, true);
+        $this->collectProperties($classInfo, $minVisibility, $filter, $properties, $seen, true);
 
         return array_values($properties);
     }
@@ -301,7 +302,7 @@ final class MemberResolver
     private function collectMethods(
         ClassInfo $classInfo,
         Visibility $minVisibility,
-        ?bool $static,
+        MemberFilter $filter,
         array &$methods,
         array &$seen,
         bool $isOriginClass,
@@ -317,7 +318,7 @@ final class MemberResolver
             if (array_key_exists($key, $methods)) {
                 continue;
             }
-            if ($static !== null && $methodInfo->isStatic !== $static) {
+            if (!$this->matchesFilter($methodInfo->isStatic, $filter)) {
                 continue;
             }
             if (!$this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass)) {
@@ -329,14 +330,14 @@ final class MemberResolver
         foreach ($classInfo->traits as $traitName) {
             $traitInfo = $this->classes->get($traitName);
             if ($traitInfo !== null) {
-                $this->collectMethods($traitInfo, $minVisibility, $static, $methods, $seen, true);
+                $this->collectMethods($traitInfo, $minVisibility, $filter, $methods, $seen, true);
             }
         }
 
         if ($classInfo->parent !== null) {
             $parentInfo = $this->classes->get($classInfo->parent);
             if ($parentInfo !== null) {
-                $this->collectMethods($parentInfo, $minVisibility, $static, $methods, $seen, false);
+                $this->collectMethods($parentInfo, $minVisibility, $filter, $methods, $seen, false);
             }
         }
     }
@@ -348,7 +349,7 @@ final class MemberResolver
     private function collectProperties(
         ClassInfo $classInfo,
         Visibility $minVisibility,
-        ?bool $static,
+        MemberFilter $filter,
         array &$properties,
         array &$seen,
         bool $isOriginClass,
@@ -363,7 +364,7 @@ final class MemberResolver
             if (array_key_exists($key, $properties)) {
                 continue;
             }
-            if ($static !== null && $propInfo->isStatic !== $static) {
+            if (!$this->matchesFilter($propInfo->isStatic, $filter)) {
                 continue;
             }
             if (!$this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass)) {
@@ -375,16 +376,25 @@ final class MemberResolver
         foreach ($classInfo->traits as $traitName) {
             $traitInfo = $this->classes->get($traitName);
             if ($traitInfo !== null) {
-                $this->collectProperties($traitInfo, $minVisibility, $static, $properties, $seen, true);
+                $this->collectProperties($traitInfo, $minVisibility, $filter, $properties, $seen, true);
             }
         }
 
         if ($classInfo->parent !== null) {
             $parentInfo = $this->classes->get($classInfo->parent);
             if ($parentInfo !== null) {
-                $this->collectProperties($parentInfo, $minVisibility, $static, $properties, $seen, false);
+                $this->collectProperties($parentInfo, $minVisibility, $filter, $properties, $seen, false);
             }
         }
+    }
+
+    private function matchesFilter(bool $isStatic, MemberFilter $filter): bool
+    {
+        return match ($filter) {
+            MemberFilter::All => true,
+            MemberFilter::Static => $isStatic,
+            MemberFilter::Instance => !$isStatic,
+        };
     }
 
     /**

--- a/src/Resolution/MemberAccessContext.php
+++ b/src/Resolution/MemberAccessContext.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Domain\Visibility;
+
+/**
+ * Context for member access completion.
+ * Captures the type being accessed, visibility level, and access kind.
+ */
+final readonly class MemberAccessContext
+{
+    public function __construct(
+        public Type $type,
+        public Visibility $minVisibility,
+        public MemberAccessKind $kind,
+        public string $prefix,
+    ) {
+    }
+}

--- a/src/Resolution/MemberAccessContext.php
+++ b/src/Resolution/MemberAccessContext.php
@@ -13,6 +13,9 @@ use Firehed\PhpLsp\Domain\Visibility;
  */
 final readonly class MemberAccessContext
 {
+    /**
+     * @codeCoverageIgnore
+     */
     public function __construct(
         public Type $type,
         public Visibility $minVisibility,

--- a/src/Resolution/MemberAccessKind.php
+++ b/src/Resolution/MemberAccessKind.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+enum MemberAccessKind
+{
+    case Instance;  // $obj-> or $obj?->
+    case Static;    // Class:: (includes self::, static::)
+    case Parent;    // parent::
+}

--- a/src/Resolution/MemberFilter.php
+++ b/src/Resolution/MemberFilter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+enum MemberFilter
+{
+    case Instance;
+    case Static;
+    case All;
+}

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -103,15 +103,15 @@ final class SymbolResolver
      * Get members accessible on a type.
      * Used by: Completion (after -> or ::)
      *
-     * For instance access (->): returns methods and properties.
-     * For static access (::): also includes constants and enum cases.
+     * For instance access: returns methods and properties.
+     * For static access: also includes constants and enum cases.
      *
      * @return list<ResolvedMember>
      */
     public function getAccessibleMembers(
         Type $type,
         Visibility $minVisibility,
-        bool $staticOnly = false,
+        MemberFilter $filter = MemberFilter::Instance,
     ): array {
         $classNames = $type->getResolvableClassNames();
         if ($classNames === []) {
@@ -119,19 +119,20 @@ final class SymbolResolver
         }
 
         $members = [];
+        $includeStatic = $filter !== MemberFilter::Instance;
 
         foreach ($classNames as $className) {
-            $methods = $this->memberResolver->getMethods($className, $minVisibility, $staticOnly);
+            $methods = $this->memberResolver->getMethods($className, $minVisibility, $filter);
             foreach ($methods as $methodInfo) {
                 $members[] = new ResolvedMethod($methodInfo);
             }
 
-            $properties = $this->memberResolver->getProperties($className, $minVisibility, $staticOnly);
+            $properties = $this->memberResolver->getProperties($className, $minVisibility, $filter);
             foreach ($properties as $propertyInfo) {
                 $members[] = new ResolvedProperty($propertyInfo);
             }
 
-            if ($staticOnly) {
+            if ($includeStatic) {
                 $constants = $this->memberResolver->getConstants($className, $minVisibility);
                 foreach ($constants as $constantInfo) {
                     $members[] = new ResolvedConstant($constantInfo);

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -148,6 +148,157 @@ final class SymbolResolver
     }
 
     /**
+     * Get member access context at position.
+     * Used by: Completion (after -> or ::)
+     */
+    public function getMemberAccessContext(
+        TextDocument $document,
+        int $line,
+        int $character,
+    ): ?MemberAccessContext {
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('Parser returned null');
+            // @codeCoverageIgnoreEnd
+        }
+
+        $offset = $document->offsetAt($line, $character);
+
+        // Use offset - 1 because cursor is after the -> and we want the member access node
+        $nodeFinder = new NodeAtPosition();
+        $node = $nodeFinder->find($ast, $offset > 0 ? $offset - 1 : 0);
+
+        if ($node === null) {
+            return null;
+        }
+
+        // Handle identifier/error by checking parent
+        if ($node instanceof Identifier || $node instanceof Node\Expr\Error) {
+            $parent = $node->getAttribute('parent');
+            if ($parent instanceof Node) {
+                $node = $parent;
+            } else {
+                return null;
+            }
+        }
+
+        // Instance access: $obj->member or $obj?->member
+        if (MemberAccessResolver::isMethodCall($node) || MemberAccessResolver::isPropertyFetch($node)) {
+            /** @var MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node */
+            $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
+            $type = $this->resolveInstanceAccessType($node, $ast);
+            if ($type === null) {
+                return null;
+            }
+
+            $isThis = $node->var instanceof Variable && $node->var->name === 'this';
+            $enclosingClassName = ScopeFinder::findEnclosingClassName($node);
+            $classNames = $type->getResolvableClassNames();
+            $className = $classNames[0] ?? null;
+            $isSameClass = $enclosingClassName !== null && $className !== null
+                && $enclosingClassName === $className->fqn;
+            $visibility = ($isThis || $isSameClass) ? Visibility::Private : Visibility::Public;
+
+            return new MemberAccessContext($type, $visibility, MemberAccessKind::Instance, $prefix);
+        }
+
+        // Static access: ClassName::member
+        if ($node instanceof StaticPropertyFetch || $node instanceof StaticCall || $node instanceof ClassConstFetch) {
+            return $this->resolveStaticAccessContext($node, $ast, $line);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function resolveStaticAccessContext(
+        StaticPropertyFetch|StaticCall|ClassConstFetch $node,
+        array $ast,
+        int $line,
+    ): ?MemberAccessContext {
+        $class = $node->class;
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        $prefix = $node->name instanceof Identifier ? $node->name->toString() : '';
+        $rawName = $class->toString();
+
+        // parent:: has special behavior
+        if ($rawName === 'parent') {
+            $classNode = ScopeFinder::findClassAtLine($ast, $line);
+            if ($classNode === null || $classNode->extends === null) {
+                return null;
+            }
+            $parentClassName = ScopeFinder::resolveExtendsName($classNode);
+            assert($parentClassName !== null);
+            return new MemberAccessContext(
+                new ClassName($parentClassName),
+                Visibility::Protected,
+                MemberAccessKind::Parent,
+                $prefix,
+            );
+        }
+
+        // For self::, static::, and regular class names
+        $className = ScopeFinder::resolveClassNameInContext($class, $node);
+        if ($className === null) {
+            return null;
+        }
+
+        $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);
+        $minVisibility = $this->getMinVisibilityForStaticAccess($enclosingClass, $className);
+
+        return new MemberAccessContext(
+            new ClassName($className),
+            $minVisibility,
+            MemberAccessKind::Static,
+            $prefix,
+        );
+    }
+
+    /**
+     * Determine minimum visibility for static access from enclosing class.
+     *
+     * @param class-string $targetClassName
+     */
+    private function getMinVisibilityForStaticAccess(
+        ?Stmt\Class_ $enclosingClass,
+        string $targetClassName,
+    ): Visibility {
+        if ($enclosingClass === null) {
+            return Visibility::Public;
+        }
+
+        $enclosingClassName = ScopeFinder::getClassLikeName($enclosingClass);
+        if ($enclosingClassName === null) {
+            return Visibility::Public;
+        }
+
+        if ($enclosingClassName === $targetClassName) {
+            return Visibility::Private;
+        }
+
+        if (ScopeFinder::resolveExtendsName($enclosingClass) === $targetClassName) {
+            return Visibility::Protected;
+        }
+
+        if (
+            $this->classRepository->isSubclassOf(
+                new ClassName($enclosingClassName),
+                new ClassName($targetClassName),
+            )
+        ) {
+            return Visibility::Protected;
+        }
+
+        return Visibility::Public;
+    }
+
+    /**
      * Get variables in scope at position.
      * Used by: Completion (variable names)
      *
@@ -369,6 +520,18 @@ final class SymbolResolver
     }
 
     /**
+     * Resolve the type of the object in an instance member access.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function resolveInstanceAccessType(
+        MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node,
+        array $ast,
+    ): ?Type {
+        return ExpressionTypeResolver::resolveExpressionType($node->var, $ast, $this->typeResolver);
+    }
+
+    /**
      * Resolve the class name of the object in an instance member access.
      *
      * @param array<Stmt> $ast
@@ -377,7 +540,7 @@ final class SymbolResolver
         MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node,
         array $ast,
     ): ?ClassName {
-        $type = ExpressionTypeResolver::resolveExpressionType($node->var, $ast, $this->typeResolver);
+        $type = $this->resolveInstanceAccessType($node, $ast);
         $classNames = $type?->getResolvableClassNames() ?? [];
         return $classNames[0] ?? null;
     }

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -350,10 +350,7 @@ final class SymbolResolver
             return null;
         }
 
-        $type = ExpressionTypeResolver::resolveExpressionType($call->var, $ast, $this->typeResolver);
-        $classNames = $type?->getResolvableClassNames() ?? [];
-        $className = $classNames[0] ?? null;
-
+        $className = $this->resolveInstanceAccessClassName($call, $ast);
         if ($className === null) {
             return null;
         }
@@ -369,6 +366,20 @@ final class SymbolResolver
         }
 
         return new ResolvedMethod($methodInfo);
+    }
+
+    /**
+     * Resolve the class name of the object in an instance member access.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function resolveInstanceAccessClassName(
+        MethodCall|NullsafeMethodCall|PropertyFetch|NullsafePropertyFetch $node,
+        array $ast,
+    ): ?ClassName {
+        $type = ExpressionTypeResolver::resolveExpressionType($node->var, $ast, $this->typeResolver);
+        $classNames = $type?->getResolvableClassNames() ?? [];
+        return $classNames[0] ?? null;
     }
 
     private function resolveStaticCallCallable(StaticCall $call): ?ResolvedCallable
@@ -790,10 +801,7 @@ final class SymbolResolver
         }
         // @codeCoverageIgnoreEnd
 
-        $type = ExpressionTypeResolver::resolveExpressionType($fetch->var, $ast, $this->typeResolver);
-        $classNames = $type?->getResolvableClassNames() ?? [];
-        $className = $classNames[0] ?? null;
-
+        $className = $this->resolveInstanceAccessClassName($fetch, $ast);
         if ($className === null) {
             return null;
         }

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -180,7 +180,10 @@ final class SymbolResolver
             if ($parent instanceof Node) {
                 $node = $parent;
             } else {
-                return null;
+                // @codeCoverageIgnoreStart
+                // ParserService always sets parent via NodeConnectingVisitor
+                throw new \LogicException('Node missing parent attribute');
+                // @codeCoverageIgnoreEnd
             }
         }
 
@@ -247,7 +250,10 @@ final class SymbolResolver
         // For self::, static::, and regular class names
         $className = ScopeFinder::resolveClassNameInContext($class, $node);
         if ($className === null) {
+            // @codeCoverageIgnoreStart
+            // self::/static:: outside a class - parser error recovery makes this hard to reach
             return null;
+            // @codeCoverageIgnoreEnd
         }
 
         $enclosingClass = ScopeFinder::findClassAtLine($ast, $line);

--- a/src/Server.php
+++ b/src/Server.php
@@ -89,8 +89,6 @@ final class Server
             $this->documentManager,
             $parser,
             $symbolIndex,
-            $classRepository,
-            $memberAccessResolver,
             $symbolResolver,
         );
     }

--- a/tests/Fixtures/TopLevel/static_access.php
+++ b/tests/Fixtures/TopLevel/static_access.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Fixtures\Domain\User;
+
+User::/*|toplevel_static*/
+
+self::cla/*|toplevel_self*/
+
+$anon = new class {
+    public function test(): void
+    {
+        User::/*|anon_class_static*/
+    }
+};

--- a/tests/Fixtures/src/Completion/EdgeCases.php
+++ b/tests/Fixtures/src/Completion/EdgeCases.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\User;
+
+class EdgeCases
+{
+    public function unresolvedVariable(): void
+    {
+        $unknownVar->/*|unresolved_var*/
+    }
+
+    public function dynamicClassAccess(string $className): void
+    {
+        $className::/*|dynamic_class*/
+    }
+
+    public function unrelatedStaticAccess(): void
+    {
+        User::/*|unrelated_static*/
+    }
+
+    public function notMemberAccess(): void
+    {
+        $x = 1;
+        /*|not_member_access*/
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -66,8 +66,6 @@ class CompletionHandlerTest extends TestCase
             $this->documents,
             $this->parser,
             $this->symbolIndex,
-            $this->classRepository,
-            $memberAccessResolver,
             $symbolResolver,
         );
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -18,6 +18,7 @@ use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\MemberFilter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -503,8 +504,8 @@ final class MemberResolverTest extends TestCase
 
         $resolver = new MemberResolver($repo);
 
-        $staticOnly = $resolver->getMethods($className, Visibility::Public, static: true);
-        $instanceOnly = $resolver->getMethods($className, Visibility::Public, static: false);
+        $staticOnly = $resolver->getMethods($className, Visibility::Public, MemberFilter::Static);
+        $instanceOnly = $resolver->getMethods($className, Visibility::Public, MemberFilter::Instance);
 
         self::assertSame([$staticMethod], $staticOnly);
         self::assertSame([$instanceMethod], $instanceOnly);
@@ -587,8 +588,8 @@ final class MemberResolverTest extends TestCase
 
         $resolver = new MemberResolver($repo);
 
-        $staticOnly = $resolver->getProperties($className, Visibility::Public, static: true);
-        $instanceOnly = $resolver->getProperties($className, Visibility::Public, static: false);
+        $staticOnly = $resolver->getProperties($className, Visibility::Public, MemberFilter::Static);
+        $instanceOnly = $resolver->getProperties($className, Visibility::Public, MemberFilter::Instance);
 
         self::assertSame([$staticProp], $staticOnly);
         self::assertSame([$instanceProp], $instanceOnly);

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -23,6 +23,8 @@ use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Resolution\CallContext;
+use Firehed\PhpLsp\Resolution\MemberAccessContext;
+use Firehed\PhpLsp\Resolution\MemberAccessKind;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedParameter;
 use Firehed\PhpLsp\Resolution\ResolvedVariable;
@@ -783,5 +785,94 @@ final class SymbolResolverTest extends TestCase
         $result = $this->resolver->resolveAtPosition($document, $lineNum, $character);
 
         self::assertNull($result);
+    }
+
+    public function testGetMemberAccessContextForInstanceAccess(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'this_empty');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+        self::assertSame(Visibility::Private, $context->minVisibility);
+        self::assertSame('', $context->prefix);
+    }
+
+    public function testGetMemberAccessContextForInstanceAccessWithPrefix(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'this_prefix');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+        self::assertSame('get', $context->prefix);
+    }
+
+    public function testGetMemberAccessContextForNullsafeAccess(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'nullsafe_this_empty');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+    }
+
+    public function testGetMemberAccessContextForStaticAccess(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/StaticAccess.php', 'self_empty');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        self::assertSame(Visibility::Private, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextForParentAccess(): void
+    {
+        $this->openFixture('src/Inheritance/ParentClass.php');
+        $this->openFixture('src/Inheritance/ChildClass.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/InheritanceCompletion.php', 'parent_access');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Parent, $context->kind);
+        self::assertSame(Visibility::Protected, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextReturnsNullOutsideMemberAccess(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $document = $this->documents->get('file:///fixtures/src/Domain/User.php');
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, 0, 0);
+
+        self::assertNull($context);
+    }
+
+    public function testGetMemberAccessContextReturnsNullForNoParent(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/NoParent.php', 'parent_no_parent');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertNull($context);
     }
 }

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -25,6 +25,7 @@ use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Resolution\CallContext;
 use Firehed\PhpLsp\Resolution\MemberAccessContext;
 use Firehed\PhpLsp\Resolution\MemberAccessKind;
+use Firehed\PhpLsp\Resolution\MemberFilter;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedParameter;
 use Firehed\PhpLsp\Resolution\ResolvedVariable;
@@ -383,7 +384,7 @@ final class SymbolResolverTest extends TestCase
 
         // @phpstan-ignore argument.type (test uses fixture class name)
         $type = new ClassName('Fixtures\\Domain\\User');
-        $members = $this->resolver->getAccessibleMembers($type, Visibility::Public, staticOnly: true);
+        $members = $this->resolver->getAccessibleMembers($type, Visibility::Public, MemberFilter::Static);
 
         self::assertNotEmpty($members);
 
@@ -408,7 +409,7 @@ final class SymbolResolverTest extends TestCase
 
         // @phpstan-ignore argument.type (test uses fixture class name)
         $type = new ClassName('Fixtures\\Enum\\Status');
-        $members = $this->resolver->getAccessibleMembers($type, Visibility::Public, staticOnly: true);
+        $members = $this->resolver->getAccessibleMembers($type, Visibility::Public, MemberFilter::Static);
 
         $hasEnumCase = false;
         foreach ($members as $member) {

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -876,4 +876,119 @@ final class SymbolResolverTest extends TestCase
 
         self::assertNull($context);
     }
+
+    public function testGetMemberAccessContextReturnsNullForUnresolvedVariable(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/EdgeCases.php', 'unresolved_var');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertNull($context);
+    }
+
+    public function testGetMemberAccessContextReturnsNullForDynamicClass(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/EdgeCases.php', 'dynamic_class');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertNull($context);
+    }
+
+    public function testGetMemberAccessContextStaticFromDirectSubclass(): void
+    {
+        $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtCursor('src/Inheritance/ChildClass.php', 'direct_parent_static');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        self::assertSame(Visibility::Protected, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextStaticFromDeepSubclass(): void
+    {
+        $this->openFixture('src/Inheritance/Grandparent.php');
+        $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtCursor('src/Inheritance/ChildClass.php', 'grandparent_access');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        self::assertSame(Visibility::Protected, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextStaticFromUnrelatedClass(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/EdgeCases.php', 'unrelated_static');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        self::assertSame(Visibility::Public, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextReturnsNullForSelfOutsideClass(): void
+    {
+        $cursor = $this->openFixtureAtCursor('TopLevel/static_access.php', 'toplevel_self');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertNull($context);
+    }
+
+    public function testGetMemberAccessContextReturnsNullForNonMemberAccess(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/EdgeCases.php', 'not_member_access');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertNull($context);
+    }
+
+    public function testGetMemberAccessContextStaticFromTopLevel(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtCursor('TopLevel/static_access.php', 'toplevel_static');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        self::assertSame(Visibility::Public, $context->minVisibility);
+    }
+
+    public function testGetMemberAccessContextStaticFromAnonymousClass(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtCursor('TopLevel/static_access.php', 'anon_class_static');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Static, $context->kind);
+        self::assertSame(Visibility::Public, $context->minVisibility);
+    }
 }


### PR DESCRIPTION
Closes #261

## Summary
- Add `getMemberAccessContext()` to SymbolResolver for centralized member access detection
- Add `MemberFilter` enum replacing `?bool $static` tri-state
- Refactor CompletionHandler to delegate member access context to SymbolResolver
- Remove ~200 lines of duplicate logic from CompletionHandler

## Changes

**New domain objects:**
- `MemberAccessContext` - captures type, visibility, access kind, and prefix
- `MemberAccessKind` - Instance, Static, Parent
- `MemberFilter` - Instance, Static, All (replaces nullable bool)

**SymbolResolver additions:**
- `getMemberAccessContext()` - detects and resolves member access at cursor position
- Extracted shared helpers for instance access type resolution

**CompletionHandler simplification:**
- Removed `handleMemberAccessNode`, `handleMemberAccess`, `handleStaticAccess`
- Removed `getParentCompletions`, `getStaticCompletions`, `getMinVisibilityForAccess`
- Removed `resolveClassName`, `MemberAccessResolver` dependency
- Single `handleMemberAccessContext()` method uses SymbolResolver

## Test plan
- [x] All 871 tests pass
- [x] PHPStan clean
- [x] PHPCS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)