### PR TITLE
Add tests verifying trait-defined property resolution

### DIFF
--- a/tests/Fixtures/src/Completion/InheritanceCompletion.php
+++ b/tests/Fixtures/src/Completion/InheritanceCompletion.php
@@ -6,9 +6,12 @@ namespace Fixtures\Completion;
 
 use Fixtures\Inheritance\ChildClass;
 use Fixtures\Inheritance\ParentClass;
+use Fixtures\Traits\HasTimestamps;
 
 class InheritanceCompletion extends ChildClass
 {
+    use HasTimestamps;
+
     private string $ownProperty = '';
 
     public function ownMethod(): void

--- a/tests/Fixtures/src/Domain/User.php
+++ b/tests/Fixtures/src/Domain/User.php
@@ -310,4 +310,10 @@ class User implements Entity, Person
     {
         self::nonexistentStatic(/*|sig_nonexistent_static*/);
     }
+
+    public function triggerTraitPropertyFromConsumer(): void
+    {
+        echo $this->createdAt; //hover:trait_property_consumer
+    }
+
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -146,6 +146,26 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('grandparentMethod', $labels);
     }
 
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/185
+     */
+    public function testThisCompletionIncludesTraitMembers(): void
+    {
+        $this->openFixture('src/Traits/HasTimestamps.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/InheritanceCompletion.php', 'this_inherited');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Trait properties from HasTimestamps
+        self::assertContains('createdAt', $labels);
+        self::assertContains('updatedAt', $labels);
+        // Trait methods from HasTimestamps
+        self::assertContains('getCreatedAt', $labels);
+        self::assertContains('markCreated', $labels);
+    }
+
     public function testStaticMethodCompletion(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/StaticCaller.php', 'external_static');

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -591,4 +591,21 @@ class DefinitionHandlerTest extends TestCase
         // $id promoted property is defined on line 24 (0-indexed: 23)
         self::assertSame(23, $result['range']['start']['line']);
     }
+
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/185
+     */
+    public function testGoToTraitPropertyDefinition(): void
+    {
+        $traitUri = $this->openFixture('src/Traits/HasTimestamps.php');
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'trait_property_consumer');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($traitUri, $result['uri']);
+        // $createdAt is defined on line 17 (0-indexed: 16)
+        self::assertSame(16, $result['range']['start']['line']);
+    }
 }

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -635,4 +635,19 @@ class HoverHandlerTest extends TestCase
         self::assertStringContainsString('string', $result['contents']);
         self::assertStringContainsString('readonly', $result['contents']);
     }
+
+    /**
+     * @see https://github.com/Firehed/php-lsp/issues/185
+     */
+    public function testHoverOnTraitPropertyFromConsumingClass(): void
+    {
+        $this->openFixture('src/Traits/HasTimestamps.php');
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'trait_property_consumer');
+
+        $result = $this->handler->handle($this->hoverRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('$createdAt', $result['contents']);
+        self::assertStringContainsString('DateTimeImmutable', $result['contents']);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds hover marker in User.php for trait property access from consuming class
- Adds HasTimestamps trait to InheritanceCompletion fixture for completion testing
- Adds test for hover on trait property from consuming class
- Adds test for go-to-definition navigating to trait property definition
- Adds test for completion including trait members

All three features work correctly for trait-defined properties accessed from consuming classes.

Closes #185

Generated with Claude Code