### PR TITLE
Refactor: Separate completion context-detection from item-sourcing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ composer phpcs -- -q --report=emacs # run code style checks (PSR-12)
 - `src/Index/` — Symbol indexing and workspace scanning
 - `src/Document/` — Open document management
 - `src/Utility/` — AST helpers (ScopeFinder, Scope, TypeFactory, DocblockParser)
-- `src/Completion/` — Completion context detection (`ContextDetector`)
+- `src/Completion/` — Completion context detection (`ContextDetector`, `CompletionClassifier`) and per-kind sources (`*Candidates`, `CompletionItemFactory`)
 - `docs/features/` — Feature status documentation
 - `tests/Fixtures/` — Test fixture files (see Testing section)
 
@@ -38,6 +38,10 @@ All symbol resolution flows through the `CodeResolver` interface (implemented by
 - `getAccessibleMembers(doc, type, minVisibility, filter): list<ResolvedMember>` — members of a type
 - `getVariablesInScope(doc, line, char): list<ResolvedVariable>` — Completion of `$`
 - `getCallContext(doc, line, char): ?CallContext` — SignatureHelp, named-argument completion
+
+**File queries** (parser-agnostic; keep completion sources off the raw AST):
+- `getImports(doc): array<string, string>` — `use` imports as short name => FQCN
+- `getFileFunctions(doc): list<FunctionInfo>` — user-defined functions declared in the document
 
 **Type checks:**
 - `isInstantiable(ClassName): bool` — valid after `new`
@@ -124,9 +128,11 @@ Handlers DO:
 - Call `CodeResolver` methods
 - Format the result for their specific LSP response
 
-`CompletionHandler` additionally uses `ParserService` and `SymbolIndex`, but only for
-completion-specific work (import extraction, workspace class lookup, keyword/type-hint
-context detection) — never for symbol resolution.
+`CompletionHandler` is a coordinator: it classifies the position and delegates to
+completion *sources* (`src/Completion/*Candidates`), then merges and deduplicates.
+It no longer parses documents or touches `ParserService`/`SymbolIndex` directly —
+sources own their lookups, and anything parser-derived (imports, file functions,
+members, variables, types) flows through `CodeResolver`. See Completion System.
 
 **Adding support for a new AST node type:**
 1. Add handling in `SymbolResolver` (ONE place)
@@ -164,9 +170,29 @@ Note: `MemberAccessResolver` was removed in #262 — instance/static member acce
 
 See `docs/features/completion.md` for current capabilities.
 
-Architecture: `SymbolResolver::getMemberAccessContext()` uses AST analysis to detect member/static access contexts (handles both `->` and `?->` automatically). `ContextDetector` classifies the broader completion context (e.g. variables-only inside interpolated strings); regex-based detection in `CompletionHandler` covers the remaining positions (type hints, keywords, `new`).
+Architecture (`CompletionHandler` is a coordinator, not a resolver):
 
-**Prefer AST-based context detection over regex.** The parser's error recovery produces usable AST even for incomplete code like `$this->`. AST detection handles operator variants (e.g., `->` vs `?->`) automatically without pattern duplication.
+1. **Coarse gate** — `ContextDetector` (token-based) classifies the broad context
+   (None / VariablesOnly / Full); token analysis survives unparseable code.
+2. **Member/static/call** — detected via `CodeResolver` (`MemberCandidates`,
+   `getCallContext`), which is AST-first with a text fallback (`TextFallbackHelper`).
+3. **Everything else** — `CompletionClassifier` maps the text before the cursor to a
+   typed `CompletionKind`; the handler dispatches to a source per kind.
+
+**Completion sources** (`src/Completion/*Candidates`) each own one candidate kind
+(classes, functions, keywords, variables, members, named arguments, builtin types):
+lookup + prefix filter + item construction (via `CompletionItemFactory`). Adding a
+completion kind = a new source + a `CompletionKind`/enum case, not handler edits.
+`ClassCandidates` is filtered by intent (`ClassCandidateFilter`); the mapping is the
+extension point for context-specific class filtering (e.g. `implements` → interfaces,
+issue #298).
+
+**Detection stays text-based where it is the mid-edit resilience layer.** This is a live
+server: completion must keep working on temporarily-broken code (see
+`CompletionHandlerTest::testCompletionThisInVeryBrokenFile`, where the parser yields no
+AST). `CompletionClassifier` and `ContextDetector` are deliberately text/token-based —
+do **not** convert them to AST analysis. Only member/static/call access flow through the
+AST+fallback `CodeResolver` path.
 
 ## Testing
 

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -43,7 +43,9 @@ CompletionHandler (coordinator)
 │     via CodeResolver (AST-first, text fallback for mid-edit code)
 ├── call context (CodeResolver::getCallContext)
 │     ├── NamedArgumentCandidates     → name: arguments
-│     └── VariableCandidates          → $var in argument position
+│     ├── VariableCandidates          → $var in argument position
+│     └── after name: (value position) → KeywordCandidates (expression)
+│                                         + ClassCandidates (any)
 └── CompletionClassifier (text-based) → typed CompletionKind, dispatched to:
       ├── VariableCandidates          → $var
       ├── ClassCandidates             → new X / expression / type hints (by ClassCandidateFilter)

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -12,6 +12,7 @@ This document tracks the current state of code completion in php-lsp.
 | Static access | `ClassName::` | Static methods, constants, static properties (visibility-aware) | ✅ Working |
 | `new` expression | `new ` | Classes from composer classmap | ✅ Working |
 | Function calls | identifier at expression start | Built-in PHP functions + file-local functions | ✅ Working |
+| Keywords | `fore` → `foreach` | Context-aware PHP keywords (statement/expression start, class body, after visibility) | ✅ Working |
 
 All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
@@ -26,7 +27,6 @@ lexical scope, which includes global scope.
 
 | Context | Example | Notes |
 |---------|---------|-------|
-| Keywords | `fore` → `foreach` | No language keyword suggestions |
 | Array keys | `$config['` | No key suggestions from array shapes |
 | Docblock tags | `@par` → `@param` | No PHPDoc completion |
 | Snippets | Method inserting `()` | No snippet support in completion items |

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -34,19 +34,29 @@ lexical scope, which includes global scope.
 
 ## Architecture
 
+`CompletionHandler` is a coordinator: it detects the position, delegates to a
+completion source, then merges and deduplicates. It never parses documents itself.
+
 ```
-CompletionHandler
-├── AST-based context detection (via CompletionContextResolver)
-│   ├── $this-> and $this?-> member completions
-│   ├── $variable-> and $variable?-> typed variable completions
-│   ├── ClassName:: static completions
-│   └── self::/static::/parent:: completions
-└── Regex-based fallback for other contexts
-    ├── $var variable completions
-    ├── new ClassName completions
-    ├── Type hint completions
-    └── Function/keyword completions
+CompletionHandler (coordinator)
+├── MemberCandidates                  → -> ?-> :: (member/static/parent access)
+│     via CodeResolver (AST-first, text fallback for mid-edit code)
+├── call context (CodeResolver::getCallContext)
+│     ├── NamedArgumentCandidates     → name: arguments
+│     └── VariableCandidates          → $var in argument position
+└── CompletionClassifier (text-based) → typed CompletionKind, dispatched to:
+      ├── VariableCandidates          → $var
+      ├── ClassCandidates             → new X / expression / type hints (by ClassCandidateFilter)
+      ├── FunctionCandidates          → user-defined + built-in functions
+      ├── KeywordCandidates           → keywords (by KeywordGroup)
+      └── BuiltinTypeCandidates       → built-in type hints
 ```
+
+Sources live in `src/Completion/*Candidates`; each owns lookup + prefix filter +
+item construction (`CompletionItemFactory`). Parser-derived data (imports, file
+functions, members, variables, types) flows through `CodeResolver`, so sources are
+agnostic to the parsing strategy. Detection stays text/token-based (`ContextDetector`,
+`CompletionClassifier`) so completion keeps working on temporarily-broken code.
 
 ## Testing
 

--- a/src/Completion/BuiltinTypeCandidates.php
+++ b/src/Completion/BuiltinTypeCandidates.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * Produces built-in type completion items valid in a given type-hint position.
+ *
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
+final class BuiltinTypeCandidates
+{
+    /** Types valid in every type-hint position */
+    private const COMMON_TYPES = [
+        'string', 'int', 'float', 'bool', 'array', 'object',
+        'mixed', 'null', 'callable', 'iterable', 'true', 'false',
+    ];
+
+    /**
+     * @return list<CompletionItem>
+     */
+    public function find(string $prefix, TypeHintContext $context): array
+    {
+        $items = [];
+        foreach ($this->typesFor($context) as $type) {
+            if (PrefixMatcher::matches($type, $prefix)) {
+                $items[] = CompletionItemFactory::forBuiltinType($type);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Context-specific type validity:
+     *
+     * | Type   | Property | Parameter | Return |
+     * |--------|----------|-----------|--------|
+     * | void   | No       | No        | Yes    |
+     * | never  | No       | No        | Yes    |
+     * | self   | No       | Yes       | Yes    |
+     * | static | No       | No        | Yes    |
+     * | parent | No       | Yes       | Yes    |
+     *
+     * @return list<string>
+     */
+    private function typesFor(TypeHintContext $context): array
+    {
+        return match ($context) {
+            TypeHintContext::Property => self::COMMON_TYPES,
+            TypeHintContext::Parameter => [...self::COMMON_TYPES, 'self', 'parent'],
+            TypeHintContext::ReturnType => [...self::COMMON_TYPES, 'void', 'never', 'self', 'static', 'parent'],
+        };
+    }
+}

--- a/src/Completion/ClassCandidateFilter.php
+++ b/src/Completion/ClassCandidateFilter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * The intent behind a class-name completion, which determines both the index
+ * kinds queried and the resolution predicate applied.
+ *
+ * Adding a context-specific filter (e.g. interfaces-only after `implements`,
+ * traits-only after `use` in a class body — see issue #298) is a matter of
+ * adding a case here and a row to the mapping in {@see ClassCandidates}; no
+ * caller or structural change is required.
+ */
+enum ClassCandidateFilter
+{
+    /** Any class-like: classes, interfaces, traits, enums (expression positions) */
+    case Any;
+
+    /** Only types that can be instantiated with `new` */
+    case Instantiable;
+
+    /** Only types valid as a type hint (traits excluded) */
+    case TypeHint;
+}

--- a/src/Completion/ClassCandidates.php
+++ b/src/Completion/ClassCandidates.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Resolution\CodeResolver;
+
+/**
+ * Produces class-name completion items from two sources: classes imported via
+ * `use` statements in the current file, and classes in the workspace symbol
+ * index. Filtering for each source is driven centrally by
+ * {@see ClassCandidateFilter}.
+ *
+ * Imports are read through {@see CodeResolver} rather than the raw AST, so this
+ * source is agnostic to the parsing strategy (and to whether imports were
+ * recovered via AST or a text fallback).
+ *
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
+final class ClassCandidates
+{
+    public function __construct(
+        private readonly SymbolIndex $symbolIndex,
+        private readonly CodeResolver $codeResolver,
+    ) {
+    }
+
+    /**
+     * @return list<CompletionItem>
+     */
+    public function find(string $prefix, TextDocument $document, ClassCandidateFilter $filter): array
+    {
+        $items = $this->fromImports($prefix, $document, $filter);
+        return array_merge($items, $this->fromIndex($prefix, $filter));
+    }
+
+    /**
+     * @return list<CompletionItem>
+     */
+    private function fromImports(string $prefix, TextDocument $document, ClassCandidateFilter $filter): array
+    {
+        $items = [];
+        foreach ($this->codeResolver->getImports($document) as $shortName => $fqcn) {
+            if (!PrefixMatcher::matches($shortName, $prefix)) {
+                continue;
+            }
+            /** @var class-string $fqcn */
+            if (!$this->passesResolutionFilter(new ClassName($fqcn), $filter)) {
+                continue;
+            }
+            $items[] = CompletionItemFactory::forClass($shortName, $fqcn);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<CompletionItem>
+     */
+    private function fromIndex(string $prefix, ClassCandidateFilter $filter): array
+    {
+        $symbols = $this->symbolIndex->findByPrefix($prefix, $this->indexKinds($filter));
+        $items = [];
+
+        foreach ($symbols as $symbol) {
+            /** @var class-string $fqcn */
+            $fqcn = $symbol->fullyQualifiedName;
+            if (!$this->passesResolutionFilter(new ClassName($fqcn), $filter)) {
+                continue;
+            }
+            $items[] = CompletionItemFactory::forClass($symbol->name, $fqcn);
+        }
+
+        return $items;
+    }
+
+    /**
+     * The same semantic rule applies to both sources: a type that is invalid in
+     * the target position is excluded regardless of whether it came from an
+     * import or the index. The index kind pre-filter is an optimization, not a
+     * separate policy.
+     */
+    private function passesResolutionFilter(ClassName $className, ClassCandidateFilter $filter): bool
+    {
+        return match ($filter) {
+            ClassCandidateFilter::Any => true,
+            ClassCandidateFilter::Instantiable => $this->codeResolver->isInstantiable($className),
+            ClassCandidateFilter::TypeHint => $this->codeResolver->isValidTypeHint($className),
+        };
+    }
+
+    /**
+     * @return list<SymbolKind>
+     */
+    private function indexKinds(ClassCandidateFilter $filter): array
+    {
+        return match ($filter) {
+            ClassCandidateFilter::Any => [
+                SymbolKind::Class_,
+                SymbolKind::Interface_,
+                SymbolKind::Trait_,
+                SymbolKind::Enum_,
+            ],
+            ClassCandidateFilter::Instantiable => [
+                SymbolKind::Class_,
+                SymbolKind::Enum_,
+            ],
+            ClassCandidateFilter::TypeHint => [
+                SymbolKind::Class_,
+                SymbolKind::Interface_,
+                SymbolKind::Enum_,
+            ],
+        };
+    }
+}

--- a/src/Completion/CompletionClassification.php
+++ b/src/Completion/CompletionClassification.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * The result of classifying a cursor position: the kind of completion that
+ * applies and the identifier prefix already typed at that position.
+ */
+final readonly class CompletionClassification
+{
+    public function __construct(
+        public CompletionKind $kind,
+        public string $prefix,
+    ) {
+    }
+}

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * Classifies a cursor position into a {@see CompletionKind} using only the text
+ * before the cursor.
+ *
+ * Detection is deliberately text-based rather than AST-based: this is a live
+ * language server, and completion must keep working while code is temporarily
+ * broken mid-edit (see CompletionHandlerTest::testCompletionThisInVeryBrokenFile,
+ * where the parser produces no AST at all). Member, static, and call-argument
+ * contexts are AST-first with a text fallback and are detected upstream via
+ * {@see \Firehed\PhpLsp\Resolution\CodeResolver}, so they never reach here.
+ *
+ * The ordering of checks is significant: earlier, more specific patterns must be
+ * tested before later, broader ones (e.g. a visibility keyword before the general
+ * type-hint fallback).
+ */
+final class CompletionClassifier
+{
+    // Matches property type continuations: "private ?", "public int|", "protected Foo&"
+    private const PROPERTY_TYPE_PATTERN = '/(?:public|private|protected)\s+(?:readonly\s+)?(?:\w+\s*)?[?|&]\s*(\w*)$/';
+
+    public static function classify(string $textBeforeCursor): CompletionClassification
+    {
+        // Variable completion
+        if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::Variable, $matches[1]);
+        }
+
+        // new ClassName completion
+        if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::New_, $matches[1]);
+        }
+
+        // After visibility keyword - keywords or property type.
+        // Must check before the general type hint fallback since both patterns overlap.
+        if (preg_match('/(?:public|private|protected)\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::AfterVisibility, $matches[1]);
+        }
+
+        // Return type context - after ): with optional space
+        if (preg_match('/\):\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::ReturnType, $matches[1]);
+        }
+
+        // Return type context - nullable/union/intersection (e.g., "): ?", "): int|", "): Foo&")
+        if (preg_match('/\):\s*(?:\?\s*|(?:\w+\s*[|&]\s*)+)(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::ReturnType, $matches[1]);
+        }
+
+        // Property type context - nullable/union/intersection after visibility keyword
+        if (preg_match(self::PROPERTY_TYPE_PATTERN, $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::PropertyType, $matches[1]);
+        }
+
+        // Parameter type context - fallback for type positions not matched above.
+        // Matches after (, ,, ?, |, & which occur in parameter lists and complex types
+        if (preg_match('/[(,?|&]\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::ParameterType, $matches[1]);
+        }
+
+        // Class body context - only class-level keywords, no functions
+        if (self::isInClassBody($textBeforeCursor)) {
+            if (preg_match('/(?:^|[\s{;])(\w+)$/', $textBeforeCursor, $matches) === 1) {
+                return new CompletionClassification(CompletionKind::ClassBody, $matches[1]);
+            }
+            return new CompletionClassification(CompletionKind::None, '');
+        }
+
+        // Function/class/keyword completion (at start of expression or after operators)
+        if (preg_match('/(?:^|[(\s=,!&|])(\w+)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::Expression, $matches[1]);
+        }
+
+        return new CompletionClassification(CompletionKind::None, '');
+    }
+
+    /**
+     * Check if cursor is inside a class/interface/trait/enum body (but not inside a method).
+     */
+    private static function isInClassBody(string $textBeforeCursor): bool
+    {
+        // Count braces to detect if we're inside a class body
+        // This is a heuristic - look for class/interface/trait/enum followed by unbalanced {
+        if (preg_match('/(?:class|interface|trait|enum)\s+\w+/', $textBeforeCursor) !== 1) {
+            return false;
+        }
+
+        // Count brace depth after the class declaration
+        $classPos = strrpos($textBeforeCursor, 'class ');
+        $interfacePos = strrpos($textBeforeCursor, 'interface ');
+        $traitPos = strrpos($textBeforeCursor, 'trait ');
+        $enumPos = strrpos($textBeforeCursor, 'enum ');
+        $lastClassPos = max(
+            $classPos !== false ? $classPos : 0,
+            $interfacePos !== false ? $interfacePos : 0,
+            $traitPos !== false ? $traitPos : 0,
+            $enumPos !== false ? $enumPos : 0,
+        );
+
+        $afterClass = substr($textBeforeCursor, $lastClassPos);
+        $depth = 0;
+        $inString = false;
+        $stringChar = '';
+
+        for ($i = 0; $i < strlen($afterClass); $i++) {
+            $char = $afterClass[$i];
+
+            if ($inString) {
+                if ($char === $stringChar && ($i === 0 || $afterClass[$i - 1] !== '\\')) {
+                    $inString = false;
+                }
+                continue;
+            }
+
+            if ($char === '"' || $char === "'") {
+                $inString = true;
+                $stringChar = $char;
+            } elseif ($char === '{') {
+                $depth++;
+            } elseif ($char === '}') {
+                $depth--;
+            }
+        }
+
+        // depth === 1 means we're directly inside the class body (not in a method)
+        return $depth === 1;
+    }
+}

--- a/src/Completion/CompletionItemFactory.php
+++ b/src/Completion/CompletionItemFactory.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Resolution\ResolvedConstant;
+use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
+use Firehed\PhpLsp\Resolution\ResolvedMember;
+use Firehed\PhpLsp\Resolution\ResolvedMethod;
+use Firehed\PhpLsp\Resolution\ResolvedProperty;
+use Firehed\PhpLsp\Utility\DocblockParser;
+
+/**
+ * Builds LSP completion items. Centralizing construction here keeps item shape,
+ * kind assignment, and documentation extraction consistent across every
+ * completion source.
+ *
+ * @phpstan-type CompletionItem array{
+ *   label: string,
+ *   kind?: int,
+ *   detail?: string,
+ *   documentation?: string,
+ * }
+ */
+final class CompletionItemFactory
+{
+    /**
+     * @return CompletionItem
+     */
+    public static function forResolvedMember(ResolvedMember $member): array
+    {
+        $kind = match (true) {
+            $member instanceof ResolvedMethod => CompletionItemKind::Method,
+            $member instanceof ResolvedProperty => CompletionItemKind::Property,
+            $member instanceof ResolvedConstant => CompletionItemKind::Constant,
+            $member instanceof ResolvedEnumCase => CompletionItemKind::EnumMember,
+            // @codeCoverageIgnoreStart
+            default => throw new \LogicException('Unexpected member type: ' . $member::class),
+            // @codeCoverageIgnoreEnd
+        };
+
+        $item = [
+            'label' => $member->getName()->name,
+            'kind' => $kind->value,
+            'detail' => $member->format(),
+        ];
+
+        $doc = $member->getDocumentation();
+        if ($doc !== null) {
+            $item['documentation'] = $doc;
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    public static function forFunction(FunctionInfo $function): array
+    {
+        return self::withDocumentation([
+            'label' => $function->name,
+            'kind' => CompletionItemKind::Function->value,
+            'detail' => $function->format(),
+        ], $function->docblock);
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    public static function forBuiltinFunction(string $name): array
+    {
+        return [
+            'label' => $name,
+            'kind' => CompletionItemKind::Function->value,
+        ];
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    public static function forClass(string $shortName, string $fullyQualifiedName): array
+    {
+        return [
+            'label' => $shortName,
+            'kind' => CompletionItemKind::Class_->value,
+            'detail' => $fullyQualifiedName,
+        ];
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    public static function forKeyword(string $keyword): array
+    {
+        return [
+            'label' => $keyword,
+            'kind' => CompletionItemKind::Keyword->value,
+        ];
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    public static function forBuiltinType(string $type): array
+    {
+        return [
+            'label' => $type,
+            'kind' => CompletionItemKind::Keyword->value,
+            'detail' => 'builtin type',
+        ];
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    public static function forVariable(string $name, string $typeLabel): array
+    {
+        return [
+            'label' => '$' . $name,
+            'kind' => CompletionItemKind::Variable->value,
+            'detail' => $typeLabel,
+        ];
+    }
+
+    /**
+     * @return CompletionItem
+     */
+    public static function forNamedArgument(ParameterInfo $parameter): array
+    {
+        return [
+            'label' => $parameter->name . ':',
+            'kind' => CompletionItemKind::Field->value,
+            'detail' => $parameter->format(),
+        ];
+    }
+
+    /**
+     * The `::class` magic constant offered after static access.
+     *
+     * @return CompletionItem
+     */
+    public static function forClassConstant(): array
+    {
+        return [
+            'label' => 'class',
+            'kind' => CompletionItemKind::Constant->value,
+            'detail' => 'string (fully qualified class name)',
+        ];
+    }
+
+    /**
+     * @param CompletionItem $item
+     * @return CompletionItem
+     */
+    private static function withDocumentation(array $item, string|false|null $docText): array
+    {
+        if ($docText !== null && $docText !== false && $docText !== '') {
+            $doc = DocblockParser::extractDescription($docText);
+            if ($doc !== '') {
+                $item['documentation'] = $doc;
+            }
+        }
+        return $item;
+    }
+}

--- a/src/Completion/CompletionItemKind.php
+++ b/src/Completion/CompletionItemKind.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * LSP CompletionItemKind values.
+ *
+ * @see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind
+ */
+enum CompletionItemKind: int
+{
+    case Method = 2;
+    case Function = 3;
+    case Field = 5;
+    case Variable = 6;
+    case Class_ = 7;
+    case Property = 10;
+    case Keyword = 14;
+    case EnumMember = 20;
+    case Constant = 21;
+}

--- a/src/Completion/CompletionKind.php
+++ b/src/Completion/CompletionKind.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * The kind of completion appropriate at a cursor position, as determined by
+ * text-based analysis of the code before the cursor.
+ *
+ * Detection is intentionally text-based so completion keeps working on
+ * temporarily-broken, mid-edit code where the parser cannot produce a usable
+ * AST. Member, static, and call-argument contexts are detected separately via
+ * {@see \Firehed\PhpLsp\Resolution\CodeResolver} and are not represented here.
+ */
+enum CompletionKind
+{
+    /** After `$`, e.g. `$fo` — variables in scope */
+    case Variable;
+
+    /** After `new`, e.g. `new Fo` — instantiable class names */
+    case New_;
+
+    /** After a visibility keyword, e.g. `private fo` — member keywords or a property type */
+    case AfterVisibility;
+
+    /** In a return type position, e.g. `): Fo` or `): ?Fo` */
+    case ReturnType;
+
+    /** In a property type position, e.g. `private ?Fo` */
+    case PropertyType;
+
+    /** In a parameter type position, e.g. `(Fo` or `int|Fo` */
+    case ParameterType;
+
+    /** Directly inside a class body — class-level keywords only */
+    case ClassBody;
+
+    /** At the start of an expression — keywords, functions, and class names */
+    case Expression;
+
+    /** No completion applies at this position */
+    case None;
+}

--- a/src/Completion/FunctionCandidates.php
+++ b/src/Completion/FunctionCandidates.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Resolution\CodeResolver;
+
+/**
+ * Produces function completion items: user-defined functions declared in the
+ * document (read through {@see CodeResolver}, so parser-agnostic) followed by
+ * built-in PHP functions.
+ *
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
+final class FunctionCandidates
+{
+    private const RESULT_LIMIT = 100;
+
+    public function __construct(
+        private readonly CodeResolver $codeResolver,
+    ) {
+    }
+
+    /**
+     * @return list<CompletionItem>
+     */
+    public function find(string $prefix, TextDocument $document): array
+    {
+        $items = [];
+
+        foreach ($this->codeResolver->getFileFunctions($document) as $function) {
+            if (PrefixMatcher::matches($function->name, $prefix)) {
+                $items[] = CompletionItemFactory::forFunction($function);
+            }
+        }
+
+        foreach (get_defined_functions()['internal'] as $name) {
+            if (PrefixMatcher::matches($name, $prefix)) {
+                $items[] = CompletionItemFactory::forBuiltinFunction($name);
+            }
+        }
+
+        return array_slice($items, 0, self::RESULT_LIMIT);
+    }
+}

--- a/src/Completion/KeywordCandidates.php
+++ b/src/Completion/KeywordCandidates.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * Produces keyword completion items for a given {@see KeywordGroup}.
+ *
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
+final class KeywordCandidates
+{
+    private const KEYWORDS_ALL = [
+        // Control flow
+        'if', 'else', 'elseif', 'switch', 'case', 'default',
+        'while', 'do', 'for', 'foreach', 'break', 'continue',
+        'return', 'throw', 'try', 'catch', 'finally',
+        // Declarations
+        'function', 'class', 'interface', 'trait', 'enum', 'namespace', 'use',
+        'extends', 'implements', 'const', 'public', 'protected', 'private',
+        'static', 'final', 'abstract', 'readonly',
+        // Operators and other
+        'new', 'instanceof', 'clone', 'yield', 'match',
+        'echo', 'print', 'include', 'include_once', 'require', 'require_once',
+        'global', 'unset', 'isset', 'empty', 'list', 'fn',
+    ];
+
+    private const KEYWORDS_CLASS_BODY = [
+        'public', 'private', 'protected',
+        'static', 'final', 'abstract', 'readonly',
+        'const', 'function', 'use',
+    ];
+
+    private const KEYWORDS_AFTER_VISIBILITY = ['function', 'static', 'readonly', 'const'];
+
+    private const KEYWORDS_EXPRESSION = [
+        'new', 'clone', 'yield', 'match', 'fn',
+        'isset', 'empty', 'list',
+        'true', 'false', 'null',
+    ];
+
+    /**
+     * @return list<CompletionItem>
+     */
+    public function find(string $prefix, KeywordGroup $group): array
+    {
+        $items = [];
+        foreach ($this->keywords($group) as $keyword) {
+            if (PrefixMatcher::matches($keyword, $prefix)) {
+                $items[] = CompletionItemFactory::forKeyword($keyword);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function keywords(KeywordGroup $group): array
+    {
+        return match ($group) {
+            KeywordGroup::All => self::KEYWORDS_ALL,
+            KeywordGroup::ClassBody => self::KEYWORDS_CLASS_BODY,
+            KeywordGroup::AfterVisibility => self::KEYWORDS_AFTER_VISIBILITY,
+            KeywordGroup::Expression => self::KEYWORDS_EXPRESSION,
+        };
+    }
+}

--- a/src/Completion/KeywordGroup.php
+++ b/src/Completion/KeywordGroup.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * A named set of PHP keywords valid in a particular completion position.
+ */
+enum KeywordGroup
+{
+    /** Every keyword — valid at the start of a statement/expression */
+    case All;
+
+    /** Keywords valid directly inside a class body */
+    case ClassBody;
+
+    /** Keywords valid immediately after a visibility modifier */
+    case AfterVisibility;
+
+    /** Keywords valid at the start of an expression (e.g. a named-argument value) */
+    case Expression;
+}

--- a/src/Completion/MemberCandidates.php
+++ b/src/Completion/MemberCandidates.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Resolution\CodeResolver;
+use Firehed\PhpLsp\Resolution\MemberAccessContext;
+use Firehed\PhpLsp\Resolution\MemberAccessKind;
+use Firehed\PhpLsp\Resolution\MemberFilter;
+use Firehed\PhpLsp\Resolution\ResolvedMethod;
+
+/**
+ * Produces member completion items after `->`, `?->`, or `::`.
+ *
+ * Detection and resolution both flow through {@see CodeResolver}, so this source
+ * owns the whole member-access case: it returns null when the position is not a
+ * member access (letting the caller try other completion kinds) and a list of
+ * items — possibly empty — when it is.
+ *
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
+final class MemberCandidates
+{
+    public function __construct(
+        private readonly CodeResolver $codeResolver,
+    ) {
+    }
+
+    /**
+     * @return list<CompletionItem>|null Null when the position is not a member access.
+     */
+    public function find(TextDocument $document, int $line, int $character): ?array
+    {
+        $context = $this->codeResolver->getMemberAccessContext($document, $line, $character);
+        if ($context === null) {
+            return null;
+        }
+
+        return $this->itemsFor($context, $document);
+    }
+
+    /**
+     * @return list<CompletionItem>
+     */
+    private function itemsFor(MemberAccessContext $context, TextDocument $document): array
+    {
+        $filter = match ($context->kind) {
+            MemberAccessKind::Instance => MemberFilter::Instance,
+            MemberAccessKind::Static => MemberFilter::Static,
+            MemberAccessKind::Parent => MemberFilter::All,
+        };
+
+        $members = $this->codeResolver->getAccessibleMembers(
+            $document,
+            $context->type,
+            $context->minVisibility,
+            $filter,
+        );
+
+        $items = [];
+        foreach ($members as $member) {
+            if ($context->kind === MemberAccessKind::Parent && !$member instanceof ResolvedMethod) {
+                continue;
+            }
+            if (PrefixMatcher::matches($member->getName()->name, $context->prefix)) {
+                $items[] = CompletionItemFactory::forResolvedMember($member);
+            }
+        }
+
+        if ($context->kind === MemberAccessKind::Static && PrefixMatcher::matches('class', $context->prefix)) {
+            $items[] = CompletionItemFactory::forClassConstant();
+        }
+
+        return $items;
+    }
+}

--- a/src/Completion/NamedArgumentCandidates.php
+++ b/src/Completion/NamedArgumentCandidates.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use Firehed\PhpLsp\Resolution\CallContext;
+
+/**
+ * Produces named-argument completion items (`name:`) for a call, skipping
+ * parameters already supplied positionally or by name and variadics.
+ *
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
+final class NamedArgumentCandidates
+{
+    /**
+     * @return list<CompletionItem>
+     */
+    public function find(CallContext $callContext, string $textBeforeCursor): array
+    {
+        $prefix = $this->extractPrefix($textBeforeCursor);
+        $usedNames = $callContext->usedParameterNames;
+        $positionallyFilledCount = $callContext->positionallyFilledCount;
+
+        $items = [];
+        foreach ($callContext->callable->getParameters() as $param) {
+            // Skip parameters already used as named arguments
+            if (in_array($param->name, $usedNames, true)) {
+                continue;
+            }
+
+            // Skip parameters filled positionally (before the first named arg)
+            if ($param->position < $positionallyFilledCount) {
+                continue;
+            }
+
+            // Skip variadic parameters as named arguments (they use array syntax instead)
+            if ($param->isVariadic) {
+                continue;
+            }
+
+            if (PrefixMatcher::matches($param->name, $prefix)) {
+                $items[] = CompletionItemFactory::forNamedArgument($param);
+            }
+        }
+
+        return $items;
+    }
+
+    private function extractPrefix(string $textBeforeCursor): string
+    {
+        if (preg_match('/[(,]\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return $matches[1];
+        }
+        return '';
+    }
+}

--- a/src/Completion/PrefixMatcher.php
+++ b/src/Completion/PrefixMatcher.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * Case-insensitive prefix matching shared by completion sources.
+ */
+final class PrefixMatcher
+{
+    public static function matches(string $name, string $prefix): bool
+    {
+        return $prefix === '' || str_starts_with(strtolower($name), strtolower($prefix));
+    }
+}

--- a/src/Completion/VariableCandidates.php
+++ b/src/Completion/VariableCandidates.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Resolution\CodeResolver;
+
+/**
+ * Produces variable completion items for the variables in scope at a position.
+ *
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
+final class VariableCandidates
+{
+    public function __construct(
+        private readonly CodeResolver $codeResolver,
+    ) {
+    }
+
+    /**
+     * @return list<CompletionItem>
+     */
+    public function find(string $prefix, TextDocument $document, int $line, int $character): array
+    {
+        $items = [];
+        foreach ($this->codeResolver->getVariablesInScope($document, $line, $character) as $variable) {
+            if (PrefixMatcher::matches($variable->getName(), $prefix)) {
+                $items[] = CompletionItemFactory::forVariable(
+                    $variable->getName(),
+                    $variable->getType()?->format() ?? 'mixed',
+                );
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -16,6 +16,7 @@ use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\KeywordGroup;
 use Firehed\PhpLsp\Completion\MemberCandidates;
+use Firehed\PhpLsp\Completion\NamedArgumentCandidates;
 use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Completion\VariableCandidates;
@@ -42,6 +43,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly KeywordCandidates $keywordCandidates,
         private readonly VariableCandidates $variableCandidates,
         private readonly MemberCandidates $memberCandidates,
+        private readonly NamedArgumentCandidates $namedArgumentCandidates,
     ) {
     }
 
@@ -132,8 +134,7 @@ final class CompletionHandler implements HandlerInterface
         // Inside a call context, offer named arguments + variables
         $callContext = $this->codeResolver->getCallContext($document, $line, $character);
         if ($callContext !== null) {
-            $namedArgPrefix = $this->extractNamedArgPrefix($textBeforeCursor);
-            $items = $this->getNamedArgumentCompletions($callContext, $namedArgPrefix);
+            $items = $this->namedArgumentCandidates->find($callContext, $textBeforeCursor);
 
             // Also offer variables - filter by prefix if cursor is on one
             $varPrefix = '';
@@ -286,58 +287,5 @@ final class CompletionHandler implements HandlerInterface
         $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::TypeHint));
 
         return $this->deduplicateCompletions($items);
-    }
-
-    /**
-     * Extract the prefix for named argument completion from text before cursor.
-     */
-    private function extractNamedArgPrefix(string $textBeforeCursor): string
-    {
-        if (preg_match('/[(,]\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            return $matches[1];
-        }
-        return '';
-    }
-
-    /**
-     * Get named argument completions for a function/method call.
-     *
-     * @return list<CompletionItem>
-     */
-    private function getNamedArgumentCompletions(
-        \Firehed\PhpLsp\Resolution\CallContext $callContext,
-        string $prefix,
-    ): array {
-        $callable = $callContext->callable;
-        $params = $callable->getParameters();
-        $usedNames = $callContext->usedParameterNames;
-        $positionallyFilledCount = $callContext->positionallyFilledCount;
-
-        $items = [];
-        foreach ($params as $param) {
-            // Skip parameters already used as named arguments
-            if (in_array($param->name, $usedNames, true)) {
-                continue;
-            }
-
-            // Skip parameters filled positionally (before the first named arg)
-            if ($param->position < $positionallyFilledCount) {
-                continue;
-            }
-
-            // Skip variadic parameters as named arguments (they use array syntax instead)
-            if ($param->isVariadic) {
-                continue;
-            }
-
-            // Match prefix
-            if (!self::matchesPrefix($param->name, $prefix)) {
-                continue;
-            }
-
-            $items[] = CompletionItemFactory::forNamedArgument($param);
-        }
-
-        return $items;
     }
 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Completion\CompletionClassifier;
 use Firehed\PhpLsp\Completion\CompletionContext;
+use Firehed\PhpLsp\Completion\CompletionItemFactory;
+use Firehed\PhpLsp\Completion\CompletionItemKind;
 use Firehed\PhpLsp\Completion\CompletionKind;
 use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\TypeHintContext;
@@ -20,55 +22,19 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Resolution\MemberAccessContext;
 use Firehed\PhpLsp\Resolution\MemberAccessKind;
 use Firehed\PhpLsp\Resolution\MemberFilter;
-use Firehed\PhpLsp\Resolution\ResolvedConstant;
-use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
-use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
-use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Resolution\CodeResolver;
-use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Stmt;
 
 /**
- * @phpstan-type CompletionItem array{
- *   label: string,
- *   kind?: int,
- *   detail?: string,
- *   documentation?: string,
- * }
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
  */
 final class CompletionHandler implements HandlerInterface
 {
-    // LSP CompletionItemKind constants
-    private const KIND_METHOD = 2;
-    private const KIND_FUNCTION = 3;
-    private const KIND_FIELD = 5;
-    private const KIND_VARIABLE = 6;
-    private const KIND_CLASS = 7;
-    private const KIND_PROPERTY = 10;
-    private const KIND_KEYWORD = 14;
-    private const KIND_ENUM_MEMBER = 20;
-    private const KIND_CONSTANT = 21;
-
     private static function matchesPrefix(string $name, string $prefix): bool
     {
         return $prefix === '' || str_starts_with(strtolower($name), strtolower($prefix));
-    }
-
-    /**
-     * @param CompletionItem $item
-     * @return CompletionItem
-     */
-    private static function withDocumentation(array $item, string|false|null $docText): array
-    {
-        if ($docText !== null && $docText !== false && $docText !== '') {
-            $doc = DocblockParser::extractDescription($docText);
-            if ($doc !== '') {
-                $item['documentation'] = $doc;
-            }
-        }
-        return $item;
     }
 
     public function __construct(
@@ -145,7 +111,7 @@ final class CompletionHandler implements HandlerInterface
         if ($context === CompletionContext::VariablesOnly) {
             $items = array_values(array_filter(
                 $items,
-                static fn(array $item): bool => ($item['kind'] ?? 0) === self::KIND_VARIABLE,
+                static fn(array $item): bool => ($item['kind'] ?? 0) === CompletionItemKind::Variable->value,
             ));
         }
 
@@ -294,16 +260,12 @@ final class CompletionHandler implements HandlerInterface
                 continue;
             }
             if (self::matchesPrefix($member->getName()->name, $context->prefix)) {
-                $items[] = $this->formatResolvedMemberCompletion($member);
+                $items[] = CompletionItemFactory::forResolvedMember($member);
             }
         }
 
         if ($context->kind === MemberAccessKind::Static && self::matchesPrefix('class', $context->prefix)) {
-            $items[] = [
-                'label' => 'class',
-                'kind' => self::KIND_CONSTANT,
-                'detail' => 'string (fully qualified class name)',
-            ];
+            $items[] = CompletionItemFactory::forClassConstant();
         }
 
         return $items;
@@ -322,7 +284,7 @@ final class CompletionHandler implements HandlerInterface
             if ($stmt instanceof Stmt\Function_) {
                 $name = $stmt->name->toString();
                 if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = $this->formatFunctionCompletion($stmt);
+                    $items[] = CompletionItemFactory::forFunction(FunctionInfo::fromNode($stmt));
                 }
             }
         }
@@ -331,58 +293,12 @@ final class CompletionHandler implements HandlerInterface
         $definedFunctions = get_defined_functions();
         foreach ($definedFunctions['internal'] as $name) {
             if (self::matchesPrefix($name, $prefix)) {
-                $items[] = [
-                    'label' => $name,
-                    'kind' => self::KIND_FUNCTION,
-                ];
+                $items[] = CompletionItemFactory::forBuiltinFunction($name);
             }
         }
 
         // Limit results
         return array_slice($items, 0, 100);
-    }
-
-    /**
-     * @return CompletionItem
-     */
-    private function formatResolvedMemberCompletion(ResolvedMember $member): array
-    {
-        $kind = match (true) {
-            $member instanceof ResolvedMethod => self::KIND_METHOD,
-            $member instanceof ResolvedProperty => self::KIND_PROPERTY,
-            $member instanceof ResolvedConstant => self::KIND_CONSTANT,
-            $member instanceof ResolvedEnumCase => self::KIND_ENUM_MEMBER,
-            // @codeCoverageIgnoreStart
-            default => throw new \LogicException('Unexpected member type: ' . $member::class),
-            // @codeCoverageIgnoreEnd
-        };
-
-        $item = [
-            'label' => $member->getName()->name,
-            'kind' => $kind,
-            'detail' => $member->format(),
-        ];
-
-        $doc = $member->getDocumentation();
-        if ($doc !== null) {
-            $item['documentation'] = $doc;
-        }
-
-        return $item;
-    }
-
-    /**
-     * @return CompletionItem
-     */
-    private function formatFunctionCompletion(Stmt\Function_ $func): array
-    {
-        $funcInfo = FunctionInfo::fromNode($func);
-
-        return self::withDocumentation([
-            'label' => $funcInfo->name,
-            'kind' => self::KIND_FUNCTION,
-            'detail' => $funcInfo->format(),
-        ], $funcInfo->docblock);
     }
 
     /**
@@ -411,11 +327,7 @@ final class CompletionHandler implements HandlerInterface
             if ($typeHintContext && !$this->codeResolver->isValidTypeHint(new ClassName($fqcn))) {
                 continue;
             }
-            $items[] = [
-                'label' => $shortName,
-                'kind' => self::KIND_CLASS,
-                'detail' => $fqcn,
-            ];
+            $items[] = CompletionItemFactory::forClass($shortName, $fqcn);
         }
 
         return $items;
@@ -479,11 +391,7 @@ final class CompletionHandler implements HandlerInterface
             if ($instantiableOnly && !$this->codeResolver->isInstantiable(new ClassName($fqcn))) {
                 continue;
             }
-            $items[] = [
-                'label' => $symbol->name,
-                'kind' => self::KIND_CLASS,
-                'detail' => $fqcn,
-            ];
+            $items[] = CompletionItemFactory::forClass($symbol->name, $fqcn);
         }
 
         return $items;
@@ -543,11 +451,7 @@ final class CompletionHandler implements HandlerInterface
 
         foreach ($builtinTypes as $type) {
             if (self::matchesPrefix($type, $prefix)) {
-                $items[] = [
-                    'label' => $type,
-                    'kind' => self::KIND_KEYWORD,
-                    'detail' => 'builtin type',
-                ];
+                $items[] = CompletionItemFactory::forBuiltinType($type);
             }
         }
 
@@ -605,10 +509,7 @@ final class CompletionHandler implements HandlerInterface
 
         foreach ($keywords as $keyword) {
             if ($prefix === '' || str_starts_with($keyword, $prefixLower)) {
-                $items[] = [
-                    'label' => $keyword,
-                    'kind' => self::KIND_KEYWORD,
-                ];
+                $items[] = CompletionItemFactory::forKeyword($keyword);
             }
         }
 
@@ -631,11 +532,10 @@ final class CompletionHandler implements HandlerInterface
         $items = [];
         foreach ($variables as $variable) {
             if (self::matchesPrefix($variable->getName(), $prefix)) {
-                $items[] = [
-                    'label' => '$' . $variable->getName(),
-                    'kind' => self::KIND_VARIABLE,
-                    'detail' => $variable->getType()?->format() ?? 'mixed',
-                ];
+                $items[] = CompletionItemFactory::forVariable(
+                    $variable->getName(),
+                    $variable->getType()?->format() ?? 'mixed',
+                );
             }
         }
 
@@ -689,11 +589,7 @@ final class CompletionHandler implements HandlerInterface
                 continue;
             }
 
-            $items[] = [
-                'label' => $param->name . ':',
-                'kind' => self::KIND_FIELD,
-                'detail' => $param->format(),
-            ];
+            $items[] = CompletionItemFactory::forNamedArgument($param);
         }
 
         return $items;

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Completion\CompletionItemFactory;
 use Firehed\PhpLsp\Completion\CompletionItemKind;
 use Firehed\PhpLsp\Completion\CompletionKind;
 use Firehed\PhpLsp\Completion\ContextDetector;
+use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
@@ -34,7 +35,7 @@ final class CompletionHandler implements HandlerInterface
 {
     private static function matchesPrefix(string $name, string $prefix): bool
     {
-        return $prefix === '' || str_starts_with(strtolower($name), strtolower($prefix));
+        return PrefixMatcher::matches($name, $prefix);
     }
 
     public function __construct(

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Handler;
 
+use Firehed\PhpLsp\Completion\ClassCandidateFilter;
+use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\CompletionClassifier;
 use Firehed\PhpLsp\Completion\CompletionContext;
 use Firehed\PhpLsp\Completion\CompletionItemFactory;
@@ -14,10 +16,7 @@ use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Index\SymbolIndex;
-use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Resolution\MemberAccessContext;
@@ -25,7 +24,6 @@ use Firehed\PhpLsp\Resolution\MemberAccessKind;
 use Firehed\PhpLsp\Resolution\MemberFilter;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\CodeResolver;
-use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Stmt;
 
 /**
@@ -41,8 +39,8 @@ final class CompletionHandler implements HandlerInterface
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly ParserService $parser,
-        private readonly SymbolIndex $symbolIndex,
         private readonly CodeResolver $codeResolver,
+        private readonly ClassCandidates $classCandidates,
     ) {
     }
 
@@ -156,13 +154,10 @@ final class CompletionHandler implements HandlerInterface
             if (preg_match('/\w+:\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
                 $prefix = $matches[1];
                 $items = array_merge($items, $this->filterKeywords(self::KEYWORDS_EXPRESSION, $prefix));
-                $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
-                $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
-                    SymbolKind::Class_,
-                    SymbolKind::Interface_,
-                    SymbolKind::Trait_,
-                    SymbolKind::Enum_,
-                ]));
+                $items = array_merge(
+                    $items,
+                    $this->classCandidates->find($prefix, $document, ClassCandidateFilter::Any),
+                );
             }
 
             return $this->deduplicateCompletions($items);
@@ -175,45 +170,50 @@ final class CompletionHandler implements HandlerInterface
 
         return match ($classification->kind) {
             CompletionKind::Variable => $this->getVariableCompletions($prefix, $document, $line, $character),
-            CompletionKind::New_ => $this->getNewCompletions($prefix, $ast),
-            CompletionKind::AfterVisibility => $this->getAfterVisibilityCompletions($prefix, $ast),
-            CompletionKind::ReturnType => $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::ReturnType),
-            CompletionKind::PropertyType => $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Property),
-            CompletionKind::ParameterType => $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Parameter),
+            CompletionKind::New_ => $this->getNewCompletions($prefix, $document),
+            CompletionKind::AfterVisibility => $this->getAfterVisibilityCompletions($prefix, $document),
+            CompletionKind::ReturnType => $this->getTypeHintCompletions(
+                $prefix,
+                $document,
+                TypeHintContext::ReturnType,
+            ),
+            CompletionKind::PropertyType => $this->getTypeHintCompletions(
+                $prefix,
+                $document,
+                TypeHintContext::Property,
+            ),
+            CompletionKind::ParameterType => $this->getTypeHintCompletions(
+                $prefix,
+                $document,
+                TypeHintContext::Parameter,
+            ),
             CompletionKind::ClassBody => $this->filterKeywords(self::KEYWORDS_CLASS_BODY, $prefix),
-            CompletionKind::Expression => $this->getExpressionCompletions($prefix, $ast),
+            CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document, $ast),
             CompletionKind::None => [],
         };
     }
 
     /**
-     * Suggest imported classes and indexed instantiable types after `new`.
+     * Suggest instantiable class names after `new`.
      *
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getNewCompletions(string $prefix, array $ast): array
+    private function getNewCompletions(string $prefix, TextDocument $document): array
     {
-        $items = $this->getImportedClassCompletions($prefix, $ast, instantiableOnly: true);
-        $indexedItems = $this->getIndexedClassCompletions(
-            $prefix,
-            [SymbolKind::Class_, SymbolKind::Enum_],
-            instantiableOnly: true,
+        return $this->deduplicateCompletions(
+            $this->classCandidates->find($prefix, $document, ClassCandidateFilter::Instantiable),
         );
-        $items = array_merge($items, $indexedItems);
-        return $this->deduplicateCompletions($items);
     }
 
     /**
      * Suggest member keywords or a property type after a visibility keyword.
      *
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getAfterVisibilityCompletions(string $prefix, array $ast): array
+    private function getAfterVisibilityCompletions(string $prefix, TextDocument $document): array
     {
         $items = $this->filterKeywords(self::KEYWORDS_AFTER_VISIBILITY, $prefix);
-        $items = array_merge($items, $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Property));
+        $items = array_merge($items, $this->getTypeHintCompletions($prefix, $document, TypeHintContext::Property));
         return $this->deduplicateCompletions($items);
     }
 
@@ -223,17 +223,11 @@ final class CompletionHandler implements HandlerInterface
      * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getExpressionCompletions(string $prefix, array $ast): array
+    private function getExpressionCompletions(string $prefix, TextDocument $document, array $ast): array
     {
         $items = $this->filterKeywords(self::KEYWORDS_ALL, $prefix);
         $items = array_merge($items, $this->getFunctionCompletions($prefix, $ast));
-        $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
-        $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
-            SymbolKind::Class_,
-            SymbolKind::Interface_,
-            SymbolKind::Trait_,
-            SymbolKind::Enum_,
-        ]));
+        $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::Any));
         return $this->deduplicateCompletions($items);
     }
 
@@ -303,102 +297,6 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * Get completions for imported classes (from use statements).
-     *
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function getImportedClassCompletions(
-        string $prefix,
-        array $ast,
-        bool $instantiableOnly = false,
-        bool $typeHintContext = false,
-    ): array {
-        $items = [];
-        $imports = $this->getImports($ast);
-
-        foreach ($imports as $shortName => $fqcn) {
-            if (!self::matchesPrefix($shortName, $prefix)) {
-                continue;
-            }
-            /** @var class-string $fqcn */
-            if ($instantiableOnly && !$this->codeResolver->isInstantiable(new ClassName($fqcn))) {
-                continue;
-            }
-            if ($typeHintContext && !$this->codeResolver->isValidTypeHint(new ClassName($fqcn))) {
-                continue;
-            }
-            $items[] = CompletionItemFactory::forClass($shortName, $fqcn);
-        }
-
-        return $items;
-    }
-
-    /**
-     * Extract all imports from use statements.
-     *
-     * @param array<Stmt> $ast
-     * @return array<string, string> Short name => FQCN
-     */
-    private function getImports(array $ast): array
-    {
-        $imports = [];
-
-        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
-            $this->extractImportsFromUse($stmt, $imports);
-        }
-
-        return $imports;
-    }
-
-    /**
-     * @param array<string, string> $imports
-     */
-    private function extractImportsFromUse(Stmt $stmt, array &$imports): void
-    {
-        if ($stmt instanceof Stmt\Use_) {
-            foreach ($stmt->uses as $use) {
-                $shortName = $use->alias?->toString() ?? $use->name->getLast();
-                $fqcn = $use->name->toString();
-                $imports[$shortName] = $fqcn;
-            }
-        } elseif ($stmt instanceof Stmt\GroupUse) {
-            $prefix = $stmt->prefix->toString();
-            foreach ($stmt->uses as $use) {
-                $shortName = $use->alias?->toString() ?? $use->name->getLast();
-                $fqcn = $prefix . '\\' . $use->name->toString();
-                $imports[$shortName] = $fqcn;
-            }
-        }
-    }
-
-    /**
-     * Get class completions from the workspace symbol index.
-     *
-     * @param list<SymbolKind> $kinds
-     * @return list<CompletionItem>
-     */
-    private function getIndexedClassCompletions(
-        string $prefix,
-        array $kinds,
-        bool $instantiableOnly = false,
-    ): array {
-        $symbols = $this->symbolIndex->findByPrefix($prefix, $kinds);
-        $items = [];
-
-        foreach ($symbols as $symbol) {
-            /** @var class-string $fqcn */
-            $fqcn = $symbol->fullyQualifiedName;
-            if ($instantiableOnly && !$this->codeResolver->isInstantiable(new ClassName($fqcn))) {
-                continue;
-            }
-            $items[] = CompletionItemFactory::forClass($symbol->name, $fqcn);
-        }
-
-        return $items;
-    }
-
-    /**
      * Remove duplicate completions, preferring items that appear earlier.
      *
      * @param list<CompletionItem> $items
@@ -423,10 +321,9 @@ final class CompletionHandler implements HandlerInterface
     /**
      * Get completions for type hint positions.
      *
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getTypeHintCompletions(string $prefix, array $ast, TypeHintContext $context): array
+    private function getTypeHintCompletions(string $prefix, TextDocument $document, TypeHintContext $context): array
     {
         $items = [];
 
@@ -456,15 +353,8 @@ final class CompletionHandler implements HandlerInterface
             }
         }
 
-        // Imported classes (traits are not valid type hints)
-        $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast, typeHintContext: true));
-
-        // Indexed types (traits are not valid type hints)
-        $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
-            SymbolKind::Class_,
-            SymbolKind::Interface_,
-            SymbolKind::Enum_,
-        ]));
+        // Class-likes valid as type hints (traits excluded)
+        $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::TypeHint));
 
         return $this->deduplicateCompletions($items);
     }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -17,6 +17,7 @@ use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\KeywordGroup;
 use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
+use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Protocol\Message;
@@ -42,6 +43,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly ClassCandidates $classCandidates,
         private readonly FunctionCandidates $functionCandidates,
         private readonly KeywordCandidates $keywordCandidates,
+        private readonly VariableCandidates $variableCandidates,
     ) {
     }
 
@@ -140,7 +142,10 @@ final class CompletionHandler implements HandlerInterface
             if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
                 $varPrefix = $matches[1];
             }
-            $items = array_merge($items, $this->getVariableCompletions($varPrefix, $document, $line, $character));
+            $items = array_merge(
+                $items,
+                $this->variableCandidates->find($varPrefix, $document, $line, $character),
+            );
 
             // After named arg colon (value position), also offer expression keywords and classes
             if (preg_match('/\w+:\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
@@ -161,7 +166,7 @@ final class CompletionHandler implements HandlerInterface
         $prefix = $classification->prefix;
 
         return match ($classification->kind) {
-            CompletionKind::Variable => $this->getVariableCompletions($prefix, $document, $line, $character),
+            CompletionKind::Variable => $this->variableCandidates->find($prefix, $document, $line, $character),
             CompletionKind::New_ => $this->getNewCompletions($prefix, $document),
             CompletionKind::AfterVisibility => $this->getAfterVisibilityCompletions($prefix, $document),
             CompletionKind::ReturnType => $this->getTypeHintCompletions(
@@ -318,32 +323,6 @@ final class CompletionHandler implements HandlerInterface
         $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::TypeHint));
 
         return $this->deduplicateCompletions($items);
-    }
-
-    /**
-     * Get variable completions for the current scope.
-     *
-     * @return list<CompletionItem>
-     */
-    private function getVariableCompletions(
-        string $prefix,
-        TextDocument $document,
-        int $line,
-        int $character,
-    ): array {
-        $variables = $this->codeResolver->getVariablesInScope($document, $line, $character);
-
-        $items = [];
-        foreach ($variables as $variable) {
-            if (self::matchesPrefix($variable->getName(), $prefix)) {
-                $items[] = CompletionItemFactory::forVariable(
-                    $variable->getName(),
-                    $variable->getType()?->format() ?? 'mixed',
-                );
-            }
-        }
-
-        return $items;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -12,19 +12,17 @@ use Firehed\PhpLsp\Completion\CompletionItemFactory;
 use Firehed\PhpLsp\Completion\CompletionItemKind;
 use Firehed\PhpLsp\Completion\CompletionKind;
 use Firehed\PhpLsp\Completion\ContextDetector;
+use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Resolution\MemberAccessContext;
 use Firehed\PhpLsp\Resolution\MemberAccessKind;
 use Firehed\PhpLsp\Resolution\MemberFilter;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\CodeResolver;
-use PhpParser\Node\Stmt;
 
 /**
  * @phpstan-import-type CompletionItem from CompletionItemFactory
@@ -38,9 +36,9 @@ final class CompletionHandler implements HandlerInterface
 
     public function __construct(
         private readonly DocumentManager $documentManager,
-        private readonly ParserService $parser,
         private readonly CodeResolver $codeResolver,
         private readonly ClassCandidates $classCandidates,
+        private readonly FunctionCandidates $functionCandidates,
     ) {
     }
 
@@ -93,18 +91,11 @@ final class CompletionHandler implements HandlerInterface
             ];
         }
 
-        $ast = $this->parser->parse($document);
-        if ($ast === null) {
-            // @codeCoverageIgnoreStart
-            throw new \LogicException('Parser returned null with error-collecting handler');
-            // @codeCoverageIgnoreEnd
-        }
-
         // Get text before cursor to determine completion context
         $lineText = $document->getLine($line);
         $textBeforeCursor = substr($lineText, 0, $character);
 
-        $items = $this->getCompletionItems($textBeforeCursor, $document, $ast, $line, $character);
+        $items = $this->getCompletionItems($textBeforeCursor, $document, $line, $character);
 
         // In interpolated strings, only variable completions are valid
         if ($context === CompletionContext::VariablesOnly) {
@@ -121,13 +112,11 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
     private function getCompletionItems(
         string $textBeforeCursor,
         TextDocument $document,
-        array $ast,
         int $line,
         int $character,
     ): array {
@@ -188,7 +177,7 @@ final class CompletionHandler implements HandlerInterface
                 TypeHintContext::Parameter,
             ),
             CompletionKind::ClassBody => $this->filterKeywords(self::KEYWORDS_CLASS_BODY, $prefix),
-            CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document, $ast),
+            CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document),
             CompletionKind::None => [],
         };
     }
@@ -220,13 +209,12 @@ final class CompletionHandler implements HandlerInterface
     /**
      * Suggest keywords, functions, and class names at the start of an expression.
      *
-     * @param array<Stmt> $ast
      * @return list<CompletionItem>
      */
-    private function getExpressionCompletions(string $prefix, TextDocument $document, array $ast): array
+    private function getExpressionCompletions(string $prefix, TextDocument $document): array
     {
         $items = $this->filterKeywords(self::KEYWORDS_ALL, $prefix);
-        $items = array_merge($items, $this->getFunctionCompletions($prefix, $ast));
+        $items = array_merge($items, $this->functionCandidates->find($prefix, $document));
         $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::Any));
         return $this->deduplicateCompletions($items);
     }
@@ -264,36 +252,6 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $items;
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     * @return list<CompletionItem>
-     */
-    private function getFunctionCompletions(string $prefix, array $ast): array
-    {
-        $items = [];
-
-        // User-defined functions in current file
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Function_) {
-                $name = $stmt->name->toString();
-                if (self::matchesPrefix($name, $prefix)) {
-                    $items[] = CompletionItemFactory::forFunction(FunctionInfo::fromNode($stmt));
-                }
-            }
-        }
-
-        // Built-in functions
-        $definedFunctions = get_defined_functions();
-        foreach ($definedFunctions['internal'] as $name) {
-            if (self::matchesPrefix($name, $prefix)) {
-                $items[] = CompletionItemFactory::forBuiltinFunction($name);
-            }
-        }
-
-        // Limit results
-        return array_slice($items, 0, 100);
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -15,16 +15,13 @@ use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\KeywordGroup;
+use Firehed\PhpLsp\Completion\MemberCandidates;
 use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\Resolution\MemberAccessContext;
-use Firehed\PhpLsp\Resolution\MemberAccessKind;
-use Firehed\PhpLsp\Resolution\MemberFilter;
-use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
 /**
@@ -44,6 +41,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly FunctionCandidates $functionCandidates,
         private readonly KeywordCandidates $keywordCandidates,
         private readonly VariableCandidates $variableCandidates,
+        private readonly MemberCandidates $memberCandidates,
     ) {
     }
 
@@ -125,10 +123,10 @@ final class CompletionHandler implements HandlerInterface
         int $line,
         int $character,
     ): array {
-        // Member/static access via SymbolResolver
-        $memberContext = $this->codeResolver->getMemberAccessContext($document, $line, $character);
-        if ($memberContext !== null) {
-            return $this->handleMemberAccessContext($memberContext, $document);
+        // Member/static access (after -> or ::)
+        $memberItems = $this->memberCandidates->find($document, $line, $character);
+        if ($memberItems !== null) {
+            return $memberItems;
         }
 
         // Inside a call context, offer named arguments + variables
@@ -225,41 +223,6 @@ final class CompletionHandler implements HandlerInterface
         $items = array_merge($items, $this->functionCandidates->find($prefix, $document));
         $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::Any));
         return $this->deduplicateCompletions($items);
-    }
-
-    /**
-     * @return list<CompletionItem>
-     */
-    private function handleMemberAccessContext(MemberAccessContext $context, TextDocument $document): array
-    {
-        $items = [];
-        $filter = match ($context->kind) {
-            MemberAccessKind::Instance => MemberFilter::Instance,
-            MemberAccessKind::Static => MemberFilter::Static,
-            MemberAccessKind::Parent => MemberFilter::All,
-        };
-
-        $members = $this->codeResolver->getAccessibleMembers(
-            $document,
-            $context->type,
-            $context->minVisibility,
-            $filter,
-        );
-
-        foreach ($members as $member) {
-            if ($context->kind === MemberAccessKind::Parent && !$member instanceof ResolvedMethod) {
-                continue;
-            }
-            if (self::matchesPrefix($member->getName()->name, $context->prefix)) {
-                $items[] = CompletionItemFactory::forResolvedMember($member);
-            }
-        }
-
-        if ($context->kind === MemberAccessKind::Static && self::matchesPrefix('class', $context->prefix)) {
-            $items[] = CompletionItemFactory::forClassConstant();
-        }
-
-        return $items;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Handler;
 
+use Firehed\PhpLsp\Completion\CompletionClassifier;
 use Firehed\PhpLsp\Completion\CompletionContext;
+use Firehed\PhpLsp\Completion\CompletionKind;
 use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Document\DocumentManager;
@@ -48,9 +50,6 @@ final class CompletionHandler implements HandlerInterface
     private const KIND_KEYWORD = 14;
     private const KIND_ENUM_MEMBER = 20;
     private const KIND_CONSTANT = 21;
-
-    // Matches property type continuations: "private ?", "public int|", "protected Foo&"
-    private const PROPERTY_TYPE_PATTERN = '/(?:public|private|protected)\s+(?:readonly\s+)?(?:\w+\s*)?[?|&]\s*(\w*)$/';
 
     private static function matchesPrefix(string $name, string $prefix): bool
     {
@@ -202,80 +201,73 @@ final class CompletionHandler implements HandlerInterface
             return $this->deduplicateCompletions($items);
         }
 
-        // Variable completion outside call context
-        if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            return $this->getVariableCompletions($matches[1], $document, $line, $character);
-        }
+        // Remaining positions are classified by text before the cursor. Detection
+        // stays text-based so completion keeps working on mid-edit, unparseable code.
+        $classification = CompletionClassifier::classify($textBeforeCursor);
+        $prefix = $classification->prefix;
 
-        // new ClassName completion - suggest imported classes and indexed instantiable types
-        if (preg_match('/new\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            $items = $this->getImportedClassCompletions($prefix, $ast, instantiableOnly: true);
-            $kinds = [SymbolKind::Class_, SymbolKind::Enum_];
-            $indexedItems = $this->getIndexedClassCompletions($prefix, $kinds, instantiableOnly: true);
-            $items = array_merge($items, $indexedItems);
-            return $this->deduplicateCompletions($items);
-        }
+        return match ($classification->kind) {
+            CompletionKind::Variable => $this->getVariableCompletions($prefix, $document, $line, $character),
+            CompletionKind::New_ => $this->getNewCompletions($prefix, $ast),
+            CompletionKind::AfterVisibility => $this->getAfterVisibilityCompletions($prefix, $ast),
+            CompletionKind::ReturnType => $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::ReturnType),
+            CompletionKind::PropertyType => $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Property),
+            CompletionKind::ParameterType => $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Parameter),
+            CompletionKind::ClassBody => $this->filterKeywords(self::KEYWORDS_CLASS_BODY, $prefix),
+            CompletionKind::Expression => $this->getExpressionCompletions($prefix, $ast),
+            CompletionKind::None => [],
+        };
+    }
 
-        // After visibility keyword - suggest function, static, readonly, const, or types
-        // Must check before general type hint context since both patterns overlap
-        if (preg_match('/(?:public|private|protected)\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            $items = $this->filterKeywords(self::KEYWORDS_AFTER_VISIBILITY, $prefix);
-            $items = array_merge($items, $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Property));
-            return $this->deduplicateCompletions($items);
-        }
+    /**
+     * Suggest imported classes and indexed instantiable types after `new`.
+     *
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function getNewCompletions(string $prefix, array $ast): array
+    {
+        $items = $this->getImportedClassCompletions($prefix, $ast, instantiableOnly: true);
+        $indexedItems = $this->getIndexedClassCompletions(
+            $prefix,
+            [SymbolKind::Class_, SymbolKind::Enum_],
+            instantiableOnly: true,
+        );
+        $items = array_merge($items, $indexedItems);
+        return $this->deduplicateCompletions($items);
+    }
 
-        // Return type context - after ): with optional space
-        if (preg_match('/\):\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            return $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::ReturnType);
-        }
+    /**
+     * Suggest member keywords or a property type after a visibility keyword.
+     *
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function getAfterVisibilityCompletions(string $prefix, array $ast): array
+    {
+        $items = $this->filterKeywords(self::KEYWORDS_AFTER_VISIBILITY, $prefix);
+        $items = array_merge($items, $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Property));
+        return $this->deduplicateCompletions($items);
+    }
 
-        // Return type context - nullable/union/intersection (e.g., "): ?", "): int|", "): Foo&")
-        if (preg_match('/\):\s*(?:\?\s*|(?:\w+\s*[|&]\s*)+)(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            return $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::ReturnType);
-        }
-
-        // Property type context - nullable/union/intersection after visibility keyword
-        if (preg_match(self::PROPERTY_TYPE_PATTERN, $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            return $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Property);
-        }
-
-        // Parameter type context - fallback for type positions not matched above
-        // Matches after (, ,, ?, |, & which occur in parameter lists and complex types
-        if (preg_match('/[(,?|&]\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            return $this->getTypeHintCompletions($prefix, $ast, TypeHintContext::Parameter);
-        }
-
-        // Class body context - only class-level keywords, no functions
-        if ($this->isInClassBody($textBeforeCursor)) {
-            if (preg_match('/(?:^|[\s{;])(\w+)$/', $textBeforeCursor, $matches) === 1) {
-                $prefix = $matches[1];
-                return $this->filterKeywords(self::KEYWORDS_CLASS_BODY, $prefix);
-            }
-            return [];
-        }
-
-        // Function/class/keyword completion (at start of expression or after operators)
-        if (preg_match('/(?:^|[(\s=,!&|])(\w+)$/', $textBeforeCursor, $matches) === 1) {
-            $prefix = $matches[1];
-            $items = $this->filterKeywords(self::KEYWORDS_ALL, $prefix);
-            $items = array_merge($items, $this->getFunctionCompletions($prefix, $ast));
-            $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
-            $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
-                SymbolKind::Class_,
-                SymbolKind::Interface_,
-                SymbolKind::Trait_,
-                SymbolKind::Enum_,
-            ]));
-            return $this->deduplicateCompletions($items);
-        }
-
-        return [];
+    /**
+     * Suggest keywords, functions, and class names at the start of an expression.
+     *
+     * @param array<Stmt> $ast
+     * @return list<CompletionItem>
+     */
+    private function getExpressionCompletions(string $prefix, array $ast): array
+    {
+        $items = $this->filterKeywords(self::KEYWORDS_ALL, $prefix);
+        $items = array_merge($items, $this->getFunctionCompletions($prefix, $ast));
+        $items = array_merge($items, $this->getImportedClassCompletions($prefix, $ast));
+        $items = array_merge($items, $this->getIndexedClassCompletions($prefix, [
+            SymbolKind::Class_,
+            SymbolKind::Interface_,
+            SymbolKind::Trait_,
+            SymbolKind::Enum_,
+        ]));
+        return $this->deduplicateCompletions($items);
     }
 
     /**
@@ -621,58 +613,6 @@ final class CompletionHandler implements HandlerInterface
         }
 
         return $items;
-    }
-
-    /**
-     * Check if cursor is inside a class/interface/trait/enum body (but not inside a method).
-     */
-    private function isInClassBody(string $textBeforeCursor): bool
-    {
-        // Count braces to detect if we're inside a class body
-        // This is a heuristic - look for class/interface/trait/enum followed by unbalanced {
-        if (preg_match('/(?:class|interface|trait|enum)\s+\w+/', $textBeforeCursor) !== 1) {
-            return false;
-        }
-
-        // Count brace depth after the class declaration
-        $classPos = strrpos($textBeforeCursor, 'class ');
-        $interfacePos = strrpos($textBeforeCursor, 'interface ');
-        $traitPos = strrpos($textBeforeCursor, 'trait ');
-        $enumPos = strrpos($textBeforeCursor, 'enum ');
-        $lastClassPos = max(
-            $classPos !== false ? $classPos : 0,
-            $interfacePos !== false ? $interfacePos : 0,
-            $traitPos !== false ? $traitPos : 0,
-            $enumPos !== false ? $enumPos : 0,
-        );
-
-        $afterClass = substr($textBeforeCursor, $lastClassPos);
-        $depth = 0;
-        $inString = false;
-        $stringChar = '';
-
-        for ($i = 0; $i < strlen($afterClass); $i++) {
-            $char = $afterClass[$i];
-
-            if ($inString) {
-                if ($char === $stringChar && ($i === 0 || $afterClass[$i - 1] !== '\\')) {
-                    $inString = false;
-                }
-                continue;
-            }
-
-            if ($char === '"' || $char === "'") {
-                $inString = true;
-                $stringChar = $char;
-            } elseif ($char === '{') {
-                $depth++;
-            } elseif ($char === '}') {
-                $depth--;
-            }
-        }
-
-        // depth === 1 means we're directly inside the class body (not in a method)
-        return $depth === 1;
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Handler;
 
+use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
 use Firehed\PhpLsp\Completion\ClassCandidateFilter;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\CompletionClassifier;
@@ -17,7 +18,6 @@ use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\KeywordGroup;
 use Firehed\PhpLsp\Completion\MemberCandidates;
 use Firehed\PhpLsp\Completion\NamedArgumentCandidates;
-use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
@@ -30,11 +30,6 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  */
 final class CompletionHandler implements HandlerInterface
 {
-    private static function matchesPrefix(string $name, string $prefix): bool
-    {
-        return PrefixMatcher::matches($name, $prefix);
-    }
-
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
@@ -44,6 +39,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly VariableCandidates $variableCandidates,
         private readonly MemberCandidates $memberCandidates,
         private readonly NamedArgumentCandidates $namedArgumentCandidates,
+        private readonly BuiltinTypeCandidates $builtinTypeCandidates,
     ) {
     }
 
@@ -255,33 +251,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getTypeHintCompletions(string $prefix, TextDocument $document, TypeHintContext $context): array
     {
-        $items = [];
-
-        // Types valid in all contexts
-        $commonTypes = [
-            'string', 'int', 'float', 'bool', 'array', 'object',
-            'mixed', 'null', 'callable', 'iterable', 'true', 'false',
-        ];
-
-        // Context-specific type validity:
-        // | Type   | Property | Parameter | Return |
-        // |--------|----------|-----------|--------|
-        // | void   | No       | No        | Yes    |
-        // | never  | No       | No        | Yes    |
-        // | self   | No       | Yes       | Yes    |
-        // | static | No       | No        | Yes    |
-        // | parent | No       | Yes       | Yes    |
-        $builtinTypes = match ($context) {
-            TypeHintContext::Property => $commonTypes,
-            TypeHintContext::Parameter => [...$commonTypes, 'self', 'parent'],
-            TypeHintContext::ReturnType => [...$commonTypes, 'void', 'never', 'self', 'static', 'parent'],
-        };
-
-        foreach ($builtinTypes as $type) {
-            if (self::matchesPrefix($type, $prefix)) {
-                $items[] = CompletionItemFactory::forBuiltinType($type);
-            }
-        }
+        $items = $this->builtinTypeCandidates->find($prefix, $context);
 
         // Class-likes valid as type hints (traits excluded)
         $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::TypeHint));

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -13,6 +13,8 @@ use Firehed\PhpLsp\Completion\CompletionItemKind;
 use Firehed\PhpLsp\Completion\CompletionKind;
 use Firehed\PhpLsp\Completion\ContextDetector;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
+use Firehed\PhpLsp\Completion\KeywordCandidates;
+use Firehed\PhpLsp\Completion\KeywordGroup;
 use Firehed\PhpLsp\Completion\PrefixMatcher;
 use Firehed\PhpLsp\Completion\TypeHintContext;
 use Firehed\PhpLsp\Document\DocumentManager;
@@ -39,6 +41,7 @@ final class CompletionHandler implements HandlerInterface
         private readonly CodeResolver $codeResolver,
         private readonly ClassCandidates $classCandidates,
         private readonly FunctionCandidates $functionCandidates,
+        private readonly KeywordCandidates $keywordCandidates,
     ) {
     }
 
@@ -142,7 +145,7 @@ final class CompletionHandler implements HandlerInterface
             // After named arg colon (value position), also offer expression keywords and classes
             if (preg_match('/\w+:\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
                 $prefix = $matches[1];
-                $items = array_merge($items, $this->filterKeywords(self::KEYWORDS_EXPRESSION, $prefix));
+                $items = array_merge($items, $this->keywordCandidates->find($prefix, KeywordGroup::Expression));
                 $items = array_merge(
                     $items,
                     $this->classCandidates->find($prefix, $document, ClassCandidateFilter::Any),
@@ -176,7 +179,7 @@ final class CompletionHandler implements HandlerInterface
                 $document,
                 TypeHintContext::Parameter,
             ),
-            CompletionKind::ClassBody => $this->filterKeywords(self::KEYWORDS_CLASS_BODY, $prefix),
+            CompletionKind::ClassBody => $this->keywordCandidates->find($prefix, KeywordGroup::ClassBody),
             CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document),
             CompletionKind::None => [],
         };
@@ -201,7 +204,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getAfterVisibilityCompletions(string $prefix, TextDocument $document): array
     {
-        $items = $this->filterKeywords(self::KEYWORDS_AFTER_VISIBILITY, $prefix);
+        $items = $this->keywordCandidates->find($prefix, KeywordGroup::AfterVisibility);
         $items = array_merge($items, $this->getTypeHintCompletions($prefix, $document, TypeHintContext::Property));
         return $this->deduplicateCompletions($items);
     }
@@ -213,7 +216,7 @@ final class CompletionHandler implements HandlerInterface
      */
     private function getExpressionCompletions(string $prefix, TextDocument $document): array
     {
-        $items = $this->filterKeywords(self::KEYWORDS_ALL, $prefix);
+        $items = $this->keywordCandidates->find($prefix, KeywordGroup::All);
         $items = array_merge($items, $this->functionCandidates->find($prefix, $document));
         $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::Any));
         return $this->deduplicateCompletions($items);
@@ -315,54 +318,6 @@ final class CompletionHandler implements HandlerInterface
         $items = array_merge($items, $this->classCandidates->find($prefix, $document, ClassCandidateFilter::TypeHint));
 
         return $this->deduplicateCompletions($items);
-    }
-
-    private const KEYWORDS_ALL = [
-        // Control flow
-        'if', 'else', 'elseif', 'switch', 'case', 'default',
-        'while', 'do', 'for', 'foreach', 'break', 'continue',
-        'return', 'throw', 'try', 'catch', 'finally',
-        // Declarations
-        'function', 'class', 'interface', 'trait', 'enum', 'namespace', 'use',
-        'extends', 'implements', 'const', 'public', 'protected', 'private',
-        'static', 'final', 'abstract', 'readonly',
-        // Operators and other
-        'new', 'instanceof', 'clone', 'yield', 'match',
-        'echo', 'print', 'include', 'include_once', 'require', 'require_once',
-        'global', 'unset', 'isset', 'empty', 'list', 'fn',
-    ];
-
-    private const KEYWORDS_CLASS_BODY = [
-        'public', 'private', 'protected',
-        'static', 'final', 'abstract', 'readonly',
-        'const', 'function', 'use',
-    ];
-
-    private const KEYWORDS_AFTER_VISIBILITY = ['function', 'static', 'readonly', 'const'];
-
-    // Keywords valid at the start of an expression (e.g., after `name: ` in named args)
-    private const KEYWORDS_EXPRESSION = [
-        'new', 'clone', 'yield', 'match', 'fn',
-        'isset', 'empty', 'list',
-        'true', 'false', 'null',
-    ];
-
-    /**
-     * @param list<string> $keywords
-     * @return list<CompletionItem>
-     */
-    private function filterKeywords(array $keywords, string $prefix): array
-    {
-        $items = [];
-        $prefixLower = strtolower($prefix);
-
-        foreach ($keywords as $keyword) {
-            if ($prefix === '' || str_starts_with($keyword, $prefixLower)) {
-                $items[] = CompletionItemFactory::forKeyword($keyword);
-            }
-        }
-
-        return $items;
     }
 
     /**

--- a/src/Resolution/CodeResolver.php
+++ b/src/Resolution/CodeResolver.php
@@ -84,4 +84,12 @@ interface CodeResolver
         int $line,
         int $character,
     ): ?CallContext;
+
+    /**
+     * Get class imports (`use` statements) in a document as short name => FQCN.
+     * Used by: Completion
+     *
+     * @return array<string, string>
+     */
+    public function getImports(TextDocument $document): array;
 }

--- a/src/Resolution/CodeResolver.php
+++ b/src/Resolution/CodeResolver.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 
@@ -92,4 +93,12 @@ interface CodeResolver
      * @return array<string, string>
      */
     public function getImports(TextDocument $document): array;
+
+    /**
+     * Get the user-defined functions declared in a document.
+     * Used by: Completion
+     *
+     * @return list<FunctionInfo>
+     */
+    public function getFileFunctions(TextDocument $document): array;
 }

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -565,6 +565,21 @@ final class SymbolResolver implements CodeResolver
     }
 
     /**
+     * @return array<string, string>
+     */
+    public function getImports(TextDocument $document): array
+    {
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            // @codeCoverageIgnoreStart
+            throw new LogicException('Parser returned null');
+            // @codeCoverageIgnoreEnd
+        }
+
+        return ScopeFinder::extractImports($ast);
+    }
+
+    /**
      * @param array<Stmt> $ast
      * @return array{0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_, 1: int, 2: list<string>, 3: int}|null
      */

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -580,6 +580,28 @@ final class SymbolResolver implements CodeResolver
     }
 
     /**
+     * @return list<FunctionInfo>
+     */
+    public function getFileFunctions(TextDocument $document): array
+    {
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            // @codeCoverageIgnoreStart
+            throw new LogicException('Parser returned null');
+            // @codeCoverageIgnoreEnd
+        }
+
+        $functions = [];
+        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
+            if ($stmt instanceof Stmt\Function_) {
+                $functions[] = FunctionInfo::fromNode($stmt);
+            }
+        }
+
+        return $functions;
+    }
+
+    /**
      * @param array<Stmt> $ast
      * @return array{0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_, 1: int, 2: list<string>, 3: int}|null
      */

--- a/src/Server.php
+++ b/src/Server.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp;
 
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
+use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
@@ -90,6 +91,7 @@ final class Server
             $symbolResolver,
             new ClassCandidates($symbolIndex, $symbolResolver),
             new FunctionCandidates($symbolResolver),
+            new KeywordCandidates(),
         );
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp;
 
+use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
@@ -98,6 +99,7 @@ final class Server
             new VariableCandidates($symbolResolver),
             new MemberCandidates($symbolResolver),
             new NamedArgumentCandidates(),
+            new BuiltinTypeCandidates(),
         );
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp;
 
 use Firehed\PhpLsp\Completion\ClassCandidates;
+use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
@@ -86,9 +87,9 @@ final class Server
         );
         $this->handlers[] = new CompletionHandler(
             $this->documentManager,
-            $parser,
             $symbolResolver,
             new ClassCandidates($symbolIndex, $symbolResolver),
+            new FunctionCandidates($symbolResolver),
         );
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp;
 
+use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
@@ -86,8 +87,8 @@ final class Server
         $this->handlers[] = new CompletionHandler(
             $this->documentManager,
             $parser,
-            $symbolIndex,
             $symbolResolver,
+            new ClassCandidates($symbolIndex, $symbolResolver),
         );
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
+use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
@@ -92,6 +93,7 @@ final class Server
             new ClassCandidates($symbolIndex, $symbolResolver),
             new FunctionCandidates($symbolResolver),
             new KeywordCandidates(),
+            new VariableCandidates($symbolResolver),
         );
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\MemberCandidates;
+use Firehed\PhpLsp\Completion\NamedArgumentCandidates;
 use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
@@ -96,6 +97,7 @@ final class Server
             new KeywordCandidates(),
             new VariableCandidates($symbolResolver),
             new MemberCandidates($symbolResolver),
+            new NamedArgumentCandidates(),
         );
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
+use Firehed\PhpLsp\Completion\MemberCandidates;
 use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
@@ -94,6 +95,7 @@ final class Server
             new FunctionCandidates($symbolResolver),
             new KeywordCandidates(),
             new VariableCandidates($symbolResolver),
+            new MemberCandidates($symbolResolver),
         );
     }
 

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -271,6 +271,34 @@ final class ScopeFinder
     }
 
     /**
+     * Extract all class imports from `use` statements as short name => FQCN.
+     *
+     * @param array<Stmt> $ast
+     * @return array<string, string>
+     */
+    public static function extractImports(array $ast): array
+    {
+        $imports = [];
+
+        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
+            if ($stmt instanceof Stmt\Use_) {
+                foreach ($stmt->uses as $use) {
+                    $shortName = $use->alias?->toString() ?? $use->name->getLast();
+                    $imports[$shortName] = $use->name->toString();
+                }
+            } elseif ($stmt instanceof Stmt\GroupUse) {
+                $prefix = $stmt->prefix->toString();
+                foreach ($stmt->uses as $use) {
+                    $shortName = $use->alias?->toString() ?? $use->name->getLast();
+                    $imports[$shortName] = $prefix . '\\' . $use->name->toString();
+                }
+            }
+        }
+
+        return $imports;
+    }
+
+    /**
      * Resolve a simple class name using use statements from AST.
      *
      * Returns the fully qualified name if found in a use statement,
@@ -280,26 +308,7 @@ final class ScopeFinder
      */
     public static function resolveFromUseStatements(string $className, array $ast): ?string
     {
-        foreach (self::iterateTopLevelStatements($ast) as $stmt) {
-            if ($stmt instanceof Stmt\Use_) {
-                foreach ($stmt->uses as $use) {
-                    $alias = $use->alias !== null ? $use->alias->name : $use->name->getLast();
-                    if ($alias === $className) {
-                        return $use->name->toString();
-                    }
-                }
-            } elseif ($stmt instanceof Stmt\GroupUse) {
-                $prefix = $stmt->prefix->toString();
-                foreach ($stmt->uses as $use) {
-                    $alias = $use->alias !== null ? $use->alias->name : $use->name->getLast();
-                    if ($alias === $className) {
-                        return $prefix . '\\' . $use->name->toString();
-                    }
-                }
-            }
-        }
-
-        return null;
+        return self::extractImports($ast)[$className] ?? null;
     }
 
     /**

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Completion;
+
+use Firehed\PhpLsp\Completion\CompletionClassification;
+use Firehed\PhpLsp\Completion\CompletionClassifier;
+use Firehed\PhpLsp\Completion\CompletionKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The classifier consumes the text before the cursor (a line fragment), not a
+ * whole file, so inputs are inline fragments rather than fixtures.
+ */
+#[CoversClass(CompletionClassifier::class)]
+#[CoversClass(CompletionClassification::class)]
+#[CoversClass(CompletionKind::class)]
+class CompletionClassifierTest extends TestCase
+{
+    #[DataProvider('provideClassifications')]
+    public function testClassify(string $textBeforeCursor, CompletionKind $kind, string $prefix): void
+    {
+        $result = CompletionClassifier::classify($textBeforeCursor);
+
+        self::assertSame($kind, $result->kind, 'Classified kind should match');
+        self::assertSame($prefix, $result->prefix, 'Extracted prefix should match');
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, CompletionKind, string}>
+     */
+    public static function provideClassifications(): iterable
+    {
+        yield 'variable with prefix' => ['$fo', CompletionKind::Variable, 'fo'];
+        yield 'variable bare' => ['        $', CompletionKind::Variable, ''];
+
+        yield 'new with prefix' => ['new Fo', CompletionKind::New_, 'Fo'];
+        yield 'new bare' => ['new ', CompletionKind::New_, ''];
+
+        yield 'after private' => ['    private fo', CompletionKind::AfterVisibility, 'fo'];
+        yield 'after public bare' => ['    public ', CompletionKind::AfterVisibility, ''];
+        yield 'after protected bare' => ['    protected ', CompletionKind::AfterVisibility, ''];
+
+        yield 'return type plain' => ['    public function f(): Fo', CompletionKind::ReturnType, 'Fo'];
+        yield 'return type bare' => ['    public function f(): ', CompletionKind::ReturnType, ''];
+        yield 'return type nullable' => ['    public function f(): ?Fo', CompletionKind::ReturnType, 'Fo'];
+        yield 'return type union' => ['    public function f(): int|Fo', CompletionKind::ReturnType, 'Fo'];
+        yield 'return type intersection' => ['    public function f(): Foo&Ba', CompletionKind::ReturnType, 'Ba'];
+
+        yield 'property type nullable' => ['    private ?Fo', CompletionKind::PropertyType, 'Fo'];
+        yield 'property type union' => ['    public int|Fo', CompletionKind::PropertyType, 'Fo'];
+        yield 'property type readonly intersection' => [
+            '    protected readonly Foo&Ba',
+            CompletionKind::PropertyType,
+            'Ba',
+        ];
+        yield 'property type bare nullable' => ['    private ?', CompletionKind::PropertyType, ''];
+
+        yield 'parameter type after paren' => ['    public function f(Fo', CompletionKind::ParameterType, 'Fo'];
+        yield 'parameter type after comma' => ['    public function f(int $a, Ba', CompletionKind::ParameterType, 'Ba'];
+        yield 'parameter type bare paren' => ['    public function f(', CompletionKind::ParameterType, ''];
+        yield 'parameter type nullable' => ['    public function f(?Fo', CompletionKind::ParameterType, 'Fo'];
+
+        yield 'class body member' => ['class Foo { pub', CompletionKind::ClassBody, 'pub'];
+        yield 'interface body member' => ['interface Foo { pub', CompletionKind::ClassBody, 'pub'];
+        yield 'trait body member' => ['trait Foo { pub', CompletionKind::ClassBody, 'pub'];
+        yield 'enum body member' => ['enum Foo { cas', CompletionKind::ClassBody, 'cas'];
+        yield 'class body no word' => ['class Foo { ', CompletionKind::None, ''];
+        yield 'class body brace only' => ['class Foo {', CompletionKind::None, ''];
+        yield 'class body after completed method' => [
+            'class Foo { function a() {} pub',
+            CompletionKind::ClassBody,
+            'pub',
+        ];
+        yield 'class body string with brace' => [
+            'class Foo { const C = "{" ; pub',
+            CompletionKind::ClassBody,
+            'pub',
+        ];
+        yield 'class body string with escaped quote' => [
+            'class Foo { const C = "a\\"b" ; pub',
+            CompletionKind::ClassBody,
+            'pub',
+        ];
+
+        yield 'expression at start' => ['fo', CompletionKind::Expression, 'fo'];
+        yield 'expression after assignment' => ['$x = fo', CompletionKind::Expression, 'fo'];
+        yield 'expression inside method body' => [
+            'class Foo { public function bar() { retur',
+            CompletionKind::Expression,
+            'retur',
+        ];
+
+        yield 'none empty' => ['', CompletionKind::None, ''];
+        yield 'none after member arrow' => ['$foo->', CompletionKind::None, ''];
+        yield 'none after operator no word' => ['1 + ', CompletionKind::None, ''];
+    }
+}

--- a/tests/Completion/PrefixMatcherTest.php
+++ b/tests/Completion/PrefixMatcherTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Completion;
+
+use Firehed\PhpLsp\Completion\PrefixMatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PrefixMatcher::class)]
+class PrefixMatcherTest extends TestCase
+{
+    #[DataProvider('provideMatches')]
+    public function testMatches(string $name, string $prefix, bool $expected): void
+    {
+        self::assertSame($expected, PrefixMatcher::matches($name, $prefix));
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string, bool}>
+     */
+    public static function provideMatches(): iterable
+    {
+        yield 'empty prefix matches anything' => ['getName', '', true];
+        yield 'case-insensitive prefix' => ['getName', 'GET', true];
+        yield 'exact prefix' => ['getName', 'getN', true];
+        yield 'non-matching prefix' => ['getName', 'set', false];
+        yield 'prefix longer than name' => ['id', 'identifier', false];
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
+use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
@@ -70,6 +71,7 @@ class CompletionHandlerTest extends TestCase
             new ClassCandidates($this->symbolIndex, $symbolResolver),
             new FunctionCandidates($symbolResolver),
             new KeywordCandidates(),
+            new VariableCandidates($symbolResolver),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
 use Firehed\PhpLsp\Completion\ClassCandidates;
+use Firehed\PhpLsp\Completion\CompletionItemFactory;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\MemberCandidates;
@@ -34,6 +35,14 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(CompletionHandler::class)]
+#[CoversClass(BuiltinTypeCandidates::class)]
+#[CoversClass(ClassCandidates::class)]
+#[CoversClass(CompletionItemFactory::class)]
+#[CoversClass(FunctionCandidates::class)]
+#[CoversClass(KeywordCandidates::class)]
+#[CoversClass(MemberCandidates::class)]
+#[CoversClass(NamedArgumentCandidates::class)]
+#[CoversClass(VariableCandidates::class)]
 class CompletionHandlerTest extends TestCase
 {
     use OpensDocumentsTrait;

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Completion\ClassCandidates;
+use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
@@ -64,9 +65,9 @@ class CompletionHandlerTest extends TestCase
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
         $this->handler = new CompletionHandler(
             $this->documents,
-            $this->parser,
             $symbolResolver,
             new ClassCandidates($this->symbolIndex, $symbolResolver),
+            new FunctionCandidates($symbolResolver),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
+use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
@@ -68,6 +69,7 @@ class CompletionHandlerTest extends TestCase
             $symbolResolver,
             new ClassCandidates($this->symbolIndex, $symbolResolver),
             new FunctionCandidates($symbolResolver),
+            new KeywordCandidates(),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Handler;
 
+use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
@@ -64,8 +65,8 @@ class CompletionHandlerTest extends TestCase
         $this->handler = new CompletionHandler(
             $this->documents,
             $this->parser,
-            $this->symbolIndex,
             $symbolResolver,
+            new ClassCandidates($this->symbolIndex, $symbolResolver),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
+use Firehed\PhpLsp\Completion\MemberCandidates;
 use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
@@ -72,6 +73,7 @@ class CompletionHandlerTest extends TestCase
             new FunctionCandidates($symbolResolver),
             new KeywordCandidates(),
             new VariableCandidates($symbolResolver),
+            new MemberCandidates($symbolResolver),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\MemberCandidates;
+use Firehed\PhpLsp\Completion\NamedArgumentCandidates;
 use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\CompletionHandler;
@@ -74,6 +75,7 @@ class CompletionHandlerTest extends TestCase
             new KeywordCandidates(),
             new VariableCandidates($symbolResolver),
             new MemberCandidates($symbolResolver),
+            new NamedArgumentCandidates(),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Handler;
 
+use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
@@ -76,6 +77,7 @@ class CompletionHandlerTest extends TestCase
             new VariableCandidates($symbolResolver),
             new MemberCandidates($symbolResolver),
             new NamedArgumentCandidates(),
+            new BuiltinTypeCandidates(),
         );
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -21,6 +21,7 @@ use Firehed\PhpLsp\Resolution\ResolvedFunction;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\IntersectionType;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Resolution\CallContext;
@@ -2066,5 +2067,37 @@ final class SymbolResolverTest extends TestCase
     private static function variableNames(array $variables): array
     {
         return array_map(fn(ResolvedVariable $v) => $v->getName(), $variables);
+    }
+
+    public function testGetImportsIncludesAliasedAndGroupedUses(): void
+    {
+        $uri = $this->openFixture('Namespacing/ImportCompletion.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $imports = $this->resolver->getImports($document);
+
+        self::assertSame(
+            'Fixtures\Namespacing\Models\UserRepository',
+            $imports['Repo'] ?? null,
+            'An aliased import should map the alias to its FQCN',
+        );
+        self::assertArrayHasKey('Post', $imports, 'Group use members should be included');
+        self::assertArrayHasKey('SingletonTrait', $imports, 'Plain imports should be included');
+    }
+
+    public function testGetFileFunctionsFindsNamespacedFunctions(): void
+    {
+        $uri = $this->openFixture('src/Completion/FunctionCompletion.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $names = array_map(
+            static fn(FunctionInfo $fn): string => $fn->name,
+            $this->resolver->getFileFunctions($document),
+        );
+
+        self::assertContains('calculateSum', $names, 'Functions inside a namespace should be found');
+        self::assertContains('getConfig', $names, 'Functions inside a namespace should be found');
     }
 }


### PR DESCRIPTION
Closes #54, closes #289.

Splits `CompletionHandler` (was 761 lines) into a coordinator plus focused completion sources. The original issue predated the `CodeResolver` centralization and text-based fallback work, so its 8-provider-by-context plan would have re-created the M×N problem along the Context×Source axis; #54 has been rewritten to describe this approach.

## Two seams

**Context classification.** The ordering-sensitive regex dispatch is now a single text-based `CompletionClassifier` returning a typed `CompletionKind`. Detection stays text/token-based on purpose — it is the mid-edit resilience layer. This is a live server, and completion must keep working when the parser produces no AST (`CompletionHandlerTest::testCompletionThisInVeryBrokenFile`). Only member/static/call access flow through the AST-first + text-fallback `CodeResolver` path.

**Item sourcing.** Seven `src/Completion/*Candidates` sources (class, function, keyword, variable, member, named-argument, builtin-type), each owning lookup + prefix filter + item construction. Shared primitives: `CompletionItemFactory`, `CompletionItemKind`, `PrefixMatcher`. The handler is now a `classify → dispatch → dedup` coordinator (261 lines) and no longer parses documents.

## Parser-agnostic sources

Imports and file functions moved behind `CodeResolver::getImports` / `getFileFunctions`, so no completion source touches the raw AST. A future tree-sitter parser or a text-fallback for imports is a single central change rather than an edit to every source. `ScopeFinder::extractImports` was added (and `resolveFromUseStatements` now delegates to it, removing a duplicate iteration).

## Extensibility for #298

`ClassCandidates` is filtered by intent (`ClassCandidateFilter`) with a central mapping of index kinds + resolution predicate. Adding context-specific class filtering (e.g. `implements` → interfaces only) is a new enum case + mapping row — no caller or structural change. The behavior itself is intentionally left for a follow-up.

## Behavior

Behavior-preserving, with one strict improvement called out: `getFileFunctions` is namespace-aware, so functions declared inside a `namespace {}` now complete (previously missed). The type-hint class filter was also normalized to apply the same semantic rule to both imports and the index (identical output, uniform logic).

## Notes

- Coverage of the new sources is credited through the existing integration test via `#[CoversClass]`, matching the project's integration-first style; `SymbolResolver::getImports` / `getFileFunctions` got dedicated unit tests.
- Docs updated (`CLAUDE.md`, `docs/features/completion.md`) to describe the coordinator/source architecture and the text-based-detection invariant.

