### PR TITLE
Add tests verifying promoted property support

### DIFF
--- a/tests/Fixtures/src/Domain/User.php
+++ b/tests/Fixtures/src/Domain/User.php
@@ -34,7 +34,7 @@ class User implements Entity, Person
 
     public function getId(): string
     {
-        return $this->id;
+        return $this->id; //hover:promoted_property
     }
 
     public function getName(): string

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -575,4 +575,20 @@ class DefinitionHandlerTest extends TestCase
         // manager property is defined on line 29 (0-indexed: 28)
         self::assertSame(28, $result['range']['start']['line']);
     }
+
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/93
+     */
+    public function testGoToPromotedPropertyDefinition(): void
+    {
+        $userUri = $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'promoted_property');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($userUri, $result['uri']);
+        // $id promoted property is defined on line 24 (0-indexed: 23)
+        self::assertSame(23, $result['range']['start']['line']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -633,5 +633,6 @@ class HoverHandlerTest extends TestCase
         self::assertIsArray($result);
         self::assertStringContainsString('$id', $result['contents']);
         self::assertStringContainsString('string', $result['contents']);
+        self::assertStringContainsString('readonly', $result['contents']);
     }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -620,4 +620,18 @@ class HoverHandlerTest extends TestCase
         self::assertStringContainsString('$typed', $result['contents']);
         self::assertStringContainsString('User', $result['contents']);
     }
+
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/8
+     */
+    public function testHoverOnPromotedProperty(): void
+    {
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'promoted_property');
+
+        $result = $this->handler->handle($this->hoverRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$id', $result['contents']);
+        self::assertStringContainsString('string', $result['contents']);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds hover marker for promoted property in User fixture
- Adds test confirming hover on promoted properties shows type
- Adds test confirming go-to-definition navigates to promoted property parameter

The SymbolResolver refactoring enabled these features; these tests document that they work.

Closes #8
Closes #93

Generated with Claude Code