### PR TITLE
Exclude imported traits from type hint completions

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -370,6 +370,7 @@ final class CompletionHandler implements HandlerInterface
         string $prefix,
         array $ast,
         bool $instantiableOnly = false,
+        bool $typeHintContext = false,
     ): array {
         $items = [];
         $imports = $this->getImports($ast);
@@ -380,6 +381,9 @@ final class CompletionHandler implements HandlerInterface
             }
             /** @var class-string $fqcn */
             if ($instantiableOnly && !$this->symbolResolver->isInstantiable(new ClassName($fqcn))) {
+                continue;
+            }
+            if ($typeHintContext && !$this->symbolResolver->isValidTypeHint(new ClassName($fqcn))) {
                 continue;
             }
             $items[] = [
@@ -522,8 +526,8 @@ final class CompletionHandler implements HandlerInterface
             }
         }
 
-        // Imported classes
-        $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
+        // Imported classes (traits are not valid type hints)
+        $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast, typeHintContext: true));
 
         // Indexed types (traits are not valid type hints)
         $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -163,6 +163,20 @@ final class SymbolResolver
     }
 
     /**
+     * Check if a class-like can be used as a type hint.
+     * Traits are not valid type hints; classes, interfaces, and enums are.
+     * Returns true for unknown classes (optimistic filtering).
+     */
+    public function isValidTypeHint(ClassName $className): bool
+    {
+        $classInfo = $this->classRepository->get($className);
+        if ($classInfo === null) {
+            return true;
+        }
+        return $classInfo->kind !== ClassKind::Trait_;
+    }
+
+    /**
      * Get member access context at position.
      * Used by: Completion (after -> or ::)
      */

--- a/tests/Fixtures/Namespacing/ImportCompletion.php
+++ b/tests/Fixtures/Namespacing/ImportCompletion.php
@@ -6,6 +6,7 @@ namespace Fixtures\Namespacing\ImportCompletion {
 
     use Fixtures\Namespacing\Models\User;
     use Fixtures\Namespacing\Models\UserRepository as Repo;
+    use Fixtures\Traits\SingletonTrait;
 
     function triggerImportedClassPartial()
     {
@@ -15,6 +16,15 @@ namespace Fixtures\Namespacing\ImportCompletion {
     function triggerAliasedClassPartial()
     {
         $x = Rep/*|aliased_class_partial*/
+    }
+
+    function triggerTraitInExpression()
+    {
+        $x = Sing/*|trait_expression_partial*/
+    }
+
+    function triggerTypeHintReturn(): /*|type_hint_return*/
+    {
     }
 
 }

--- a/tests/Fixtures/src/Completion/TypeHints.php
+++ b/tests/Fixtures/src/Completion/TypeHints.php
@@ -6,6 +6,7 @@ namespace Fixtures\Completion;
 
 use Fixtures\Domain\User;
 use Fixtures\Domain\Entity;
+use Fixtures\Traits\SingletonTrait;
 
 class TypeHints
 {

--- a/tests/Fixtures/src/Completion/TypeHints.php
+++ b/tests/Fixtures/src/Completion/TypeHints.php
@@ -6,7 +6,6 @@ namespace Fixtures\Completion;
 
 use Fixtures\Domain\User;
 use Fixtures\Domain\Entity;
-use Fixtures\Traits\SingletonTrait;
 
 class TypeHints
 {

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -896,6 +896,31 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('never', $labels);
     }
 
+    public function testTypeHintExcludesImportedTraits(): void
+    {
+        // Issue #90: Traits imported via `use` statements should not appear in type hints
+        // Open class fixtures so they're known to the class repository
+        $this->openFixture('src/Domain/User.php');
+        $this->openFixture('src/Domain/Entity.php');
+        $this->openFixture('src/Traits/SingletonTrait.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/TypeHints.php', 'return_type');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+
+        // Should be detected as type hint context
+        self::assertContains('string', $labels);
+
+        // Imported classes should appear
+        self::assertContains('User', $labels);
+        self::assertContains('Entity', $labels);
+
+        // Imported trait should NOT appear in type hint context
+        self::assertNotContains('SingletonTrait', $labels);
+    }
+
     public function testKeywordCompletions(): void
     {
         $code = '<?php fore';

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -896,14 +896,26 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('never', $labels);
     }
 
+    public function testImportedTraitAppearsInExpressionContext(): void
+    {
+        // Verify traits DO appear in expression context (control for type hint test)
+        $this->openFixture('src/Traits/SingletonTrait.php');
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportCompletion.php', 'trait_expression_partial');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+
+        // Imported trait should appear in expression context
+        self::assertContains('SingletonTrait', $labels);
+    }
+
     public function testTypeHintExcludesImportedTraits(): void
     {
         // Issue #90: Traits imported via `use` statements should not appear in type hints
-        // Open class fixtures so they're known to the class repository
-        $this->openFixture('src/Domain/User.php');
-        $this->openFixture('src/Domain/Entity.php');
         $this->openFixture('src/Traits/SingletonTrait.php');
-        $cursor = $this->openFixtureAtCursor('src/Completion/TypeHints.php', 'return_type');
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportCompletion.php', 'type_hint_return');
 
         $result = $this->handler->handle($this->completionRequestAt($cursor));
 
@@ -915,7 +927,6 @@ class CompletionHandlerTest extends TestCase
 
         // Imported classes should appear
         self::assertContains('User', $labels);
-        self::assertContains('Entity', $labels);
 
         // Imported trait should NOT appear in type hint context
         self::assertNotContains('SingletonTrait', $labels);

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -1026,4 +1026,38 @@ final class SymbolResolverTest extends TestCase
         /** @phpstan-ignore argument.type (intentionally non-existent) */
         self::assertTrue($this->resolver->isInstantiable(new ClassName('NonExistent\\Unknown')));
     }
+
+    public function testIsValidTypeHintReturnsTrueForClass(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertTrue($this->resolver->isValidTypeHint(new ClassName('Fixtures\\Domain\\User')));
+    }
+
+    public function testIsValidTypeHintReturnsTrueForInterface(): void
+    {
+        $this->openFixture('src/Domain/Entity.php');
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertTrue($this->resolver->isValidTypeHint(new ClassName('Fixtures\\Domain\\Entity')));
+    }
+
+    public function testIsValidTypeHintReturnsTrueForEnum(): void
+    {
+        $this->openFixture('src/Enum/Status.php');
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertTrue($this->resolver->isValidTypeHint(new ClassName('Fixtures\\Enum\\Status')));
+    }
+
+    public function testIsValidTypeHintReturnsFalseForTrait(): void
+    {
+        $this->openFixture('src/Traits/SingletonTrait.php');
+        /** @phpstan-ignore argument.type (fixture class) */
+        self::assertFalse($this->resolver->isValidTypeHint(new ClassName('Fixtures\\Traits\\SingletonTrait')));
+    }
+
+    public function testIsValidTypeHintReturnsTrueForUnknownClass(): void
+    {
+        /** @phpstan-ignore argument.type (intentionally non-existent) */
+        self::assertTrue($this->resolver->isValidTypeHint(new ClassName('NonExistent\\Unknown')));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `SymbolResolver::isValidTypeHint()` to check if a class-like can be used as a type hint
- Filter imported traits from type hint completions using the new method

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)