### PR TITLE
Unify constructor-callable resolution into one helper

### DIFF
--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -1155,8 +1155,18 @@ final class SymbolResolver implements CodeResolver
             return null;
         }
 
+        return $this->resolveConstructorCallable(new ClassName($classNameStr));
+    }
+
+    /**
+     * Resolve a class's constructor to a callable. Shared by `new X(...)` and
+     * attribute usages `#[X(...)]`, which are both constructor calls on the class.
+     * Uses private visibility so promoted/private constructors are found.
+     */
+    private function resolveConstructorCallable(ClassName $className): ?ResolvedCallable
+    {
         $methodInfo = $this->memberResolver->findMethod(
-            new ClassName($classNameStr),
+            $className,
             new MethodName('__construct'),
             Visibility::Private,
         );
@@ -1472,20 +1482,12 @@ final class SymbolResolver implements CodeResolver
     private function resolveAttributeNamedArgument(Identifier $node, Attribute $attribute): ?ResolvedParameter
     {
         $classNameStr = ScopeFinder::resolveClassName($attribute->name);
-        $className = new ClassName($classNameStr);
 
-        // Resolve constructor of attribute class
-        $methodInfo = $this->memberResolver->findMethod(
-            $className,
-            new MethodName('__construct'),
-            Visibility::Private,
-        );
-
-        if ($methodInfo === null) {
+        $callable = $this->resolveConstructorCallable(new ClassName($classNameStr));
+        if ($callable === null) {
             return null;
         }
 
-        $callable = new ResolvedMethod($methodInfo);
         $paramInfo = $callable->getParameterByName($node->toString());
         if ($paramInfo === null) {
             return null;


### PR DESCRIPTION
Closes #322.

## What

Extract `SymbolResolver::resolveConstructorCallable(ClassName): ?ResolvedCallable` and
route both constructor-call resolvers through it:

- `resolveNewCallable` (`new X(...)`)
- `resolveAttributeNamedArgument` (`#[X(...)]` point queries)

Both previously did the same `findMethod(__construct, Private)` → `new ResolvedMethod`;
now there is one notion of "a class's constructor as a callable." Each caller keeps only
its node-specific class-name extraction.

## Why

Removes a latent M×N seam (each new callable-shaped node risked another copy) and
unblocks #321, which will add `Attribute` as a `getCallContext` node routed through this
same helper rather than introducing a third constructor resolver.

## Behavior

No change. Covered by the existing `new`, attribute-resolution, and signature-help tests
(green, unchanged count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
