### PR TITLE
Compute the shortest reference that resolves at a cursor

### DIFF
--- a/src/Resolution/CodeResolver.php
+++ b/src/Resolution/CodeResolver.php
@@ -118,6 +118,16 @@ interface CodeResolver
     public function getImports(TextDocument $document): array;
 
     /**
+     * Get the name-resolution context at a line: the enclosing namespace and the
+     * import tables (`use`, `use function`, `use const`) in effect there.
+     *
+     * Paired with {@see ReferenceResolver} to decide how a symbol must be written
+     * at the cursor.
+     * Used by: Completion
+     */
+    public function getNameContext(TextDocument $document, int $line): NameContext;
+
+    /**
      * Get the user-defined functions declared in a document.
      * Used by: Completion
      *

--- a/src/Resolution/NameContext.php
+++ b/src/Resolution/NameContext.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+/**
+ * The name-resolution context at a cursor: the enclosing namespace and the
+ * import tables in effect.
+ *
+ * PHP keeps three separate import tables (`use`, `use function`, `use const`),
+ * and consults a different one depending on the kind of the name being
+ * resolved — so they cannot be collapsed into a single map. See
+ * {@see ReferenceResolver} for how each is used.
+ *
+ * Each table maps the short name (or alias) to the fully qualified name it
+ * binds, without a leading separator.
+ */
+final readonly class NameContext
+{
+    /**
+     * @param array<string, string> $classImports
+     * @param array<string, string> $functionImports
+     * @param array<string, string> $constantImports
+     */
+    public function __construct(
+        public string $namespace,
+        public array $classImports = [],
+        public array $functionImports = [],
+        public array $constantImports = [],
+    ) {
+    }
+
+    /**
+     * The import table consulted for an *unqualified* name of the given kind.
+     *
+     * PHP manual, name resolution rule 5.
+     *
+     * @return array<string, string>
+     */
+    public function importsFor(NameKind $kind): array
+    {
+        return match ($kind) {
+            NameKind::ClassLike => $this->classImports,
+            NameKind::Constant => $this->constantImports,
+            NameKind::Function_ => $this->functionImports,
+        };
+    }
+}

--- a/src/Resolution/NameContextFactory.php
+++ b/src/Resolution/NameContextFactory.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+use PhpParser\Node\Stmt;
+use PhpParser\Node\UseItem;
+
+/**
+ * Builds the {@see NameContext} in effect at a given line.
+ *
+ * Imports are scoped to their namespace block: a file may declare several
+ * namespaces, and a `use` inside one is not in effect inside another. The
+ * statements are therefore read from the block enclosing the line, rather than
+ * from a flattened view of the file.
+ */
+final class NameContextFactory
+{
+    /**
+     * @param array<Stmt> $ast
+     * @param int $line Zero-based, as LSP positions are
+     */
+    public static function fromAst(array $ast, int $line): NameContext
+    {
+        $namespace = self::enclosingNamespace($ast, $line);
+
+        $imports = [
+            Stmt\Use_::TYPE_NORMAL => [],
+            Stmt\Use_::TYPE_FUNCTION => [],
+            Stmt\Use_::TYPE_CONSTANT => [],
+        ];
+
+        foreach (self::statementsIn($ast, $namespace) as $stmt) {
+            if ($stmt instanceof Stmt\Use_) {
+                foreach ($stmt->uses as $use) {
+                    $imports[self::typeOf($use, $stmt->type)][self::aliasOf($use)] = $use->name->toString();
+                }
+            } elseif ($stmt instanceof Stmt\GroupUse) {
+                $prefix = $stmt->prefix->toString();
+                foreach ($stmt->uses as $use) {
+                    $imports[self::typeOf($use, $stmt->type)][self::aliasOf($use)]
+                        = $prefix . '\\' . $use->name->toString();
+                }
+            }
+        }
+
+        return new NameContext(
+            namespace: $namespace?->name?->toString() ?? '',
+            classImports: $imports[Stmt\Use_::TYPE_NORMAL],
+            functionImports: $imports[Stmt\Use_::TYPE_FUNCTION],
+            constantImports: $imports[Stmt\Use_::TYPE_CONSTANT],
+        );
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private static function enclosingNamespace(array $ast, int $line): ?Stmt\Namespace_
+    {
+        foreach ($ast as $stmt) {
+            if (!$stmt instanceof Stmt\Namespace_) {
+                continue;
+            }
+            // AST lines are one-based.
+            if ($stmt->getStartLine() <= $line + 1 && $line + 1 <= $stmt->getEndLine()) {
+                return $stmt;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The statements whose imports are in effect: those of the enclosing
+     * namespace block, or the file's own when the line is outside any block.
+     *
+     * @param array<Stmt> $ast
+     * @return array<Stmt>
+     */
+    private static function statementsIn(array $ast, ?Stmt\Namespace_ $namespace): array
+    {
+        if ($namespace === null) {
+            return $ast;
+        }
+
+        return $namespace->stmts;
+    }
+
+    /**
+     * A group use may mix kinds (`use Foo\{function bar, const BAZ, Qux}`), in
+     * which case the item carries the type; otherwise the statement does.
+     *
+     * @param Stmt\Use_::TYPE_* $statementType
+     * @return Stmt\Use_::TYPE_NORMAL|Stmt\Use_::TYPE_FUNCTION|Stmt\Use_::TYPE_CONSTANT
+     */
+    private static function typeOf(UseItem $use, int $statementType): int
+    {
+        $type = $use->type === Stmt\Use_::TYPE_UNKNOWN ? $statementType : $use->type;
+
+        if ($type === Stmt\Use_::TYPE_UNKNOWN) {
+            // @codeCoverageIgnoreStart
+            throw new \LogicException('A use statement and its items cannot both be untyped');
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $type;
+    }
+
+    private static function aliasOf(UseItem $use): string
+    {
+        return $use->alias?->toString() ?? $use->name->getLast();
+    }
+}

--- a/src/Resolution/NameContextFactory.php
+++ b/src/Resolution/NameContextFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Resolution;
 
+use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\UseItem;
 
@@ -23,7 +24,7 @@ final class NameContextFactory
      */
     public static function fromAst(array $ast, int $line): NameContext
     {
-        $namespace = self::enclosingNamespace($ast, $line);
+        $namespace = ScopeFinder::findNamespaceNodeAtLine($ast, $line);
 
         $imports = [
             Stmt\Use_::TYPE_NORMAL => [],
@@ -51,24 +52,6 @@ final class NameContextFactory
             functionImports: $imports[Stmt\Use_::TYPE_FUNCTION],
             constantImports: $imports[Stmt\Use_::TYPE_CONSTANT],
         );
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private static function enclosingNamespace(array $ast, int $line): ?Stmt\Namespace_
-    {
-        foreach ($ast as $stmt) {
-            if (!$stmt instanceof Stmt\Namespace_) {
-                continue;
-            }
-            // AST lines are one-based.
-            if ($stmt->getStartLine() <= $line + 1 && $line + 1 <= $stmt->getEndLine()) {
-                return $stmt;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/Resolution/NameKind.php
+++ b/src/Resolution/NameKind.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+/**
+ * The category of symbol a name refers to, which determines how PHP resolves it
+ * when unqualified.
+ *
+ * Only three categories exist because only three participate in name
+ * resolution: class-likes, functions, and constants. Members and variables are
+ * reached through an already-resolved type, so namespaces never enter.
+ */
+enum NameKind
+{
+    case ClassLike;
+
+    case Constant;
+
+    case Function_;
+
+    /**
+     * Whether an unqualified name of this kind falls back to the global
+     * namespace at runtime when the current namespace has no such symbol.
+     *
+     * PHP manual, name resolution rule 7: the fallback applies to functions and
+     * constants. Rule 6: an unqualified class-like name prepends the current
+     * namespace and never falls back.
+     */
+    public function fallsBackToGlobal(): bool
+    {
+        return match ($this) {
+            self::ClassLike => false,
+            self::Constant, self::Function_ => true,
+        };
+    }
+
+    /**
+     * Whether names of this kind are matched case-sensitively. Class and
+     * function names are case-insensitive in PHP; constant names are not.
+     */
+    public function isCaseSensitive(): bool
+    {
+        return $this === self::Constant;
+    }
+}

--- a/src/Resolution/Reference.php
+++ b/src/Resolution/Reference.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+/**
+ * How a symbol is written at a particular cursor: the shortest form that
+ * resolves back to it, plus why.
+ *
+ * When the symbol is not reachable, the text is its fully qualified form with a
+ * leading separator — the reference that would work if qualified.
+ */
+final readonly class Reference
+{
+    public function __construct(
+        public string $text,
+        public ReferenceKind $kind,
+    ) {
+    }
+
+    public function isReachable(): bool
+    {
+        return $this->kind !== ReferenceKind::Unreachable;
+    }
+}

--- a/src/Resolution/ReferenceKind.php
+++ b/src/Resolution/ReferenceKind.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+/**
+ * Why a {@see Reference} resolves at the cursor — or that it does not.
+ *
+ * The cases are ordered from nearest to furthest, which is also their ranking
+ * order in completion: a symbol usable as a bare name outranks one that needs a
+ * qualified reference, which outranks one that cannot be referenced at all
+ * without qualifying it or adding an import.
+ */
+enum ReferenceKind
+{
+    /** Declared in the cursor's own namespace; the last segment resolves. */
+    case CurrentNamespace;
+
+    /** Bound directly by a `use` / `use function` / `use const` import. */
+    case Import;
+
+    /** Reached through an import of one of its parent namespaces, e.g. `User\Repository`. */
+    case PrefixImport;
+
+    /** In a sub-namespace of the cursor's namespace; a relative qualified name resolves. */
+    case SubNamespace;
+
+    /** A global function or constant, reached by PHP's runtime fallback. */
+    case GlobalFallback;
+
+    /** Not referenceable here without a leading `\` or an added import. */
+    case Unreachable;
+}

--- a/src/Resolution/ReferenceResolver.php
+++ b/src/Resolution/ReferenceResolver.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Resolution;
+
+/**
+ * Computes how a symbol must be written at a given cursor: the shortest
+ * reference that resolves back to it, or that no unqualified reference does.
+ *
+ * This is the inverse of what the parser does. PhpParser's `NameResolver` turns
+ * source text into an FQN; this turns an FQN back into the source text that
+ * would produce it, under the namespace and imports in effect at the cursor.
+ *
+ * The rules are PHP's, from the manual's "Name resolution rules"
+ * (language.namespaces.rules), applied shortest-first:
+ *
+ * 1. Declared in the current namespace → its last segment (rule 6).
+ * 2. Bound by an import of its own kind → that alias (rule 5).
+ * 3. Reached through an imported parent namespace → alias + remaining segments
+ *    (rule 3 — which consults the *class* import table even when the symbol is
+ *    a function or constant, because the resulting name is qualified).
+ * 4. In a sub-namespace of the current one → a relative qualified name.
+ * 5. A global function or constant → its last segment, via the runtime fallback
+ *    (rule 7). Class-likes have no such fallback (rule 6).
+ * 6. Otherwise unreachable: it needs a leading `\` or an added import.
+ *
+ * Each unqualified form is only offered when an import has not bound that name
+ * to something else; an import always wins over the current namespace, so a
+ * shadowed symbol is not reachable by its short name at all.
+ */
+final class ReferenceResolver
+{
+    public static function resolve(string $fullyQualifiedName, NameKind $kind, NameContext $context): Reference
+    {
+        $fqn = ltrim($fullyQualifiedName, '\\');
+        $namespace = self::namespaceOf($fqn);
+        $shortName = self::shortNameOf($fqn);
+
+        if (
+            self::namespacesMatch($namespace, $context->namespace)
+            && !self::isShadowed($shortName, $fqn, $context->importsFor($kind), $kind)
+        ) {
+            return new Reference($shortName, ReferenceKind::CurrentNamespace);
+        }
+
+        $alias = self::findImportOf($fqn, $context->importsFor($kind), $kind);
+        if ($alias !== null) {
+            return new Reference($alias, ReferenceKind::Import);
+        }
+
+        $viaPrefix = self::findPrefixImport($namespace, $context->classImports);
+        if ($viaPrefix !== null) {
+            [$prefixAlias, $remainder] = $viaPrefix;
+            return new Reference(
+                self::join([$prefixAlias, $remainder, $shortName]),
+                ReferenceKind::PrefixImport,
+            );
+        }
+
+        $relative = self::relativeNamespace($namespace, $context->namespace);
+        if (
+            $relative !== null
+            && !self::isShadowed(self::firstSegment($relative), $fqn, $context->classImports, $kind)
+        ) {
+            return new Reference(
+                self::join([$relative, $shortName]),
+                ReferenceKind::SubNamespace,
+            );
+        }
+
+        if (
+            $namespace === ''
+            && $kind->fallsBackToGlobal()
+            && !self::isShadowed($shortName, $fqn, $context->importsFor($kind), $kind)
+        ) {
+            return new Reference($shortName, ReferenceKind::GlobalFallback);
+        }
+
+        return new Reference('\\' . $fqn, ReferenceKind::Unreachable);
+    }
+
+    /**
+     * Whether an import binds this name to some *other* symbol. Imports take
+     * precedence over the current namespace and over the global fallback, so a
+     * shadowed name cannot be used unqualified.
+     *
+     * @param array<string, string> $imports
+     */
+    private static function isShadowed(string $name, string $fqn, array $imports, NameKind $kind): bool
+    {
+        foreach ($imports as $alias => $target) {
+            if (!self::namesMatch($alias, $name, $kind)) {
+                continue;
+            }
+            return !self::namesMatch($target, $fqn, $kind);
+        }
+
+        return false;
+    }
+
+    /**
+     * The alias under which an import binds exactly this symbol.
+     *
+     * @param array<string, string> $imports
+     */
+    private static function findImportOf(string $fqn, array $imports, NameKind $kind): ?string
+    {
+        foreach ($imports as $alias => $target) {
+            if (self::namesMatch($target, $fqn, $kind)) {
+                return $alias;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The longest class import that names the symbol's namespace or an ancestor
+     * of it, as [alias, remaining segments].
+     *
+     * @param array<string, string> $classImports
+     * @return array{string, string}|null
+     */
+    private static function findPrefixImport(string $namespace, array $classImports): ?array
+    {
+        $best = null;
+
+        foreach ($classImports as $alias => $target) {
+            $remainder = self::relativeNamespace($namespace, $target, allowExact: true);
+            if ($remainder === null) {
+                continue;
+            }
+            if ($best !== null && strlen($target) <= $best[0]) {
+                continue;
+            }
+            $best = [strlen($target), $alias, $remainder];
+        }
+
+        return $best === null ? null : [$best[1], $best[2]];
+    }
+
+    /**
+     * The portion of $namespace below $ancestor, or null when $ancestor does not
+     * contain it. Matching is on segment boundaries, so `App\Models` is not
+     * inside `App\Model`.
+     */
+    private static function relativeNamespace(string $namespace, string $ancestor, bool $allowExact = false): ?string
+    {
+        if (self::namespacesMatch($namespace, $ancestor)) {
+            return $allowExact ? '' : null;
+        }
+
+        if ($ancestor === '') {
+            return $namespace === '' ? null : $namespace;
+        }
+
+        $prefix = $ancestor . '\\';
+        if (strncasecmp($namespace, $prefix, strlen($prefix)) !== 0) {
+            return null;
+        }
+
+        return substr($namespace, strlen($prefix));
+    }
+
+    private static function namespaceOf(string $fqn): string
+    {
+        $separator = strrpos($fqn, '\\');
+        return $separator === false ? '' : substr($fqn, 0, $separator);
+    }
+
+    private static function shortNameOf(string $fqn): string
+    {
+        $separator = strrpos($fqn, '\\');
+        return $separator === false ? $fqn : substr($fqn, $separator + 1);
+    }
+
+    private static function firstSegment(string $name): string
+    {
+        $separator = strpos($name, '\\');
+        return $separator === false ? $name : substr($name, 0, $separator);
+    }
+
+    /**
+     * Namespaces are always case-insensitive, even for constants — only a
+     * constant's final segment is case-sensitive.
+     */
+    private static function namespacesMatch(string $a, string $b): bool
+    {
+        return strcasecmp($a, $b) === 0;
+    }
+
+    private static function namesMatch(string $a, string $b, NameKind $kind): bool
+    {
+        if (!$kind->isCaseSensitive()) {
+            return strcasecmp($a, $b) === 0;
+        }
+
+        return self::namespacesMatch(self::namespaceOf($a), self::namespaceOf($b))
+            && self::shortNameOf($a) === self::shortNameOf($b);
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    private static function join(array $segments): string
+    {
+        return implode('\\', array_filter($segments, static fn(string $s): bool => $s !== ''));
+    }
+}

--- a/src/Resolution/ReferenceResolver.php
+++ b/src/Resolution/ReferenceResolver.php
@@ -61,7 +61,10 @@ final class ReferenceResolver
         $relative = self::relativeNamespace($namespace, $context->namespace);
         if (
             $relative !== null
-            && !self::isShadowed(self::firstSegment($relative), $fqn, $context->classImports, $kind)
+            // The leading segment of a qualified name is bound by the class
+            // import table (rule 3), so it matches on that table's terms —
+            // case-insensitively — whatever the leaf symbol's kind.
+            && !self::isShadowed(self::firstSegment($relative), $fqn, $context->classImports, NameKind::ClassLike)
         ) {
             return new Reference(
                 self::join([$relative, $shortName]),

--- a/src/Resolution/ReferenceResolver.php
+++ b/src/Resolution/ReferenceResolver.php
@@ -28,6 +28,12 @@ namespace Firehed\PhpLsp\Resolution;
  * Each unqualified form is only offered when an import has not bound that name
  * to something else; an import always wins over the current namespace, so a
  * shadowed symbol is not reachable by its short name at all.
+ *
+ * The rules are ordered, and in one corner that is not the shortest form: an
+ * import of an *ancestor of the cursor's own namespace* (`use App;` inside
+ * `namespace App\Model;`) makes rule 3 fire with a longer result than rule 4
+ * would give. Both resolve to the symbol; the import is redundant in the first
+ * place, since everything it reaches is already reachable relatively.
  */
 final class ReferenceResolver
 {
@@ -154,8 +160,10 @@ final class ReferenceResolver
             return $allowExact ? '' : null;
         }
 
+        // Everything is below the global namespace. Two empty namespaces are
+        // equal, so they have already been handled above.
         if ($ancestor === '') {
-            return $namespace === '' ? null : $namespace;
+            return $namespace;
         }
 
         $prefix = $ancestor . '\\';

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -643,6 +643,18 @@ final class SymbolResolver implements CodeResolver
         return ScopeFinder::extractImports($ast);
     }
 
+    public function getNameContext(TextDocument $document, int $line): NameContext
+    {
+        $ast = $this->parser->parse($document);
+        if ($ast === null) {
+            // @codeCoverageIgnoreStart
+            throw new LogicException('Parser returned null');
+            // @codeCoverageIgnoreEnd
+        }
+
+        return NameContextFactory::fromAst($ast, $line);
+    }
+
     /**
      * @return list<FunctionInfo>
      */

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -273,6 +273,11 @@ final class ScopeFinder
     /**
      * Extract all class imports from `use` statements as short name => FQCN.
      *
+     * Superseded by {@see NameContextFactory}, which is type-aware and scoped to
+     * one namespace block. This one folds `use function` and `use const` into the
+     * class map and flattens every block in the file; its callers are moved over
+     * in #331, after which it goes away.
+     *
      * @param array<Stmt> $ast
      * @return array<string, string>
      */

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -314,24 +314,49 @@ final class ScopeFinder
     /**
      * Find the namespace declaration containing a given zero-based line.
      *
-     * AST line numbers are one-based, so the incoming line is incremented before
-     * comparison. Returns null when the line is outside any namespace block or the
-     * enclosing namespace is the global namespace.
+     * Returns null when the line is outside any namespace block or the enclosing
+     * namespace is the global namespace.
      *
      * @param array<Stmt> $ast
      */
     public static function findNamespaceAtLine(array $ast, int $line): ?string
     {
+        return self::findNamespaceNodeAtLine($ast, $line)?->name?->toString();
+    }
+
+    /**
+     * The namespace declaration enclosing a given zero-based line.
+     *
+     * A braced namespace ends at its closing brace. A semicolon-style one has no
+     * closing token: it runs until the next namespace declaration, or to the end
+     * of the file. Its node cannot say so — the parser moves the following
+     * statements into the node and extends its end line only to the last of them
+     * — so everything after that last statement, where a cursor routinely sits,
+     * would otherwise look like it were outside the namespace entirely.
+     *
+     * @param array<Stmt> $ast
+     */
+    public static function findNamespaceNodeAtLine(array $ast, int $line): ?Stmt\Namespace_
+    {
+        // AST line numbers are one-based.
+        $target = $line + 1;
+        $enclosing = null;
+
         foreach ($ast as $stmt) {
-            if (
-                $stmt instanceof Stmt\Namespace_
-                && $stmt->getStartLine() <= $line + 1
-                && $line + 1 <= $stmt->getEndLine()
-            ) {
-                return $stmt->name?->toString();
+            if (!$stmt instanceof Stmt\Namespace_ || $stmt->getStartLine() > $target) {
+                continue;
             }
+
+            if ($stmt->getAttribute('kind') === Stmt\Namespace_::KIND_BRACED) {
+                if ($target <= $stmt->getEndLine()) {
+                    return $stmt;
+                }
+                continue;
+            }
+
+            $enclosing = $stmt;
         }
 
-        return null;
+        return $enclosing;
     }
 }

--- a/tests/Fixtures/Namespacing/FileWide.php
+++ b/tests/Fixtures/Namespacing/FileWide.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Fixtures\Namespacing;
 
+use Fixtures\Namespacing\Models\UserRepository as Repo;
+use function Fixtures\Namespacing\Models\makeUser;
+use const Fixtures\Namespacing\Models\DEFAULT_LIMIT;
+
 class FileWide
 {
     public function greet(): string

--- a/tests/Fixtures/Namespacing/ImportCompletion.php
+++ b/tests/Fixtures/Namespacing/ImportCompletion.php
@@ -41,3 +41,18 @@ namespace Fixtures\Namespacing\ImportCompletion\Grouped {
     }
 
 }
+
+namespace Fixtures\Namespacing\ImportCompletion\MixedGroup {
+
+    use Fixtures\Namespacing\Models\{
+        UserRepository,
+        function makeUser,
+        const DEFAULT_LIMIT,
+    };
+
+    function triggerMixedGroupPartial()
+    {
+        $x = User/*|mixed_group_partial*/
+    }
+
+}

--- a/tests/Fixtures/Namespacing/ImportCompletion.php
+++ b/tests/Fixtures/Namespacing/ImportCompletion.php
@@ -7,6 +7,8 @@ namespace Fixtures\Namespacing\ImportCompletion {
     use Fixtures\Namespacing\Models\User;
     use Fixtures\Namespacing\Models\UserRepository as Repo;
     use Fixtures\Traits\SingletonTrait;
+    use function Fixtures\Namespacing\Models\makeUser;
+    use const Fixtures\Namespacing\Models\DEFAULT_LIMIT;
 
     function triggerImportedClassPartial()
     {

--- a/tests/Fixtures/Namespacing/ImportCompletion.php
+++ b/tests/Fixtures/Namespacing/ImportCompletion.php
@@ -33,7 +33,7 @@ namespace Fixtures\Namespacing\ImportCompletion {
 
 namespace Fixtures\Namespacing\ImportCompletion\Grouped {
 
-    use Fixtures\Namespacing\Models\{User, Post};
+    use Fixtures\Namespacing\Models\{User, Post, UserRepository as Repos};
 
     function triggerGroupedImportPartial()
     {

--- a/tests/Fixtures/Namespacing/MultiNamespaceImports.php
+++ b/tests/Fixtures/Namespacing/MultiNamespaceImports.php
@@ -37,6 +37,13 @@ namespace Fixtures\Namespacing\Models {
         }
     }
 
+    const DEFAULT_LIMIT = 25;
+
+    function makeUser(): User
+    {
+        return new User();
+    }
+
 }
 
 namespace Fixtures\Namespacing\Controllers {

--- a/tests/Resolution/ReferenceResolverTest.php
+++ b/tests/Resolution/ReferenceResolverTest.php
@@ -297,5 +297,15 @@ class ReferenceResolverTest extends TestCase
             'MY_CONST',
             ReferenceKind::CurrentNamespace,
         ];
+        // Rule 3 consults the class import table, which is case-insensitive
+        // whatever the leaf symbol's kind: `use Other\sub;` binds the segment
+        // `Sub`, so `Sub\MY_CONST` would resolve to `Other\sub\MY_CONST`.
+        yield 'a class import shadows a qualified constant regardless of the alias case' => [
+            'App\Sub\MY_CONST',
+            NameKind::Constant,
+            new NameContext('App', classImports: ['sub' => 'Other\sub']),
+            '\App\Sub\MY_CONST',
+            ReferenceKind::Unreachable,
+        ];
     }
 }

--- a/tests/Resolution/ReferenceResolverTest.php
+++ b/tests/Resolution/ReferenceResolverTest.php
@@ -53,6 +53,34 @@ class ReferenceResolverTest extends TestCase
         );
     }
 
+    #[DataProvider('provideImportTables')]
+    public function testImportsForConsultsTheTableForTheKind(NameKind $kind, string $expected): void
+    {
+        $context = new NameContext(
+            'App',
+            classImports: ['Thing' => 'Other\Thing'],
+            functionImports: ['helper' => 'Other\helper'],
+            constantImports: ['FOO' => 'Other\FOO'],
+        );
+
+        self::assertSame(
+            [$expected],
+            array_values($context->importsFor($kind)),
+            'An unqualified name is resolved against the import table for its own kind',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{NameKind, string}>
+     */
+    public static function provideImportTables(): iterable
+    {
+        yield 'class-likes use the class table' => [NameKind::ClassLike, 'Other\Thing'];
+        yield 'functions use the function table' => [NameKind::Function_, 'Other\helper'];
+        yield 'constants use the constant table' => [NameKind::Constant, 'Other\FOO'];
+    }
+
     #[DataProvider('provideReachability')]
     public function testIsReachable(ReferenceKind $kind, bool $expected): void
     {
@@ -174,6 +202,13 @@ class ReferenceResolverTest extends TestCase
             'Psr\Log\LoggerInterface',
             NameKind::ClassLike,
             new NameContext('App', classImports: ['Psr' => 'Psr', 'Log' => 'Psr\Log']),
+            'Log\LoggerInterface',
+            ReferenceKind::PrefixImport,
+        ];
+        yield 'longest prefix import wins regardless of import order' => [
+            'Psr\Log\LoggerInterface',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['Log' => 'Psr\Log', 'Psr' => 'Psr']),
             'Log\LoggerInterface',
             ReferenceKind::PrefixImport,
         ];

--- a/tests/Resolution/ReferenceResolverTest.php
+++ b/tests/Resolution/ReferenceResolverTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Resolution;
+
+use Firehed\PhpLsp\Resolution\NameContext;
+use Firehed\PhpLsp\Resolution\NameKind;
+use Firehed\PhpLsp\Resolution\Reference;
+use Firehed\PhpLsp\Resolution\ReferenceKind;
+use Firehed\PhpLsp\Resolution\ReferenceResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Cases are derived from the PHP manual, "Name resolution rules"
+ * (language.namespaces.rules):
+ *
+ * - Rule 3: a qualified name's first segment is translated via the
+ *   class/namespace import table — regardless of the leaf symbol's kind.
+ * - Rule 5: an unqualified name is translated via the import table for its own
+ *   symbol type (class / function / constant).
+ * - Rule 6: an unqualified class-like name prepends the current namespace; it
+ *   never falls back to global.
+ * - Rule 7: an unqualified function or constant name falls back to global.
+ */
+#[CoversClass(Reference::class)]
+#[CoversClass(ReferenceResolver::class)]
+#[CoversClass(NameContext::class)]
+#[CoversClass(NameKind::class)]
+class ReferenceResolverTest extends TestCase
+{
+    #[DataProvider('provideReferences')]
+    public function testResolve(
+        string $fqn,
+        NameKind $kind,
+        NameContext $context,
+        string $expectedText,
+        ReferenceKind $expectedKind,
+    ): void {
+        $reference = ReferenceResolver::resolve($fqn, $kind, $context);
+
+        self::assertSame(
+            $expectedText,
+            $reference->text,
+            'The reference text must be the shortest form that resolves to the symbol',
+        );
+        self::assertSame(
+            $expectedKind,
+            $reference->kind,
+            'The reference kind identifies why it resolves, and drives ranking',
+        );
+    }
+
+    #[DataProvider('provideReachability')]
+    public function testIsReachable(ReferenceKind $kind, bool $expected): void
+    {
+        $reference = new Reference('Whatever', $kind);
+
+        self::assertSame(
+            $expected,
+            $reference->isReachable(),
+            'Only an unreachable reference requires qualification or an added import',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{ReferenceKind, bool}>
+     */
+    public static function provideReachability(): iterable
+    {
+        yield 'current namespace' => [ReferenceKind::CurrentNamespace, true];
+        yield 'import' => [ReferenceKind::Import, true];
+        yield 'prefix import' => [ReferenceKind::PrefixImport, true];
+        yield 'sub namespace' => [ReferenceKind::SubNamespace, true];
+        yield 'global fallback' => [ReferenceKind::GlobalFallback, true];
+        yield 'unreachable' => [ReferenceKind::Unreachable, false];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, NameKind, NameContext, string, ReferenceKind}>
+     */
+    public static function provideReferences(): iterable
+    {
+        // Rule 6 / same namespace: the last segment is enough.
+        yield 'global class from global namespace' => [
+            'Exception',
+            NameKind::ClassLike,
+            new NameContext(''),
+            'Exception',
+            ReferenceKind::CurrentNamespace,
+        ];
+        yield 'class in current namespace' => [
+            'App\Thing',
+            NameKind::ClassLike,
+            new NameContext('App'),
+            'Thing',
+            ReferenceKind::CurrentNamespace,
+        ];
+        yield 'namespace comparison is case-insensitive' => [
+            'App\Thing',
+            NameKind::ClassLike,
+            new NameContext('app'),
+            'Thing',
+            ReferenceKind::CurrentNamespace,
+        ];
+        yield 'function in current namespace' => [
+            'App\helper',
+            NameKind::Function_,
+            new NameContext('App'),
+            'helper',
+            ReferenceKind::CurrentNamespace,
+        ];
+
+        // An import binding the short name to a *different* symbol shadows the
+        // same-namespace one, leaving it reachable only when fully qualified.
+        yield 'same-namespace class shadowed by an import' => [
+            'App\Thing',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['Thing' => 'Other\Thing']),
+            '\App\Thing',
+            ReferenceKind::Unreachable,
+        ];
+
+        // Rule 5: unqualified names use the import table for their own kind.
+        yield 'exact class import' => [
+            'Psr\Log\LoggerInterface',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['LoggerInterface' => 'Psr\Log\LoggerInterface']),
+            'LoggerInterface',
+            ReferenceKind::Import,
+        ];
+        yield 'aliased class import' => [
+            'Psr\Log\LoggerInterface',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['Logger' => 'Psr\Log\LoggerInterface']),
+            'Logger',
+            ReferenceKind::Import,
+        ];
+        yield 'use function import' => [
+            'Other\helper',
+            NameKind::Function_,
+            new NameContext('App', functionImports: ['helper' => 'Other\helper']),
+            'helper',
+            ReferenceKind::Import,
+        ];
+        yield 'use const import' => [
+            'Other\FOO',
+            NameKind::Constant,
+            new NameContext('App', constantImports: ['FOO' => 'Other\FOO']),
+            'FOO',
+            ReferenceKind::Import,
+        ];
+        yield 'a class import does not make an unqualified function reachable' => [
+            'Other\Thing',
+            NameKind::Function_,
+            new NameContext('App', classImports: ['Thing' => 'Other\Thing']),
+            '\Other\Thing',
+            ReferenceKind::Unreachable,
+        ];
+
+        // Rule 3: a qualified name's first segment always uses the class table.
+        yield 'prefix import' => [
+            'Psr\Log\LoggerInterface',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['Log' => 'Psr\Log']),
+            'Log\LoggerInterface',
+            ReferenceKind::PrefixImport,
+        ];
+        yield 'longest prefix import wins' => [
+            'Psr\Log\LoggerInterface',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['Psr' => 'Psr', 'Log' => 'Psr\Log']),
+            'Log\LoggerInterface',
+            ReferenceKind::PrefixImport,
+        ];
+        yield 'an import may be both a class and a namespace prefix' => [
+            'App\Model\User\Repository',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['User' => 'App\Model\User']),
+            'User\Repository',
+            ReferenceKind::PrefixImport,
+        ];
+        yield 'a qualified function uses the class import table' => [
+            'App\Model\helper',
+            NameKind::Function_,
+            new NameContext('App', classImports: ['Model' => 'App\Model']),
+            'Model\helper',
+            ReferenceKind::PrefixImport,
+        ];
+
+        // Sub-namespace of the current namespace: a relative qualified name.
+        yield 'class in a sub-namespace' => [
+            'App\Sub\Thing',
+            NameKind::ClassLike,
+            new NameContext('App'),
+            'Sub\Thing',
+            ReferenceKind::SubNamespace,
+        ];
+        yield 'namespaced class from the global namespace' => [
+            'Psr\Log\LoggerInterface',
+            NameKind::ClassLike,
+            new NameContext(''),
+            'Psr\Log\LoggerInterface',
+            ReferenceKind::SubNamespace,
+        ];
+        yield 'sub-namespace shadowed by an import of its first segment' => [
+            'App\Sub\Thing',
+            NameKind::ClassLike,
+            new NameContext('App', classImports: ['Sub' => 'Other\Sub']),
+            '\App\Sub\Thing',
+            ReferenceKind::Unreachable,
+        ];
+
+        // Rule 7: functions and constants fall back to global; classes do not.
+        yield 'global function from a namespace' => [
+            'strlen',
+            NameKind::Function_,
+            new NameContext('App'),
+            'strlen',
+            ReferenceKind::GlobalFallback,
+        ];
+        yield 'global constant from a namespace' => [
+            'PHP_EOL',
+            NameKind::Constant,
+            new NameContext('App'),
+            'PHP_EOL',
+            ReferenceKind::GlobalFallback,
+        ];
+        yield 'global fallback shadowed by a function import' => [
+            'strlen',
+            NameKind::Function_,
+            new NameContext('App', functionImports: ['strlen' => 'Other\strlen']),
+            '\strlen',
+            ReferenceKind::Unreachable,
+        ];
+        yield 'a global class has no fallback from a namespace' => [
+            'Exception',
+            NameKind::ClassLike,
+            new NameContext('App'),
+            '\Exception',
+            ReferenceKind::Unreachable,
+        ];
+
+        // Unrelated namespaces are only reachable fully qualified.
+        yield 'class in an unrelated namespace' => [
+            'Other\Thing',
+            NameKind::ClassLike,
+            new NameContext('App'),
+            '\Other\Thing',
+            ReferenceKind::Unreachable,
+        ];
+
+        // Constant names are case-sensitive; their namespace is not.
+        yield 'constant short names are case-sensitive' => [
+            'App\MY_CONST',
+            NameKind::Constant,
+            new NameContext('App', constantImports: ['my_const' => 'App\my_const']),
+            'MY_CONST',
+            ReferenceKind::CurrentNamespace,
+        ];
+    }
+}

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\NameContextFactory;
 use Firehed\PhpLsp\Resolution\ResolvedClass;
 use Firehed\PhpLsp\Resolution\ResolvedConstant;
 use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
@@ -43,6 +44,7 @@ use Throwable;
 use TypeError;
 
 #[CoversClass(SymbolResolver::class)]
+#[CoversClass(NameContextFactory::class)]
 #[CoversClass(TextFallbackHelper::class)]
 final class SymbolResolverTest extends TestCase
 {
@@ -2395,6 +2397,31 @@ final class SymbolResolverTest extends TestCase
             'makeUser',
             $context->functionImports,
             'Function imports from another namespace block are not in scope here',
+        );
+    }
+
+    public function testGetNameContextSplitsAMixedGroupUseByItemKind(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportCompletion.php', 'mixed_group_partial');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getNameContext($document, $cursor['line']);
+
+        self::assertSame(
+            ['UserRepository' => 'Fixtures\Namespacing\Models\UserRepository'],
+            $context->classImports,
+            'In a mixed group use, the kind is carried by the item rather than the statement',
+        );
+        self::assertSame(
+            ['makeUser' => 'Fixtures\Namespacing\Models\makeUser'],
+            $context->functionImports,
+            'A `function` item of a group use belongs to the function table',
+        );
+        self::assertSame(
+            ['DEFAULT_LIMIT' => 'Fixtures\Namespacing\Models\DEFAULT_LIMIT'],
+            $context->constantImports,
+            'A `const` item of a group use belongs to the constant table',
         );
     }
 

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -2328,6 +2328,87 @@ final class SymbolResolverTest extends TestCase
         return array_map(fn(ResolvedVariable $v) => $v->getName(), $variables);
     }
 
+    public function testGetNameContextSeparatesImportsByKind(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportCompletion.php', 'imported_class_partial');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getNameContext($document, $cursor['line']);
+
+        self::assertSame(
+            'Fixtures\Namespacing\ImportCompletion',
+            $context->namespace,
+            'The namespace is the one enclosing the cursor',
+        );
+        self::assertSame(
+            'Fixtures\Namespacing\Models\UserRepository',
+            $context->classImports['Repo'] ?? null,
+            'An aliased class import maps the alias to its FQCN',
+        );
+        self::assertSame(
+            ['Fixtures\Namespacing\Models\makeUser'],
+            array_values($context->functionImports),
+            'A `use function` import belongs to the function table',
+        );
+        self::assertSame(
+            ['Fixtures\Namespacing\Models\DEFAULT_LIMIT'],
+            array_values($context->constantImports),
+            'A `use const` import belongs to the constant table',
+        );
+        self::assertArrayNotHasKey(
+            'makeUser',
+            $context->classImports,
+            'A `use function` import must not leak into the class table',
+        );
+        self::assertArrayNotHasKey(
+            'DEFAULT_LIMIT',
+            $context->classImports,
+            'A `use const` import must not leak into the class table',
+        );
+    }
+
+    public function testGetNameContextIsScopedToTheEnclosingNamespaceBlock(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportCompletion.php', 'grouped_import_partial');
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getNameContext($document, $cursor['line']);
+
+        self::assertSame(
+            'Fixtures\Namespacing\ImportCompletion\Grouped',
+            $context->namespace,
+            'The namespace is the block containing the cursor, not the first one in the file',
+        );
+        self::assertArrayHasKey(
+            'Post',
+            $context->classImports,
+            'Group use members should be included',
+        );
+        self::assertArrayNotHasKey(
+            'Repo',
+            $context->classImports,
+            'Imports from another namespace block are not in scope here',
+        );
+        self::assertArrayNotHasKey(
+            'makeUser',
+            $context->functionImports,
+            'Function imports from another namespace block are not in scope here',
+        );
+    }
+
+    public function testGetNameContextInTheGlobalNamespace(): void
+    {
+        $uri = $this->openFixture('Namespacing/GlobalNamespace.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $context = $this->resolver->getNameContext($document, 0);
+
+        self::assertSame('', $context->namespace, 'A file with no namespace declaration is global');
+    }
+
     public function testGetImportsIncludesAliasedAndGroupedUses(): void
     {
         $uri = $this->openFixture('Namespacing/ImportCompletion.php');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -2425,6 +2425,42 @@ final class SymbolResolverTest extends TestCase
         );
     }
 
+    public function testGetNameContextAfterTheLastStatementOfASemicolonNamespace(): void
+    {
+        $uri = $this->openFixture('Namespacing/FileWide.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        // A semicolon-style namespace runs to the end of the file, but the AST
+        // node ends at its last statement. This is the line a cursor lands on
+        // after pressing enter at the end of the file — a routine place to ask
+        // for a completion, and still inside the namespace.
+        $lineAfterLastStatement = substr_count($document->getContent(), "\n");
+
+        $context = $this->resolver->getNameContext($document, $lineAfterLastStatement);
+
+        self::assertSame(
+            'Fixtures\Namespacing',
+            $context->namespace,
+            'A semicolon namespace extends past its last statement, to the end of the file',
+        );
+        self::assertSame(
+            ['Repo' => 'Fixtures\Namespacing\Models\UserRepository'],
+            $context->classImports,
+            'The imports of a semicolon namespace are in effect after its last statement',
+        );
+        self::assertSame(
+            ['makeUser' => 'Fixtures\Namespacing\Models\makeUser'],
+            $context->functionImports,
+            'The function imports of a semicolon namespace are in effect after its last statement',
+        );
+        self::assertSame(
+            ['DEFAULT_LIMIT' => 'Fixtures\Namespacing\Models\DEFAULT_LIMIT'],
+            $context->constantImports,
+            'The constant imports of a semicolon namespace are in effect after its last statement',
+        );
+    }
+
     public function testGetNameContextInTheGlobalNamespace(): void
     {
         $uri = $this->openFixture('Namespacing/GlobalNamespace.php');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -2388,6 +2388,11 @@ final class SymbolResolverTest extends TestCase
             $context->classImports,
             'Group use members should be included',
         );
+        self::assertSame(
+            'Fixtures\Namespacing\Models\UserRepository',
+            $context->classImports['Repos'] ?? null,
+            'An aliased member of a group use binds its alias to the prefixed FQCN',
+        );
         self::assertArrayNotHasKey(
             'Repo',
             $context->classImports,

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -804,6 +804,22 @@ class ScopeFinderTest extends TestCase
         self::assertSame('First', ScopeFinder::findNamespaceAtLine($ast, 2));
     }
 
+    public function testFindNamespaceAtLineCoversTheTailOfASemicolonNamespace(): void
+    {
+        $code = $this->loadFixture('Namespacing/FileWide.php');
+        $ast = self::parseWithParents($code);
+
+        // The blank line past the closing brace of the last class. The namespace
+        // node ends at that class, but the namespace itself runs to end of file.
+        $lineAfterLastStatement = substr_count($code, "\n");
+
+        self::assertSame(
+            'Fixtures\Namespacing',
+            ScopeFinder::findNamespaceAtLine($ast, $lineAfterLastStatement),
+            'A semicolon namespace extends past its last statement, to the end of the file',
+        );
+    }
+
     public function testFindNamespaceAtLineReturnsNullOutsideAnyNamespace(): void
     {
         $code = $this->loadFixture('TopLevel/two_namespaces.php');


### PR DESCRIPTION
Closes #329.

## What

Adds the piece the completion epic (#308) is built on: given a symbol's fully qualified
name and the cursor's namespace and imports, compute **the shortest reference that actually
resolves there** — or report that none does.

This is the inverse of what the parser already does. PhpParser's `NameResolver` turns source
text into an FQN; `ReferenceResolver` turns an FQN back into the text that would produce it.
Nothing did that before, which is why every class candidate is currently emitted as a bare
short name — wrong whenever that name doesn't resolve, and wrong even when a *shorter,
qualified* reference is the right answer.

- `ReferenceResolver` — pure, no parser and no I/O.
- `Reference` / `ReferenceKind` — the resulting text plus *why* it resolves. The kinds are
  ordered nearest-to-furthest, so they double as the ranking key #330 needs.
- `NameKind` — the three kinds that participate in name resolution, and the rules that differ
  between them.
- `NameContext` / `NameContextFactory` / `CodeResolver::getNameContext()` — the namespace and
  the three import tables in effect at a line.

## Rules

Implemented from the PHP manual's name resolution rules (`language.namespaces.rules`),
applied shortest-first. The ones worth calling out because they are easy to get wrong:

- **Rule 3** — a *qualified* name's first segment is translated through the **class** import
  table, even when the leaf symbol is a function or constant. So `use App\Model;` makes both
  `Model\Thing` and `Model\helper()` resolve, and an import can be simultaneously a class and
  a namespace prefix: with `use App\Model\User;`, `App\Model\User\Repository` is written
  `User\Repository`.
- **Rules 6 / 7** — unqualified functions and constants fall back to the global namespace;
  class-likes never do.
- **Shadowing** — an import always beats the current namespace, so with `use Other\Thing;` in
  scope, a local `App\Thing` is not reachable as a bare `Thing` at all.

## Two bugs the new extraction does not inherit

Both are in the existing import extraction, and both are load-bearing for the above — which is
why `NameContextFactory` does not build on it:

- `ScopeFinder::extractImports()` collects `Stmt\Use_` without checking `->type`, so
  `use function Foo\bar;` and `use const Foo\BAZ;` are folded into the **class** import map.
- It reads through `iterateTopLevelStatements()`, which flattens every namespace block — so in
  a multi-namespace file, one block's imports leak into another's.

The new extraction is type-aware and block-scoped, and handles mixed group uses
(`use Foo\{Bar, function baz, const QUX}`), where the kind is carried by the item rather than
the statement.

To be clear about what that does **not** mean: `extractImports()` is untouched and still backs
`getImports()`, so both bugs are still live on that path. It is marked as superseded; its
callers move over in #331, after which it is deleted.

## One bug actually fixed

A semicolon-style `namespace App;` has no closing token, and the parser extends its node only
to its last statement. So a cursor on a blank line at the end of the file — the ordinary place
to ask for a completion — looked like it sat outside the namespace altogether, and resolved
against the global namespace with no imports at all.

`ScopeFinder::findNamespaceNodeAtLine()` now runs a semicolon namespace to the next namespace
declaration, or to the end of the file; braced blocks still end at their brace. This also fixes
`findNamespaceAtLine()`, which `TextFallbackHelper` and `SymbolResolver` already relied on.

## Out of scope

`getImports()` and its consumers are untouched. Routing the completion sources through this —
which is the user-visible behavior change — is #331 by design; folding it in here would mix a
behavior change into a foundation.

## Notes

Import shadowing is handled; shadowing by a *declaration* in the current namespace (a local
`App\strlen()` making the global `strlen` unreachable unqualified) needs the symbol catalog
from #328 and is not knowable from this context alone.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

