### PR TITLE
Complete Throwable types after catch (

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -16,6 +16,7 @@ This document tracks the current state of code completion in php-lsp.
 | `implements` list | `class Foo implements Ba` | Interfaces only (from imports + workspace index); classes, traits, and functions excluded | ✅ Working |
 | `interface … extends` list | `interface Foo extends Ba` | Interfaces only (from imports + workspace index); distinguished from `class … extends` by the `interface` keyword | ✅ Working |
 | `class … extends` | `class Foo extends Ba` | Extendable (non-final) classes only (from imports + workspace index); final classes, interfaces, traits, enums, and functions excluded | ✅ Working |
+| `catch` clause | `catch (Ba` or `catch (Foo \| Ba` | Throwable types only (from imports + workspace index): `Throwable` and any class or interface extending/implementing it. Multi-catch (`\|`-separated) supported; non-throwable types, functions, and keywords excluded | ✅ Working |
 | Attribute position | `#[Ro` | Attribute classes only (from imports + workspace index); classes, interfaces, traits, enums, and functions excluded. Grouped (`#[A, Ba`) supported; target-aware filtering is not yet (#252) | ✅ Working |
 | Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
 
@@ -53,7 +54,7 @@ CompletionHandler (coordinator)
 │                                         + ClassCandidates (any)
 └── CompletionClassifier (text-based) → typed CompletionKind, dispatched to:
       ├── VariableCandidates          → $var
-      ├── ClassCandidates             → new X / expression / type hints / implements + extends / attributes (by ClassCandidateFilter)
+      ├── ClassCandidates             → new X / expression / type hints / implements + extends / catch / attributes (by ClassCandidateFilter)
       ├── FunctionCandidates          → user-defined + built-in functions
       ├── KeywordCandidates           → keywords (by KeywordGroup)
       └── BuiltinTypeCandidates       → built-in type hints

--- a/src/Completion/ClassCandidateFilter.php
+++ b/src/Completion/ClassCandidateFilter.php
@@ -30,6 +30,9 @@ enum ClassCandidateFilter
     /** Only extendable classes: non-final classes (e.g. after `class X extends`) */
     case ExtendableClass;
 
+    /** Only catchable types: Throwable and its subtypes (e.g. after `catch (`) */
+    case Throwable;
+
     /** Only attribute classes (e.g. in a `#[...]` position) */
     case Attribute;
 }

--- a/src/Completion/ClassCandidates.php
+++ b/src/Completion/ClassCandidates.php
@@ -93,6 +93,7 @@ final class ClassCandidates
             ClassCandidateFilter::TypeHint => $this->codeResolver->isValidTypeHint($className),
             ClassCandidateFilter::Interface_ => $this->codeResolver->isInterface($className),
             ClassCandidateFilter::ExtendableClass => $this->codeResolver->isExtendableClass($className),
+            ClassCandidateFilter::Throwable => $this->codeResolver->isThrowable($className),
             ClassCandidateFilter::Attribute => $this->codeResolver->isAttribute($className),
         };
     }
@@ -124,6 +125,12 @@ final class ClassCandidates
             // A class extends exactly one class; isExtendableClass excludes final ones.
             ClassCandidateFilter::ExtendableClass => [
                 SymbolKind::Class_,
+            ],
+            // A catch clause accepts classes and interfaces; isThrowable narrows to
+            // Throwable subtypes.
+            ClassCandidateFilter::Throwable => [
+                SymbolKind::Class_,
+                SymbolKind::Interface_,
             ],
             // Attributes are always classes; isAttribute narrows further per candidate.
             ClassCandidateFilter::Attribute => [

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -31,6 +31,11 @@ final class CompletionClassifier
     // there is no comma-list form.
     private const CLASS_EXTENDS_PATTERN = '/\bclass\s+\w+\s+extends\s+(\w*)$/';
 
+    // Matches a catch clause's type position, including the `|`-separated multi-catch
+    // continuation ("catch (Foo | Ba"). The caught variable is matched by the variable
+    // pattern, which is checked first, so this only sees type positions.
+    private const CATCH_PATTERN = '/\bcatch\s*\(\s*(?:[\w\\\\]+\s*\|\s*)*(\w*)$/';
+
     // Matches an attribute-name position: "#[", including grouped attributes
     // ("#[Foo, Ba", "#[Foo(1), Ba"). It deliberately does not match inside an
     // attribute's own argument list ("#[Foo(Ba"), which is a value position.
@@ -73,6 +78,12 @@ final class CompletionClassifier
         // and lack of a comma-list distinguish this from `interface X extends`.
         if (preg_match(self::CLASS_EXTENDS_PATTERN, $textBeforeCursor, $matches) === 1) {
             return new CompletionClassification(CompletionKind::ExtendableClass, $matches[1]);
+        }
+
+        // catch clause - Throwable types only. Must check before the parameter-type
+        // fallback, since the "(" and "|" in "catch (Foo | Ba" also match it.
+        if (preg_match(self::CATCH_PATTERN, $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::Throwable, $matches[1]);
         }
 
         // After visibility keyword - keywords or property type.

--- a/src/Completion/CompletionKind.php
+++ b/src/Completion/CompletionKind.php
@@ -39,6 +39,9 @@ enum CompletionKind
     /** After `class X extends`, e.g. `class Foo extends Ba` — extendable classes only */
     case ExtendableClass;
 
+    /** In a `catch` clause, e.g. `catch (Ba` or `catch (Foo | Ba` — Throwable types only */
+    case Throwable;
+
     /** In an attribute position, e.g. `#[Ba` — attribute classes only */
     case Attribute;
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -189,6 +189,11 @@ final class CompletionHandler implements HandlerInterface
                 $document,
                 ClassCandidateFilter::ExtendableClass,
             ),
+            CompletionKind::Throwable => $this->classCandidates->find(
+                $prefix,
+                $document,
+                ClassCandidateFilter::Throwable,
+            ),
             CompletionKind::Attribute => $this->classCandidates->find(
                 $prefix,
                 $document,

--- a/src/Resolution/CodeResolver.php
+++ b/src/Resolution/CodeResolver.php
@@ -66,6 +66,13 @@ interface CodeResolver
     public function isExtendableClass(ClassName $className): bool;
 
     /**
+     * Check if a class-like can be caught (e.g. valid after `catch (`). True for
+     * `Throwable` itself and for any class or interface that extends or implements
+     * it, directly or transitively.
+     */
+    public function isThrowable(ClassName $className): bool;
+
+    /**
      * Check if a class is a PHP attribute (e.g. valid in a `#[...]` position).
      */
     public function isAttribute(ClassName $className): bool;

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -48,6 +48,7 @@ use PhpParser\Node\Stmt;
 use LogicException;
 use ReflectionException;
 use ReflectionFunction;
+use Throwable;
 
 /**
  * Centralizes symbol resolution for LSP handlers.
@@ -240,6 +241,26 @@ final class SymbolResolver implements CodeResolver
             return false;
         }
         return $classInfo->kind === ClassKind::Class_ && !$classInfo->isFinal;
+    }
+
+    /**
+     * Check if a class-like can be caught.
+     * True for `Throwable` itself and anything that extends or implements it
+     * transitively (classes and interfaces alike). Returns false for unknown
+     * classes: a catch clause must only offer confirmed Throwables.
+     */
+    public function isThrowable(ClassName $className): bool
+    {
+        $classInfo = $this->classRepository->get($className);
+        if ($classInfo === null) {
+            return false;
+        }
+
+        $throwable = new ClassName(Throwable::class);
+        if ($classInfo->name->equals($throwable)) {
+            return true;
+        }
+        return $this->classRepository->isSubclassOf($className, $throwable);
     }
 
     /**

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -130,6 +130,32 @@ class CompletionClassifierTest extends TestCase
             'Ba',
         ];
 
+        // A catch clause accepts Throwable types only, single or `|`-separated (#314).
+        yield 'catch with prefix' => ['        } catch (Ba', CompletionKind::Throwable, 'Ba'];
+        yield 'catch bare' => ['        } catch (', CompletionKind::Throwable, ''];
+        yield 'catch no space before paren' => ['        } catch(Ba', CompletionKind::Throwable, 'Ba'];
+        yield 'multi-catch continuation' => [
+            '        } catch (Foo | Ba',
+            CompletionKind::Throwable,
+            'Ba',
+        ];
+        yield 'multi-catch continuation without spaces' => [
+            '        } catch (Foo|Ba',
+            CompletionKind::Throwable,
+            'Ba',
+        ];
+        yield 'multi-catch bare continuation' => [
+            '        } catch (Foo\\Bar | ',
+            CompletionKind::Throwable,
+            '',
+        ];
+        // Once the caught variable is reached, the position is no longer a type.
+        yield 'catch variable is not a type' => [
+            '        } catch (Foo $e',
+            CompletionKind::Variable,
+            'e',
+        ];
+
         yield 'expression at start' => ['fo', CompletionKind::Expression, 'fo'];
         yield 'expression after assignment' => ['$x = fo', CompletionKind::Expression, 'fo'];
         yield 'expression inside method body' => [

--- a/tests/Fixtures/src/Completion/CatchCompletion.php
+++ b/tests/Fixtures/src/Completion/CatchCompletion.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\Entity;
+use Fixtures\Domain\User;
+use Fixtures\Enum\Status;
+use Fixtures\Exception\AppException;
+use Fixtures\Exception\ExceptionInterface;
+use Fixtures\Traits\SingletonTrait;
+
+class CatchCompletion
+{
+    public function trigger(): void
+    {
+        try {
+            $value = 1;
+        } catch (/*|catch_empty*/
+    }
+}

--- a/tests/Fixtures/src/Completion/CatchPrefixCompletion.php
+++ b/tests/Fixtures/src/Completion/CatchPrefixCompletion.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Exception\AppException;
+
+class CatchPrefixCompletion
+{
+    public function trigger(): void
+    {
+        try {
+            $value = 1;
+        } catch (A/*|catch_a_prefix*/
+    }
+}

--- a/tests/Fixtures/src/Completion/MultiCatchCompletion.php
+++ b/tests/Fixtures/src/Completion/MultiCatchCompletion.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\User;
+use Fixtures\Exception\AppException;
+use Fixtures\Exception\ExceptionInterface;
+
+class MultiCatchCompletion
+{
+    public function trigger(): void
+    {
+        try {
+            $value = 1;
+        } catch (AppException | /*|catch_multi*/
+    }
+}

--- a/tests/Fixtures/src/Exception/AppException.php
+++ b/tests/Fixtures/src/Exception/AppException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Exception;
+
+use RuntimeException;
+
+/**
+ * Reaches Throwable transitively: AppException -> RuntimeException -> Exception -> Throwable.
+ */
+class AppException extends RuntimeException implements ExceptionInterface
+{
+}

--- a/tests/Fixtures/src/Exception/ExceptionInterface.php
+++ b/tests/Fixtures/src/Exception/ExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Exception;
+
+use Throwable;
+
+interface ExceptionInterface extends Throwable
+{
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2925,6 +2925,65 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testCatchContextOffersOnlyThrowables(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/CatchCompletion.php', 'catch_empty');
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('AppException', $labels, 'A Throwable subclass can be caught');
+        self::assertContains('ExceptionInterface', $labels, 'An interface extending Throwable can be caught');
+        self::assertNotContains('User', $labels, 'A non-Throwable class cannot be caught');
+        self::assertNotContains('Entity', $labels, 'A non-Throwable interface cannot be caught');
+        self::assertNotContains('SingletonTrait', $labels, 'A trait cannot be caught');
+        self::assertNotContains('Status', $labels, 'An enum cannot be caught');
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'Functions must not leak into a catch clause (issue #314)',
+        );
+        self::assertNotContains(
+            CompletionItemKind::Keyword->value,
+            $kinds,
+            'Keywords must not leak into a catch clause (issue #314)',
+        );
+    }
+
+    public function testMultiCatchContinuationOffersThrowables(): void
+    {
+        // The `|`-separated multi-catch form must keep offering Throwables (issue #314).
+        $cursor = $this->openFixtureAtCursor('src/Completion/MultiCatchCompletion.php', 'catch_multi');
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('ExceptionInterface', $labels, 'A Throwable is offered after the multi-catch pipe');
+        self::assertNotContains('User', $labels, 'A non-Throwable class cannot be caught');
+    }
+
+    public function testCatchWithPrefixOffersThrowableNotFunctions(): void
+    {
+        // Mirrors the #298 report for the catch position: `catch (A` must offer the
+        // in-scope Throwable starting with `A`, not built-in functions.
+        $cursor = $this->openFixtureAtCursor('src/Completion/CatchPrefixCompletion.php', 'catch_a_prefix');
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('AppException', $labels, 'An in-scope Throwable starting with A should be offered');
+        self::assertNotContains('array_map', $labels, 'Built-in functions must not be offered in a catch clause');
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'No function should be offered in a catch clause (issue #314)',
+        );
+    }
+
     public function testImplementsAcrossMultipleLinesOffersInterfaces(): void
     {
         self::markTestSkipped(

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -38,6 +38,9 @@ use Firehed\PhpLsp\Tests\Handler\OpensDocumentsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Exception;
+use Throwable;
+use TypeError;
 
 #[CoversClass(SymbolResolver::class)]
 #[CoversClass(TextFallbackHelper::class)]
@@ -1479,6 +1482,84 @@ final class SymbolResolverTest extends TestCase
             'NonExistent\\Unknown',
             false,
             'An unresolvable name must not be offered as a base class',
+        ];
+    }
+
+    #[DataProvider('throwableProvider')]
+    public function testIsThrowable(?string $fixture, string $fqcn, bool $expected, string $message): void
+    {
+        if ($fixture !== null) {
+            $this->openFixture($fixture);
+        }
+        /** @phpstan-ignore argument.type (fixture / intentionally non-existent class) */
+        self::assertSame($expected, $this->resolver->isThrowable(new ClassName($fqcn)), $message);
+    }
+
+    /**
+     * @return iterable<string, array{?string, string, bool, string}>
+     * @codeCoverageIgnore
+     */
+    public static function throwableProvider(): iterable
+    {
+        yield 'Throwable itself' => [
+            null,
+            Throwable::class,
+            true,
+            'Throwable is catchable',
+        ];
+        yield 'built-in exception' => [
+            null,
+            Exception::class,
+            true,
+            'A built-in class implementing Throwable is catchable',
+        ];
+        yield 'built-in error' => [
+            null,
+            TypeError::class,
+            true,
+            'Errors are catchable: TypeError transitively implements Throwable',
+        ];
+        yield 'user class extending a built-in exception' => [
+            'src/Exception/AppException.php',
+            'Fixtures\\Exception\\AppException',
+            true,
+            'A class transitively extending a Throwable is catchable',
+        ];
+        yield 'user interface extending Throwable' => [
+            'src/Exception/ExceptionInterface.php',
+            'Fixtures\\Exception\\ExceptionInterface',
+            true,
+            'An interface extending Throwable is catchable',
+        ];
+        yield 'plain class' => [
+            'src/Domain/User.php',
+            'Fixtures\\Domain\\User',
+            false,
+            'A class unrelated to Throwable is not catchable',
+        ];
+        yield 'plain interface' => [
+            'src/Domain/Entity.php',
+            'Fixtures\\Domain\\Entity',
+            false,
+            'An interface unrelated to Throwable is not catchable',
+        ];
+        yield 'trait' => [
+            'src/Traits/SingletonTrait.php',
+            'Fixtures\\Traits\\SingletonTrait',
+            false,
+            'A trait cannot be caught',
+        ];
+        yield 'enum' => [
+            'src/Enum/Status.php',
+            'Fixtures\\Enum\\Status',
+            false,
+            'An enum cannot be caught',
+        ];
+        yield 'unknown class' => [
+            null,
+            'NonExistent\\Unknown',
+            false,
+            'An unresolvable name must not be offered in a catch clause',
         ];
     }
 


### PR DESCRIPTION
Closes #314.

## What

`catch (<cursor>` now completes **Throwable types only** — from `use` imports and the
workspace index — mirroring `implements` (#309), `interface … extends` (#318), and
`class … extends` (#313). The `|`-separated multi-catch continuation
(`catch (Foo | <cursor>`) is handled. Non-throwable classes, interfaces, traits, enums,
functions, and keywords are excluded.

## How

Built on the #307/#309 foundation:

- `CompletionClassifier` — one new regex (`CATCH_PATTERN`, covering the bare, prefixed,
  and `|`-continuation forms) → new `CompletionKind::Throwable`. It must be checked
  before the parameter-type fallback, since the `(` and `|` in `catch (Foo | Ba` also
  match that pattern. The caught variable (`catch (Foo $e`) is claimed earlier by the
  variable pattern, so this only ever sees type positions.
- `ClassCandidateFilter::Throwable` + one row each in `ClassCandidates::indexKinds()`
  (`[Class_, Interface_]`) / `passesResolutionFilter()`.
- New `CodeResolver::isThrowable` predicate + `SymbolResolver` impl, reusing the existing
  `ClassRepository::isSubclassOf` traversal (parent chain + implemented interfaces) with
  an identity check for `Throwable` itself. Like `isInterface`, it returns **false** for
  unresolvable names — a catch clause must only offer confirmed Throwables. Classes and
  interfaces both qualify.
- One handler dispatch arm.

## Tests

- `SymbolResolverTest` — `isThrowable` across `Throwable`, `Exception`, `TypeError`, a
  user class transitively extending a built-in exception, a user interface extending
  `Throwable`, a plain class/interface, a trait, an enum, and an unknown name
  (DataProvider).
- `CompletionClassifierTest` — bare / prefixed / no-space-before-paren / multi-catch
  continuation, and `catch (Foo $e` remaining a variable position.
- `CompletionHandlerTest` — Throwable class and interface offered while a non-throwable
  class, interface, trait, and enum are not; multi-catch continuation; and the prefix
  report (`catch (A` offers the in-scope Throwable, not built-in functions).

New fixtures: `Fixtures\Exception\{AppException, ExceptionInterface}` plus catch-position
completion fixtures.

## Out of scope

Tracked centrally: wrapped/multi-line detection (#310) and built-in / cross-namespace
sourcing (#308) — built-in `Exception` is offered only when imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)