### PR TITLE
Complete interfaces after `interface X extends`

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -14,6 +14,7 @@ This document tracks the current state of code completion in php-lsp.
 | Function calls | identifier at expression start | Built-in PHP functions + file-local functions | ✅ Working |
 | Keywords | `fore` → `foreach` | Context-aware PHP keywords (statement/expression start, class body, after visibility) | ✅ Working |
 | `implements` list | `class Foo implements Ba` | Interfaces only (from imports + workspace index); classes, traits, and functions excluded | ✅ Working |
+| `interface … extends` list | `interface Foo extends Ba` | Interfaces only (from imports + workspace index); distinguished from `class … extends` by the `interface` keyword | ✅ Working |
 
 All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
@@ -49,7 +50,7 @@ CompletionHandler (coordinator)
 │                                         + ClassCandidates (any)
 └── CompletionClassifier (text-based) → typed CompletionKind, dispatched to:
       ├── VariableCandidates          → $var
-      ├── ClassCandidates             → new X / expression / type hints / implements (by ClassCandidateFilter)
+      ├── ClassCandidates             → new X / expression / type hints / implements + interface extends (by ClassCandidateFilter)
       ├── FunctionCandidates          → user-defined + built-in functions
       ├── KeywordCandidates           → keywords (by KeywordGroup)
       └── BuiltinTypeCandidates       → built-in type hints

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -42,6 +42,14 @@ final class CompletionClassifier
             return new CompletionClassification(CompletionKind::InterfaceList, $matches[1]);
         }
 
+        // interface X extends list - interfaces only (an interface may extend many).
+        // The literal `interface` keyword distinguishes this from `class X extends`,
+        // which resolves to a single class. Like implements, the comma-list form must
+        // be checked before the parameter-type fallback.
+        if (preg_match('/\binterface\s+\w+\s+extends\s+(?:[\w\\\\]+\s*,\s*)*(\w*)$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::InterfaceList, $matches[1]);
+        }
+
         // After visibility keyword - keywords or property type.
         // Must check before the general type hint fallback since both patterns overlap.
         if (preg_match('/(?:public|private|protected)\s+(\w*)$/', $textBeforeCursor, $matches) === 1) {

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -24,6 +24,9 @@ final class CompletionClassifier
     // Matches property type continuations: "private ?", "public int|", "protected Foo&"
     private const PROPERTY_TYPE_PATTERN = '/(?:public|private|protected)\s+(?:readonly\s+)?(?:\w+\s*)?[?|&]\s*(\w*)$/';
 
+    // Matches an "interface X extends …" list (single or comma-separated).
+    private const INTERFACE_EXTENDS_PATTERN = '/\binterface\s+\w+\s+extends\s+(?:[\w\\\\]+\s*,\s*)*(\w*)$/';
+
     public static function classify(string $textBeforeCursor): CompletionClassification
     {
         // Variable completion
@@ -46,7 +49,7 @@ final class CompletionClassifier
         // The literal `interface` keyword distinguishes this from `class X extends`,
         // which resolves to a single class. Like implements, the comma-list form must
         // be checked before the parameter-type fallback.
-        if (preg_match('/\binterface\s+\w+\s+extends\s+(?:[\w\\\\]+\s*,\s*)*(\w*)$/', $textBeforeCursor, $matches) === 1) {
+        if (preg_match(self::INTERFACE_EXTENDS_PATTERN, $textBeforeCursor, $matches) === 1) {
             return new CompletionClassification(CompletionKind::InterfaceList, $matches[1]);
         }
 

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -91,6 +91,26 @@ class CompletionClassifierTest extends TestCase
         yield 'implements bare' => ['class Foo implements ', CompletionKind::InterfaceList, ''];
         yield 'implements list continuation' => ['class Foo implements A, My', CompletionKind::InterfaceList, 'My'];
 
+        yield 'interface extends with prefix' => [
+            'interface Foo extends My',
+            CompletionKind::InterfaceList,
+            'My',
+        ];
+        yield 'interface extends bare' => ['interface Foo extends ', CompletionKind::InterfaceList, ''];
+        yield 'interface extends list continuation' => [
+            'interface Foo extends A, My',
+            CompletionKind::InterfaceList,
+            'My',
+        ];
+
+        // `class X extends` resolves to a single class, not an interface list, so it
+        // must not match the interface-extends pattern (issue #312).
+        yield 'class extends is not an interface list' => [
+            'class Foo extends Ba',
+            CompletionKind::Expression,
+            'Ba',
+        ];
+
         yield 'expression at start' => ['fo', CompletionKind::Expression, 'fo'];
         yield 'expression after assignment' => ['$x = fo', CompletionKind::Expression, 'fo'];
         yield 'expression inside method body' => [

--- a/tests/Fixtures/src/Completion/InterfaceExtendsCompletion.php
+++ b/tests/Fixtures/src/Completion/InterfaceExtendsCompletion.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\Entity;
+use Fixtures\Domain\User;
+use Fixtures\Traits\SingletonTrait;
+
+interface InterfaceExtendsCompletion extends /*|interface_extends_empty*/
+{
+}

--- a/tests/Fixtures/src/Completion/InterfaceExtendsCompletion.php
+++ b/tests/Fixtures/src/Completion/InterfaceExtendsCompletion.php
@@ -6,6 +6,7 @@ namespace Fixtures\Completion;
 
 use Fixtures\Domain\Entity;
 use Fixtures\Domain\User;
+use Fixtures\Enum\Status;
 use Fixtures\Traits\SingletonTrait;
 
 interface InterfaceExtendsCompletion extends /*|interface_extends_empty*/

--- a/tests/Fixtures/src/Completion/InterfaceExtendsListCompletion.php
+++ b/tests/Fixtures/src/Completion/InterfaceExtendsListCompletion.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\Describable;
+use Fixtures\Domain\Entity;
+
+interface InterfaceExtendsListCompletion extends Entity, D/*|interface_extends_list*/
+{
+}

--- a/tests/Fixtures/src/Completion/InterfaceExtendsPrefixCompletion.php
+++ b/tests/Fixtures/src/Completion/InterfaceExtendsPrefixCompletion.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\Describable;
+
+interface InterfaceExtendsPrefixCompletion extends D/*|interface_extends_d_prefix*/
+{
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2680,6 +2680,81 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testInterfaceExtendsContextOffersOnlyInterfaces(): void
+    {
+        $cursor = $this->openFixtureAtCursor(
+            'src/Completion/InterfaceExtendsCompletion.php',
+            'interface_extends_empty',
+        );
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('Entity', $labels, 'Imported interfaces are valid in an interface extends list');
+        self::assertNotContains('User', $labels, 'An interface cannot extend a class');
+        self::assertNotContains('SingletonTrait', $labels, 'An interface cannot extend a trait');
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'Functions must not leak into an interface extends list (issue #312)',
+        );
+        self::assertNotContains(
+            CompletionItemKind::Keyword->value,
+            $kinds,
+            'Keywords must not leak into an interface extends list',
+        );
+    }
+
+    public function testInterfaceExtendsWithPrefixOffersInterfaceNotFunctions(): void
+    {
+        // Mirrors the #298 report for the extends position: `extends D` must offer the
+        // in-scope interface starting with `D`, not built-in `date_*` functions.
+        $cursor = $this->openFixtureAtCursor(
+            'src/Completion/InterfaceExtendsPrefixCompletion.php',
+            'interface_extends_d_prefix',
+        );
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('Describable', $labels, 'An in-scope interface starting with D should be offered');
+        self::assertNotContains('date_add', $labels, 'Built-in functions must not be offered in an extends list');
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'No function should be offered in an interface extends list (issue #312)',
+        );
+    }
+
+    public function testInterfaceExtendsListContinuationOffersInterfaces(): void
+    {
+        // The comma-list form: an interface may extend several interfaces.
+        $cursor = $this->openFixtureAtCursor(
+            'src/Completion/InterfaceExtendsListCompletion.php',
+            'interface_extends_list',
+        );
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains(
+            'Describable',
+            $labels,
+            'Interfaces are valid after a comma in an interface extends list',
+        );
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'Functions must not leak into a comma-separated interface extends list (issue #312)',
+        );
+    }
+
     public function testImplementsAcrossMultipleLinesOffersInterfaces(): void
     {
         self::markTestSkipped(

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2693,6 +2693,7 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('Entity', $labels, 'Imported interfaces are valid in an interface extends list');
         self::assertNotContains('User', $labels, 'An interface cannot extend a class');
         self::assertNotContains('SingletonTrait', $labels, 'An interface cannot extend a trait');
+        self::assertNotContains('Status', $labels, 'An interface cannot extend an enum');
 
         $kinds = array_column($result['items'], 'kind');
         self::assertNotContains(


### PR DESCRIPTION
Closes #312.

## What

`interface Foo extends <cursor>` now completes **interfaces only** — from `use` imports and the workspace index — mirroring the `implements` behavior added in #309. Single and comma-list forms are both handled (an interface may extend many).

## How

Built directly on the #309 foundation; the machinery already existed:

- `CompletionClassifier` — one new regex (`INTERFACE_EXTENDS_PATTERN`) → `CompletionKind::InterfaceList`, placed right after the `implements` check so the comma-list form is caught before the parameter-type fallback (same reasoning as `implements`).
- Dispatch, `CompletionKind::InterfaceList`, and `ClassCandidateFilter::Interface_` were all already in place — no new enum case, `CodeResolver` predicate, or handler edit required.

The literal `interface` keyword in the pattern distinguishes this from `class X extends …`, which resolves to a single class and is intentionally left as expression completion.

## Tests

- `CompletionClassifierTest` — single / bare / comma-list classification, plus a guard that `class Foo extends Ba` stays `Expression`.
- `CompletionHandlerTest` — three integration cases: imported interfaces offered while classes/traits/keywords/functions are not; the `extends D` report (interface offered, `date_*` excluded); and the comma-list continuation form.

## Out of scope

Tracked centrally: wrapped/multi-line detection (#310) and built-in / cross-namespace sourcing (#308).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
