### PR TITLE
Exclude abstract classes from new context completions

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
@@ -170,8 +171,8 @@ final class CompletionHandler implements HandlerInterface
         // new ClassName completion - suggest imported classes and indexed instantiable types
         if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
-            $items = $this->getImportedClassCompletions($prefix, $ast);
-            $indexedItems = $this->getIndexedClassCompletions($prefix, [SymbolKind::Class_, SymbolKind::Enum_]);
+            $items = $this->getImportedClassCompletions($prefix, $ast, instantiableOnly: true);
+            $indexedItems = $this->getIndexedClassCompletions($prefix, [SymbolKind::Class_], instantiableOnly: true);
             $items = array_merge($items, $indexedItems);
             return $this->deduplicateCompletions($items);
         }
@@ -364,19 +365,27 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getImportedClassCompletions(string $prefix, array $ast): array
-    {
+    private function getImportedClassCompletions(
+        string $prefix,
+        array $ast,
+        bool $instantiableOnly = false,
+    ): array {
         $items = [];
         $imports = $this->getImports($ast);
 
         foreach ($imports as $shortName => $fqcn) {
-            if (self::matchesPrefix($shortName, $prefix)) {
-                $items[] = [
-                    'label' => $shortName,
-                    'kind' => self::KIND_CLASS,
-                    'detail' => $fqcn,
-                ];
+            if (!self::matchesPrefix($shortName, $prefix)) {
+                continue;
             }
+            /** @var class-string $fqcn */
+            if ($instantiableOnly && !$this->symbolResolver->isInstantiable(new ClassName($fqcn))) {
+                continue;
+            }
+            $items[] = [
+                'label' => $shortName,
+                'kind' => self::KIND_CLASS,
+                'detail' => $fqcn,
+            ];
         }
 
         return $items;
@@ -426,16 +435,24 @@ final class CompletionHandler implements HandlerInterface
      * @param list<SymbolKind> $kinds
      * @return list<CompletionItem>
      */
-    private function getIndexedClassCompletions(string $prefix, array $kinds): array
-    {
+    private function getIndexedClassCompletions(
+        string $prefix,
+        array $kinds,
+        bool $instantiableOnly = false,
+    ): array {
         $symbols = $this->symbolIndex->findByPrefix($prefix, $kinds);
         $items = [];
 
         foreach ($symbols as $symbol) {
+            /** @var class-string $fqcn */
+            $fqcn = $symbol->fullyQualifiedName;
+            if ($instantiableOnly && !$this->symbolResolver->isInstantiable(new ClassName($fqcn))) {
+                continue;
+            }
             $items[] = [
                 'label' => $symbol->name,
                 'kind' => self::KIND_CLASS,
-                'detail' => $symbol->fullyQualifiedName,
+                'detail' => $fqcn,
             ];
         }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -172,7 +172,8 @@ final class CompletionHandler implements HandlerInterface
         if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
             $prefix = $matches[1];
             $items = $this->getImportedClassCompletions($prefix, $ast, instantiableOnly: true);
-            $indexedItems = $this->getIndexedClassCompletions($prefix, [SymbolKind::Class_], instantiableOnly: true);
+            $kinds = [SymbolKind::Class_, SymbolKind::Enum_];
+            $indexedItems = $this->getIndexedClassCompletions($prefix, $kinds, instantiableOnly: true);
             $items = array_merge($items, $indexedItems);
             return $this->deduplicateCompletions($items);
         }

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -149,11 +149,15 @@ final class SymbolResolver
         return $members;
     }
 
+    /**
+     * Check if a class can be instantiated with `new`.
+     * Returns true for unknown classes (optimistic filtering).
+     */
     public function isInstantiable(ClassName $className): bool
     {
         $classInfo = $this->classRepository->get($className);
         if ($classInfo === null) {
-            return true; // Unknown class - can't prove it's not instantiable
+            return true;
         }
         return !$classInfo->isAbstract && $classInfo->kind === ClassKind::Class_;
     }

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -12,6 +12,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
+use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
@@ -146,6 +147,15 @@ final class SymbolResolver
         }
 
         return $members;
+    }
+
+    public function isInstantiable(string $fqcn): bool
+    {
+        $classInfo = $this->classRepository->get(new ClassName($fqcn));
+        if ($classInfo === null) {
+            return false;
+        }
+        return !$classInfo->isAbstract && $classInfo->kind === ClassKind::Class_;
     }
 
     /**

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -149,11 +149,11 @@ final class SymbolResolver
         return $members;
     }
 
-    public function isInstantiable(string $fqcn): bool
+    public function isInstantiable(ClassName $className): bool
     {
-        $classInfo = $this->classRepository->get(new ClassName($fqcn));
+        $classInfo = $this->classRepository->get($className);
         if ($classInfo === null) {
-            return false;
+            return true; // Unknown class - can't prove it's not instantiable
         }
         return !$classInfo->isAbstract && $classInfo->kind === ClassKind::Class_;
     }

--- a/tests/Fixtures/src/Completion/NewCompletion.php
+++ b/tests/Fixtures/src/Completion/NewCompletion.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Utility\AbstractBase;
+use Fixtures\Utility\SealedClass;
+
+class NewCompletion
+{
+    public function newAbstract(): void
+    {
+        $x = new /*|new_abstract*/
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -433,6 +433,23 @@ class CompletionHandlerTest extends TestCase
         self::assertNotContains('MyInterface', $labels);
     }
 
+    public function testNewCompletionExcludesAbstractClasses(): void
+    {
+        // Index the classes first (AbstractBase is abstract, SealedClass is concrete)
+        $this->openFixture('src/Utility/ClassModifiers.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/NewCompletion.php', 'new_abstract');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('items', $result);
+        $labels = array_column($result['items'], 'label');
+        // Should include concrete class (imported via use statement)
+        self::assertContains('SealedClass', $labels);
+        // Should NOT include abstract class
+        self::assertNotContains('AbstractBase', $labels);
+    }
+
     public function testExpressionCompletionIncludesAllIndexedTypes(): void
     {
         // Add various symbol types to the index

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -995,29 +995,35 @@ final class SymbolResolverTest extends TestCase
     public function testIsInstantiableReturnsFalseForAbstractClass(): void
     {
         $this->openFixture('src/Utility/ClassModifiers.php');
-        self::assertFalse($this->resolver->isInstantiable('Fixtures\\Utility\\AbstractBase'));
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertFalse($this->resolver->isInstantiable(new ClassName('Fixtures\\Utility\\AbstractBase')));
     }
 
     public function testIsInstantiableReturnsTrueForConcreteClass(): void
     {
         $this->openFixture('src/Utility/ClassModifiers.php');
-        self::assertTrue($this->resolver->isInstantiable('Fixtures\\Utility\\SealedClass'));
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertTrue($this->resolver->isInstantiable(new ClassName('Fixtures\\Utility\\SealedClass')));
     }
 
     public function testIsInstantiableReturnsFalseForInterface(): void
     {
         $this->openFixture('src/Domain/Entity.php');
-        self::assertFalse($this->resolver->isInstantiable('Fixtures\\Domain\\Entity'));
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertFalse($this->resolver->isInstantiable(new ClassName('Fixtures\\Domain\\Entity')));
     }
 
     public function testIsInstantiableReturnsFalseForEnum(): void
     {
         $this->openFixture('src/Enum/Status.php');
-        self::assertFalse($this->resolver->isInstantiable('Fixtures\\Enum\\Status'));
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertFalse($this->resolver->isInstantiable(new ClassName('Fixtures\\Enum\\Status')));
     }
 
-    public function testIsInstantiableReturnsFalseForUnknownClass(): void
+    public function testIsInstantiableReturnsTrueForUnknownClass(): void
     {
-        self::assertFalse($this->resolver->isInstantiable('NonExistent\\Unknown'));
+        // Unknown classes are assumed instantiable (optimistic filtering)
+        /** @phpstan-ignore argument.type (intentionally non-existent) */
+        self::assertTrue($this->resolver->isInstantiable(new ClassName('NonExistent\\Unknown')));
     }
 }

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -991,4 +991,33 @@ final class SymbolResolverTest extends TestCase
         self::assertSame(MemberAccessKind::Static, $context->kind);
         self::assertSame(Visibility::Public, $context->minVisibility);
     }
+
+    public function testIsInstantiableReturnsFalseForAbstractClass(): void
+    {
+        $this->openFixture('src/Utility/ClassModifiers.php');
+        self::assertFalse($this->resolver->isInstantiable('Fixtures\\Utility\\AbstractBase'));
+    }
+
+    public function testIsInstantiableReturnsTrueForConcreteClass(): void
+    {
+        $this->openFixture('src/Utility/ClassModifiers.php');
+        self::assertTrue($this->resolver->isInstantiable('Fixtures\\Utility\\SealedClass'));
+    }
+
+    public function testIsInstantiableReturnsFalseForInterface(): void
+    {
+        $this->openFixture('src/Domain/Entity.php');
+        self::assertFalse($this->resolver->isInstantiable('Fixtures\\Domain\\Entity'));
+    }
+
+    public function testIsInstantiableReturnsFalseForEnum(): void
+    {
+        $this->openFixture('src/Enum/Status.php');
+        self::assertFalse($this->resolver->isInstantiable('Fixtures\\Enum\\Status'));
+    }
+
+    public function testIsInstantiableReturnsFalseForUnknownClass(): void
+    {
+        self::assertFalse($this->resolver->isInstantiable('NonExistent\\Unknown'));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `isInstantiable(ClassName)` method to `SymbolResolver` that checks if a class can be instantiated with `new`
- Filter abstract classes (and interfaces/enums/traits) from `new` context completions
- Unknown classes are assumed instantiable (optimistic filtering)

Closes #41

## Test plan

- [x] New test `testNewCompletionExcludesAbstractClasses` verifies abstract classes are filtered
- [x] Existing tests pass - concrete classes and unknown classes still appear
- [x] PHPStan and PHPCS pass

🤖 Generated with [Claude Code](https://claude.ai/code)