### PR TITLE
Use namespace context for function lookup

### DIFF
--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -430,8 +430,7 @@ final class SymbolResolver
     private function findCallAtPosition(array $ast, int $offset): ?array
     {
         $finder = new class ($offset) extends NodeVisitorAbstract {
-            /** @var FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|null */
-            public ?Node $found = null;
+            public FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|null $found = null;
             public int $activeParameter = 0;
             /** @var list<string> */
             public array $usedNames = [];

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -99,7 +99,7 @@ final class BasicTypeResolver implements TypeResolverInterface
         // Function call: functionName()
         if ($expr instanceof Expr\FuncCall) {
             if ($expr->name instanceof Node\Name) {
-                return $this->getFunctionReturnType($expr->name->toString(), $ast);
+                return $this->getFunctionReturnType($expr->name, $ast);
             }
             return null;
         }
@@ -277,16 +277,38 @@ final class BasicTypeResolver implements TypeResolverInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function getFunctionReturnType(string $functionName, array $ast): ?Type
+    private function getFunctionReturnType(Node\Name $functionName, array $ast): ?Type
     {
-        $func = $this->findFunctionInAst($functionName, $ast);
+        $shortName = $functionName->toString();
+
+        // If NameResolver provided a FQN, use it directly
+        $resolvedName = $functionName->getAttribute('resolvedName');
+        if ($resolvedName instanceof Node\Name) {
+            $func = $this->findFunctionInAst($resolvedName->toString(), $ast);
+            if ($func !== null) {
+                return TypeFactory::fromNode($func->returnType);
+            }
+        }
+
+        // For unqualified names, try the enclosing namespace first (PHP's fallback behavior)
+        $namespace = ScopeFinder::findEnclosingNamespace($functionName);
+        if ($namespace !== null && $namespace->name !== null) {
+            $namespacedFqn = $namespace->name->toString() . '\\' . $shortName;
+            $func = $this->findFunctionInAst($namespacedFqn, $ast);
+            if ($func !== null) {
+                return TypeFactory::fromNode($func->returnType);
+            }
+        }
+
+        // Try global namespace
+        $func = $this->findFunctionInAst($shortName, $ast);
         if ($func !== null) {
             return TypeFactory::fromNode($func->returnType);
         }
 
         // Try reflection for built-in functions
         try {
-            $reflection = new \ReflectionFunction($functionName);
+            $reflection = new \ReflectionFunction($shortName);
             return TypeFactory::fromReflection($reflection->getReturnType());
         } catch (\ReflectionException) {
             return null;
@@ -296,16 +318,19 @@ final class BasicTypeResolver implements TypeResolverInterface
     /**
      * @param array<Stmt> $ast
      */
-    private function findFunctionInAst(string $functionName, array $ast): ?Stmt\Function_
+    private function findFunctionInAst(string $functionFqn, array $ast): ?Stmt\Function_
     {
         foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Function_ && $stmt->name->toString() === $functionName) {
+            if ($stmt instanceof Stmt\Function_ && $stmt->name->toString() === $functionFqn) {
                 return $stmt;
             }
             if ($stmt instanceof Stmt\Namespace_) {
                 foreach ($stmt->stmts as $nsStmt) {
-                    if ($nsStmt instanceof Stmt\Function_ && $nsStmt->name->toString() === $functionName) {
-                        return $nsStmt;
+                    if ($nsStmt instanceof Stmt\Function_) {
+                        $fqn = $nsStmt->namespacedName?->toString() ?? $nsStmt->name->toString();
+                        if ($fqn === $functionFqn) {
+                            return $nsStmt;
+                        }
                     }
                 }
             }

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -64,6 +64,23 @@ final class ScopeFinder
     }
 
     /**
+     * Find the enclosing namespace node for a given node.
+     *
+     * Walks up the parent chain to find the namespace statement, if any.
+     */
+    public static function findEnclosingNamespace(Node $node): ?Stmt\Namespace_
+    {
+        $current = $node->getAttribute('parent');
+        while ($current instanceof Node) {
+            if ($current instanceof Stmt\Namespace_) {
+                return $current;
+            }
+            $current = $current->getAttribute('parent');
+        }
+        return null;
+    }
+
+    /**
      * Resolve a Name node to its fully qualified name.
      *
      * Uses the resolved name attribute if available (from NameResolver),

--- a/tests/Fixtures/src/TypeInference/MultiNamespaceBracketed.php
+++ b/tests/Fixtures/src/TypeInference/MultiNamespaceBracketed.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference\BracketedA {
+
+    class BracketedConfigA
+    {
+        public function getValueA(): string
+        {
+            return 'A';
+        }
+    }
+
+    function getConfig(): BracketedConfigA
+    {
+        return new BracketedConfigA();
+    }
+}
+
+namespace Fixtures\TypeInference\BracketedB {
+
+    class BracketedConfigB
+    {
+        public function getValueB(): string
+        {
+            return 'B';
+        }
+    }
+
+    function getConfig(): BracketedConfigB
+    {
+        return new BracketedConfigB();
+    }
+
+    function testBracketedNamespaceBFunction(): void
+    {
+        $config = getConfig();
+        echo $config;
+    }
+}

--- a/tests/Fixtures/src/TypeInference/MultiNamespaceFunction.php
+++ b/tests/Fixtures/src/TypeInference/MultiNamespaceFunction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference\NamespaceA;
+
+class ConfigA
+{
+    public function getValueA(): string
+    {
+        return 'A';
+    }
+}
+
+function getConfig(): ConfigA
+{
+    return new ConfigA();
+}
+
+namespace Fixtures\TypeInference\NamespaceB;
+
+class ConfigB
+{
+    public function getValueB(): string
+    {
+        return 'B';
+    }
+}
+
+function getConfig(): ConfigB
+{
+    return new ConfigB();
+}
+
+function testNamespaceBFunction(): void
+{
+    $config = getConfig();
+    echo $config;
+}

--- a/tests/Fixtures/src/TypeInference/UseFunctionImport.php
+++ b/tests/Fixtures/src/TypeInference/UseFunctionImport.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\TypeInference\ImportSource;
+
+class ImportedConfig
+{
+    public function getImportedValue(): string
+    {
+        return 'imported';
+    }
+}
+
+function getConfig(): ImportedConfig
+{
+    return new ImportedConfig();
+}
+
+namespace Fixtures\TypeInference\ShadowedFunction;
+
+use function Fixtures\TypeInference\ImportSource\getConfig;
+
+class LocalConfig
+{
+    public function getLocalValue(): string
+    {
+        return 'local';
+    }
+}
+
+function getConfig(): LocalConfig
+{
+    return new LocalConfig();
+}
+
+class ShadowedFunctionTest
+{
+    public function testImportedShadowsLocal(): void
+    {
+        $config = getConfig();
+        echo $config;
+    }
+
+    public function testFqnCallsLocal(): void
+    {
+        $config = \Fixtures\TypeInference\ShadowedFunction\getConfig();
+        echo $config;
+    }
+
+    public function testNamespaceKeywordCallsLocal(): void
+    {
+        $config = namespace\getConfig();
+        echo $config;
+    }
+}

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -536,6 +536,42 @@ class BasicTypeResolverTest extends TestCase
         self::assertSame('GlobalConfig', $type->fqn);
     }
 
+    #[\PHPUnit\Framework\Attributes\DataProvider('multiNamespaceFunctionProvider')]
+    public function testResolveFunctionInCorrectNamespace(
+        string $fixturePath,
+        string $functionName,
+        string $expectedFqn,
+    ): void {
+        $ast = $this->parseFixture($fixturePath);
+        $function = $this->findFunctionByName($ast, $functionName);
+        $finder = new \PhpParser\NodeFinder();
+        $funcCall = $finder->findFirstInstanceOf($function, Expr\FuncCall::class);
+        assert($funcCall instanceof Expr\FuncCall);
+
+        $type = $this->resolver->resolveExpressionType($funcCall, $function, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame($expectedFqn, $type->fqn);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function multiNamespaceFunctionProvider(): iterable
+    {
+        yield 'stacked namespaces' => [
+            'src/TypeInference/MultiNamespaceFunction.php',
+            'testNamespaceBFunction',
+            'Fixtures\\TypeInference\\NamespaceB\\ConfigB',
+        ];
+        yield 'bracketed namespaces' => [
+            'src/TypeInference/MultiNamespaceBracketed.php',
+            'testBracketedNamespaceBFunction',
+            'Fixtures\\TypeInference\\BracketedB\\BracketedConfigB',
+        ];
+    }
+
     public function testResolveDynamicFunctionCallReturnsNull(): void
     {
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -607,6 +607,49 @@ class BasicTypeResolverTest extends TestCase
         ];
     }
 
+    public function testResolveImportedFunctionUsesFullyQualifiedName(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/UseFunctionImport.php');
+        $method = $this->findMethodByName($ast, 'testImportedShadowsLocal');
+        $finder = new \PhpParser\NodeFinder();
+        $funcCall = $finder->findFirstInstanceOf($method, Expr\FuncCall::class);
+
+        self::assertNotNull($funcCall, 'No FuncCall found in method');
+
+        // NameResolver replaces the Name with a FullyQualified name for use function imports
+        self::assertInstanceOf(Name\FullyQualified::class, $funcCall->name);
+        self::assertSame(
+            'Fixtures\\TypeInference\\ImportSource\\getConfig',
+            $funcCall->name->toString(),
+        );
+
+        // Verify the type is resolved correctly
+        $type = $this->resolver->resolveExpressionType($funcCall, $method, $ast);
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\TypeInference\\ImportSource\\ImportedConfig', $type->fqn);
+    }
+
+    public function testResolveFunctionWithResolvedNameAttribute(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/MultiNamespaceFunction.php');
+        $function = $this->findFunctionByName($ast, 'testNamespaceBFunction');
+        $finder = new \PhpParser\NodeFinder();
+        $funcCall = $finder->findFirstInstanceOf($function, Expr\FuncCall::class);
+        assert($funcCall instanceof Expr\FuncCall);
+        assert($funcCall->name instanceof Name);
+
+        // Manually set resolvedName attribute (simulates alternative NameResolver behavior)
+        $funcCall->name->setAttribute(
+            'resolvedName',
+            new Name\FullyQualified('Fixtures\\TypeInference\\NamespaceB\\getConfig'),
+        );
+
+        $type = $this->resolver->resolveExpressionType($funcCall, $function, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame('Fixtures\\TypeInference\\NamespaceB\\ConfigB', $type->fqn);
+    }
+
     public function testResolveDynamicFunctionCallReturnsNull(): void
     {
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -572,6 +572,41 @@ class BasicTypeResolverTest extends TestCase
         ];
     }
 
+    #[\PHPUnit\Framework\Attributes\DataProvider('useFunctionImportProvider')]
+    public function testResolveUseFunctionImport(string $methodName, string $expectedFqn): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/UseFunctionImport.php');
+        $method = $this->findMethodByName($ast, $methodName);
+        $finder = new \PhpParser\NodeFinder();
+        $funcCall = $finder->findFirstInstanceOf($method, Expr\FuncCall::class);
+        assert($funcCall instanceof Expr\FuncCall);
+
+        $type = $this->resolver->resolveExpressionType($funcCall, $method, $ast);
+
+        self::assertInstanceOf(ClassName::class, $type);
+        self::assertSame($expectedFqn, $type->fqn);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string}>
+     */
+    public static function useFunctionImportProvider(): iterable
+    {
+        yield 'imported shadows local' => [
+            'testImportedShadowsLocal',
+            'Fixtures\\TypeInference\\ImportSource\\ImportedConfig',
+        ];
+        yield 'FQN calls local despite import' => [
+            'testFqnCallsLocal',
+            'Fixtures\\TypeInference\\ShadowedFunction\\LocalConfig',
+        ];
+        yield 'namespace keyword calls local' => [
+            'testNamespaceKeywordCallsLocal',
+            'Fixtures\\TypeInference\\ShadowedFunction\\LocalConfig',
+        ];
+    }
+
     public function testResolveDynamicFunctionCallReturnsNull(): void
     {
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -574,6 +574,32 @@ class ScopeFinderTest extends TestCase
         self::assertNull($resolved);
     }
 
+    public function testFindEnclosingNamespaceReturnsNamespace(): void
+    {
+        $code = $this->loadFixture('src/Domain/User.php');
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($varNode);
+        $namespace = ScopeFinder::findEnclosingNamespace($varNode);
+
+        self::assertInstanceOf(Stmt\Namespace_::class, $namespace);
+        self::assertNotNull($namespace->name);
+        self::assertSame('Fixtures\Domain', $namespace->name->toString());
+    }
+
+    public function testFindEnclosingNamespaceReturnsNullOutsideNamespace(): void
+    {
+        $code = $this->loadFixture('TypeInference/GlobalFunction.php');
+        $ast = self::parseWithParents($code);
+        $varNode = self::findVariableNode('this', $ast);
+
+        self::assertNotNull($varNode);
+        $namespace = ScopeFinder::findEnclosingNamespace($varNode);
+
+        self::assertNull($namespace);
+    }
+
     /**
      * @template T of Stmt\ClassLike
      * @param array<Stmt> $stmts


### PR DESCRIPTION
## Summary

- Fixes function lookup in multi-namespace files to resolve functions from the correct namespace
- Adds `ScopeFinder::findEnclosingNamespace()` to find namespace context
- Updates `BasicTypeResolver` to try namespace-qualified function name before falling back to global

Closes #222

## Test plan

- [x] Stacked namespace syntax (`namespace A; ... namespace B;`)
- [x] Bracketed namespace syntax (`namespace A { } namespace B { }`)
- [x] `use function` imports shadowing local functions
- [x] FQN calls (`\Namespace\func()`) bypass imports
- [x] `namespace\func()` keyword calls local function

🤖 Generated with [Claude Code](https://claude.ai/code)