### PR TITLE
Complete extendable classes after class X extends

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -15,6 +15,7 @@ This document tracks the current state of code completion in php-lsp.
 | Keywords | `fore` → `foreach` | Context-aware PHP keywords (statement/expression start, class body, after visibility) | ✅ Working |
 | `implements` list | `class Foo implements Ba` | Interfaces only (from imports + workspace index); classes, traits, and functions excluded | ✅ Working |
 | `interface … extends` list | `interface Foo extends Ba` | Interfaces only (from imports + workspace index); distinguished from `class … extends` by the `interface` keyword | ✅ Working |
+| `class … extends` | `class Foo extends Ba` | Extendable (non-final) classes only (from imports + workspace index); final classes, interfaces, traits, enums, and functions excluded | ✅ Working |
 | Attribute position | `#[Ro` | Attribute classes only (from imports + workspace index); classes, interfaces, traits, enums, and functions excluded. Grouped (`#[A, Ba`) supported; target-aware filtering is not yet (#252) | ✅ Working |
 | Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
 
@@ -52,7 +53,7 @@ CompletionHandler (coordinator)
 │                                         + ClassCandidates (any)
 └── CompletionClassifier (text-based) → typed CompletionKind, dispatched to:
       ├── VariableCandidates          → $var
-      ├── ClassCandidates             → new X / expression / type hints / implements + interface extends / attributes (by ClassCandidateFilter)
+      ├── ClassCandidates             → new X / expression / type hints / implements + extends / attributes (by ClassCandidateFilter)
       ├── FunctionCandidates          → user-defined + built-in functions
       ├── KeywordCandidates           → keywords (by KeywordGroup)
       └── BuiltinTypeCandidates       → built-in type hints

--- a/src/Completion/ClassCandidateFilter.php
+++ b/src/Completion/ClassCandidateFilter.php
@@ -27,6 +27,9 @@ enum ClassCandidateFilter
     /** Only interfaces (e.g. after `implements`) */
     case Interface_;
 
+    /** Only extendable classes: non-final classes (e.g. after `class X extends`) */
+    case ExtendableClass;
+
     /** Only attribute classes (e.g. in a `#[...]` position) */
     case Attribute;
 }

--- a/src/Completion/ClassCandidates.php
+++ b/src/Completion/ClassCandidates.php
@@ -92,6 +92,7 @@ final class ClassCandidates
             ClassCandidateFilter::Instantiable => $this->codeResolver->isInstantiable($className),
             ClassCandidateFilter::TypeHint => $this->codeResolver->isValidTypeHint($className),
             ClassCandidateFilter::Interface_ => $this->codeResolver->isInterface($className),
+            ClassCandidateFilter::ExtendableClass => $this->codeResolver->isExtendableClass($className),
             ClassCandidateFilter::Attribute => $this->codeResolver->isAttribute($className),
         };
     }
@@ -119,6 +120,10 @@ final class ClassCandidates
             ],
             ClassCandidateFilter::Interface_ => [
                 SymbolKind::Interface_,
+            ],
+            // A class extends exactly one class; isExtendableClass excludes final ones.
+            ClassCandidateFilter::ExtendableClass => [
+                SymbolKind::Class_,
             ],
             // Attributes are always classes; isAttribute narrows further per candidate.
             ClassCandidateFilter::Attribute => [

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -27,6 +27,10 @@ final class CompletionClassifier
     // Matches an "interface X extends …" list (single or comma-separated).
     private const INTERFACE_EXTENDS_PATTERN = '/\binterface\s+\w+\s+extends\s+(?:[\w\\\\]+\s*,\s*)*(\w*)$/';
 
+    // Matches a "class X extends …" clause. A class extends exactly one class, so
+    // there is no comma-list form.
+    private const CLASS_EXTENDS_PATTERN = '/\bclass\s+\w+\s+extends\s+(\w*)$/';
+
     // Matches an attribute-name position: "#[", including grouped attributes
     // ("#[Foo, Ba", "#[Foo(1), Ba"). It deliberately does not match inside an
     // attribute's own argument list ("#[Foo(Ba"), which is a value position.
@@ -63,6 +67,12 @@ final class CompletionClassifier
         // be checked before the parameter-type fallback.
         if (preg_match(self::INTERFACE_EXTENDS_PATTERN, $textBeforeCursor, $matches) === 1) {
             return new CompletionClassification(CompletionKind::InterfaceList, $matches[1]);
+        }
+
+        // class X extends - a single extendable class. The literal `class` keyword
+        // and lack of a comma-list distinguish this from `interface X extends`.
+        if (preg_match(self::CLASS_EXTENDS_PATTERN, $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::ExtendableClass, $matches[1]);
         }
 
         // After visibility keyword - keywords or property type.

--- a/src/Completion/CompletionKind.php
+++ b/src/Completion/CompletionKind.php
@@ -36,6 +36,9 @@ enum CompletionKind
     /** In an `implements` list, e.g. `class Foo implements Ba` — interfaces only */
     case InterfaceList;
 
+    /** After `class X extends`, e.g. `class Foo extends Ba` — extendable classes only */
+    case ExtendableClass;
+
     /** In an attribute position, e.g. `#[Ba` — attribute classes only */
     case Attribute;
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -184,6 +184,11 @@ final class CompletionHandler implements HandlerInterface
                 $document,
                 ClassCandidateFilter::Interface_,
             ),
+            CompletionKind::ExtendableClass => $this->classCandidates->find(
+                $prefix,
+                $document,
+                ClassCandidateFilter::ExtendableClass,
+            ),
             CompletionKind::Attribute => $this->classCandidates->find(
                 $prefix,
                 $document,

--- a/src/Resolution/CodeResolver.php
+++ b/src/Resolution/CodeResolver.php
@@ -60,6 +60,12 @@ interface CodeResolver
     public function isInterface(ClassName $className): bool;
 
     /**
+     * Check if a class-like can be extended by a class (e.g. valid after
+     * `class X extends`). True for non-final classes, abstract included.
+     */
+    public function isExtendableClass(ClassName $className): bool;
+
+    /**
      * Check if a class is a PHP attribute (e.g. valid in a `#[...]` position).
      */
     public function isAttribute(ClassName $className): bool;

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -228,6 +228,21 @@ final class SymbolResolver implements CodeResolver
     }
 
     /**
+     * Check if a class-like can be extended by a class.
+     * True for non-final classes (abstract included); false for final classes,
+     * interfaces, traits, enums, and unknown classes: an extends clause must
+     * only offer confirmed base classes.
+     */
+    public function isExtendableClass(ClassName $className): bool
+    {
+        $classInfo = $this->classRepository->get($className);
+        if ($classInfo === null) {
+            return false;
+        }
+        return $classInfo->kind === ClassKind::Class_ && !$classInfo->isFinal;
+    }
+
+    /**
      * Check if a class is a PHP attribute.
      * Returns false for unknown classes: an attribute position must only offer
      * confirmed attributes.

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -116,11 +116,17 @@ class CompletionClassifierTest extends TestCase
             'Ro',
         ];
 
-        // `class X extends` resolves to a single class, not an interface list, so it
-        // must not match the interface-extends pattern (issue #312).
-        yield 'class extends is not an interface list' => [
+        // `class X extends` resolves to a single extendable class, distinct from the
+        // interface-extends list (issues #312, #313).
+        yield 'class extends with prefix' => [
             'class Foo extends Ba',
-            CompletionKind::Expression,
+            CompletionKind::ExtendableClass,
+            'Ba',
+        ];
+        yield 'class extends bare' => ['class Foo extends ', CompletionKind::ExtendableClass, ''];
+        yield 'abstract class extends with prefix' => [
+            'abstract class Foo extends Ba',
+            CompletionKind::ExtendableClass,
             'Ba',
         ];
 

--- a/tests/Fixtures/src/Completion/ClassExtendsCompletion.php
+++ b/tests/Fixtures/src/Completion/ClassExtendsCompletion.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\Entity;
+use Fixtures\Enum\Status;
+use Fixtures\Inheritance\FinalDescendant;
+use Fixtures\Inheritance\ParentClass;
+use Fixtures\Traits\SingletonTrait;
+
+class ClassExtendsCompletion extends /*|class_extends_empty*/
+{
+}

--- a/tests/Fixtures/src/Completion/ClassExtendsPrefixCompletion.php
+++ b/tests/Fixtures/src/Completion/ClassExtendsPrefixCompletion.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Inheritance\ParentClass;
+
+class ClassExtendsPrefixCompletion extends P/*|class_extends_p_prefix*/
+{
+}

--- a/tests/Fixtures/src/Inheritance/FinalDescendant.php
+++ b/tests/Fixtures/src/Inheritance/FinalDescendant.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Inheritance;
+
+final class FinalDescendant extends ParentClass
+{
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2873,6 +2873,58 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testClassExtendsContextOffersOnlyExtendableClasses(): void
+    {
+        $cursor = $this->openFixtureAtCursor(
+            'src/Completion/ClassExtendsCompletion.php',
+            'class_extends_empty',
+        );
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('ParentClass', $labels, 'A non-final class can be extended');
+        self::assertNotContains('FinalDescendant', $labels, 'A final class cannot be extended');
+        self::assertNotContains('Entity', $labels, 'A class cannot extend an interface');
+        self::assertNotContains('SingletonTrait', $labels, 'A class cannot extend a trait');
+        self::assertNotContains('Status', $labels, 'A class cannot extend an enum');
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'Functions must not leak into a class extends clause (issue #313)',
+        );
+        self::assertNotContains(
+            CompletionItemKind::Keyword->value,
+            $kinds,
+            'Keywords must not leak into a class extends clause (issue #313)',
+        );
+    }
+
+    public function testClassExtendsWithPrefixOffersClassNotFunctions(): void
+    {
+        // Mirrors the #298 report for the extends position: `extends P` must offer the
+        // in-scope class starting with `P`, not built-in `printf`/`print_r`.
+        $cursor = $this->openFixtureAtCursor(
+            'src/Completion/ClassExtendsPrefixCompletion.php',
+            'class_extends_p_prefix',
+        );
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('ParentClass', $labels, 'An in-scope class starting with P should be offered');
+        self::assertNotContains('printf', $labels, 'Built-in functions must not be offered in an extends clause');
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'No function should be offered in a class extends clause (issue #313)',
+        );
+    }
+
     public function testImplementsAcrossMultipleLinesOffersInterfaces(): void
     {
         self::markTestSkipped(

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -1416,6 +1416,72 @@ final class SymbolResolverTest extends TestCase
         self::assertFalse($this->resolver->isInterface(new ClassName('NonExistent\\Unknown')));
     }
 
+    #[DataProvider('extendableClassProvider')]
+    public function testIsExtendableClass(?string $fixture, string $fqcn, bool $expected, string $message): void
+    {
+        if ($fixture !== null) {
+            $this->openFixture($fixture);
+        }
+        /** @phpstan-ignore argument.type (fixture / intentionally non-existent class) */
+        self::assertSame($expected, $this->resolver->isExtendableClass(new ClassName($fqcn)), $message);
+    }
+
+    /**
+     * @return iterable<string, array{?string, string, bool, string}>
+     * @codeCoverageIgnore
+     */
+    public static function extendableClassProvider(): iterable
+    {
+        yield 'non-final class' => [
+            'src/Domain/User.php',
+            'Fixtures\\Domain\\User',
+            true,
+            'A non-final class can be extended',
+        ];
+        yield 'abstract class' => [
+            'src/Utility/ClassModifiers.php',
+            'Fixtures\\Utility\\AbstractBase',
+            true,
+            'An abstract class can be extended',
+        ];
+        yield 'readonly non-final class' => [
+            'src/Utility/ClassModifiers.php',
+            'Fixtures\\Utility\\ImmutableClass',
+            true,
+            'A readonly but non-final class can be extended',
+        ];
+        yield 'final class' => [
+            'src/Utility/ClassModifiers.php',
+            'Fixtures\\Utility\\SealedClass',
+            false,
+            'A final class cannot be extended',
+        ];
+        yield 'interface' => [
+            'src/Domain/Entity.php',
+            'Fixtures\\Domain\\Entity',
+            false,
+            'An interface is not a class and cannot be extended by a class',
+        ];
+        yield 'trait' => [
+            'src/Traits/SingletonTrait.php',
+            'Fixtures\\Traits\\SingletonTrait',
+            false,
+            'A trait cannot be extended by a class',
+        ];
+        yield 'enum' => [
+            'src/Enum/Status.php',
+            'Fixtures\\Enum\\Status',
+            false,
+            'An enum cannot be extended',
+        ];
+        yield 'unknown class' => [
+            null,
+            'NonExistent\\Unknown',
+            false,
+            'An unresolvable name must not be offered as a base class',
+        ];
+    }
+
     public function testIsAttributeReturnsTrueForAttributeClass(): void
     {
         $this->openFixture('src/Attributes/Route.php');


### PR DESCRIPTION
Closes #313.

## What

`class Foo extends <cursor>` now completes **extendable classes only** — from
`use` imports and the workspace index — mirroring the `implements` (#309) and
`interface … extends` (#318) behavior. A class extends exactly one class, so
there is no comma-list form. Final classes, interfaces, traits, enums, and
functions/keywords are excluded; abstract classes are offered.

## How

Built on the #307/#309 foundation:

- `CompletionClassifier` — one new regex (`CLASS_EXTENDS_PATTERN`, single name,
  no comma list) → new `CompletionKind::ExtendableClass`, placed right after the
  `interface … extends` check. The literal `class` keyword and lack of a
  comma-list distinguish the two.
- `ClassCandidateFilter::ExtendableClass` + one row each in
  `ClassCandidates::indexKinds()` (`[Class_]`) / `passesResolutionFilter()`.
- New `CodeResolver::isExtendableClass` predicate + `SymbolResolver` impl. Like
  `isInterface`, it returns **false** for unresolvable names — an extends clause
  must only offer confirmed base classes. A class is extendable if it is a class
  and not `final` (abstract is allowed).
- One handler dispatch arm.

The #318 classifier guard (`class Foo extends Ba`, previously asserted to fall
through to `Expression`) is updated to assert the new `ExtendableClass` kind.

## Tests

- `SymbolResolverTest` — `isExtendableClass` across non-final / abstract /
  readonly / final class, interface, trait, enum, and unknown (DataProvider).
- `CompletionClassifierTest` — `class extends` prefix / bare / `abstract class`.
- `CompletionHandlerTest` — extendable class offered while a final class,
  interface, trait, enum, functions, and keywords are not; and the `extends P`
  report (in-scope class offered, `printf` excluded).

## Out of scope

Tracked centrally: wrapped/multi-line detection (#310) and built-in /
cross-namespace sourcing (#308).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
