### PR TITLE
Complete named arguments and signature help inside attributes

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -16,6 +16,7 @@ This document tracks the current state of code completion in php-lsp.
 | `implements` list | `class Foo implements Ba` | Interfaces only (from imports + workspace index); classes, traits, and functions excluded | ✅ Working |
 | `interface … extends` list | `interface Foo extends Ba` | Interfaces only (from imports + workspace index); distinguished from `class … extends` by the `interface` keyword | ✅ Working |
 | Attribute position | `#[Ro` | Attribute classes only (from imports + workspace index); classes, interfaces, traits, enums, and functions excluded. Grouped (`#[A, Ba`) supported; target-aware filtering is not yet (#252) | ✅ Working |
+| Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
 
 All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -631,12 +631,17 @@ final class SymbolResolver implements CodeResolver
 
     /**
      * @param array<Stmt> $ast
-     * @return array{0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_, 1: int, 2: list<string>, 3: int}|null
+     * @return array{
+     *   0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|Attribute,
+     *   1: int,
+     *   2: list<string>,
+     *   3: int,
+     * }|null
      */
     private function findCallAtPosition(array $ast, int $offset): ?array
     {
         $finder = new class ($offset) extends NodeVisitorAbstract {
-            public FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|null $found = null;
+            public FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|Attribute|null $found = null;
             public int $activeParameter = 0;
             /** @var list<string> */
             public array $usedNames = [];
@@ -654,6 +659,7 @@ final class SymbolResolver implements CodeResolver
                     && !$node instanceof NullsafeMethodCall
                     && !$node instanceof StaticCall
                     && !$node instanceof New_
+                    && !$node instanceof Attribute
                 ) {
                     return null;
                 }
@@ -711,7 +717,12 @@ final class SymbolResolver implements CodeResolver
      * Handles incomplete code where the parser couldn't create proper call nodes.
      *
      * @param array<Stmt> $ast
-     * @return array{0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_, 1: int, 2: list<string>, 3: int}|null
+     * @return array{
+     *   0: FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|Attribute,
+     *   1: int,
+     *   2: list<string>,
+     *   3: int,
+     * }|null
      */
     private function findCallFromText(array $ast, int $offset, string $content, int $line): ?array
     {
@@ -764,15 +775,22 @@ final class SymbolResolver implements CodeResolver
      * Parse call pattern from text before opening paren.
      *
      * @param array<Stmt> $ast
-     * @return FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|null
+     * @return FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|Attribute|null
      */
     private function parseCallPattern(
         string $textBeforeParen,
         array $ast,
         int $line,
         string $content,
-    ): FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|null {
+    ): FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|Attribute|null {
         $text = rtrim($textBeforeParen);
+
+        // Attribute: #[AttributeName — a constructor call on the attribute class.
+        // Checked before the function-call catch-all, which would match the name.
+        if (preg_match('/#\[\s*(?:[\w\\\\]+\s*,\s*)*([A-Za-z_\\\\][A-Za-z0-9_\\\\]*)\s*$/', $text, $m) === 1) {
+            $name = $this->resolveNameFromText($m[1], $ast, $line);
+            return new Attribute($name);
+        }
 
         // Static call: ClassName::methodName
         if (preg_match('/([A-Za-z_\\\\][A-Za-z0-9_\\\\]*)::(\w+)\s*$/', $text, $m) === 1) {
@@ -954,11 +972,11 @@ final class SymbolResolver implements CodeResolver
     }
 
     /**
-     * @param FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_ $call
+     * @param FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|Attribute $call
      * @param array<Stmt> $ast
      */
     private function resolveCallable(
-        FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_ $call,
+        FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_|Attribute $call,
         array $ast,
     ): ?ResolvedCallable {
         if ($call instanceof FuncCall) {
@@ -971,6 +989,11 @@ final class SymbolResolver implements CodeResolver
 
         if ($call instanceof StaticCall) {
             return $this->resolveStaticCallCallable($call);
+        }
+
+        // An attribute usage `#[X(...)]` is a constructor call on the attribute class.
+        if ($call instanceof Attribute) {
+            return $this->resolveConstructorCallable(new ClassName(ScopeFinder::resolveClassName($call->name)));
         }
 
         // New_ - resolve constructor

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -1155,8 +1155,18 @@ final class SymbolResolver implements CodeResolver
             return null;
         }
 
+        return $this->resolveConstructorCallable(new ClassName($classNameStr));
+    }
+
+    /**
+     * Resolve a class's constructor to a callable. Shared by `new X(...)` and
+     * attribute usages `#[X(...)]`, which are both constructor calls on the class.
+     * Uses private visibility so promoted/private constructors are found.
+     */
+    private function resolveConstructorCallable(ClassName $className): ?ResolvedCallable
+    {
         $methodInfo = $this->memberResolver->findMethod(
-            new ClassName($classNameStr),
+            $className,
             new MethodName('__construct'),
             Visibility::Private,
         );
@@ -1472,20 +1482,12 @@ final class SymbolResolver implements CodeResolver
     private function resolveAttributeNamedArgument(Identifier $node, Attribute $attribute): ?ResolvedParameter
     {
         $classNameStr = ScopeFinder::resolveClassName($attribute->name);
-        $className = new ClassName($classNameStr);
 
-        // Resolve constructor of attribute class
-        $methodInfo = $this->memberResolver->findMethod(
-            $className,
-            new MethodName('__construct'),
-            Visibility::Private,
-        );
-
-        if ($methodInfo === null) {
+        $callable = $this->resolveConstructorCallable(new ClassName($classNameStr));
+        if ($callable === null) {
             return null;
         }
 
-        $callable = new ResolvedMethod($methodInfo);
         $paramInfo = $callable->getParameterByName($node->toString());
         if ($paramInfo === null) {
             return null;

--- a/tests/Fixtures/src/Completion/AttributeNamedArguments.php
+++ b/tests/Fixtures/src/Completion/AttributeNamedArguments.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Attributes\Route;
+
+class AttributeNamedArguments
+{
+    #[Route(/*|attr_arg_empty*/)]
+    public function emptyArgs(): void
+    {
+    }
+
+    #[Route('/x', /*|attr_arg_second*/)]
+    public function afterPositional(): void
+    {
+    }
+}

--- a/tests/Fixtures/src/Completion/AttributeNamedArgumentsIncomplete.php
+++ b/tests/Fixtures/src/Completion/AttributeNamedArgumentsIncomplete.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Attributes\Route;
+
+class AttributeNamedArgumentsIncomplete
+{
+    #[Route(/*|attr_arg_incomplete*/
+    public function trigger(): void
+    {
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2223,6 +2223,32 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('active:', $labels);
     }
 
+    public function testAttributeNamedArgumentCompletion(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/AttributeNamedArguments.php', 'attr_arg_empty');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('path:', $labels, 'Attribute constructor named arguments are offered');
+        self::assertContains('method:', $labels, 'Attribute constructor named arguments are offered');
+    }
+
+    public function testAttributeNamedArgumentCompletionAfterPositional(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/AttributeNamedArguments.php', 'attr_arg_second');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertNotContains('path:', $labels, 'The first parameter is already filled positionally');
+        self::assertContains('method:', $labels, 'Remaining named arguments are still offered');
+    }
+
     public function testNamedArgumentCompletionAfterPositional(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/NamedArguments.php', 'after_positional');

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -126,6 +126,17 @@ class SignatureHelpHandlerTest extends TestCase
         self::assertStringContainsString('int $score', $result['signatures'][0]['label']);
     }
 
+    public function testSignatureHelpOnAttribute(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/AttributeNamedArguments.php', 'attr_arg_empty');
+        $result = $this->handler->handle($this->signatureHelpRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertStringContainsString('string $path', $result['signatures'][0]['label']);
+        self::assertEquals(0, $result['activeParameter']);
+    }
+
     public function testSignatureHelpOnSelfStaticMethod(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Domain/User.php', 'sig_self_call');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -1471,6 +1471,23 @@ final class SymbolResolverTest extends TestCase
         self::assertStringContainsString('multipleParams', $context->callable->format());
     }
 
+    public function testGetCallContextForAttribute(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $cursor = $this->openFixtureAtCursor('src/Completion/AttributeNamedArguments.php', 'attr_arg_empty');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getCallContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(CallContext::class, $context, 'An attribute is a constructor call');
+        self::assertStringContainsString('__construct', $context->callable->format());
+        self::assertNotNull(
+            $context->callable->getParameterByName('path'),
+            'The attribute constructor parameters are resolved',
+        );
+    }
+
     public function testGetCallContextForIncompleteCode(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/NamedArguments.php', 'incomplete_with_prefix');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -1488,6 +1488,22 @@ final class SymbolResolverTest extends TestCase
         );
     }
 
+    public function testGetCallContextForIncompleteAttribute(): void
+    {
+        $this->openFixture('src/Attributes/Route.php');
+        $cursor = $this->openFixtureAtCursor(
+            'src/Completion/AttributeNamedArgumentsIncomplete.php',
+            'attr_arg_incomplete',
+        );
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getCallContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(CallContext::class, $context, 'Call context resolves inside an unclosed #[X(');
+        self::assertStringContainsString('__construct', $context->callable->format());
+    }
+
     public function testGetCallContextForIncompleteCode(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/NamedArguments.php', 'incomplete_with_prefix');


### PR DESCRIPTION
Closes #321.

## What

Named-argument completion and signature help now work inside an attribute's argument
list: `#[Route(|)]` offers `path:` / `method:` and shows the constructor signature.

## How

An attribute usage is a constructor call on the attribute class, so this is a new
*entry point* into the existing single `getCallContext` chokepoint — not a parallel
path. Both consumers (`CompletionHandler` named args, `SignatureHelpHandler`) light up
from one change:

- Add `PhpParser\Node\Attribute` to the `getCallContext` finder and `resolveCallable`,
  resolving it via the shared `resolveConstructorCallable` (no third constructor
  resolver).
- Add a text-fallback pattern for the incomplete `#[X(` case (parser error recovery does
  not produce a usable node there — confirmed by a failing test before the fallback was
  added), synthesizing an `Attribute` node routed through the same arm.

## Tests

- Resolver: `getCallContext` inside a complete `#[Route(…)]` and an unclosed `#[Route(`.
- Completion: named args offered inside `#[Route(|)]`; after a positional arg, the
  filled parameter drops out.
- Signature help: constructor signature + active parameter inside the attribute.
