### PR TITLE
Support symbol resolution in procedural / global-scope code (#255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ composer phpcs -- -q --report=emacs # run code style checks (PSR-12)
 - `src/Domain/` — Domain objects representing code constructs
 - `src/Index/` — Symbol indexing and workspace scanning
 - `src/Document/` — Open document management
-- `src/Utility/` — AST helpers (ScopeFinder, TypeFactory, DocblockParser)
+- `src/Utility/` — AST helpers (ScopeFinder, Scope, TypeFactory, DocblockParser)
 - `src/Completion/` — Completion context detection (`ContextDetector`)
 - `docs/features/` — Feature status documentation
 - `tests/Fixtures/` — Test fixture files (see Testing section)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ context detection) — never for symbol resolution.
 ### Utility Classes
 
 - `ScopeFinder` — Finds enclosing class/method scope in AST, resolves names, finds functions
+- `Scope` — Value object modelling a lexical scope (params, statements, self/parent context, `$this`, closure captures). Function-like nodes and file-level/global code both map onto it via `Scope::atOffset()`/`forNode()`/`global()`, so type/variable resolution never branches on node type or handles a "no enclosing function" case.
 - `DocblockParser` — Extracts description from docblocks
 - `ExpressionTypeResolver` — Resolves expression types (wraps TypeResolverInterface, handles `$this`)
 - `TypeFactory` — Creates Type domain objects from AST nodes and reflection

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -8,10 +8,14 @@ This document tracks the current state of code completion in php-lsp.
 |---------|---------|------------------|--------|
 | `$this->` member access | `$this->` or `$this?->` | Methods and properties from current class + inherited via reflection | ✅ Working |
 | Typed variable member access | `$user->` or `$user?->` | Public methods and properties when type is known (parameter types, `new` expressions) | ✅ Working |
-| Variable completions | `$log` | Local variables, parameters, `$this` in methods | ✅ Working |
+| Variable completions | `$log` | Local variables, parameters, `$this` in methods, and file-level variables in procedural code | ✅ Working |
 | Static access | `ClassName::` | Static methods, constants, static properties (visibility-aware) | ✅ Working |
 | `new` expression | `new ` | Classes from composer classmap | ✅ Working |
 | Function calls | identifier at expression start | Built-in PHP functions + file-local functions | ✅ Working |
+
+All of the above work identically in class methods, free functions, and
+file-level (procedural) code — variable and member resolution use the enclosing
+lexical scope, which includes global scope.
 
 ## Limitations
 

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -1127,6 +1127,12 @@ final class SymbolResolver implements CodeResolver
                 continue;
             }
 
+            // Nested function/class declarations introduce their own scope;
+            // their bodies must not contribute variables to this one.
+            if ($stmt instanceof Stmt\Function_ || $stmt instanceof Stmt\ClassLike) {
+                continue;
+            }
+
             if ($stmt instanceof Stmt\Expression && $stmt->expr instanceof Assign) {
                 $assign = $stmt->expr;
                 if ($assign->var instanceof Variable && is_string($assign->var->name)) {

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -16,6 +16,7 @@ use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Utility\ExpressionTypeResolver;
+use Firehed\PhpLsp\Utility\Scope;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node;
 use Firehed\PhpLsp\Domain\ConstantName;
@@ -346,14 +347,11 @@ final class SymbolResolver implements CodeResolver
         }
 
         $offset = $document->offsetAt($line, 0);
-        $scope = $this->findScopeAtOffset($ast, $offset);
+        $scope = Scope::atOffset($ast, $offset);
 
-        $type = null;
-        if ($scope !== null) {
-            $type = $this->typeResolver->resolveVariableType($varName, $scope, $line, $ast);
-        }
+        $type = $this->typeResolver->resolveVariableType($varName, $scope, $line, $ast);
 
-        // Fall back to text-based parameter type resolution when AST scope fails
+        // Fall back to text-based parameter type resolution when AST resolution fails
         if ($type === null) {
             $type = $this->textFallback->findParameterType($document, $line, $varName, $ast);
         }
@@ -362,9 +360,7 @@ final class SymbolResolver implements CodeResolver
             return null;
         }
 
-        $enclosingClassName = $scope !== null
-            ? ScopeFinder::findEnclosingClassName($scope)
-            : null;
+        $enclosingClassName = $scope->getSelfContext();
         $classNames = $type->getResolvableClassNames();
         $className = $classNames[0] ?? null;
         $isSameClass = $enclosingClassName !== null && $className !== null
@@ -484,17 +480,13 @@ final class SymbolResolver implements CodeResolver
 
         $offset = $document->offsetAt($line, $character);
 
-        // Find enclosing scope
-        $scope = $this->findScopeAtOffset($ast, $offset);
-        if ($scope === null) {
-            return [];
-        }
+        $scope = Scope::atOffset($ast, $offset);
 
         $variables = [];
         $seen = [];
 
         // Add parameters
-        foreach ($scope->params as $param) {
+        foreach ($scope->getParams() as $param) {
             if ($param->var instanceof Variable && is_string($param->var->name)) {
                 $name = $param->var->name;
                 if (!isset($seen[$name])) {
@@ -505,18 +497,15 @@ final class SymbolResolver implements CodeResolver
             }
         }
 
-        // Add $this if in a method
-        if ($scope instanceof Stmt\ClassMethod) {
-            $className = ScopeFinder::findEnclosingClassName($scope);
-            if ($className !== null && !isset($seen['this'])) {
-                $variables[] = new ResolvedVariable('this', new ClassName($className));
-                $seen['this'] = true;
-            }
+        // Add $this when bound (non-static methods)
+        $thisType = $scope->getThisType();
+        if ($thisType !== null && !isset($seen['this'])) {
+            $variables[] = new ResolvedVariable('this', $thisType);
+            $seen['this'] = true;
         }
 
         // Find variable assignments before cursor
-        $stmts = $scope->stmts ?? [];
-        $this->collectVariablesFromStatements($stmts, $line, $scope, $ast, $variables, $seen);
+        $this->collectVariablesFromStatements($scope->getStatements(), $line, $scope, $ast, $variables, $seen);
 
         return $variables;
     }
@@ -1118,40 +1107,8 @@ final class SymbolResolver implements CodeResolver
      * @param array<Stmt> $ast
      * @return Stmt\Function_|Stmt\ClassMethod|Closure|null
      */
-    private function findScopeAtOffset(array $ast, int $offset): Stmt\Function_|Stmt\ClassMethod|Closure|null
-    {
-        $visitor = new class ($offset) extends NodeVisitorAbstract {
-            public Stmt\Function_|Stmt\ClassMethod|Closure|null $found = null;
-            private int $offset;
-
-            public function __construct(int $offset)
-            {
-                $this->offset = $offset;
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if (
-                    ($node instanceof Stmt\Function_ || $node instanceof Stmt\ClassMethod || $node instanceof Closure)
-                    && $node->getStartFilePos() <= $this->offset
-                    && $node->getEndFilePos() >= $this->offset
-                ) {
-                    $this->found = $node;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($visitor);
-        $traverser->traverse($ast);
-
-        return $visitor->found;
-    }
-
     /**
      * @param array<Stmt|Node> $stmts
-     * @param Stmt\Function_|Stmt\ClassMethod|Closure $scope
      * @param array<Stmt> $ast
      * @param list<ResolvedVariable> $variables
      * @param array<string, bool> $seen
@@ -1159,7 +1116,7 @@ final class SymbolResolver implements CodeResolver
     private function collectVariablesFromStatements(
         array $stmts,
         int $line,
-        Stmt\Function_|Stmt\ClassMethod|Closure $scope,
+        Scope $scope,
         array $ast,
         array &$variables,
         array &$seen,

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Utility\Scope;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use Firehed\PhpLsp\Utility\TypeFactory;
 use PhpParser\Node;
@@ -36,7 +37,7 @@ final class BasicTypeResolver implements TypeResolverInterface
     }
     public function resolveExpressionType(
         Expr $expr,
-        Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope,
+        Scope $scope,
         array $ast,
     ): ?Type {
         // new ClassName()
@@ -70,7 +71,7 @@ final class BasicTypeResolver implements TypeResolverInterface
         }
 
         // Variable reference - delegate to resolveVariableType
-        if ($expr instanceof Expr\Variable && is_string($expr->name) && $scope !== null) {
+        if ($expr instanceof Expr\Variable && is_string($expr->name)) {
             return $this->resolveVariableType($expr->name, $scope, $expr->getStartLine() - 1, $ast);
         }
 
@@ -135,22 +136,16 @@ final class BasicTypeResolver implements TypeResolverInterface
 
     public function resolveVariableType(
         string $variableName,
-        Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction $scope,
+        Scope $scope,
         int $line,
         array $ast,
     ): ?Type {
-        // Determine class context for self/static/parent resolution
-        $selfContext = ScopeFinder::findEnclosingClassName($scope);
-        $parentContext = null;
-        if ($selfContext !== null) {
-            $classNode = ScopeFinder::findEnclosingClassNode($scope);
-            if ($classNode instanceof Stmt\Class_) {
-                $parentContext = ScopeFinder::resolveExtendsName($classNode);
-            }
-        }
+        // Class context for self/static/parent resolution
+        $selfContext = $scope->getSelfContext();
+        $parentContext = $scope->getParentContext();
 
         // Check parameters first
-        foreach ($scope->params as $param) {
+        foreach ($scope->getParams() as $param) {
             if (
                 $param->var instanceof Expr\Variable
                 && is_string($param->var->name)
@@ -160,32 +155,26 @@ final class BasicTypeResolver implements TypeResolverInterface
             }
         }
 
-        // Check closure use() variables
-        if ($scope instanceof Expr\Closure) {
-            foreach ($scope->uses as $use) {
-                if (is_string($use->var->name) && $use->var->name === $variableName) {
-                    // Can't determine type of use() variables without more context
-                    return null;
-                }
-            }
+        // Closure use() variables are bound from the enclosing scope; their type
+        // cannot be determined from local assignments.
+        if ($scope->capturesVariable($variableName)) {
+            return null;
         }
 
         // Look for assignments before the current line
         $foundType = null;
-        $stmts = $scope instanceof Expr\ArrowFunction ? [] : ($scope->stmts ?? []);
+        $stmts = $scope->getStatements();
 
         $visitor = new class ($variableName, $line, $foundType, $this, $scope, $ast) extends NodeVisitorAbstract {
             public ?Type $foundType = null;
             private string $variableName;
             private int $line;
             private BasicTypeResolver $resolver;
-            /** @var Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction */
-            private $scope;
+            private Scope $scope;
             /** @var array<Stmt> */
             private array $ast;
 
             /**
-             * @param Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction $scope
              * @param array<Stmt> $ast
              */
             public function __construct(
@@ -193,7 +182,7 @@ final class BasicTypeResolver implements TypeResolverInterface
                 int $line,
                 ?Type &$foundType,
                 BasicTypeResolver $resolver,
-                $scope,
+                Scope $scope,
                 array $ast,
             ) {
                 $this->variableName = $variableName;

--- a/src/TypeInference/TypeResolverInterface.php
+++ b/src/TypeInference/TypeResolverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\TypeInference;
 
 use Firehed\PhpLsp\Domain\Type;
+use Firehed\PhpLsp\Utility\Scope;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 
@@ -20,13 +21,12 @@ interface TypeResolverInterface
      * Resolve the type of an expression.
      *
      * @param Expr $expr The expression to resolve
-     * @param Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope
-     *        The enclosing scope, if any
+     * @param Scope $scope The enclosing lexical scope
      * @param array<Stmt> $ast The full AST for context (class lookups, etc.)
      */
     public function resolveExpressionType(
         Expr $expr,
-        Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction|null $scope,
+        Scope $scope,
         array $ast,
     ): ?Type;
 
@@ -34,14 +34,13 @@ interface TypeResolverInterface
      * Resolve the type of a variable at a given position.
      *
      * @param string $variableName The variable name (without $)
-     * @param Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction $scope
-     *        The enclosing scope
+     * @param Scope $scope The enclosing lexical scope
      * @param int $line The line number (0-based) where the variable is used
      * @param array<Stmt> $ast The full AST for context
      */
     public function resolveVariableType(
         string $variableName,
-        Stmt\Function_|Stmt\ClassMethod|Expr\Closure|Expr\ArrowFunction $scope,
+        Scope $scope,
         int $line,
         array $ast,
     ): ?Type;

--- a/src/Utility/ExpressionTypeResolver.php
+++ b/src/Utility/ExpressionTypeResolver.php
@@ -52,10 +52,7 @@ final class ExpressionTypeResolver
             return null;
         }
 
-        $scope = ScopeFinder::findEnclosingScope($expr);
-        if ($scope === null) {
-            return null;
-        }
+        $scope = Scope::atOffset($ast, $expr->getStartFilePos());
 
         return $typeResolver->resolveExpressionType($expr, $scope, $ast);
     }

--- a/src/Utility/Scope.php
+++ b/src/Utility/Scope.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * The lexical scope a variable resolves against.
+ *
+ * A scope provides everything variable resolution needs: the parameters and
+ * statements that can introduce variables, the class context for self/parent,
+ * whether `$this` is bound, and any closure `use()` captures. Function-like AST
+ * nodes and file-level (global/procedural) code both map onto this uniformly, so
+ * consumers never branch on node type or handle a "no enclosing function" case.
+ */
+final class Scope
+{
+    /**
+     * @param list<Node\Param> $params
+     * @param array<Stmt> $statements
+     * @param ?class-string $selfContext
+     * @param ?class-string $parentContext
+     * @param list<string> $capturedVariableNames
+     */
+    private function __construct(
+        private readonly array $params,
+        private readonly array $statements,
+        private readonly ?string $selfContext,
+        private readonly ?string $parentContext,
+        private readonly ?ClassName $thisType,
+        private readonly array $capturedVariableNames,
+    ) {
+    }
+
+    /**
+     * Build the scope enclosing a file offset: the innermost function-like node
+     * containing it, or file-level (global) scope when there is none.
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function atOffset(array $ast, int $offset): self
+    {
+        $node = self::findEnclosingFunctionLike($ast, $offset);
+        if ($node !== null) {
+            return self::forNode($node);
+        }
+
+        return self::global(self::globalStatementsAtOffset($ast, $offset));
+    }
+
+    public static function forNode(Stmt\Function_|Stmt\ClassMethod|Closure|ArrowFunction $node): self
+    {
+        $selfContext = ScopeFinder::findEnclosingClassName($node);
+        $parentContext = null;
+        if ($selfContext !== null) {
+            $classNode = ScopeFinder::findEnclosingClassNode($node);
+            if ($classNode instanceof Stmt\Class_) {
+                $parentContext = ScopeFinder::resolveExtendsName($classNode);
+            }
+        }
+
+        $thisType = ($node instanceof Stmt\ClassMethod && $selfContext !== null)
+            ? new ClassName($selfContext)
+            : null;
+
+        // Arrow functions have an expression body, not a statement list; their
+        // captured variables come from the enclosing scope, not local assignments.
+        $statements = $node instanceof ArrowFunction ? [] : ($node->stmts ?? []);
+
+        $capturedVariableNames = [];
+        if ($node instanceof Closure) {
+            foreach ($node->uses as $use) {
+                if (is_string($use->var->name)) {
+                    $capturedVariableNames[] = $use->var->name;
+                }
+            }
+        }
+
+        /** @var ?class-string $selfContext */
+        /** @var ?class-string $parentContext */
+        return new self($node->params, $statements, $selfContext, $parentContext, $thisType, $capturedVariableNames);
+    }
+
+    /**
+     * @param array<Stmt> $statements
+     */
+    public static function global(array $statements): self
+    {
+        return new self([], $statements, null, null, null, []);
+    }
+
+    /**
+     * @return list<Node\Param>
+     */
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    /**
+     * Statements that can introduce variables in this scope.
+     *
+     * @return array<Stmt>
+     */
+    public function getStatements(): array
+    {
+        return $this->statements;
+    }
+
+    /**
+     * @return ?class-string
+     */
+    public function getSelfContext(): ?string
+    {
+        return $this->selfContext;
+    }
+
+    /**
+     * @return ?class-string
+     */
+    public function getParentContext(): ?string
+    {
+        return $this->parentContext;
+    }
+
+    /**
+     * The type of `$this` in this scope, or null when `$this` is not bound
+     * (free functions, closures, and file-level code).
+     */
+    public function getThisType(): ?ClassName
+    {
+        return $this->thisType;
+    }
+
+    /**
+     * Whether the named variable is captured by a closure `use()` clause. Such
+     * variables are bound from the enclosing scope, so their type cannot be
+     * determined from local assignments.
+     */
+    public function capturesVariable(string $name): bool
+    {
+        return in_array($name, $this->capturedVariableNames, true);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findEnclosingFunctionLike(
+        array $ast,
+        int $offset,
+    ): Stmt\Function_|Stmt\ClassMethod|Closure|ArrowFunction|null {
+        $visitor = new class ($offset) extends NodeVisitorAbstract {
+            public Stmt\Function_|Stmt\ClassMethod|Closure|ArrowFunction|null $found = null;
+
+            public function __construct(private readonly int $offset)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if (
+                    ($node instanceof Stmt\Function_
+                        || $node instanceof Stmt\ClassMethod
+                        || $node instanceof Closure
+                        || $node instanceof ArrowFunction)
+                    && $node->getStartFilePos() <= $this->offset
+                    && $node->getEndFilePos() >= $this->offset
+                ) {
+                    $this->found = $node;
+                }
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->found;
+    }
+
+    /**
+     * The file-level statement list containing the offset: the body of the
+     * enclosing namespace block, or the AST root when there is no namespace.
+     *
+     * @param array<Stmt> $ast
+     * @return array<Stmt>
+     */
+    private static function globalStatementsAtOffset(array $ast, int $offset): array
+    {
+        foreach ($ast as $stmt) {
+            if (
+                $stmt instanceof Stmt\Namespace_
+                && $stmt->getStartFilePos() <= $offset
+                && $stmt->getEndFilePos() >= $offset
+            ) {
+                return $stmt->stmts;
+            }
+        }
+
+        return $ast;
+    }
+}

--- a/src/Utility/Scope.php
+++ b/src/Utility/Scope.php
@@ -24,7 +24,7 @@ use PhpParser\NodeVisitorAbstract;
 final class Scope
 {
     /**
-     * @param list<Node\Param> $params
+     * @param array<Node\Param> $params
      * @param array<Stmt> $statements
      * @param ?class-string $selfContext
      * @param ?class-string $parentContext
@@ -98,7 +98,7 @@ final class Scope
     }
 
     /**
-     * @return list<Node\Param>
+     * @return array<Node\Param>
      */
     public function getParams(): array
     {

--- a/tests/Fixtures/TopLevel/global_scope_completion.php
+++ b/tests/Fixtures/TopLevel/global_scope_completion.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Fixtures\Domain\User;
+
+// Procedural code at file scope (no namespace): variable completion and
+// member completion on a typed variable should both work here.
+$currentUser = new User('1', 'Ada', 'ada@example.com');
+$loginCount = 5;
+
+$currentUser->/*|global_member_access*/

--- a/tests/Fixtures/TopLevel/global_scope_completion_ns.php
+++ b/tests/Fixtures/TopLevel/global_scope_completion_ns.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Legacy;
+
+use Fixtures\Domain\User;
+
+// Procedural code inside a (braceless) namespace: the file-level statements
+// live under a Namespace_ node rather than at the AST root.
+$currentUser = new User('1', 'Ada', 'ada@example.com');
+
+$currentUser->/*|global_member_access_ns*/

--- a/tests/Fixtures/TopLevel/global_scope_hover.php
+++ b/tests/Fixtures/TopLevel/global_scope_hover.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Fixtures\Domain\User;
+
+// Complete (parseable) procedural code at file scope: hover and go-to-definition
+// on a member call, and hover on the variable itself, should work here.
+$activeUser = new User('2', 'Bob', 'bob@example.com');
+
+$activeUser->getName(); //hover:global_method_call
+
+$activeUser; //hover:global_var

--- a/tests/Fixtures/TopLevel/global_scope_nested.php
+++ b/tests/Fixtures/TopLevel/global_scope_nested.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// Variables local to nested function/class scopes must NOT leak into the
+// file-level scope's variable collection.
+
+function helper(): void
+{
+    $localToFunction = 1;
+}
+
+class Widget
+{
+    public function render(): void
+    {
+        $localToMethod = 2;
+    }
+}
+
+$globalOne = 1;
+$globalTwo = 2;
+/*|nested_marker*/

--- a/tests/Fixtures/TopLevel/global_scope_variable.php
+++ b/tests/Fixtures/TopLevel/global_scope_variable.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+// Variable completion should suggest file-level variables in procedural code.
+$currentUser = 'ada';
+$loginCount = 5;
+$c/*|global_var_prefix*/

--- a/tests/Fixtures/src/Utility/ScopePatterns.php
+++ b/tests/Fixtures/src/Utility/ScopePatterns.php
@@ -24,4 +24,12 @@ class ScopePatterns
     {
         $fn = fn() => $arrowVar = 1;
     }
+
+    public function methodWithClosureUse(): void
+    {
+        $captured = 1;
+        $fn = function () use ($captured) {
+            return $captured;
+        };
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1116,6 +1116,29 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('$logger', $labels);
     }
 
+    public function testVariableCompletionWorksInGlobalScope(): void
+    {
+        $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_variable.php', 'global_var_prefix');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('$currentUser', $labels, 'File-level variable should be offered');
+        self::assertNotContains('$loginCount', $labels, 'Prefix "c" should filter out $loginCount');
+    }
+
+    public function testMemberCompletionWorksOnGlobalVariable(): void
+    {
+        $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_completion.php', 'global_member_access');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('getName', $labels, 'Members of a typed file-level variable should be offered');
+    }
+
     public function testVariableCompletionSuggestsThisInMethod(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/Variables.php', 'this_prefix');

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -154,6 +154,18 @@ class DefinitionHandlerTest extends TestCase
         self::assertSame(47, $result['range']['start']['line']);
     }
 
+    public function testGoToMethodDefinitionInGlobalScope(): void
+    {
+        $userUri = $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('TopLevel/global_scope_hover.php', 'global_method_call');
+
+        $result = $this->handler->handle($this->definitionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame($userUri, $result['uri']);
+        self::assertSame(39, $result['range']['start']['line'], 'Jumps to User::getName declaration');
+    }
+
     public function testGoToMethodDefinitionViaAssignment(): void
     {
         $userUri = $this->openFixture('src/Domain/User.php');

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -128,6 +128,17 @@ class HoverHandlerTest extends TestCase
         self::assertStringContainsString('Updates the user', $result['contents']);
     }
 
+    public function testHoverOnMethodCallInGlobalScope(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('TopLevel/global_scope_hover.php', 'global_method_call');
+
+        $result = $this->handler->handle($this->hoverRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('getName', $result['contents']);
+    }
+
     public function testHoverOnProperty(): void
     {
         $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'manager');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -574,6 +574,21 @@ final class SymbolResolverTest extends TestCase
         );
     }
 
+    public function testGetVariablesInScopeExcludesNestedScopeVariables(): void
+    {
+        $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_nested.php', 'nested_marker');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $variables = $this->resolver->getVariablesInScope($document, $cursor['line'], $cursor['character']);
+
+        $names = array_map(fn($v) => $v->getName(), $variables);
+        self::assertContains('globalOne', $names, 'File-level variable should be in scope');
+        self::assertContains('globalTwo', $names, 'File-level variable should be in scope');
+        self::assertNotContains('localToFunction', $names, 'Function-local variable must not leak to file scope');
+        self::assertNotContains('localToMethod', $names, 'Method-local variable must not leak to file scope');
+    }
+
     public function testGetMemberAccessContextForGlobalVariable(): void
     {
         $this->openFixture('src/Domain/User.php');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -33,6 +33,7 @@ use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\Resolution\TextFallbackHelper;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use Firehed\PhpLsp\Tests\Handler\OpensDocumentsTrait;
+use Fixtures\Domain\User;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -543,6 +544,90 @@ final class SymbolResolverTest extends TestCase
 
         $names = array_map(fn($v) => $v->getName(), $variables);
         self::assertContains('ex', $names);
+    }
+
+    public function testGetVariablesInScopeIncludesGlobalScopeVariables(): void
+    {
+        $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_completion.php', 'global_member_access');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $variables = $this->resolver->getVariablesInScope($document, $cursor['line'], $cursor['character']);
+
+        $names = array_map(fn($v) => $v->getName(), $variables);
+        self::assertContains('currentUser', $names, 'Global-scope assigned variable should be in scope');
+        self::assertContains('loginCount', $names, 'Global-scope assigned variable should be in scope');
+    }
+
+    public function testGetVariablesInScopeIncludesGlobalScopeVariablesInNamespace(): void
+    {
+        $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_completion_ns.php', 'global_member_access_ns');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $variables = $this->resolver->getVariablesInScope($document, $cursor['line'], $cursor['character']);
+
+        $names = array_map(fn($v) => $v->getName(), $variables);
+        self::assertContains(
+            'currentUser',
+            $names,
+            'File-level variable inside a namespace block should be in scope',
+        );
+    }
+
+    public function testGetMemberAccessContextForGlobalVariable(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_completion.php', 'global_member_access');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+        self::assertSame(Visibility::Public, $context->minVisibility, 'External access from global scope is public-only');
+        self::assertContains(new ClassName(User::class), $context->type->getResolvableClassNames());
+    }
+
+    public function testGetMemberAccessContextForGlobalVariableInNamespace(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_completion_ns.php', 'global_member_access_ns');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame(MemberAccessKind::Instance, $context->kind);
+        self::assertContains(new ClassName(User::class), $context->type->getResolvableClassNames());
+    }
+
+    public function testResolvesMemberCallInGlobalScope(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('TopLevel/global_scope_hover.php', 'global_method_call');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $result = $this->resolver->resolveAtPosition($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(ResolvedMethod::class, $result);
+        self::assertStringContainsString('getName', $result->format());
+    }
+
+    public function testResolvesGlobalVariableType(): void
+    {
+        $this->openFixture('src/Domain/User.php');
+        $cursor = $this->openFixtureAtHoverMarker('TopLevel/global_scope_hover.php', 'global_var');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $result = $this->resolver->resolveAtPosition($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(ResolvedVariable::class, $result);
+        self::assertSame(User::class, $result->getType()?->format(), 'Global variable type should resolve to User');
     }
 
     public function testGetCallContextReturnsContext(): void

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -453,14 +453,14 @@ final class SymbolResolverTest extends TestCase
         self::assertTrue($hasNameParam, 'Expected $name parameter in scope');
     }
 
-    public function testGetVariablesInScopeReturnsEmptyOutsideFunction(): void
+    public function testGetVariablesInScopeReturnsEmptyBeforeFirstStatement(): void
     {
-        // SignatureHelp.php has file-level code outside any function
         $this->openFixture('SignatureHelp.php');
         $document = $this->documents->get('file:///fixtures/SignatureHelp.php');
         assert($document !== null);
 
-        // Line 0, character 0 is at the very start - outside any function
+        // Line 0, character 0 is at the very start, before any statement that
+        // could introduce a variable.
         $variables = $this->resolver->getVariablesInScope($document, 0, 0);
 
         self::assertSame([], $variables);

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -33,7 +33,6 @@ use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\Resolution\TextFallbackHelper;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use Firehed\PhpLsp\Tests\Handler\OpensDocumentsTrait;
-use Fixtures\Domain\User;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -586,8 +585,8 @@ final class SymbolResolverTest extends TestCase
 
         self::assertInstanceOf(MemberAccessContext::class, $context);
         self::assertSame(MemberAccessKind::Instance, $context->kind);
-        self::assertSame(Visibility::Public, $context->minVisibility, 'External access from global scope is public-only');
-        self::assertContains(new ClassName(User::class), $context->type->getResolvableClassNames());
+        self::assertSame(Visibility::Public, $context->minVisibility, 'Global access is public-only');
+        self::assertSame('Fixtures\Domain\User', $context->type->format(), 'Resolves to User type');
     }
 
     public function testGetMemberAccessContextForGlobalVariableInNamespace(): void
@@ -601,7 +600,7 @@ final class SymbolResolverTest extends TestCase
 
         self::assertInstanceOf(MemberAccessContext::class, $context);
         self::assertSame(MemberAccessKind::Instance, $context->kind);
-        self::assertContains(new ClassName(User::class), $context->type->getResolvableClassNames());
+        self::assertSame('Fixtures\Domain\User', $context->type->format(), 'Resolves to User type');
     }
 
     public function testResolvesMemberCallInGlobalScope(): void
@@ -627,7 +626,7 @@ final class SymbolResolverTest extends TestCase
         $result = $this->resolver->resolveAtPosition($document, $cursor['line'], $cursor['character']);
 
         self::assertInstanceOf(ResolvedVariable::class, $result);
-        self::assertSame(User::class, $result->getType()?->format(), 'Global variable type should resolve to User');
+        self::assertSame('Fixtures\Domain\User', $result->getType()?->format(), 'Resolves to User type');
     }
 
     public function testGetCallContextReturnsContext(): void

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -300,6 +300,23 @@ class BasicTypeResolverTest extends TestCase
         self::assertSame(DateTime::class, $type->fqn);
     }
 
+    public function testResolveVariableTypeReturnsNullForClosureCapture(): void
+    {
+        $ast = $this->parseFixture('src/Utility/ScopePatterns.php');
+        $finder = new \PhpParser\NodeFinder();
+        $closure = $finder->findFirst($ast, fn($n) => $n instanceof Expr\Closure && $n->uses !== []);
+        assert($closure instanceof Expr\Closure);
+
+        $type = $this->resolver->resolveVariableType(
+            'captured',
+            Scope::forNode($closure),
+            $closure->getStartLine(),
+            $ast,
+        );
+
+        self::assertNull($type, 'use() captures cannot be typed from local assignments');
+    }
+
     public function testResolveArrowFunctionParameter(): void
     {
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -20,6 +20,7 @@ use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Utility\Scope;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -52,7 +53,7 @@ class BasicTypeResolverTest extends TestCase
         $expr = $finder->findFirstInstanceOf($method, Expr\New_::class);
         assert($expr instanceof Expr\New_);
 
-        $type = $this->resolver->resolveExpressionType($expr, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($expr, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(DateTime::class, $type->fqn);
@@ -63,7 +64,7 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');
         $method = $this->findMethodByName($ast, 'parameterType');
 
-        $type = $this->resolver->resolveVariableType('dt', $method, $method->getStartLine(), $ast);
+        $type = $this->resolver->resolveVariableType('dt', Scope::forNode($method), $method->getStartLine(), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(DateTime::class, $type->fqn);
@@ -74,7 +75,7 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/Completion/MethodAccess.php');
         $method = $this->findMethodByName($ast, 'withParameter');
 
-        $type = $this->resolver->resolveVariableType('param', $method, $method->getStartLine(), $ast);
+        $type = $this->resolver->resolveVariableType('param', Scope::forNode($method), $method->getStartLine(), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\Completion\\MethodAccess', $type->fqn);
@@ -85,7 +86,7 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/Inheritance/ChildClass.php');
         $method = $this->findMethodByName($ast, 'withParentParam');
 
-        $type = $this->resolver->resolveVariableType('obj', $method, $method->getStartLine(), $ast);
+        $type = $this->resolver->resolveVariableType('obj', Scope::forNode($method), $method->getStartLine(), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\Inheritance\\ParentClass', $type->fqn);
@@ -96,7 +97,7 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');
         $method = $this->findMethodByName($ast, 'assignmentFromNew');
 
-        $type = $this->resolver->resolveVariableType('x', $method, $method->getStartLine() + 1, $ast);
+        $type = $this->resolver->resolveVariableType('x', Scope::forNode($method), $method->getStartLine() + 1, $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(DateTime::class, $type->fqn);
@@ -110,7 +111,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($method, Expr\MethodCall::class);
         assert($methodCall instanceof Expr\MethodCall);
 
-        $objectType = $this->resolver->resolveExpressionType($methodCall->var, $method, $ast);
+        $objectType = $this->resolver->resolveExpressionType($methodCall->var, Scope::forNode($method), $ast);
         self::assertInstanceOf(ClassName::class, $objectType);
         self::assertSame(DateTime::class, $objectType->fqn);
     }
@@ -123,7 +124,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($method, Expr\MethodCall::class);
         assert($methodCall instanceof Expr\MethodCall);
 
-        $type = $this->resolver->resolveExpressionType($methodCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($methodCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(PrimitiveType::class, $type);
         self::assertSame('string', $type->format());
@@ -137,7 +138,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($method, Expr\MethodCall::class);
         assert($methodCall instanceof Expr\MethodCall);
 
-        $type = $this->resolver->resolveExpressionType($methodCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($methodCall, Scope::forNode($method), $ast);
 
         self::assertNull($type);
     }
@@ -150,7 +151,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($method, Expr\MethodCall::class);
         assert($methodCall instanceof Expr\MethodCall);
 
-        $type = $this->resolver->resolveExpressionType($methodCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($methodCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(PrimitiveType::class, $type);
         self::assertSame('int', $type->format());
@@ -164,7 +165,7 @@ class BasicTypeResolverTest extends TestCase
         $propertyFetch = $finder->findFirstInstanceOf($function, Expr\PropertyFetch::class);
         assert($propertyFetch instanceof Expr\PropertyFetch);
 
-        $type = $this->resolver->resolveExpressionType($propertyFetch, $function, $ast);
+        $type = $this->resolver->resolveExpressionType($propertyFetch, Scope::forNode($function), $ast);
 
         self::assertNull($type);
     }
@@ -175,7 +176,7 @@ class BasicTypeResolverTest extends TestCase
         $function = $this->findFunctionByName($ast, 'thisInFunction');
         $thisVar = $this->findThisVariable([$function]);
 
-        $type = $this->resolver->resolveExpressionType($thisVar, $function, $ast);
+        $type = $this->resolver->resolveExpressionType($thisVar, Scope::forNode($function), $ast);
 
         self::assertNull($type);
     }
@@ -188,7 +189,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($function, Expr\MethodCall::class);
         assert($methodCall instanceof Expr\MethodCall);
 
-        $type = $this->resolver->resolveExpressionType($methodCall, $function, $ast);
+        $type = $this->resolver->resolveExpressionType($methodCall, Scope::forNode($function), $ast);
 
         self::assertNull($type);
     }
@@ -201,7 +202,7 @@ class BasicTypeResolverTest extends TestCase
         $clone = $finder->findFirstInstanceOf($method, Expr\Clone_::class);
         assert($clone instanceof Expr\Clone_);
 
-        $type = $this->resolver->resolveExpressionType($clone, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($clone, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(DateTime::class, $type->fqn);
@@ -215,7 +216,7 @@ class BasicTypeResolverTest extends TestCase
         $ternary = $finder->findFirstInstanceOf($method, Expr\Ternary::class);
         assert($ternary instanceof Expr\Ternary);
 
-        $type = $this->resolver->resolveExpressionType($ternary, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($ternary, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(DateTime::class, $type->fqn);
@@ -229,7 +230,7 @@ class BasicTypeResolverTest extends TestCase
         $coalesce = $finder->findFirstInstanceOf($method, Expr\BinaryOp\Coalesce::class);
         assert($coalesce instanceof Expr\BinaryOp\Coalesce);
 
-        $type = $this->resolver->resolveExpressionType($coalesce, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($coalesce, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(UnionType::class, $type);
         self::assertTrue($type->isNullable());
@@ -241,7 +242,7 @@ class BasicTypeResolverTest extends TestCase
         $method = $this->findMethodByName($ast, 'thisReference');
         $thisVar = $this->findThisVariable([$method]);
 
-        $type = $this->resolver->resolveExpressionType($thisVar, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($thisVar, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\TypeInference\\BuiltinTypes', $type->fqn);
@@ -252,7 +253,7 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');
         $method = $this->findMethodByName($ast, 'nullableParameterType');
 
-        $type = $this->resolver->resolveVariableType('dt', $method, $method->getStartLine(), $ast);
+        $type = $this->resolver->resolveVariableType('dt', Scope::forNode($method), $method->getStartLine(), $ast);
 
         self::assertInstanceOf(UnionType::class, $type);
         self::assertTrue($type->isNullable());
@@ -266,7 +267,7 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');
         $method = $this->findMethodByName($ast, 'unionParameterType');
 
-        $type = $this->resolver->resolveVariableType('dt', $method, $method->getStartLine(), $ast);
+        $type = $this->resolver->resolveVariableType('dt', Scope::forNode($method), $method->getStartLine(), $ast);
 
         self::assertInstanceOf(UnionType::class, $type);
         $classNames = $type->getResolvableClassNames();
@@ -280,7 +281,7 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/TypeInference/BuiltinTypes.php');
         $method = $this->findMethodByName($ast, 'unknownVariableCall');
 
-        $type = $this->resolver->resolveVariableType('x', $method, $method->getStartLine() + 1, $ast);
+        $type = $this->resolver->resolveVariableType('x', Scope::forNode($method), $method->getStartLine() + 1, $ast);
 
         self::assertNull($type);
     }
@@ -293,7 +294,7 @@ class BasicTypeResolverTest extends TestCase
         $closure = $finder->findFirstInstanceOf($method, Expr\Closure::class);
         assert($closure instanceof Expr\Closure);
 
-        $type = $this->resolver->resolveVariableType('dt', $closure, $closure->getStartLine(), $ast);
+        $type = $this->resolver->resolveVariableType('dt', Scope::forNode($closure), $closure->getStartLine(), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(DateTime::class, $type->fqn);
@@ -307,7 +308,7 @@ class BasicTypeResolverTest extends TestCase
         $arrow = $finder->findFirstInstanceOf($method, Expr\ArrowFunction::class);
         assert($arrow instanceof Expr\ArrowFunction);
 
-        $type = $this->resolver->resolveVariableType('dt', $arrow, $arrow->getStartLine(), $ast);
+        $type = $this->resolver->resolveVariableType('dt', Scope::forNode($arrow), $arrow->getStartLine(), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame(DateTime::class, $type->fqn);
@@ -321,7 +322,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($method, Expr\MethodCall::class);
         assert($methodCall instanceof Expr\MethodCall);
 
-        $type = $this->resolver->resolveExpressionType($methodCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($methodCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(UnionType::class, $type);
         self::assertTrue($type->isNullable());
@@ -341,7 +342,7 @@ class BasicTypeResolverTest extends TestCase
         $getPreviousCall = $methodCalls[1];
 
         // getPrevious() returns ?Throwable as a UnionType
-        $prevType = $this->resolver->resolveExpressionType($getPreviousCall, $method, $ast);
+        $prevType = $this->resolver->resolveExpressionType($getPreviousCall, Scope::forNode($method), $ast);
         self::assertInstanceOf(UnionType::class, $prevType);
         self::assertTrue($prevType->isNullable());
         $classNames = $prevType->getResolvableClassNames();
@@ -349,7 +350,7 @@ class BasicTypeResolverTest extends TestCase
         self::assertSame(Throwable::class, $classNames[0]->fqn);
 
         // getMessage() returns string as PrimitiveType
-        $msgType = $this->resolver->resolveExpressionType($getMessageCall, $method, $ast);
+        $msgType = $this->resolver->resolveExpressionType($getMessageCall, Scope::forNode($method), $ast);
         self::assertInstanceOf(PrimitiveType::class, $msgType);
         self::assertSame('string', $msgType->format());
     }
@@ -413,7 +414,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($method, Expr\NullsafeMethodCall::class);
         assert($methodCall instanceof Expr\NullsafeMethodCall);
 
-        $type = $this->resolver->resolveExpressionType($methodCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($methodCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(PrimitiveType::class, $type);
         self::assertSame('string', $type->format());
@@ -427,7 +428,7 @@ class BasicTypeResolverTest extends TestCase
         $propertyFetch = $finder->findFirstInstanceOf($method, Expr\NullsafePropertyFetch::class);
         assert($propertyFetch instanceof Expr\NullsafePropertyFetch);
 
-        $type = $this->resolver->resolveExpressionType($propertyFetch, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($propertyFetch, Scope::forNode($method), $ast);
         self::assertNull($type);
     }
 
@@ -439,7 +440,7 @@ class BasicTypeResolverTest extends TestCase
         $methodCall = $finder->findFirstInstanceOf($method, Expr\NullsafeMethodCall::class);
         assert($methodCall instanceof Expr\NullsafeMethodCall);
 
-        $type = $this->resolver->resolveExpressionType($methodCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($methodCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(UnionType::class, $type);
         self::assertTrue($type->isNullable());
@@ -491,7 +492,7 @@ class BasicTypeResolverTest extends TestCase
         $funcCall = $finder->findFirstInstanceOf($function, Expr\FuncCall::class);
         assert($funcCall instanceof Expr\FuncCall);
 
-        $type = $this->resolver->resolveExpressionType($funcCall, $function, $ast);
+        $type = $this->resolver->resolveExpressionType($funcCall, Scope::forNode($function), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\Domain\\User', $type->fqn);
@@ -502,7 +503,12 @@ class BasicTypeResolverTest extends TestCase
         $ast = $this->parseFixture('src/TypeInference/FunctionTypes.php');
         $function = $this->findFunctionByName($ast, 'testNamespacedFunctionUsage');
 
-        $type = $this->resolver->resolveVariableType('user', $function, $function->getStartLine() + 1, $ast);
+        $type = $this->resolver->resolveVariableType(
+            'user',
+            Scope::forNode($function),
+            $function->getStartLine() + 1,
+            $ast,
+        );
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\Domain\\User', $type->fqn);
@@ -516,7 +522,7 @@ class BasicTypeResolverTest extends TestCase
         $funcCall = $finder->findFirstInstanceOf($method, Expr\FuncCall::class);
         assert($funcCall instanceof Expr\FuncCall);
 
-        $type = $this->resolver->resolveExpressionType($funcCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($funcCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(PrimitiveType::class, $type);
         self::assertSame('int', $type->format());
@@ -530,7 +536,7 @@ class BasicTypeResolverTest extends TestCase
         $funcCall = $finder->findFirstInstanceOf($function, Expr\FuncCall::class);
         assert($funcCall instanceof Expr\FuncCall);
 
-        $type = $this->resolver->resolveExpressionType($funcCall, $function, $ast);
+        $type = $this->resolver->resolveExpressionType($funcCall, Scope::forNode($function), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('GlobalConfig', $type->fqn);
@@ -548,7 +554,7 @@ class BasicTypeResolverTest extends TestCase
         $funcCall = $finder->findFirstInstanceOf($function, Expr\FuncCall::class);
         assert($funcCall instanceof Expr\FuncCall);
 
-        $type = $this->resolver->resolveExpressionType($funcCall, $function, $ast);
+        $type = $this->resolver->resolveExpressionType($funcCall, Scope::forNode($function), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame($expectedFqn, $type->fqn);
@@ -581,7 +587,7 @@ class BasicTypeResolverTest extends TestCase
         $funcCall = $finder->findFirstInstanceOf($method, Expr\FuncCall::class);
         assert($funcCall instanceof Expr\FuncCall);
 
-        $type = $this->resolver->resolveExpressionType($funcCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($funcCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame($expectedFqn, $type->fqn);
@@ -624,7 +630,7 @@ class BasicTypeResolverTest extends TestCase
         );
 
         // Verify the type is resolved correctly
-        $type = $this->resolver->resolveExpressionType($funcCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($funcCall, Scope::forNode($method), $ast);
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\TypeInference\\ImportSource\\ImportedConfig', $type->fqn);
     }
@@ -644,7 +650,7 @@ class BasicTypeResolverTest extends TestCase
             new Name\FullyQualified('Fixtures\\TypeInference\\NamespaceB\\getConfig'),
         );
 
-        $type = $this->resolver->resolveExpressionType($funcCall, $function, $ast);
+        $type = $this->resolver->resolveExpressionType($funcCall, Scope::forNode($function), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\TypeInference\\NamespaceB\\ConfigB', $type->fqn);
@@ -657,7 +663,7 @@ class BasicTypeResolverTest extends TestCase
         $funcCalls = $this->findAllExprsOfType([$method], Expr\FuncCall::class);
         $dynamicCall = $funcCalls[0];
 
-        $type = $this->resolver->resolveExpressionType($dynamicCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($dynamicCall, Scope::forNode($method), $ast);
 
         self::assertNull($type);
     }
@@ -710,7 +716,7 @@ class BasicTypeResolverTest extends TestCase
         $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
         assert($newExpr !== null);
 
-        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($newExpr, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
@@ -724,7 +730,7 @@ class BasicTypeResolverTest extends TestCase
         $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
         assert($newExpr !== null);
 
-        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($newExpr, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
@@ -738,7 +744,7 @@ class BasicTypeResolverTest extends TestCase
         $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
         assert($newExpr !== null);
 
-        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($newExpr, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\Inheritance\\ParentClass', $type->fqn);
@@ -752,7 +758,7 @@ class BasicTypeResolverTest extends TestCase
         $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
         assert($newExpr !== null);
 
-        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($newExpr, Scope::forNode($method), $ast);
 
         self::assertNull($type);
     }
@@ -765,7 +771,7 @@ class BasicTypeResolverTest extends TestCase
         $newExpr = $finder->findFirstInstanceOf($method, Expr\New_::class);
         assert($newExpr !== null);
 
-        $type = $this->resolver->resolveExpressionType($newExpr, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($newExpr, Scope::forNode($method), $ast);
 
         self::assertNull($type);
     }
@@ -779,7 +785,7 @@ class BasicTypeResolverTest extends TestCase
         $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
         assert($staticCall !== null);
 
-        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+        $type = $resolver->resolveExpressionType($staticCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
@@ -794,7 +800,7 @@ class BasicTypeResolverTest extends TestCase
         $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
         assert($staticCall !== null);
 
-        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+        $type = $resolver->resolveExpressionType($staticCall, Scope::forNode($method), $ast);
 
         self::assertInstanceOf(ClassName::class, $type);
         self::assertSame('Fixtures\\TypeInference\\NewKeywords', $type->fqn);
@@ -808,7 +814,7 @@ class BasicTypeResolverTest extends TestCase
         $staticCall = $finder->findFirstInstanceOf($func, Expr\StaticCall::class);
         assert($staticCall !== null);
 
-        $type = $this->resolver->resolveExpressionType($staticCall, $func, $ast);
+        $type = $this->resolver->resolveExpressionType($staticCall, Scope::forNode($func), $ast);
 
         self::assertNull($type);
     }
@@ -821,7 +827,7 @@ class BasicTypeResolverTest extends TestCase
         $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
         assert($staticCall !== null);
 
-        $type = $this->resolver->resolveExpressionType($staticCall, $method, $ast);
+        $type = $this->resolver->resolveExpressionType($staticCall, Scope::forNode($method), $ast);
 
         self::assertNull($type);
     }
@@ -835,7 +841,7 @@ class BasicTypeResolverTest extends TestCase
         $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
         assert($staticCall !== null);
 
-        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+        $type = $resolver->resolveExpressionType($staticCall, Scope::forNode($method), $ast);
 
         // The trait method returns `static`, which should resolve to ConcreteService
         // (the class the method was called on), not SingletonTrait (where it's defined)
@@ -852,7 +858,7 @@ class BasicTypeResolverTest extends TestCase
         $staticCall = $finder->findFirstInstanceOf($method, Expr\StaticCall::class);
         assert($staticCall !== null);
 
-        $type = $resolver->resolveExpressionType($staticCall, $method, $ast);
+        $type = $resolver->resolveExpressionType($staticCall, Scope::forNode($method), $ast);
 
         // The trait method returns `?static`, which should resolve to ?ConcreteService
         self::assertInstanceOf(UnionType::class, $type);
@@ -874,7 +880,7 @@ class BasicTypeResolverTest extends TestCase
                 new Name\FullyQualified('Fixtures\\Traits\\ConcreteService'),
                 'getInstance',
             ),
-            $method,
+            Scope::forNode($method),
             $ast,
         );
 
@@ -894,7 +900,7 @@ class BasicTypeResolverTest extends TestCase
                 new Name\FullyQualified('Fixtures\\TypeInference\\IntersectionReturn'),
                 'getIterableCounter',
             ),
-            $method,
+            Scope::forNode($method),
             $ast,
         );
 

--- a/tests/Utility/ExpressionTypeResolverTest.php
+++ b/tests/Utility/ExpressionTypeResolverTest.php
@@ -106,21 +106,6 @@ class ExpressionTypeResolverTest extends TestCase
         self::assertSame(\DateTime::class, $result->fqn);
     }
 
-    public function testResolveExpressionTypeReturnsNullForVariableOutsideScope(): void
-    {
-        // Create a variable node without any parent scope
-        $varNode = new \PhpParser\Node\Expr\Variable('orphan');
-
-        $typeResolver = self::createStub(TypeResolverInterface::class);
-        // Type resolver should not be called when there's no scope
-        $typeResolver->method('resolveExpressionType')
-            ->willReturn(new ClassName(\DateTime::class));
-
-        $result = ExpressionTypeResolver::resolveExpressionType($varNode, [], $typeResolver);
-
-        self::assertNull($result, 'Should return null when no enclosing scope');
-    }
-
     /**
      * @return array<Stmt>
      */

--- a/tests/Utility/ScopeTest.php
+++ b/tests/Utility/ScopeTest.php
@@ -4,13 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Utility;
 
-use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use Firehed\PhpLsp\Utility\Scope;
-use Fixtures\Inheritance\Grandparent;
-use Fixtures\Inheritance\ParentClass;
-use Fixtures\Traits\HasTimestamps;
-use Fixtures\Utility\ScopePatterns;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
@@ -46,9 +41,9 @@ class ScopeTest extends TestCase
 
         $scope = Scope::forNode($method);
 
-        self::assertSame(ScopePatterns::class, $scope->getSelfContext());
+        self::assertSame('Fixtures\Utility\ScopePatterns', $scope->getSelfContext());
         self::assertNull($scope->getParentContext(), 'ScopePatterns has no parent class');
-        self::assertEquals(new ClassName(ScopePatterns::class), $scope->getThisType());
+        self::assertSame('Fixtures\Utility\ScopePatterns', $scope->getThisType()?->format());
     }
 
     public function testForNodeChildMethodResolvesParentContext(): void
@@ -58,8 +53,8 @@ class ScopeTest extends TestCase
 
         $scope = Scope::forNode($method);
 
-        self::assertSame(ParentClass::class, $scope->getSelfContext());
-        self::assertSame(Grandparent::class, $scope->getParentContext());
+        self::assertSame('Fixtures\Inheritance\ParentClass', $scope->getSelfContext());
+        self::assertSame('Fixtures\Inheritance\Grandparent', $scope->getParentContext());
     }
 
     public function testForNodeTraitMethodHasNoParentContext(): void
@@ -69,9 +64,9 @@ class ScopeTest extends TestCase
 
         $scope = Scope::forNode($method);
 
-        self::assertSame(HasTimestamps::class, $scope->getSelfContext());
+        self::assertSame('Fixtures\Traits\HasTimestamps', $scope->getSelfContext());
         self::assertNull($scope->getParentContext(), 'A trait has no extends clause');
-        self::assertEquals(new ClassName(HasTimestamps::class), $scope->getThisType());
+        self::assertSame('Fixtures\Traits\HasTimestamps', $scope->getThisType()?->format());
     }
 
     public function testForNodeClosureExposesUseCaptures(): void
@@ -84,7 +79,7 @@ class ScopeTest extends TestCase
         self::assertTrue($scope->capturesVariable('captured'), 'use($captured) should be a capture');
         self::assertFalse($scope->capturesVariable('notCaptured'));
         self::assertNull($scope->getThisType(), 'A closure is not a method, so $this is not added here');
-        self::assertSame(ScopePatterns::class, $scope->getSelfContext(), 'Closure inherits enclosing class context');
+        self::assertSame('Fixtures\Utility\ScopePatterns', $scope->getSelfContext(), 'Closure inherits class context');
     }
 
     public function testForNodeArrowFunctionHasNoStatements(): void

--- a/tests/Utility/ScopeTest.php
+++ b/tests/Utility/ScopeTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
+use Firehed\PhpLsp\Utility\Scope;
+use Fixtures\Inheritance\Grandparent;
+use Fixtures\Inheritance\ParentClass;
+use Fixtures\Traits\HasTimestamps;
+use Fixtures\Utility\ScopePatterns;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Scope::class)]
+class ScopeTest extends TestCase
+{
+    use AstTestHelperTrait;
+    use LoadsFixturesTrait;
+
+    public function testForNodeFreeFunctionHasNoClassContext(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Utility/GlobalScope.php'));
+        $function = self::findFunction('utilityFunction', $ast);
+
+        $scope = Scope::forNode($function);
+
+        self::assertSame([], $scope->getParams(), 'Free function fixture declares no parameters');
+        self::assertNull($scope->getSelfContext(), 'Free function has no enclosing class');
+        self::assertNull($scope->getParentContext());
+        self::assertNull($scope->getThisType(), '$this is not bound in a free function');
+        self::assertNotEmpty($scope->getStatements(), 'Function body statements should be exposed');
+    }
+
+    public function testForNodeClassMethodBindsThisAndSelf(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Utility/ScopePatterns.php'));
+        $method = self::findMethod('methodWithThis', $ast);
+
+        $scope = Scope::forNode($method);
+
+        self::assertSame(ScopePatterns::class, $scope->getSelfContext());
+        self::assertNull($scope->getParentContext(), 'ScopePatterns has no parent class');
+        self::assertEquals(new ClassName(ScopePatterns::class), $scope->getThisType());
+    }
+
+    public function testForNodeChildMethodResolvesParentContext(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Inheritance/ParentClass.php'));
+        $method = self::findMethod('parentMethod', $ast);
+
+        $scope = Scope::forNode($method);
+
+        self::assertSame(ParentClass::class, $scope->getSelfContext());
+        self::assertSame(Grandparent::class, $scope->getParentContext());
+    }
+
+    public function testForNodeTraitMethodHasNoParentContext(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Traits/HasTimestamps.php'));
+        $method = self::findMethod('getCreatedAt', $ast);
+
+        $scope = Scope::forNode($method);
+
+        self::assertSame(HasTimestamps::class, $scope->getSelfContext());
+        self::assertNull($scope->getParentContext(), 'A trait has no extends clause');
+        self::assertEquals(new ClassName(HasTimestamps::class), $scope->getThisType());
+    }
+
+    public function testForNodeClosureExposesUseCaptures(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Utility/ScopePatterns.php'));
+        $closure = self::findClosureWithUses($ast);
+
+        $scope = Scope::forNode($closure);
+
+        self::assertTrue($scope->capturesVariable('captured'), 'use($captured) should be a capture');
+        self::assertFalse($scope->capturesVariable('notCaptured'));
+        self::assertNull($scope->getThisType(), 'A closure is not a method, so $this is not added here');
+        self::assertSame(ScopePatterns::class, $scope->getSelfContext(), 'Closure inherits enclosing class context');
+    }
+
+    public function testForNodeArrowFunctionHasNoStatements(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Utility/ScopePatterns.php'));
+        $arrow = (new NodeFinder())->findFirstInstanceOf($ast, ArrowFunction::class);
+        self::assertInstanceOf(ArrowFunction::class, $arrow);
+
+        $scope = Scope::forNode($arrow);
+
+        self::assertSame([], $scope->getStatements(), 'Arrow function body is an expression, not statements');
+    }
+
+    public function testGlobalScopeHasNoBindings(): void
+    {
+        $scope = Scope::global([]);
+
+        self::assertSame([], $scope->getParams());
+        self::assertSame([], $scope->getStatements());
+        self::assertNull($scope->getSelfContext());
+        self::assertNull($scope->getParentContext());
+        self::assertNull($scope->getThisType());
+        self::assertFalse($scope->capturesVariable('anything'));
+    }
+
+    public function testAtOffsetReturnsEnclosingClosureNotMethod(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Utility/ScopePatterns.php'));
+        $closure = self::findClosureWithUses($ast);
+        $offset = $closure->stmts[0]->getStartFilePos();
+
+        $scope = Scope::atOffset($ast, $offset);
+
+        self::assertTrue(
+            $scope->capturesVariable('captured'),
+            'Innermost function-like node (the closure) should win over the enclosing method',
+        );
+    }
+
+    public function testAtOffsetInNamespacedFileUsesNamespaceStatements(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('src/Utility/GlobalScope.php'));
+        $globalVar = self::findVariableNode('globalVar', $ast);
+        self::assertNotNull($globalVar);
+
+        $scope = Scope::atOffset($ast, $globalVar->getStartFilePos());
+
+        self::assertNull($scope->getSelfContext(), 'File-level code has no class context');
+        self::assertNull($scope->getThisType());
+        // The braceless namespace's statements (assignment + function declaration),
+        // not the AST root (which holds only the Namespace_ node).
+        $hasFunction = array_filter($scope->getStatements(), fn(Node $s) => $s instanceof Stmt\Function_);
+        self::assertNotEmpty($hasFunction, 'Namespace-level statements should be exposed for global scope');
+    }
+
+    public function testAtOffsetInFilelessNamespaceUsesAstRoot(): void
+    {
+        $ast = self::parseWithParents($this->loadFixture('TopLevel/global_scope_hover.php'));
+        $activeUser = self::findVariableNode('activeUser', $ast);
+        self::assertNotNull($activeUser);
+
+        $scope = Scope::atOffset($ast, $activeUser->getStartFilePos());
+
+        self::assertNull($scope->getSelfContext());
+        self::assertSame($ast, $scope->getStatements(), 'Without a namespace, global statements are the AST root');
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findFunction(string $name, array $ast): Stmt\Function_
+    {
+        $node = (new NodeFinder())->findFirst(
+            $ast,
+            fn(Node $n) => $n instanceof Stmt\Function_ && $n->name->toString() === $name,
+        );
+        self::assertInstanceOf(Stmt\Function_::class, $node, "Function $name not found");
+        return $node;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findMethod(string $name, array $ast): Stmt\ClassMethod
+    {
+        $node = (new NodeFinder())->findFirst(
+            $ast,
+            fn(Node $n) => $n instanceof Stmt\ClassMethod && $n->name->toString() === $name,
+        );
+        self::assertInstanceOf(Stmt\ClassMethod::class, $node, "Method $name not found");
+        return $node;
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function findClosureWithUses(array $ast): Closure
+    {
+        $node = (new NodeFinder())->findFirst(
+            $ast,
+            fn(Node $n) => $n instanceof Closure && $n->uses !== [],
+        );
+        self::assertInstanceOf(Closure::class, $node, 'Closure with use() not found');
+        return $node;
+    }
+}


### PR DESCRIPTION
Closes #255.

## Problem

In procedural / file-level PHP (no enclosing function), completion, member completion, and hover all failed. Every path dead-ended at a null scope: `ScopeFinder::findEnclosingScope()` / `SymbolResolver::findScopeAtOffset()` returned null, and the type resolver's `$scope` parameter could not represent file-level code, so `getVariablesInScope()` returned `[]` and type resolution returned null.

## Approach

Introduce a `Scope` value object (`src/Utility/Scope.php`) that models a lexical scope — parameters, statements, `self`/`parent` context, `$this`, and closure `use()` captures. Function-like AST nodes and file-level/global code both map onto it (`Scope::atOffset()` / `forNode()` / `global()`), so type and variable resolution no longer branch on node type or handle a "no enclosing function" case. The node-type branching lives in one place.

Threaded `Scope` through `TypeResolverInterface`, `BasicTypeResolver`, `ExpressionTypeResolver`, and `SymbolResolver`, removing the old node union that couldn't represent global scope.

## Result

Variable completion, member completion on a typed file-level variable, and hover on a member call / file-level variable now work in procedural code — in bare files and inside braceless `namespace` blocks — identically to how they work in methods and functions.

Also fixes a latent bug: file-level variable collection no longer descends into nested function/class bodies, and scope discovery now handles arrow functions consistently.

## Scope / follow-ups

- Go-to-definition on a variable was split to #301 (a separate, context-independent feature that builds on this `Scope` abstraction). Not included here.
- Cross-file `include`/`require` resolution is explicitly out of scope; autoloading is assumed.

## Notes

- One obsolete unit test that asserted the pre-fix "no scope → null" behavior was removed after confirming new tests make it mutually exclusive; another was renamed to reflect its true (before-first-statement) intent.
- Remaining `BasicTypeResolver` coverage gaps are pre-existing malformed-AST edge branches, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
