### PR TITLE
Add tests verifying issues #6, #101, #190 can be closed

### DIFF
--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -543,4 +543,36 @@ class DefinitionHandlerTest extends TestCase
 
         self::assertNull($result);
     }
+
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/6
+     */
+    public function testGoToClassConstantDefinition(): void
+    {
+        $parentUri = $this->openFixture('src/Inheritance/ParentClass.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ParentClass.php', 'class_constant');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($parentUri, $result['uri']);
+        // PARENT_CONST is defined on line 9 (0-indexed: 8)
+        self::assertSame(8, $result['range']['start']['line']);
+    }
+
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/190
+     */
+    public function testGoToPropertyDefinition(): void
+    {
+        $userUri = $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'manager');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($userUri, $result['uri']);
+        // manager property is defined on line 29 (0-indexed: 28)
+        self::assertSame(28, $result['range']['start']['line']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -593,4 +593,17 @@ class HoverHandlerTest extends TestCase
 
         self::assertNull($result);
     }
+
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/6
+     */
+    public function testHoverOnClassConstant(): void
+    {
+        $cursor = $this->openFixtureAtHoverMarker('src/Inheritance/ParentClass.php', 'class_constant');
+
+        $result = $this->handler->handle($this->hoverRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('PARENT_CONST', $result['contents']);
+    }
 }

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -198,6 +198,13 @@ class SignatureHelpHandlerTest extends TestCase
         self::assertStringContainsString("Updates the user's display name", $doc);
     }
 
+    /**
+     * Verifies parent:: resolves to actual parent class, not enclosing class.
+     * ChildClass has no constructor; ParentClass has __construct(string $name).
+     * Finding $name proves we resolved to ParentClass.
+     *
+     * @see https://github.com/Firehed/php-lsp/issues/101
+     */
     public function testSignatureHelpOnParentStaticCall(): void
     {
         $this->openFixture('src/Inheritance/Grandparent.php');


### PR DESCRIPTION
## Summary

- Adds test for hover on class constants - issue #6
- Adds tests for go-to-definition on class constants and properties - issues #6, #190
- Documents existing testSignatureHelpOnParentStaticCall as covering issue #101

These tests confirm the features work correctly, allowing the referenced issues to be closed.

Closes #6
Closes #101
Closes #190

Generated with Claude Code