### PR TITLE
Traverse the full type graph in member resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
-      - name: Generate fixture autoload
-        run: composer dump-autoload --working-dir=tests/Fixtures
+      - name: Install fixture dependencies
+        run: composer install --prefer-dist --no-progress --working-dir=tests/Fixtures
 
       - name: Run PHPUnit
         run: composer phpunit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,22 @@ It no longer parses documents or touches `ParserService`/`SymbolIndex` directly 
 sources own their lookups, and anything parser-derived (imports, file functions,
 members, variables, types) flows through `CodeResolver`. See Completion System.
 
+**All type-graph traversal goes through `MemberResolver::supertypes()`.**
+
+The type graph is walked in exactly ONE place. Every member lookup — methods,
+properties, constants — follows the same edges (used traits, then the parent chain,
+then interfaces), so no member kind can see a different hierarchy than another.
+
+Six hand-written traversals is how #334 happened: only the constant lookups ever
+learned to follow `interfaces`, so interface constants inherited while interface
+methods did not, and every feature was wrong at once. Do NOT reintroduce a
+per-member-kind walk. Adding an edge to the graph is a change to `supertypes()`.
+
+`TypeGraphParityTest` enforces this: the members reported for a type must equal the
+members PHP exposes at runtime (reflection is the oracle), across every shape —
+extends, implements, interface-extends-interface, trait-using-trait, and interfaces
+reached via a parent. A traversal that misses an edge fails it.
+
 **Adding support for a new AST node type:**
 1. Add handling in `SymbolResolver` (ONE place)
 2. Create a `ResolvedX` implementation if needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ Do not write new tests using inlined PHP code. ALWAYS use the fixture tooling wh
 
 ### Test Fixtures
 
-Handler tests use fixture files in `tests/Fixtures/` instead of inline PHP code. Fixtures are a nested Composer project with their own autoloading — run `composer dump-autoload` in `tests/Fixtures/` after adding files outside of the PSR-4 or PSR-0 paths.
+Handler tests use fixture files in `tests/Fixtures/` instead of inline PHP code. Fixtures are a nested Composer project with their own dependencies and autoloading — run `composer install` in `tests/Fixtures/` before running the suite, and again after adding files outside of the PSR-4 or PSR-0 paths.
 
 Re-use existing fixtures whenever possible. Prefer adapting or expanding existing fixtures over adding brand new ones.
 

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -24,10 +24,17 @@ All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
 lexical scope, which includes global scope.
 
+Member completions cover the full type graph: members declared on the type itself,
+plus those inherited through the parent chain, used traits (including traits that
+use other traits), and implemented or extended interfaces at any depth. This holds
+whether the type is read from an open document, parsed from disk, or reflected from
+a built-in.
+
 ## Limitations
 
 - **Visibility**: Typed variable completions only show public members. Use `$this->` for protected/private access within the class.
 - **Union types**: Completions on union types (e.g., `User|Admin`) show only members that exist on ALL types in the union (intersection of members). This is type-safe but may show fewer completions than expected. For intersection types (`User&Admin`), all members from all types are shown.
+- **Trait conflict resolution**: `insteadof` and `as` adaptations are ignored (#73). Methods aliased with `as` are not offered, and when two traits declare the same method the first one listed wins regardless of `insteadof`.
 
 ## Not Yet Supported
 

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -176,20 +176,10 @@ final class MemberResolver
             }
         }
 
-        foreach ($classInfo->traits as $traitName) {
-            $traitInfo = $this->classes->get($traitName);
-            if ($traitInfo !== null) {
-                $result = $this->findMethodInHierarchy($traitInfo, $method, $minVisibility, $seen, true);
-                if ($result !== null) {
-                    return $result;
-                }
-            }
-        }
-
-        if ($classInfo->parent !== null) {
-            $parentInfo = $this->classes->get($classInfo->parent);
-            if ($parentInfo !== null) {
-                return $this->findMethodInHierarchy($parentInfo, $method, $minVisibility, $seen, false);
+        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
+            $result = $this->findMethodInHierarchy($superInfo, $method, $minVisibility, $seen, $superIsOrigin);
+            if ($result !== null) {
+                return $result;
             }
         }
 
@@ -219,20 +209,10 @@ final class MemberResolver
             }
         }
 
-        foreach ($classInfo->traits as $traitName) {
-            $traitInfo = $this->classes->get($traitName);
-            if ($traitInfo !== null) {
-                $result = $this->findPropertyInHierarchy($traitInfo, $property, $minVisibility, $seen, true);
-                if ($result !== null) {
-                    return $result;
-                }
-            }
-        }
-
-        if ($classInfo->parent !== null) {
-            $parentInfo = $this->classes->get($classInfo->parent);
-            if ($parentInfo !== null) {
-                return $this->findPropertyInHierarchy($parentInfo, $property, $minVisibility, $seen, false);
+        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
+            $result = $this->findPropertyInHierarchy($superInfo, $property, $minVisibility, $seen, $superIsOrigin);
+            if ($result !== null) {
+                return $result;
             }
         }
 
@@ -262,33 +242,10 @@ final class MemberResolver
             }
         }
 
-        foreach ($classInfo->traits as $traitName) {
-            $traitInfo = $this->classes->get($traitName);
-            if ($traitInfo !== null) {
-                $result = $this->findConstantInHierarchy($traitInfo, $constant, $minVisibility, $seen, true);
-                if ($result !== null) {
-                    return $result;
-                }
-            }
-        }
-
-        if ($classInfo->parent !== null) {
-            $parentInfo = $this->classes->get($classInfo->parent);
-            if ($parentInfo !== null) {
-                $result = $this->findConstantInHierarchy($parentInfo, $constant, $minVisibility, $seen, false);
-                if ($result !== null) {
-                    return $result;
-                }
-            }
-        }
-
-        foreach ($classInfo->interfaces as $interfaceName) {
-            $interfaceInfo = $this->classes->get($interfaceName);
-            if ($interfaceInfo !== null) {
-                $result = $this->findConstantInHierarchy($interfaceInfo, $constant, $minVisibility, $seen, false);
-                if ($result !== null) {
-                    return $result;
-                }
+        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
+            $result = $this->findConstantInHierarchy($superInfo, $constant, $minVisibility, $seen, $superIsOrigin);
+            if ($result !== null) {
+                return $result;
             }
         }
 
@@ -327,18 +284,8 @@ final class MemberResolver
             $methods[$key] = $methodInfo;
         }
 
-        foreach ($classInfo->traits as $traitName) {
-            $traitInfo = $this->classes->get($traitName);
-            if ($traitInfo !== null) {
-                $this->collectMethods($traitInfo, $minVisibility, $filter, $methods, $seen, true);
-            }
-        }
-
-        if ($classInfo->parent !== null) {
-            $parentInfo = $this->classes->get($classInfo->parent);
-            if ($parentInfo !== null) {
-                $this->collectMethods($parentInfo, $minVisibility, $filter, $methods, $seen, false);
-            }
+        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
+            $this->collectMethods($superInfo, $minVisibility, $filter, $methods, $seen, $superIsOrigin);
         }
     }
 
@@ -373,19 +320,45 @@ final class MemberResolver
             $properties[$key] = $propInfo;
         }
 
-        foreach ($classInfo->traits as $traitName) {
-            $traitInfo = $this->classes->get($traitName);
-            if ($traitInfo !== null) {
-                $this->collectProperties($traitInfo, $minVisibility, $filter, $properties, $seen, true);
+        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
+            $this->collectProperties($superInfo, $minVisibility, $filter, $properties, $seen, $superIsOrigin);
+        }
+    }
+
+    /**
+     * The types to search after a class's own members, in PHP's resolution order:
+     * used traits, then the parent chain, then interfaces. Unresolvable types are
+     * skipped.
+     *
+     * Every member lookup walks the type graph through this one method, so all
+     * member kinds see the same hierarchy.
+     *
+     * @return list<array{ClassInfo, bool}> Supertype paired with its isOriginClass
+     *         flag. A trait's members are flattened into the using class, so its
+     *         private members stay visible; a parent's or interface's do not.
+     */
+    private function supertypes(ClassInfo $classInfo): array
+    {
+        $names = [];
+        foreach ($classInfo->traits as $trait) {
+            $names[] = [$trait, true];
+        }
+        if ($classInfo->parent !== null) {
+            $names[] = [$classInfo->parent, false];
+        }
+        foreach ($classInfo->interfaces as $interface) {
+            $names[] = [$interface, false];
+        }
+
+        $supertypes = [];
+        foreach ($names as [$name, $isOriginClass]) {
+            $info = $this->classes->get($name);
+            if ($info !== null) {
+                $supertypes[] = [$info, $isOriginClass];
             }
         }
 
-        if ($classInfo->parent !== null) {
-            $parentInfo = $this->classes->get($classInfo->parent);
-            if ($parentInfo !== null) {
-                $this->collectProperties($parentInfo, $minVisibility, $filter, $properties, $seen, false);
-            }
-        }
+        return $supertypes;
     }
 
     private function matchesFilter(bool $isStatic, MemberFilter $filter): bool
@@ -424,25 +397,8 @@ final class MemberResolver
             $constants[$key] = $constInfo;
         }
 
-        foreach ($classInfo->traits as $traitName) {
-            $traitInfo = $this->classes->get($traitName);
-            if ($traitInfo !== null) {
-                $this->collectConstants($traitInfo, $minVisibility, $constants, $seen, true);
-            }
-        }
-
-        if ($classInfo->parent !== null) {
-            $parentInfo = $this->classes->get($classInfo->parent);
-            if ($parentInfo !== null) {
-                $this->collectConstants($parentInfo, $minVisibility, $constants, $seen, false);
-            }
-        }
-
-        foreach ($classInfo->interfaces as $interfaceName) {
-            $interfaceInfo = $this->classes->get($interfaceName);
-            if ($interfaceInfo !== null) {
-                $this->collectConstants($interfaceInfo, $minVisibility, $constants, $seen, false);
-            }
+        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
+            $this->collectConstants($superInfo, $minVisibility, $constants, $seen, $superIsOrigin);
         }
     }
 

--- a/tests/Fixtures/composer.json
+++ b/tests/Fixtures/composer.json
@@ -12,5 +12,8 @@
             "Autoload/Classmap/",
             "TypeInference/"
         ]
+    },
+    "require-dev": {
+        "psr/http-message": "^2.0"
     }
 }

--- a/tests/Fixtures/composer.lock
+++ b/tests/Fixtures/composer.lock
@@ -1,0 +1,72 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6175089319acc5f9ed235120612027c7",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/tests/Fixtures/src/Completion/PsrRequestAccess.php
+++ b/tests/Fixtures/src/Completion/PsrRequestAccess.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Psr\Http\Message\RequestInterface;
+
+class PsrRequestAccess
+{
+    public function accessRequest(RequestInterface $request): void
+    {
+        $request->/*|psr_request_access*/
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/AbstractImplementor.php
+++ b/tests/Fixtures/src/Hierarchy/AbstractImplementor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+/**
+ * Implements an interface without redeclaring its members, and pulls in a
+ * trait that itself uses another trait.
+ */
+abstract class AbstractImplementor implements MiddleInterface
+{
+    use OuterTrait;
+
+    public const ABSTRACT_CONST = 'abstract';
+
+    public string $abstractProperty = 'abstract';
+
+    public function abstractClassMethod(): string
+    {
+        return 'abstract';
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/BaseInterface.php
+++ b/tests/Fixtures/src/Hierarchy/BaseInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+interface BaseInterface
+{
+    public const BASE_CONST = 'base';
+
+    public function baseMethod(): string;
+}

--- a/tests/Fixtures/src/Hierarchy/ConcreteDescendant.php
+++ b/tests/Fixtures/src/Hierarchy/ConcreteDescendant.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+/**
+ * Reaches an interface only through its parent class, and satisfies that
+ * interface's members here.
+ */
+class ConcreteDescendant extends AbstractImplementor
+{
+    public const CONCRETE_CONST = 'concrete';
+
+    public string $concreteProperty = 'concrete';
+
+    public function baseMethod(): string
+    {
+        return 'base';
+    }
+
+    public function middleMethod(): string
+    {
+        return 'middle';
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/GrandchildDescendant.php
+++ b/tests/Fixtures/src/Hierarchy/GrandchildDescendant.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+/**
+ * Third level of the class chain: inherits interface, trait and parent members
+ * without redeclaring any of them.
+ */
+class GrandchildDescendant extends ConcreteDescendant
+{
+    public const GRANDCHILD_CONST = 'grandchild';
+
+    public string $grandchildProperty = 'grandchild';
+
+    public function grandchildMethod(): string
+    {
+        return 'grandchild';
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/InnerTrait.php
+++ b/tests/Fixtures/src/Hierarchy/InnerTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+trait InnerTrait
+{
+    public const INNER_CONST = 'inner';
+
+    public string $innerProperty = 'inner';
+
+    public function innerMethod(): string
+    {
+        return 'inner';
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/LeafInterface.php
+++ b/tests/Fixtures/src/Hierarchy/LeafInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+use Countable;
+
+/**
+ * Extends multiple interfaces, one of them a built-in resolved via reflection.
+ */
+interface LeafInterface extends MiddleInterface, Countable
+{
+    public function leafMethod(): string;
+}

--- a/tests/Fixtures/src/Hierarchy/MiddleInterface.php
+++ b/tests/Fixtures/src/Hierarchy/MiddleInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+interface MiddleInterface extends BaseInterface
+{
+    public const MIDDLE_CONST = 'middle';
+
+    public function middleMethod(): string;
+}

--- a/tests/Fixtures/src/Hierarchy/OuterTrait.php
+++ b/tests/Fixtures/src/Hierarchy/OuterTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+/**
+ * A trait that uses another trait.
+ */
+trait OuterTrait
+{
+    use InnerTrait;
+
+    public string $outerProperty = 'outer';
+
+    public function outerMethod(): string
+    {
+        return 'outer';
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1519,6 +1519,29 @@ class CompletionHandlerTest extends TestCase
         self::assertNotContains('hiddenMethod', $labels);
     }
 
+    public function testInterfaceTypedVariableCompletionIncludesExtendedInterfaceMethods(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/PsrRequestAccess.php', 'psr_request_access');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        // Declared on RequestInterface itself
+        self::assertContains('getMethod', $labels, 'methods on the interface itself should be offered');
+        // Declared on MessageInterface, which RequestInterface extends
+        self::assertContains(
+            'getHeaders',
+            $labels,
+            'methods from an extended interface should be offered',
+        );
+        self::assertContains(
+            'getProtocolVersion',
+            $labels,
+            'methods from an extended interface should be offered',
+        );
+    }
+
     public function testStandaloneFunctionAccessExcludesNonPublicMembers(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Mixed/ProceduralWithClass.php', 'standalone_function_access');

--- a/tests/Repository/TypeGraphParityTest.php
+++ b/tests/Repository/TypeGraphParityTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Repository;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * The members reported for a type must match the members PHP actually exposes
+ * at runtime, for every shape of the type graph: extends, implements, interface
+ * extends interface, trait using trait, and interfaces reached via a parent.
+ *
+ * Uses live reflection of the fixture classes as the oracle, so a traversal that
+ * misses an edge cannot pass by agreeing with a hand-written expectation.
+ */
+#[CoversClass(MemberResolver::class)]
+final class TypeGraphParityTest extends TestCase
+{
+    private MemberResolver $resolver;
+
+    public static function setUpBeforeClass(): void
+    {
+        // Fixtures are a separate Composer project; load it so the oracle can
+        // reflect on the same classes the resolver reads from disk.
+        require_once dirname(__DIR__) . '/Fixtures/vendor/autoload.php';
+    }
+
+    /**
+     * @return array<string, array{class-string}>
+     * @codeCoverageIgnore
+     */
+    public static function hierarchyTypes(): array
+    {
+        // @phpstan-ignore return.type (fixture classes are not analyzed)
+        return [
+            'interface' => ['Fixtures\Hierarchy\BaseInterface'],
+            'interface extends interface' => ['Fixtures\Hierarchy\MiddleInterface'],
+            'interface extends several, incl. built-in' => ['Fixtures\Hierarchy\LeafInterface'],
+            'trait using a trait' => ['Fixtures\Hierarchy\OuterTrait'],
+            'abstract class implementing an interface' => ['Fixtures\Hierarchy\AbstractImplementor'],
+            'class reaching an interface via its parent' => ['Fixtures\Hierarchy\ConcreteDescendant'],
+            'class extending a class, several levels' => ['Fixtures\Hierarchy\GrandchildDescendant'],
+            'class using a trait' => ['Fixtures\Traits\ConcreteService'],
+            'interface extending a built-in' => ['Fixtures\Repository\Repository'],
+            'PSR-7 request' => ['Psr\Http\Message\RequestInterface'],
+            'PSR-7 server request' => ['Psr\Http\Message\ServerRequestInterface'],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $parser = new ParserService();
+        $repository = new DefaultClassRepository(
+            new DefaultClassInfoFactory(),
+            new ComposerClassLocator(dirname(__DIR__) . '/Fixtures'),
+            $parser,
+        );
+        $this->resolver = new MemberResolver($repository);
+    }
+
+    /**
+     * @param class-string $fqcn
+     */
+    #[DataProvider('hierarchyTypes')]
+    public function testPublicMethodsMatchRuntime(string $fqcn): void
+    {
+        $resolved = array_map(
+            fn ($method) => $method->name->name,
+            $this->resolver->getMethods(new ClassName($fqcn), Visibility::Public),
+        );
+
+        self::assertSame(
+            self::normalize(get_class_methods($fqcn)),
+            self::normalize($resolved),
+            'resolved public methods should match the methods available at runtime',
+        );
+    }
+
+    /**
+     * @param class-string $fqcn
+     */
+    #[DataProvider('hierarchyTypes')]
+    public function testPublicPropertiesMatchRuntime(string $fqcn): void
+    {
+        $expected = array_map(
+            fn (ReflectionProperty $property) => $property->getName(),
+            (new ReflectionClass($fqcn))->getProperties(ReflectionProperty::IS_PUBLIC),
+        );
+
+        $resolved = array_map(
+            fn ($property) => $property->name->name,
+            $this->resolver->getProperties(new ClassName($fqcn), Visibility::Public),
+        );
+
+        self::assertSame(
+            self::normalize($expected),
+            self::normalize($resolved),
+            'resolved public properties should match the properties available at runtime',
+        );
+    }
+
+    /**
+     * @param class-string $fqcn
+     */
+    #[DataProvider('hierarchyTypes')]
+    public function testPublicConstantsMatchRuntime(string $fqcn): void
+    {
+        $expected = [];
+        foreach ((new ReflectionClass($fqcn))->getReflectionConstants() as $constant) {
+            if ($constant->isPublic()) {
+                $expected[] = $constant->getName();
+            }
+        }
+
+        $resolved = array_map(
+            fn ($constant) => $constant->name->name,
+            $this->resolver->getConstants(new ClassName($fqcn), Visibility::Public),
+        );
+
+        self::assertSame(
+            self::normalize($expected),
+            self::normalize($resolved),
+            'resolved public constants should match the constants available at runtime',
+        );
+    }
+
+    /**
+     * Neither source is ordered, and PHP method names are case-insensitive.
+     *
+     * @param list<string> $names
+     * @return list<string>
+     */
+    private static function normalize(array $names): array
+    {
+        $lowered = array_map(strtolower(...), $names);
+        sort($lowered);
+
+        return $lowered;
+    }
+}


### PR DESCRIPTION
Closes #334.

## Problem

`MemberResolver` contained six independent hand-written hierarchy walks — one per member kind, per lookup style. All six followed the parent chain and used traits, but only the two **constant** walks followed `interfaces`. The result: interface constants inherited correctly, while interface methods and properties did not.

Because every feature routes through `MemberResolver`, this was wrong everywhere at once. Completing on a `RequestInterface` offered `getMethod()` and `getUri()` (declared on `RequestInterface`) but never `getHeaders()` or `withBody()` (declared on `MessageInterface`, which it extends). The same applied to a class reaching an interface through its parent, and to an abstract class implementing an interface without redeclaring its members.

This is a second M×N — *member kind* × *type-graph edge* — sitting one layer below the handler×node M×N that #256 removed. #256 unified **who asks** the resolution question; nothing unified **how the type graph is walked**, so the six walks drifted and only the constant paths were ever taught about interfaces.

## Change

The type graph is now walked in exactly one place: `MemberResolver::supertypes()` yields each linked type (used traits, then the parent chain, then interfaces) with its `isOriginClass` flag, and all six lookups iterate it. Traits keep `isOriginClass: true`, since a trait's private members remain visible to the using class; parents and interfaces do not. Net effect is a smaller `MemberResolver`, and adding an edge to the graph is now a one-place change.

No handler, resolver, or repository changes were needed — they all already routed through `MemberResolver`.

## Tests

`TypeGraphParityTest` asserts the members we report for a type equal the members PHP actually exposes at runtime, using reflection as the oracle, so a traversal that misses an edge cannot pass by agreeing with a hand-written expectation. It covers every shape: `extends` (multi-level), `implements`, interface-extends-interface (multi-level, multiple parents, and extending a built-in), trait-using-trait, an abstract class implementing an interface without redeclaring it, and an interface reached only via a parent class — for methods, properties, and constants alike, against both AST-parsed and reflection-sourced types.

`psr/http-message` is added to the fixtures project so the real-world case is exercised end-to-end (the completion test that failed before this fix). Fixture dependencies now need `composer install` rather than `composer dump-autoload`; CI and `CLAUDE.md` are updated accordingly.

Verified the parity test has teeth: with interface traversal removed, it fails across every interface shape.

## Notes

- A new architecture invariant is documented in `CLAUDE.md`: all type-graph traversal goes through one place, mirroring the existing "all symbol resolution goes through `CodeResolver`".
- Trait conflict resolution (`insteadof` / `as`) is deliberately **not** addressed here. `ClassInfo.traits` is a bare `list<ClassName>` that cannot express aliases or precedence, so aliased methods that exist at runtime are invisible to us and `insteadof` is decided by source order. That is a defect in the domain model rather than the traversal, and is tracked in the re-scoped #73.
