### PR TITLE
Enumerate namespaces for completion discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,34 @@ Incomplete code (e.g. `$this->`, `Foo::`) is handled inside `SymbolResolver` via
 hierarchy, and batch resolution. These require an index and will be added to
 `CodeResolver` when those features are implemented.
 
+### Namespace Catalog (Discovery)
+
+Repositories and reflection answer *lookup* ("resolve this known name"). Completion
+also needs *enumeration* ("what is inside `Psr\Log`?"), which is what the
+`NamespaceCatalog` (`src/Index/`) provides: the child namespaces of a namespace, plus
+the symbols declared directly in it.
+
+- **WorkspaceNamespaceSource** — from `SymbolIndex`. The only source that must NOT be
+  cached: the workspace changes with every keystroke.
+- **ComposerNamespaceSource** — from Composer's autoload maps (`ComposerAutoloadMap`).
+  PSR-4/PSR-0 map a namespace to a directory, so a namespace's contents are a directory
+  listing, not a parse. `vendor/` is never pre-indexed; only namespaces actually visited
+  are read.
+- **ReflectionNamespaceSource** — the language's built-ins. Filter to `isInternal()` (the
+  server's own classes are loaded in the same process), and file each symbol under the
+  namespace its reflected name carries — **internal does not imply global** (`Random\Randomizer`).
+- **CompositeNamespaceCatalog** merges and deduplicates; **CachedNamespaceCatalog** wraps
+  only the stable sources.
+
+Discovery reports a coarse `NameKind` (class-like / function / constant), not which
+flavour of class-like: a PSR-4 listing cannot know without parsing. Deciding whether a
+candidate is valid in a position stays with the `CodeResolver` predicates
+(`isInterface`, `isThrowable`, …), which resolve through the caching `ClassRepository`.
+
+Pair the catalog with `ReferenceResolver` (`src/Resolution/`), which computes the
+shortest reference that resolves at the cursor. Discovery says what exists; resolution
+says how to write it.
+
 ### Repository Pattern
 
 Class and member information flows through a repository layer:

--- a/src/Index/CachedNamespaceCatalog.php
+++ b/src/Index/CachedNamespaceCatalog.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+/**
+ * Remembers what a namespace contains, for sources whose answers cannot change.
+ *
+ * Completion re-queries on every keystroke, so without this, navigating into
+ * `Psr\Http\Message\` would re-read the directory once per character typed.
+ * Caching per namespace preserves laziness: an entry appears only for a
+ * namespace someone actually looked at.
+ *
+ * Only wrap sources that are stable for the life of the process — `vendor/` and
+ * the language's built-ins. The workspace is not one of them.
+ */
+final class CachedNamespaceCatalog implements NamespaceCatalog
+{
+    /** @var array<string, NamespaceContents> Lowercase namespace -> contents */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly NamespaceCatalog $source,
+    ) {
+    }
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        // PHP namespaces are case-insensitive, so `Psr\Log` and `psr\log` are one
+        // namespace and must not be two cache entries.
+        return $this->cache[strtolower($namespace)] ??= $this->source->childrenOf($namespace);
+    }
+}

--- a/src/Index/CatalogSymbol.php
+++ b/src/Index/CatalogSymbol.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Resolution\NameKind;
+
+/**
+ * A symbol discovered in a namespace.
+ *
+ * The kind is deliberately coarse — the three categories that participate in
+ * name resolution, no finer. Discovery cannot always know more: a PSR-4
+ * directory listing yields `LoggerInterface.php` without revealing whether it
+ * declares an interface, a class, or a trait, and finding out means parsing it.
+ *
+ * That is not a loss, because it is not discovery's decision to make. Whether a
+ * candidate is valid in a given position (an interface after `implements`, a
+ * non-final class after `extends`) is already answered by the `CodeResolver`
+ * predicates, which resolve through the caching `ClassRepository`. Discovery
+ * says what exists and where; resolution says what it is.
+ */
+final readonly class CatalogSymbol
+{
+    public function __construct(
+        public string $fullyQualifiedName,
+        public NameKind $kind,
+    ) {
+    }
+
+    public function shortName(): string
+    {
+        $separator = strrpos($this->fullyQualifiedName, '\\');
+
+        return $separator === false
+            ? $this->fullyQualifiedName
+            : substr($this->fullyQualifiedName, $separator + 1);
+    }
+}

--- a/src/Index/CatalogSymbol.php
+++ b/src/Index/CatalogSymbol.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Resolution\NameKind;
+use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * A symbol discovered in a namespace.
@@ -30,10 +31,6 @@ final readonly class CatalogSymbol
 
     public function shortName(): string
     {
-        $separator = strrpos($this->fullyQualifiedName, '\\');
-
-        return $separator === false
-            ? $this->fullyQualifiedName
-            : substr($this->fullyQualifiedName, $separator + 1);
+        return NamespacePath::shortNameOf($this->fullyQualifiedName);
     }
 }

--- a/src/Index/ComposerAutoloadMap.php
+++ b/src/Index/ComposerAutoloadMap.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+/**
+ * The autoload maps Composer generates for a project.
+ *
+ * These are what make enumerating `vendor/` affordable. A PSR-4 prefix maps a
+ * namespace onto a directory, so the contents of a namespace can be listed by
+ * reading a directory rather than by parsing every file beneath it — and only
+ * for the namespace actually being looked at.
+ *
+ * A project with no `vendor/` directory (or none installed yet) yields empty
+ * maps rather than an error; the rest of the server keeps working.
+ */
+final class ComposerAutoloadMap
+{
+    /** @var array<string, list<string>> Namespace prefix (trailing separator) -> directories */
+    private array $psr4 = [];
+
+    /** @var array<string, list<string>> Namespace prefix -> directories */
+    private array $psr0 = [];
+
+    /** @var array<string, string> Fully qualified name -> file */
+    private array $classMap = [];
+
+    public function __construct(string $projectRoot)
+    {
+        $composerDir = rtrim($projectRoot, '/') . '/vendor/composer';
+
+        /** @var array<string, list<string>> */
+        $this->psr4 = self::load($composerDir . '/autoload_psr4.php');
+        /** @var array<string, list<string>> */
+        $this->psr0 = self::load($composerDir . '/autoload_namespaces.php');
+        /** @var array<string, string> */
+        $this->classMap = self::load($composerDir . '/autoload_classmap.php');
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function psr4Prefixes(): array
+    {
+        return $this->psr4;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function psr0Prefixes(): array
+    {
+        return $this->psr0;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function classMap(): array
+    {
+        return $this->classMap;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function load(string $file): array
+    {
+        if (!file_exists($file)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> */
+        return require $file;
+    }
+}

--- a/src/Index/ComposerAutoloadMap.php
+++ b/src/Index/ComposerAutoloadMap.php
@@ -17,25 +17,27 @@ namespace Firehed\PhpLsp\Index;
  */
 final class ComposerAutoloadMap
 {
-    /** @var array<string, list<string>> Namespace prefix (trailing separator) -> directories */
-    private array $psr4 = [];
+    /**
+     * @param array<string, list<string>> $psr4 Namespace prefix -> directories
+     * @param array<string, list<string>> $psr0 Namespace prefix -> directories
+     * @param array<string, string> $classMap Fully qualified name -> file
+     */
+    public function __construct(
+        private readonly array $psr4 = [],
+        private readonly array $psr0 = [],
+        private readonly array $classMap = [],
+    ) {
+    }
 
-    /** @var array<string, list<string>> Namespace prefix -> directories */
-    private array $psr0 = [];
-
-    /** @var array<string, string> Fully qualified name -> file */
-    private array $classMap = [];
-
-    public function __construct(string $projectRoot)
+    public static function fromProjectRoot(string $projectRoot): self
     {
         $composerDir = rtrim($projectRoot, '/') . '/vendor/composer';
 
-        /** @var array<string, list<string>> */
-        $this->psr4 = self::load($composerDir . '/autoload_psr4.php');
-        /** @var array<string, list<string>> */
-        $this->psr0 = self::load($composerDir . '/autoload_namespaces.php');
-        /** @var array<string, string> */
-        $this->classMap = self::load($composerDir . '/autoload_classmap.php');
+        return new self(
+            self::loadPrefixes($composerDir . '/autoload_psr4.php'),
+            self::loadPrefixes($composerDir . '/autoload_namespaces.php'),
+            self::loadClassMap($composerDir . '/autoload_classmap.php'),
+        );
     }
 
     /**
@@ -63,7 +65,44 @@ final class ComposerAutoloadMap
     }
 
     /**
-     * @return array<string, mixed>
+     * These files are generated, but they are still data read from disk in a
+     * project we do not control, so their shape is checked rather than assumed.
+     *
+     * @return array<string, list<string>>
+     */
+    private static function loadPrefixes(string $file): array
+    {
+        $prefixes = [];
+
+        foreach (self::load($file) as $prefix => $directories) {
+            if (!is_string($prefix) || !is_array($directories)) {
+                continue;
+            }
+
+            $prefixes[$prefix] = array_values(array_filter($directories, 'is_string'));
+        }
+
+        return $prefixes;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function loadClassMap(string $file): array
+    {
+        $classMap = [];
+
+        foreach (self::load($file) as $fqn => $path) {
+            if (is_string($fqn) && is_string($path)) {
+                $classMap[$fqn] = $path;
+            }
+        }
+
+        return $classMap;
+    }
+
+    /**
+     * @return array<mixed, mixed>
      */
     private static function load(string $file): array
     {
@@ -71,7 +110,14 @@ final class ComposerAutoloadMap
             return [];
         }
 
-        /** @var array<string, mixed> */
-        return require $file;
+        $contents = require $file;
+
+        if (!is_array($contents)) {
+            // @codeCoverageIgnoreStart
+            throw new \LogicException("Composer autoload file did not return an array: $file");
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $contents;
     }
 }

--- a/src/Index/ComposerAutoloadMap.php
+++ b/src/Index/ComposerAutoloadMap.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
+use Composer\Autoload\ClassLoader;
+
 /**
- * The autoload maps Composer generates for a project.
+ * The autoload maps Composer generates for a project, held in the same
+ * `ClassLoader` Composer itself uses so the data lives in exactly one place.
  *
  * These are what make enumerating `vendor/` affordable. A PSR-4 prefix maps a
  * namespace onto a directory, so the contents of a namespace can be listed by
@@ -17,16 +20,29 @@ namespace Firehed\PhpLsp\Index;
  */
 final class ComposerAutoloadMap
 {
+    private readonly ClassLoader $loader;
+
     /**
      * @param array<string, list<string>> $psr4 Namespace prefix -> directories
      * @param array<string, list<string>> $psr0 Namespace prefix -> directories
      * @param array<string, string> $classMap Fully qualified name -> file
      */
     public function __construct(
-        private readonly array $psr4 = [],
-        private readonly array $psr0 = [],
-        private readonly array $classMap = [],
+        array $psr4 = [],
+        array $psr0 = [],
+        array $classMap = [],
     ) {
+        $loader = new ClassLoader();
+
+        foreach ($psr4 as $prefix => $directories) {
+            $loader->setPsr4($prefix, $directories);
+        }
+        foreach ($psr0 as $prefix => $directories) {
+            $loader->set($prefix, $directories);
+        }
+        $loader->addClassMap($classMap);
+
+        $this->loader = $loader;
     }
 
     public static function fromProjectRoot(string $projectRoot): self
@@ -41,11 +57,19 @@ final class ComposerAutoloadMap
     }
 
     /**
+     * The populated loader, for name -> file lookup via `findFile()`.
+     */
+    public function classLoader(): ClassLoader
+    {
+        return $this->loader;
+    }
+
+    /**
      * @return array<string, list<string>>
      */
     public function psr4Prefixes(): array
     {
-        return $this->psr4;
+        return self::withFallback($this->loader->getPrefixesPsr4(), $this->loader->getFallbackDirsPsr4());
     }
 
     /**
@@ -53,7 +77,7 @@ final class ComposerAutoloadMap
      */
     public function psr0Prefixes(): array
     {
-        return $this->psr0;
+        return self::withFallback($this->loader->getPrefixes(), $this->loader->getFallbackDirs());
     }
 
     /**
@@ -61,7 +85,25 @@ final class ComposerAutoloadMap
      */
     public function classMap(): array
     {
-        return $this->classMap;
+        return $this->loader->getClassMap();
+    }
+
+    /**
+     * A root-namespace mapping (`"": ["src"]`) is a fallback directory in
+     * Composer's loader, not a prefix, so it is absent from the prefix accessors.
+     * Fold it back to the `''` prefix so enumeration sees one uniform shape.
+     *
+     * @param array<string, list<string>> $prefixes
+     * @param list<string> $fallbackDirectories
+     * @return array<string, list<string>>
+     */
+    private static function withFallback(array $prefixes, array $fallbackDirectories): array
+    {
+        if ($fallbackDirectories !== []) {
+            $prefixes[''] = $fallbackDirectories;
+        }
+
+        return $prefixes;
     }
 
     /**

--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -20,32 +20,20 @@ final class ComposerClassLocator implements ClassLocator
             return;
         }
 
+        $map = new ComposerAutoloadMap($projectRoot);
         $loader = new ClassLoader();
 
-        $psr4File = $composerDir . '/autoload_psr4.php';
-        if (file_exists($psr4File)) {
-            /** @var array<string, list<string>> $psr4 */
-            $psr4 = require $psr4File;
-            foreach ($psr4 as $namespace => $paths) {
-                $loader->setPsr4($namespace, $paths);
-            }
+        foreach ($map->psr4Prefixes() as $namespace => $paths) {
+            $loader->setPsr4($namespace, $paths);
         }
 
-        $psr0File = $composerDir . '/autoload_namespaces.php';
-        if (file_exists($psr0File)) {
-            /** @var array<string, list<string>> $psr0 */
-            $psr0 = require $psr0File;
-            foreach ($psr0 as $namespace => $paths) {
-                $loader->set($namespace, $paths);
-            }
+        foreach ($map->psr0Prefixes() as $namespace => $paths) {
+            $loader->set($namespace, $paths);
         }
 
-        $classmapFile = $composerDir . '/autoload_classmap.php';
-        if (file_exists($classmapFile)) {
-            /** @var array<class-string, string> $classmap */
-            $classmap = require $classmapFile;
-            $loader->addClassMap($classmap);
-        }
+        /** @var array<class-string, string> $classMap */
+        $classMap = $map->classMap();
+        $loader->addClassMap($classMap);
 
         $this->loader = $loader;
     }

--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -20,7 +20,7 @@ final class ComposerClassLocator implements ClassLocator
             return;
         }
 
-        $map = new ComposerAutoloadMap($projectRoot);
+        $map = ComposerAutoloadMap::fromProjectRoot($projectRoot);
         $loader = new ClassLoader();
 
         foreach ($map->psr4Prefixes() as $namespace => $paths) {

--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -20,22 +20,7 @@ final class ComposerClassLocator implements ClassLocator
             return;
         }
 
-        $map = ComposerAutoloadMap::fromProjectRoot($projectRoot);
-        $loader = new ClassLoader();
-
-        foreach ($map->psr4Prefixes() as $namespace => $paths) {
-            $loader->setPsr4($namespace, $paths);
-        }
-
-        foreach ($map->psr0Prefixes() as $namespace => $paths) {
-            $loader->set($namespace, $paths);
-        }
-
-        /** @var array<class-string, string> $classMap */
-        $classMap = $map->classMap();
-        $loader->addClassMap($classMap);
-
-        $this->loader = $loader;
+        $this->loader = ComposerAutoloadMap::fromProjectRoot($projectRoot)->classLoader();
     }
 
     public function locate(ClassName $name): ?string

--- a/src/Index/ComposerNamespaceSource.php
+++ b/src/Index/ComposerNamespaceSource.php
@@ -193,37 +193,11 @@ final class ComposerNamespaceSource implements NamespaceCatalog
 
     private function fromClassMap(string $namespace): NamespaceContents
     {
-        $this->classMapIndex ??= self::indexClassMap($this->map->classMap());
+        $this->classMapIndex ??= NamespaceContents::indexByNamespace(array_map(
+            static fn(string $fqn): CatalogSymbol => new CatalogSymbol($fqn, NameKind::ClassLike),
+            array_keys($this->map->classMap()),
+        ));
 
         return $this->classMapIndex[strtolower($namespace)] ?? new NamespaceContents();
-    }
-
-    /**
-     * @param array<string, string> $classMap
-     * @return array<string, NamespaceContents>
-     */
-    private static function indexClassMap(array $classMap): array
-    {
-        $childNamespaces = [];
-        $symbols = [];
-
-        foreach (array_keys($classMap) as $fqn) {
-            $namespace = NamespacePath::namespaceOf($fqn);
-            $symbols[strtolower($namespace)][] = new CatalogSymbol($fqn, NameKind::ClassLike);
-
-            foreach (NamespacePath::ancestors($namespace) as $parent => $child) {
-                $childNamespaces[strtolower($parent)][strtolower($child)] = $child;
-            }
-        }
-
-        $contents = [];
-        foreach (array_keys($childNamespaces + $symbols) as $namespace) {
-            $contents[$namespace] = new NamespaceContents(
-                array_values($childNamespaces[$namespace] ?? []),
-                $symbols[$namespace] ?? [],
-            );
-        }
-
-        return $contents;
     }
 }

--- a/src/Index/ComposerNamespaceSource.php
+++ b/src/Index/ComposerNamespaceSource.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Resolution\NameKind;
+use Firehed\PhpLsp\Utility\NamespacePath;
+
+/**
+ * Discovers symbols through Composer's autoload maps, without parsing or
+ * pre-indexing `vendor/`.
+ *
+ * Under PSR-4 and PSR-0 a namespace maps to a directory, so the contents of a
+ * namespace are a directory listing: subdirectories are child namespaces, and
+ * `.php` files are class-likes named after the file. Only the directories for
+ * the namespace being asked about are read, so navigating to `Psr\Log\` costs
+ * one `scandir` no matter how large the rest of `vendor/` is.
+ *
+ * Namespaces above a prefix are known from the prefix string alone — a prefix of
+ * `Psr\Http\Message\` says `Psr\Http` exists without any disk access at all.
+ *
+ * The classmap is the exception: it maps names to files with no namespace
+ * structure, so it is turned into a namespace index once, on first use.
+ */
+final class ComposerNamespaceSource implements NamespaceCatalog
+{
+    /** @var array<string, NamespaceContents>|null Lowercase namespace -> contents */
+    private ?array $classMapIndex = null;
+
+    public function __construct(
+        private readonly ComposerAutoloadMap $map,
+    ) {
+    }
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        return NamespaceContents::merge([
+            $this->fromPrefixes($this->map->psr4Prefixes(), $namespace, nestsPrefix: false),
+            $this->fromPrefixes($this->map->psr0Prefixes(), $namespace, nestsPrefix: true),
+            $this->fromClassMap($namespace),
+        ]);
+    }
+
+    /**
+     * PSR-4 strips the prefix from the path (`App\Model` under prefix `App\` is
+     * `<dir>/Model`); PSR-0 does not (`Psr0\Sub` under prefix `Psr0` is
+     * `<dir>/Psr0/Sub`).
+     *
+     * @param array<string, list<string>> $prefixes
+     */
+    private function fromPrefixes(array $prefixes, string $namespace, bool $nestsPrefix): NamespaceContents
+    {
+        $childNamespaces = [];
+        $symbols = [];
+
+        foreach ($prefixes as $prefix => $directories) {
+            $prefixNamespace = trim($prefix, '\\');
+
+            // The namespace sits above the prefix: the prefix itself names the
+            // child, and no directory needs to be read.
+            $below = NamespacePath::relativeTo($prefixNamespace, $namespace);
+            if ($below !== null) {
+                $child = NamespacePath::join($namespace, NamespacePath::firstSegment($below));
+                $childNamespaces[strtolower($child)] = $child;
+                continue;
+            }
+
+            // The namespace is at or below the prefix: read the directory it maps to.
+            $withinPrefix = NamespacePath::equals($prefixNamespace, $namespace)
+                ? ''
+                : NamespacePath::relativeTo($namespace, $prefixNamespace);
+            if ($withinPrefix === null) {
+                continue;
+            }
+
+            // PSR-0 nests the prefix inside the directory, so the path is the
+            // whole namespace; PSR-4 strips it, so the path is only the part
+            // below the prefix.
+            $pathSegments = $nestsPrefix
+                ? self::segments($namespace)
+                : self::segments($withinPrefix);
+            $rootNamespace = $nestsPrefix ? '' : $prefixNamespace;
+
+            foreach ($directories as $directory) {
+                $resolved = self::resolveDirectory($directory, $pathSegments);
+                if ($resolved === null) {
+                    continue;
+                }
+                [$path, $realSegments] = $resolved;
+
+                // The namespace as it is really spelled: the prefix's own casing,
+                // then the casing of the directories actually on disk.
+                $canonical = NamespacePath::join($rootNamespace, ...$realSegments);
+
+                $contents = self::readDirectory($path, $canonical);
+                foreach ($contents->childNamespaces as $child) {
+                    $childNamespaces[strtolower($child)] = $child;
+                }
+                foreach ($contents->symbols as $symbol) {
+                    $symbols[strtolower($symbol->fullyQualifiedName)] = $symbol;
+                }
+            }
+        }
+
+        return new NamespaceContents(array_values($childNamespaces), array_values($symbols));
+    }
+
+    /**
+     * Walk a namespace's segments down from an autoload root, matching directory
+     * names case-insensitively (as PHP namespaces are) and reporting the names
+     * as they are actually spelled on disk.
+     *
+     * @param list<string> $segments
+     * @return array{string, list<string>}|null
+     */
+    private static function resolveDirectory(string $baseDirectory, array $segments): ?array
+    {
+        $path = $baseDirectory;
+        $realSegments = [];
+
+        foreach ($segments as $segment) {
+            $entries = is_dir($path) ? scandir($path) : false;
+            if ($entries === false) {
+                return null;
+            }
+
+            $match = null;
+            foreach ($entries as $entry) {
+                if (strcasecmp($entry, $segment) === 0 && is_dir($path . '/' . $entry)) {
+                    $match = $entry;
+                    break;
+                }
+            }
+
+            if ($match === null) {
+                return null;
+            }
+
+            $path .= '/' . $match;
+            $realSegments[] = $match;
+        }
+
+        return is_dir($path) ? [$path, $realSegments] : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function segments(string $namespace): array
+    {
+        return $namespace === '' ? [] : explode('\\', $namespace);
+    }
+
+    /**
+     * Subdirectories are child namespaces; `.php` files declare the class-like
+     * they are named after.
+     */
+    private static function readDirectory(string $path, string $namespace): NamespaceContents
+    {
+        $entries = scandir($path);
+        if ($entries === false) {
+            // @codeCoverageIgnoreStart
+            return new NamespaceContents();
+            // @codeCoverageIgnoreEnd
+        }
+
+        $childNamespaces = [];
+        $symbols = [];
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            if (is_dir($path . '/' . $entry)) {
+                $childNamespaces[] = NamespacePath::join($namespace, $entry);
+                continue;
+            }
+
+            if (!str_ends_with($entry, '.php')) {
+                continue;
+            }
+
+            $symbols[] = new CatalogSymbol(
+                NamespacePath::join($namespace, basename($entry, '.php')),
+                NameKind::ClassLike,
+            );
+        }
+
+        return new NamespaceContents($childNamespaces, $symbols);
+    }
+
+    private function fromClassMap(string $namespace): NamespaceContents
+    {
+        $this->classMapIndex ??= self::indexClassMap($this->map->classMap());
+
+        return $this->classMapIndex[strtolower($namespace)] ?? new NamespaceContents();
+    }
+
+    /**
+     * @param array<string, string> $classMap
+     * @return array<string, NamespaceContents>
+     */
+    private static function indexClassMap(array $classMap): array
+    {
+        $childNamespaces = [];
+        $symbols = [];
+
+        foreach (array_keys($classMap) as $fqn) {
+            $namespace = NamespacePath::namespaceOf($fqn);
+            $symbols[strtolower($namespace)][] = new CatalogSymbol($fqn, NameKind::ClassLike);
+
+            foreach (NamespacePath::ancestors($namespace) as $parent => $child) {
+                $childNamespaces[strtolower($parent)][strtolower($child)] = $child;
+            }
+        }
+
+        $contents = [];
+        foreach (array_keys($childNamespaces + $symbols) as $namespace) {
+            $contents[$namespace] = new NamespaceContents(
+                array_values($childNamespaces[$namespace] ?? []),
+                $symbols[$namespace] ?? [],
+            );
+        }
+
+        return $contents;
+    }
+}

--- a/src/Index/CompositeNamespaceCatalog.php
+++ b/src/Index/CompositeNamespaceCatalog.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+/**
+ * Presents several discovery sources as one catalog.
+ *
+ * Sources overlap by design — a class in the workspace is also a file under a
+ * PSR-4 prefix, and both will report it — so results are deduplicated by name.
+ *
+ * This does no caching itself. Whether an answer may be reused depends on the
+ * source: `vendor/` and the built-ins are fixed for the life of the process,
+ * while the workspace changes with every keystroke. Wrap the stable sources in
+ * {@see CachedNamespaceCatalog} instead of caching here, where the volatile
+ * source would be cached too.
+ */
+final class CompositeNamespaceCatalog implements NamespaceCatalog
+{
+    /**
+     * @param list<NamespaceCatalog> $sources
+     */
+    public function __construct(
+        private readonly array $sources,
+    ) {
+    }
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        return NamespaceContents::merge(array_map(
+            static fn(NamespaceCatalog $source): NamespaceContents => $source->childrenOf($namespace),
+            $this->sources,
+        ));
+    }
+}

--- a/src/Index/NamespaceCatalog.php
+++ b/src/Index/NamespaceCatalog.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+/**
+ * Enumerates what exists in a namespace.
+ *
+ * Completion needs to answer "what is inside `Psr\Log`?" — a question no
+ * existing component can answer. Go-to-definition and hover only ever need
+ * *lookup* (resolve one known name), which `ClassRepository` and reflection
+ * already provide; completion needs *enumeration*, which nothing did.
+ *
+ * Implementations resolve one namespace at a time and are expected to be lazy:
+ * the whole point is that navigating to `Psr\Log\` touches `Psr\Log` and
+ * nothing else, so a large `vendor/` tree costs nothing until it is visited.
+ */
+interface NamespaceCatalog
+{
+    /**
+     * The immediate children of a namespace. The global namespace is `''`.
+     */
+    public function childrenOf(string $namespace): NamespaceContents;
+}

--- a/src/Index/NamespaceContents.php
+++ b/src/Index/NamespaceContents.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+/**
+ * The immediate children of a namespace: the namespaces directly beneath it and
+ * the symbols declared directly in it.
+ *
+ * Only one level deep, which is what makes discovery affordable — navigating to
+ * `Psr\` does not require knowing anything about `Psr\Log\LoggerInterface`.
+ *
+ * Namespaces are listed by fully qualified name; the trailing segment is a
+ * presentation concern.
+ */
+final readonly class NamespaceContents
+{
+    /**
+     * @param list<string> $childNamespaces
+     * @param list<CatalogSymbol> $symbols
+     */
+    public function __construct(
+        public array $childNamespaces = [],
+        public array $symbols = [],
+    ) {
+    }
+
+    /**
+     * Combine the contents reported by several sources, discarding names that
+     * more than one of them reports.
+     *
+     * Overlap is normal rather than exceptional: a class in an open document is
+     * also on disk under a PSR-4 prefix, and both sources will report it.
+     *
+     * @param list<NamespaceContents> $contents
+     */
+    public static function merge(array $contents): self
+    {
+        $namespaces = [];
+        $symbols = [];
+
+        foreach ($contents as $part) {
+            foreach ($part->childNamespaces as $namespace) {
+                $namespaces[strtolower($namespace)] = $namespace;
+            }
+            foreach ($part->symbols as $symbol) {
+                $symbols[strtolower($symbol->fullyQualifiedName)] ??= $symbol;
+            }
+        }
+
+        return new self(array_values($namespaces), array_values($symbols));
+    }
+}

--- a/src/Index/NamespaceContents.php
+++ b/src/Index/NamespaceContents.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
+use Firehed\PhpLsp\Utility\NamespacePath;
+
 /**
  * The immediate children of a namespace: the namespaces directly beneath it and
  * the symbols declared directly in it.
@@ -24,6 +26,42 @@ final readonly class NamespaceContents
         public array $childNamespaces = [],
         public array $symbols = [],
     ) {
+    }
+
+    /**
+     * Group symbols by the namespace they are declared in.
+     *
+     * Every ancestor namespace on the way to a symbol is registered too, so an
+     * intermediate namespace that declares nothing itself is still reachable:
+     * `Random\Engine\Xoshiro256StarStar` makes `Random\Engine` a child of
+     * `Random`, and `Random` a child of the global namespace.
+     *
+     * @param iterable<CatalogSymbol> $symbols
+     * @return array<string, self> Lowercase namespace -> contents
+     */
+    public static function indexByNamespace(iterable $symbols): array
+    {
+        $childNamespaces = [];
+        $symbolsByNamespace = [];
+
+        foreach ($symbols as $symbol) {
+            $namespace = NamespacePath::namespaceOf($symbol->fullyQualifiedName);
+            $symbolsByNamespace[strtolower($namespace)][] = $symbol;
+
+            foreach (NamespacePath::ancestors($namespace) as $parent => $child) {
+                $childNamespaces[strtolower($parent)][strtolower($child)] ??= $child;
+            }
+        }
+
+        $contents = [];
+        foreach (array_keys($childNamespaces + $symbolsByNamespace) as $namespace) {
+            $contents[$namespace] = new self(
+                array_values($childNamespaces[$namespace] ?? []),
+                $symbolsByNamespace[$namespace] ?? [],
+            );
+        }
+
+        return $contents;
     }
 
     /**

--- a/src/Index/NamespaceContents.php
+++ b/src/Index/NamespaceContents.php
@@ -69,7 +69,10 @@ final readonly class NamespaceContents
      * more than one of them reports.
      *
      * Overlap is normal rather than exceptional: a class in an open document is
-     * also on disk under a PSR-4 prefix, and both sources will report it.
+     * also on disk under a PSR-4 prefix, and both sources will report it. The
+     * first source to report a name wins, so sources are passed in order of
+     * authority — the workspace knows how its own symbols are spelled better
+     * than a directory listing does.
      *
      * @param list<NamespaceContents> $contents
      */
@@ -80,7 +83,7 @@ final readonly class NamespaceContents
 
         foreach ($contents as $part) {
             foreach ($part->childNamespaces as $namespace) {
-                $namespaces[strtolower($namespace)] = $namespace;
+                $namespaces[strtolower($namespace)] ??= $namespace;
             }
             foreach ($part->symbols as $symbol) {
                 $symbols[strtolower($symbol->fullyQualifiedName)] ??= $symbol;

--- a/src/Index/ReflectionNamespaceSource.php
+++ b/src/Index/ReflectionNamespaceSource.php
@@ -107,5 +107,4 @@ final class ReflectionNamespaceSource implements NamespaceCatalog
 
         return $symbols;
     }
-
 }

--- a/src/Index/ReflectionNamespaceSource.php
+++ b/src/Index/ReflectionNamespaceSource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Resolution\NameKind;
+use Firehed\PhpLsp\Utility\NamespacePath;
 use ReflectionClass;
 
 /**
@@ -45,14 +46,14 @@ final class ReflectionNamespaceSource implements NamespaceCatalog
         $symbols = [];
 
         foreach (self::internalSymbols() as $fqn => $kind) {
-            $namespace = self::namespaceOf($fqn);
+            $namespace = NamespacePath::namespaceOf($fqn);
 
             $symbols[strtolower($namespace)][] = new CatalogSymbol($fqn, $kind);
 
             // Register the namespace with each of its ancestors, so that
             // `Random\Engine\Xoshiro256StarStar` makes `Random` a child of the
             // global namespace and `Random\Engine` a child of `Random`.
-            foreach (self::ancestorsOf($namespace) as $parent => $child) {
+            foreach (NamespacePath::ancestors($namespace) as $parent => $child) {
                 $existing = $childNamespaces[strtolower($parent)] ?? [];
                 if (!in_array($child, $existing, true)) {
                     $existing[] = $child;
@@ -107,34 +108,4 @@ final class ReflectionNamespaceSource implements NamespaceCatalog
         return $symbols;
     }
 
-    /**
-     * Each ancestor of a namespace mapped to the child leading towards it:
-     * `A\B\C` yields `'' => 'A'`, `'A' => 'A\B'`, `'A\B' => 'A\B\C'`.
-     *
-     * @return array<string, string>
-     */
-    private static function ancestorsOf(string $namespace): array
-    {
-        if ($namespace === '') {
-            return [];
-        }
-
-        $ancestors = [];
-        $parent = '';
-
-        foreach (explode('\\', $namespace) as $segment) {
-            $child = $parent === '' ? $segment : $parent . '\\' . $segment;
-            $ancestors[$parent] = $child;
-            $parent = $child;
-        }
-
-        return $ancestors;
-    }
-
-    private static function namespaceOf(string $fqn): string
-    {
-        $separator = strrpos($fqn, '\\');
-
-        return $separator === false ? '' : substr($fqn, 0, $separator);
-    }
 }

--- a/src/Index/ReflectionNamespaceSource.php
+++ b/src/Index/ReflectionNamespaceSource.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Resolution\NameKind;
-use Firehed\PhpLsp\Utility\NamespacePath;
 use ReflectionClass;
 
 /**
@@ -30,53 +29,13 @@ final class ReflectionNamespaceSource implements NamespaceCatalog
 
     public function childrenOf(string $namespace): NamespaceContents
     {
-        $this->byNamespace ??= self::build();
+        $this->byNamespace ??= NamespaceContents::indexByNamespace(self::internalSymbols());
 
         return $this->byNamespace[strtolower($namespace)] ?? new NamespaceContents();
     }
 
     /**
-     * @return array<string, NamespaceContents>
-     */
-    private static function build(): array
-    {
-        /** @var array<string, list<string>> */
-        $childNamespaces = [];
-        /** @var array<string, list<CatalogSymbol>> */
-        $symbols = [];
-
-        foreach (self::internalSymbols() as $fqn => $kind) {
-            $namespace = NamespacePath::namespaceOf($fqn);
-
-            $symbols[strtolower($namespace)][] = new CatalogSymbol($fqn, $kind);
-
-            // Register the namespace with each of its ancestors, so that
-            // `Random\Engine\Xoshiro256StarStar` makes `Random` a child of the
-            // global namespace and `Random\Engine` a child of `Random`.
-            foreach (NamespacePath::ancestors($namespace) as $parent => $child) {
-                $existing = $childNamespaces[strtolower($parent)] ?? [];
-                if (!in_array($child, $existing, true)) {
-                    $existing[] = $child;
-                    $childNamespaces[strtolower($parent)] = $existing;
-                }
-            }
-        }
-
-        $contents = [];
-        foreach (array_keys($childNamespaces + $symbols) as $namespace) {
-            $contents[$namespace] = new NamespaceContents(
-                $childNamespaces[$namespace] ?? [],
-                $symbols[$namespace] ?? [],
-            );
-        }
-
-        return $contents;
-    }
-
-    /**
-     * Every built-in symbol, as fully qualified name => kind.
-     *
-     * @return array<string, NameKind>
+     * @return list<CatalogSymbol>
      */
     private static function internalSymbols(): array
     {
@@ -89,19 +48,19 @@ final class ReflectionNamespaceSource implements NamespaceCatalog
         ];
         foreach ($classLikes as $classLike) {
             if ((new ReflectionClass($classLike))->isInternal()) {
-                $symbols[$classLike] = NameKind::ClassLike;
+                $symbols[] = new CatalogSymbol($classLike, NameKind::ClassLike);
             }
         }
 
         foreach (get_defined_functions()['internal'] as $function) {
-            $symbols[$function] = NameKind::Function_;
+            $symbols[] = new CatalogSymbol($function, NameKind::Function_);
         }
 
         $constants = get_defined_constants(categorize: true);
         unset($constants['user']);
         foreach ($constants as $category) {
             foreach (array_keys($category) as $constant) {
-                $symbols[$constant] = NameKind::Constant;
+                $symbols[] = new CatalogSymbol($constant, NameKind::Constant);
             }
         }
 

--- a/src/Index/ReflectionNamespaceSource.php
+++ b/src/Index/ReflectionNamespaceSource.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Resolution\NameKind;
+use ReflectionClass;
+
+/**
+ * Discovers the symbols built into PHP itself, via reflection.
+ *
+ * Two things make this less obvious than it looks:
+ *
+ * - `get_declared_classes()` reports every class loaded in *this* process,
+ *   which includes the language server and its own vendored dependencies. Only
+ *   the internal ones are built-ins.
+ * - Built-ins are not all global. `Random\Randomizer` and classes contributed by
+ *   extensions live in namespaces, so each symbol is filed under the namespace
+ *   its reflected name actually carries.
+ *
+ * The index is built once, on first use: the set of internal symbols is fixed
+ * for the life of the process.
+ */
+final class ReflectionNamespaceSource implements NamespaceCatalog
+{
+    /** @var array<string, NamespaceContents>|null Lowercase namespace -> contents */
+    private ?array $byNamespace = null;
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        $this->byNamespace ??= self::build();
+
+        return $this->byNamespace[strtolower($namespace)] ?? new NamespaceContents();
+    }
+
+    /**
+     * @return array<string, NamespaceContents>
+     */
+    private static function build(): array
+    {
+        /** @var array<string, list<string>> */
+        $childNamespaces = [];
+        /** @var array<string, list<CatalogSymbol>> */
+        $symbols = [];
+
+        foreach (self::internalSymbols() as $fqn => $kind) {
+            $namespace = self::namespaceOf($fqn);
+
+            $symbols[strtolower($namespace)][] = new CatalogSymbol($fqn, $kind);
+
+            // Register the namespace with each of its ancestors, so that
+            // `Random\Engine\Xoshiro256StarStar` makes `Random` a child of the
+            // global namespace and `Random\Engine` a child of `Random`.
+            foreach (self::ancestorsOf($namespace) as $parent => $child) {
+                $existing = $childNamespaces[strtolower($parent)] ?? [];
+                if (!in_array($child, $existing, true)) {
+                    $existing[] = $child;
+                    $childNamespaces[strtolower($parent)] = $existing;
+                }
+            }
+        }
+
+        $contents = [];
+        foreach (array_keys($childNamespaces + $symbols) as $namespace) {
+            $contents[$namespace] = new NamespaceContents(
+                $childNamespaces[$namespace] ?? [],
+                $symbols[$namespace] ?? [],
+            );
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Every built-in symbol, as fully qualified name => kind.
+     *
+     * @return array<string, NameKind>
+     */
+    private static function internalSymbols(): array
+    {
+        $symbols = [];
+
+        $classLikes = [
+            ...get_declared_classes(),
+            ...get_declared_interfaces(),
+            ...get_declared_traits(),
+        ];
+        foreach ($classLikes as $classLike) {
+            if ((new ReflectionClass($classLike))->isInternal()) {
+                $symbols[$classLike] = NameKind::ClassLike;
+            }
+        }
+
+        foreach (get_defined_functions()['internal'] as $function) {
+            $symbols[$function] = NameKind::Function_;
+        }
+
+        $constants = get_defined_constants(categorize: true);
+        unset($constants['user']);
+        foreach ($constants as $category) {
+            foreach (array_keys($category) as $constant) {
+                $symbols[$constant] = NameKind::Constant;
+            }
+        }
+
+        return $symbols;
+    }
+
+    /**
+     * Each ancestor of a namespace mapped to the child leading towards it:
+     * `A\B\C` yields `'' => 'A'`, `'A' => 'A\B'`, `'A\B' => 'A\B\C'`.
+     *
+     * @return array<string, string>
+     */
+    private static function ancestorsOf(string $namespace): array
+    {
+        if ($namespace === '') {
+            return [];
+        }
+
+        $ancestors = [];
+        $parent = '';
+
+        foreach (explode('\\', $namespace) as $segment) {
+            $child = $parent === '' ? $segment : $parent . '\\' . $segment;
+            $ancestors[$parent] = $child;
+            $parent = $child;
+        }
+
+        return $ancestors;
+    }
+
+    private static function namespaceOf(string $fqn): string
+    {
+        $separator = strrpos($fqn, '\\');
+
+        return $separator === false ? '' : substr($fqn, 0, $separator);
+    }
+}

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
+use Firehed\PhpLsp\Utility\NamespacePath;
+
 final class SymbolIndex
 {
     /** @var array<string, Symbol> FQN -> Symbol */
@@ -15,6 +17,9 @@ final class SymbolIndex
     /** @var array<string, list<string>> URI -> FQNs */
     private array $byUri = [];
 
+    /** @var array<string, array<string, Symbol>> Lowercase namespace -> FQN -> Symbol */
+    private array $byNamespace = [];
+
     public function add(Symbol $symbol): void
     {
         $this->byFqn[$symbol->fullyQualifiedName] = $symbol;
@@ -24,14 +29,41 @@ final class SymbolIndex
 
         $this->byUri[$symbol->location->uri] ??= [];
         $this->byUri[$symbol->location->uri][] = $symbol->fullyQualifiedName;
+
+        $namespace = strtolower(NamespacePath::namespaceOf($symbol->fullyQualifiedName));
+        $this->byNamespace[$namespace][$symbol->fullyQualifiedName] = $symbol;
     }
 
     /**
+     * The symbols declared directly in a namespace, keyed on it at write time so
+     * that discovery does not rescan the whole workspace on every keystroke.
+     *
      * @return list<Symbol>
      */
-    public function all(): array
+    public function inNamespace(string $namespace): array
     {
-        return array_values($this->byFqn);
+        return array_values($this->byNamespace[strtolower($namespace)] ?? []);
+    }
+
+    /**
+     * Every namespace that declares at least one symbol, in its real casing.
+     * Intermediate namespaces that only contain deeper ones are not listed —
+     * they are derivable from the descendant that witnesses them.
+     *
+     * @return list<string>
+     */
+    public function namespaces(): array
+    {
+        $namespaces = [];
+
+        foreach ($this->byNamespace as $symbols) {
+            foreach ($symbols as $symbol) {
+                $namespaces[] = NamespacePath::namespaceOf($symbol->fullyQualifiedName);
+                break;
+            }
+        }
+
+        return $namespaces;
     }
 
     public function findByFqn(string $fqn): ?Symbol
@@ -86,6 +118,12 @@ final class SymbolIndex
                 ));
                 if ($this->byName[$symbol->name] === []) {
                     unset($this->byName[$symbol->name]);
+                }
+
+                $namespace = strtolower(NamespacePath::namespaceOf($fqn));
+                unset($this->byNamespace[$namespace][$fqn]);
+                if (($this->byNamespace[$namespace] ?? []) === []) {
+                    unset($this->byNamespace[$namespace]);
                 }
             }
         }

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -26,6 +26,14 @@ final class SymbolIndex
         $this->byUri[$symbol->location->uri][] = $symbol->fullyQualifiedName;
     }
 
+    /**
+     * @return list<Symbol>
+     */
+    public function all(): array
+    {
+        return array_values($this->byFqn);
+    }
+
     public function findByFqn(string $fqn): ?Symbol
     {
         return $this->byFqn[$fqn] ?? null;

--- a/src/Index/WorkspaceNamespaceSource.php
+++ b/src/Index/WorkspaceNamespaceSource.php
@@ -27,24 +27,18 @@ final class WorkspaceNamespaceSource implements NamespaceCatalog
 
     public function childrenOf(string $namespace): NamespaceContents
     {
-        $childNamespaces = [];
         $symbols = [];
-
-        foreach ($this->index->all() as $symbol) {
+        foreach ($this->index->inNamespace($namespace) as $symbol) {
             $kind = self::nameKindOf($symbol->kind);
-            if ($kind === null) {
-                continue;
-            }
-
-            $symbolNamespace = NamespacePath::namespaceOf($symbol->fullyQualifiedName);
-
-            if (NamespacePath::equals($symbolNamespace, $namespace)) {
+            if ($kind !== null) {
                 $symbols[] = new CatalogSymbol($symbol->fullyQualifiedName, $kind);
-                continue;
             }
+        }
 
-            // A symbol deeper in the tree still tells us the namespace on the way
-            // to it exists, even if nothing is declared there directly.
+        // A namespace deeper in the tree still tells us the namespace on the way
+        // to it exists, even if nothing is declared there directly.
+        $childNamespaces = [];
+        foreach ($this->index->namespaces() as $symbolNamespace) {
             $below = NamespacePath::relativeTo($symbolNamespace, $namespace);
             if ($below === null) {
                 continue;

--- a/src/Index/WorkspaceNamespaceSource.php
+++ b/src/Index/WorkspaceNamespaceSource.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Resolution\NameKind;
+use Firehed\PhpLsp\Utility\NamespacePath;
+
+/**
+ * Discovers the symbols declared in the workspace, from the symbol index.
+ *
+ * Unlike the other sources this one is not cached: `vendor/` and the language's
+ * built-ins are fixed for the life of the process, but the workspace changes
+ * with every keystroke, and a stale answer here is a symbol that has just been
+ * renamed still being offered.
+ *
+ * Class members are indexed too, but they are not symbols *of a namespace* — a
+ * method is reached through its class, never by name — so they are skipped.
+ */
+final class WorkspaceNamespaceSource implements NamespaceCatalog
+{
+    public function __construct(
+        private readonly SymbolIndex $index,
+    ) {
+    }
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        $childNamespaces = [];
+        $symbols = [];
+
+        foreach ($this->index->all() as $symbol) {
+            $kind = self::nameKindOf($symbol->kind);
+            if ($kind === null) {
+                continue;
+            }
+
+            $symbolNamespace = NamespacePath::namespaceOf($symbol->fullyQualifiedName);
+
+            if (NamespacePath::equals($symbolNamespace, $namespace)) {
+                $symbols[] = new CatalogSymbol($symbol->fullyQualifiedName, $kind);
+                continue;
+            }
+
+            // A symbol deeper in the tree still tells us the namespace on the way
+            // to it exists, even if nothing is declared there directly.
+            $below = NamespacePath::relativeTo($symbolNamespace, $namespace);
+            if ($below === null) {
+                continue;
+            }
+
+            $child = NamespacePath::join($namespace, NamespacePath::firstSegment($below));
+            $childNamespaces[strtolower($child)] = $child;
+        }
+
+        return new NamespaceContents(array_values($childNamespaces), $symbols);
+    }
+
+    /**
+     * Discovery only distinguishes the kinds that name resolution distinguishes;
+     * which flavour of class-like a symbol is takes resolving it.
+     */
+    private static function nameKindOf(SymbolKind $kind): ?NameKind
+    {
+        return match ($kind) {
+            SymbolKind::Class_,
+            SymbolKind::Interface_,
+            SymbolKind::Trait_,
+            SymbolKind::Enum_ => NameKind::ClassLike,
+            SymbolKind::Function_ => NameKind::Function_,
+            SymbolKind::Constant => NameKind::Constant,
+            SymbolKind::Method, SymbolKind::Property => null,
+        };
+    }
+}

--- a/src/Resolution/ReferenceResolver.php
+++ b/src/Resolution/ReferenceResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Resolution;
 
+use Firehed\PhpLsp\Utility\NamespacePath;
+
 /**
  * Computes how a symbol must be written at a given cursor: the shortest
  * reference that resolves back to it, or that no unqualified reference does.
@@ -40,11 +42,11 @@ final class ReferenceResolver
     public static function resolve(string $fullyQualifiedName, NameKind $kind, NameContext $context): Reference
     {
         $fqn = ltrim($fullyQualifiedName, '\\');
-        $namespace = self::namespaceOf($fqn);
-        $shortName = self::shortNameOf($fqn);
+        $namespace = NamespacePath::namespaceOf($fqn);
+        $shortName = NamespacePath::shortNameOf($fqn);
 
         if (
-            self::namespacesMatch($namespace, $context->namespace)
+            NamespacePath::equals($namespace, $context->namespace)
             && !self::isShadowed($shortName, $fqn, $context->importsFor($kind), $kind)
         ) {
             return new Reference($shortName, ReferenceKind::CurrentNamespace);
@@ -59,7 +61,7 @@ final class ReferenceResolver
         if ($viaPrefix !== null) {
             [$prefixAlias, $remainder] = $viaPrefix;
             return new Reference(
-                self::join([$prefixAlias, $remainder, $shortName]),
+                NamespacePath::join($prefixAlias, $remainder, $shortName),
                 ReferenceKind::PrefixImport,
             );
         }
@@ -70,10 +72,15 @@ final class ReferenceResolver
             // The leading segment of a qualified name is bound by the class
             // import table (rule 3), so it matches on that table's terms —
             // case-insensitively — whatever the leaf symbol's kind.
-            && !self::isShadowed(self::firstSegment($relative), $fqn, $context->classImports, NameKind::ClassLike)
+            && !self::isShadowed(
+                NamespacePath::firstSegment($relative),
+                $fqn,
+                $context->classImports,
+                NameKind::ClassLike,
+            )
         ) {
             return new Reference(
-                self::join([$relative, $shortName]),
+                NamespacePath::join($relative, $shortName),
                 ReferenceKind::SubNamespace,
             );
         }
@@ -156,66 +163,24 @@ final class ReferenceResolver
      */
     private static function relativeNamespace(string $namespace, string $ancestor, bool $allowExact = false): ?string
     {
-        if (self::namespacesMatch($namespace, $ancestor)) {
-            return $allowExact ? '' : null;
+        if ($allowExact && NamespacePath::equals($namespace, $ancestor)) {
+            return '';
         }
 
-        // Everything is below the global namespace. Two empty namespaces are
-        // equal, so they have already been handled above.
-        if ($ancestor === '') {
-            return $namespace;
-        }
-
-        $prefix = $ancestor . '\\';
-        if (strncasecmp($namespace, $prefix, strlen($prefix)) !== 0) {
-            return null;
-        }
-
-        return substr($namespace, strlen($prefix));
-    }
-
-    private static function namespaceOf(string $fqn): string
-    {
-        $separator = strrpos($fqn, '\\');
-        return $separator === false ? '' : substr($fqn, 0, $separator);
-    }
-
-    private static function shortNameOf(string $fqn): string
-    {
-        $separator = strrpos($fqn, '\\');
-        return $separator === false ? $fqn : substr($fqn, $separator + 1);
-    }
-
-    private static function firstSegment(string $name): string
-    {
-        $separator = strpos($name, '\\');
-        return $separator === false ? $name : substr($name, 0, $separator);
+        return NamespacePath::relativeTo($namespace, $ancestor);
     }
 
     /**
-     * Namespaces are always case-insensitive, even for constants — only a
-     * constant's final segment is case-sensitive.
+     * Namespaces are case-insensitive even for constants — only a constant's
+     * final segment is case-sensitive.
      */
-    private static function namespacesMatch(string $a, string $b): bool
-    {
-        return strcasecmp($a, $b) === 0;
-    }
-
     private static function namesMatch(string $a, string $b, NameKind $kind): bool
     {
         if (!$kind->isCaseSensitive()) {
             return strcasecmp($a, $b) === 0;
         }
 
-        return self::namespacesMatch(self::namespaceOf($a), self::namespaceOf($b))
-            && self::shortNameOf($a) === self::shortNameOf($b);
-    }
-
-    /**
-     * @param list<string> $segments
-     */
-    private static function join(array $segments): string
-    {
-        return implode('\\', array_filter($segments, static fn(string $s): bool => $s !== ''));
+        return NamespacePath::equals(NamespacePath::namespaceOf($a), NamespacePath::namespaceOf($b))
+            && NamespacePath::shortNameOf($a) === NamespacePath::shortNameOf($b);
     }
 }

--- a/src/Utility/NamespacePath.php
+++ b/src/Utility/NamespacePath.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Utility;
+
+/**
+ * Operations on namespace and fully-qualified-name strings.
+ *
+ * Namespaces are case-insensitive in PHP, and comparisons here reflect that.
+ * Nothing in this class knows what a symbol *is* — it is string manipulation on
+ * segment boundaries, shared by name resolution and by symbol discovery.
+ */
+final class NamespacePath
+{
+    /**
+     * Every ancestor of a namespace mapped to the child leading towards it:
+     * `A\B\C` yields `'' => 'A'`, `'A' => 'A\B'`, `'A\B' => 'A\B\C'`.
+     *
+     * @return array<string, string>
+     */
+    public static function ancestors(string $namespace): array
+    {
+        if ($namespace === '') {
+            return [];
+        }
+
+        $ancestors = [];
+        $parent = '';
+
+        foreach (explode('\\', $namespace) as $segment) {
+            $child = self::join($parent, $segment);
+            $ancestors[$parent] = $child;
+            $parent = $child;
+        }
+
+        return $ancestors;
+    }
+
+    public static function equals(string $a, string $b): bool
+    {
+        return strcasecmp($a, $b) === 0;
+    }
+
+    public static function firstSegment(string $name): string
+    {
+        $separator = strpos($name, '\\');
+
+        return $separator === false ? $name : substr($name, 0, $separator);
+    }
+
+    public static function join(string ...$parts): string
+    {
+        return implode('\\', array_filter($parts, static fn(string $part): bool => $part !== ''));
+    }
+
+    public static function namespaceOf(string $fullyQualifiedName): string
+    {
+        $separator = strrpos($fullyQualifiedName, '\\');
+
+        return $separator === false ? '' : substr($fullyQualifiedName, 0, $separator);
+    }
+
+    /**
+     * The portion of $namespace below $ancestor, or null when $ancestor does not
+     * strictly contain it. Everything is below the global namespace.
+     *
+     * Matching is on segment boundaries, so `App\Models` is not inside
+     * `App\Model`.
+     */
+    public static function relativeTo(string $namespace, string $ancestor): ?string
+    {
+        if (self::equals($namespace, $ancestor)) {
+            return null;
+        }
+
+        if ($ancestor === '') {
+            return $namespace;
+        }
+
+        $prefix = $ancestor . '\\';
+        if (strncasecmp($namespace, $prefix, strlen($prefix)) !== 0) {
+            return null;
+        }
+
+        return substr($namespace, strlen($prefix));
+    }
+
+    public static function shortNameOf(string $fullyQualifiedName): string
+    {
+        $separator = strrpos($fullyQualifiedName, '\\');
+
+        return $separator === false
+            ? $fullyQualifiedName
+            : substr($fullyQualifiedName, $separator + 1);
+    }
+}

--- a/tests/Fixtures/MalformedProject/vendor/composer/autoload_psr4.php
+++ b/tests/Fixtures/MalformedProject/vendor/composer/autoload_psr4.php
@@ -1,0 +1,11 @@
+<?php
+
+// A deliberately malformed stand-in for Composer's generated autoload map, used
+// to prove that reading it validates its shape rather than trusting it. Not a
+// real project: it exists only to be read as data.
+
+return [
+    'Valid\\' => ['/tmp/valid'],
+    'Malformed\\' => 'not-a-list-of-directories',
+    12345 => ['/tmp/numeric-prefix'],
+];

--- a/tests/Index/CachedNamespaceCatalogTest.php
+++ b/tests/Index/CachedNamespaceCatalogTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CachedNamespaceCatalog::class)]
+class CachedNamespaceCatalogTest extends TestCase
+{
+    private CountingNamespaceCatalog $source;
+    private CachedNamespaceCatalog $catalog;
+
+    protected function setUp(): void
+    {
+        $this->source = new CountingNamespaceCatalog();
+        $this->catalog = new CachedNamespaceCatalog($this->source);
+    }
+
+    public function testARepeatedLookupIsServedFromTheCache(): void
+    {
+        $first = $this->catalog->childrenOf('Psr\Log');
+        $second = $this->catalog->childrenOf('Psr\Log');
+
+        self::assertSame(
+            1,
+            $this->source->calls,
+            'Completion re-queries on every keystroke; the same namespace must not be re-read each time',
+        );
+        self::assertEquals($first, $second, 'The cached answer is the same answer');
+    }
+
+    public function testDifferentNamespacesAreCachedSeparately(): void
+    {
+        $this->catalog->childrenOf('Psr\Log');
+        $this->catalog->childrenOf('Psr\Http');
+
+        self::assertSame(
+            2,
+            $this->source->calls,
+            'Each namespace is resolved on its own; only what is visited is paid for',
+        );
+    }
+
+    public function testLookupsAreCachedCaseInsensitively(): void
+    {
+        $this->catalog->childrenOf('Psr\Log');
+        $this->catalog->childrenOf('psr\log');
+
+        self::assertSame(
+            1,
+            $this->source->calls,
+            'Namespaces are case-insensitive in PHP, so these are one namespace, not two',
+        );
+    }
+}

--- a/tests/Index/ComposerAutoloadMapTest.php
+++ b/tests/Index/ComposerAutoloadMapTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Index;
 
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Tests\Fixtures\Autoload\ClassmapFixture;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -38,5 +39,27 @@ class ComposerAutoloadMapTest extends TestCase
             $map->psr4Prefixes(),
             'These files are generated, but they are still data from a project we do not control',
         );
+    }
+
+    public function testARootNamespaceMappingIsExposedAsTheEmptyPrefix(): void
+    {
+        $map = new ComposerAutoloadMap(psr4: ['' => ['/app/src']]);
+
+        self::assertSame(
+            ['' => ['/app/src']],
+            $map->psr4Prefixes(),
+            'Composer routes a root-namespace mapping to a fallback dir; enumeration needs it as the empty prefix',
+        );
+    }
+
+    public function testTheLoaderResolvesAClassToItsFile(): void
+    {
+        $map = ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures');
+
+        // @phpstan-ignore class.notFound
+        $file = $map->classLoader()->findFile(ClassmapFixture::class);
+
+        self::assertIsString($file, 'The map holds the same ClassLoader Composer uses for name -> file lookup');
+        self::assertStringEndsWith('Fixtures/Autoload/Classmap/ClassmapFixture.php', $file);
     }
 }

--- a/tests/Index/ComposerAutoloadMapTest.php
+++ b/tests/Index/ComposerAutoloadMapTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ComposerAutoloadMap::class)]
+class ComposerAutoloadMapTest extends TestCase
+{
+    public function testMapsAreReadFromTheProject(): void
+    {
+        $map = ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures');
+
+        self::assertArrayHasKey('Fixtures\\', $map->psr4Prefixes(), 'The project\'s own PSR-4 prefix');
+        self::assertArrayHasKey('Psr0', $map->psr0Prefixes(), 'The project\'s PSR-0 prefix');
+        self::assertArrayHasKey('GlobalConfig', $map->classMap(), 'A classmapped class');
+    }
+
+    public function testAProjectWithoutComposerYieldsEmptyMaps(): void
+    {
+        $map = ComposerAutoloadMap::fromProjectRoot('/nonexistent');
+
+        self::assertSame([], $map->psr4Prefixes(), 'A project with no vendor/ is not an error');
+        self::assertSame([], $map->psr0Prefixes(), 'A project with no vendor/ is not an error');
+        self::assertSame([], $map->classMap(), 'A project with no vendor/ is not an error');
+    }
+
+    public function testMalformedEntriesAreDiscarded(): void
+    {
+        $map = ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures/MalformedProject');
+
+        self::assertSame(
+            ['Valid\\' => ['/tmp/valid']],
+            $map->psr4Prefixes(),
+            'These files are generated, but they are still data from a project we do not control',
+        );
+    }
+}

--- a/tests/Index/ComposerClassLocatorTest.php
+++ b/tests/Index/ComposerClassLocatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Index;
 
+use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Tests\Fixtures\Autoload\ClassmapFixture;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -23,6 +24,17 @@ final class ComposerClassLocatorTest extends TestCase
         $path = $locator->locateClass(ClassmapFixture::class);
 
         self::assertNotNull($path);
+        self::assertStringEndsWith('Fixtures/Autoload/Classmap/ClassmapFixture.php', $path);
+    }
+
+    public function testLocateResolvesAClassName(): void
+    {
+        $locator = new ComposerClassLocator(self::FIXTURES_ROOT);
+
+        // @phpstan-ignore class.notFound
+        $path = $locator->locate(new ClassName(ClassmapFixture::class));
+
+        self::assertNotNull($path, 'The ClassLocator interface takes a ClassName rather than a string');
         self::assertStringEndsWith('Fixtures/Autoload/Classmap/ClassmapFixture.php', $path);
     }
 

--- a/tests/Index/ComposerNamespaceSourceTest.php
+++ b/tests/Index/ComposerNamespaceSourceTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\ComposerNamespaceSource;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The fixtures directory is itself a Composer project exercising all three
+ * autoload strategies (PSR-4, PSR-0, classmap) and installing a real vendor
+ * package, so it doubles as the test bed for vendor discovery.
+ */
+#[CoversClass(ComposerNamespaceSource::class)]
+#[CoversClass(ComposerAutoloadMap::class)]
+#[CoversClass(CatalogSymbol::class)]
+#[CoversClass(NamespaceContents::class)]
+class ComposerNamespaceSourceTest extends TestCase
+{
+    private const FIXTURES_ROOT = __DIR__ . '/../Fixtures';
+
+    private ComposerNamespaceSource $source;
+
+    protected function setUp(): void
+    {
+        $this->source = new ComposerNamespaceSource(new ComposerAutoloadMap(self::FIXTURES_ROOT));
+    }
+
+    public function testPsr4PrefixesAppearAsNamespacesFromTheGlobalNamespace(): void
+    {
+        $contents = $this->source->childrenOf('');
+
+        self::assertContains(
+            'Fixtures',
+            $contents->childNamespaces,
+            'A PSR-4 prefix is a child of the global namespace',
+        );
+        self::assertContains(
+            'Psr',
+            $contents->childNamespaces,
+            'A vendor package\'s prefix is discoverable without indexing vendor/',
+        );
+    }
+
+    public function testIntermediateNamespacesComeFromThePrefixItself(): void
+    {
+        $contents = $this->source->childrenOf('Psr');
+
+        self::assertSame(
+            ['Psr\Http'],
+            $contents->childNamespaces,
+            'The intermediate segments of a PSR-4 prefix are known without touching the disk',
+        );
+        self::assertSame([], $contents->symbols, 'No files map to this namespace');
+    }
+
+    public function testVendorSymbolsAreListedFromTheDirectory(): void
+    {
+        $contents = $this->source->childrenOf('Psr\Http\Message');
+
+        self::assertContains(
+            'Psr\Http\Message\RequestInterface',
+            self::fqns($contents),
+            'A PSR-4 namespace maps to a directory, so its contents are a directory listing',
+        );
+        self::assertContains(
+            'Psr\Http\Message\ServerRequestInterface',
+            self::fqns($contents),
+            'All files in the directory are symbols of that namespace',
+        );
+    }
+
+    public function testSymbolsFromADirectoryAreClassLikes(): void
+    {
+        $contents = $this->source->childrenOf('Psr\Http\Message');
+
+        foreach ($contents->symbols as $symbol) {
+            self::assertSame(
+                NameKind::ClassLike,
+                $symbol->kind,
+                'A file in an autoloaded directory declares a class-like; which one it is takes parsing',
+            );
+        }
+    }
+
+    public function testSubdirectoriesBecomeChildNamespaces(): void
+    {
+        $contents = $this->source->childrenOf('Fixtures');
+
+        self::assertContains(
+            'Fixtures\Domain',
+            $contents->childNamespaces,
+            'A subdirectory of a PSR-4 root is a child namespace',
+        );
+        self::assertContains(
+            'Fixtures\Domain\User',
+            self::fqns($this->source->childrenOf('Fixtures\Domain')),
+            'Files in that subdirectory are its symbols',
+        );
+    }
+
+    public function testPsr0PrefixesAreDiscovered(): void
+    {
+        $contents = $this->source->childrenOf('Psr0');
+
+        self::assertContains(
+            'Psr0\Psr0Fixture',
+            self::fqns($contents),
+            'PSR-0 nests the whole namespace under the base directory, unlike PSR-4',
+        );
+    }
+
+    public function testClassmapEntriesAreDiscovered(): void
+    {
+        $contents = $this->source->childrenOf('Firehed\PhpLsp\Tests\Fixtures\Autoload');
+
+        self::assertContains(
+            'Firehed\PhpLsp\Tests\Fixtures\Autoload\ClassmapFixture',
+            self::fqns($contents),
+            'A classmapped class is discoverable even though no prefix maps its namespace',
+        );
+    }
+
+    public function testClassmapEntriesInTheGlobalNamespace(): void
+    {
+        $contents = $this->source->childrenOf('');
+
+        self::assertContains(
+            'GlobalConfig',
+            self::fqns($contents),
+            'A classmapped class with no namespace belongs to the global namespace',
+        );
+    }
+
+    public function testNamespaceMatchingIsCaseInsensitive(): void
+    {
+        $contents = $this->source->childrenOf('psr\http\message');
+
+        self::assertContains(
+            'Psr\Http\Message\RequestInterface',
+            self::fqns($contents),
+            'Namespaces are case-insensitive in PHP',
+        );
+    }
+
+    public function testUnknownNamespaceIsEmpty(): void
+    {
+        $contents = $this->source->childrenOf('No\Such\Namespace');
+
+        self::assertSame([], $contents->childNamespaces, 'An unknown namespace has no children');
+        self::assertSame([], $contents->symbols, 'An unknown namespace has no symbols');
+    }
+
+    public function testAProjectWithoutComposerYieldsNothing(): void
+    {
+        $source = new ComposerNamespaceSource(new ComposerAutoloadMap('/nonexistent'));
+
+        $contents = $source->childrenOf('');
+
+        self::assertSame([], $contents->childNamespaces, 'A project with no vendor/ still works');
+        self::assertSame([], $contents->symbols, 'A project with no vendor/ still works');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function fqns(NamespaceContents $contents): array
+    {
+        return array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $contents->symbols,
+        );
+    }
+}

--- a/tests/Index/ComposerNamespaceSourceTest.php
+++ b/tests/Index/ComposerNamespaceSourceTest.php
@@ -157,6 +157,19 @@ class ComposerNamespaceSourceTest extends TestCase
         self::assertSame([], $contents->symbols, 'An unknown namespace has no symbols');
     }
 
+    public function testARootNamespacePrefixEnumeratesFromItsDirectory(): void
+    {
+        $source = new ComposerNamespaceSource(new ComposerAutoloadMap(
+            psr4: ['' => [self::FIXTURES_ROOT . '/src']],
+        ));
+
+        self::assertContains(
+            'Domain',
+            $source->childrenOf('')->childNamespaces,
+            'A root-namespace ("": [dir]) mapping lists its directory as children of the global namespace',
+        );
+    }
+
     public function testAProjectWithoutComposerYieldsNothing(): void
     {
         $source = new ComposerNamespaceSource(ComposerAutoloadMap::fromProjectRoot('/nonexistent'));

--- a/tests/Index/ComposerNamespaceSourceTest.php
+++ b/tests/Index/ComposerNamespaceSourceTest.php
@@ -29,7 +29,7 @@ class ComposerNamespaceSourceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->source = new ComposerNamespaceSource(new ComposerAutoloadMap(self::FIXTURES_ROOT));
+        $this->source = new ComposerNamespaceSource(ComposerAutoloadMap::fromProjectRoot(self::FIXTURES_ROOT));
     }
 
     public function testPsr4PrefixesAppearAsNamespacesFromTheGlobalNamespace(): void
@@ -159,12 +159,69 @@ class ComposerNamespaceSourceTest extends TestCase
 
     public function testAProjectWithoutComposerYieldsNothing(): void
     {
-        $source = new ComposerNamespaceSource(new ComposerAutoloadMap('/nonexistent'));
+        $source = new ComposerNamespaceSource(ComposerAutoloadMap::fromProjectRoot('/nonexistent'));
 
         $contents = $source->childrenOf('');
 
         self::assertSame([], $contents->childNamespaces, 'A project with no vendor/ still works');
         self::assertSame([], $contents->symbols, 'A project with no vendor/ still works');
+    }
+
+    public function testAPrefixWhoseDirectoryIsMissingYieldsNothing(): void
+    {
+        $source = new ComposerNamespaceSource(new ComposerAutoloadMap(
+            psr4: ['Stale\\' => ['/nonexistent/src']],
+        ));
+
+        self::assertSame(
+            [],
+            $source->childrenOf('Stale')->symbols,
+            'An autoload map can outlive the directory it points at; that is not a crash',
+        );
+        self::assertSame(
+            [],
+            $source->childrenOf('Stale\Sub')->symbols,
+            'Nor when the walk into the missing directory has segments left to match',
+        );
+    }
+
+    public function testANamespaceWithNoDirectoryUnderItsPrefixYieldsNothing(): void
+    {
+        $contents = $this->source->childrenOf('Fixtures\NotADirectory');
+
+        self::assertSame(
+            [],
+            $contents->symbols,
+            'The prefix matches but nothing on disk does',
+        );
+        self::assertSame([], $contents->childNamespaces, 'The prefix matches but nothing on disk does');
+    }
+
+    public function testNonPhpFilesAreNotSymbols(): void
+    {
+        // The fixtures root holds composer.json and a vendor/ directory beside
+        // its PHP, so pointing a prefix at it exercises both skips.
+        $source = new ComposerNamespaceSource(new ComposerAutoloadMap(
+            psr4: ['Root\\' => [self::FIXTURES_ROOT]],
+        ));
+
+        $contents = $source->childrenOf('Root');
+
+        self::assertNotContains(
+            'Root\composer',
+            self::fqns($contents),
+            'composer.json is not a class-like; only .php files are',
+        );
+        self::assertContains(
+            'Root\NoNamespace',
+            self::fqns($contents),
+            'The .php files beside it still are',
+        );
+        self::assertContains(
+            'Root\src',
+            $contents->childNamespaces,
+            'Directories are child namespaces',
+        );
     }
 
     /**

--- a/tests/Index/CompositeNamespaceCatalogTest.php
+++ b/tests/Index/CompositeNamespaceCatalogTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\CompositeNamespaceCatalog;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\ComposerNamespaceSource;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Index\ReflectionNamespaceSource;
+use Firehed\PhpLsp\Index\Symbol;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Index\WorkspaceNamespaceSource;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CompositeNamespaceCatalog::class)]
+#[CoversClass(NamespaceContents::class)]
+class CompositeNamespaceCatalogTest extends TestCase
+{
+    private const FIXTURES_ROOT = __DIR__ . '/../Fixtures';
+
+    private SymbolIndex $index;
+    private CompositeNamespaceCatalog $catalog;
+
+    protected function setUp(): void
+    {
+        $this->index = new SymbolIndex();
+        $this->catalog = new CompositeNamespaceCatalog([
+            new WorkspaceNamespaceSource($this->index),
+            new ComposerNamespaceSource(ComposerAutoloadMap::fromProjectRoot(self::FIXTURES_ROOT)),
+            new ReflectionNamespaceSource(),
+        ]);
+    }
+
+    public function testEverySourceContributes(): void
+    {
+        $this->index->add(new Symbol(
+            name: 'Workspace',
+            fullyQualifiedName: 'Fixtures\Workspace',
+            kind: SymbolKind::Class_,
+            location: new Location('file:///Workspace.php', 0, 0, 0, 1),
+        ));
+
+        self::assertContains(
+            'Fixtures\Workspace',
+            self::fqns($this->catalog->childrenOf('Fixtures')),
+            'A workspace symbol is discoverable',
+        );
+        self::assertContains(
+            'Psr\Http\Message\RequestInterface',
+            self::fqns($this->catalog->childrenOf('Psr\Http\Message')),
+            'A vendor symbol is discoverable',
+        );
+        self::assertContains(
+            'SessionHandlerInterface',
+            self::fqns($this->catalog->childrenOf('')),
+            'A built-in symbol is discoverable',
+        );
+    }
+
+    public function testASymbolReportedByTwoSourcesIsOfferedOnce(): void
+    {
+        // Fixtures\Domain\User is both a file under the PSR-4 prefix and, once
+        // opened or scanned, a workspace symbol.
+        $this->index->add(new Symbol(
+            name: 'User',
+            fullyQualifiedName: 'Fixtures\Domain\User',
+            kind: SymbolKind::Class_,
+            location: new Location('file:///User.php', 0, 0, 0, 1),
+        ));
+
+        $users = array_filter(
+            self::fqns($this->catalog->childrenOf('Fixtures\Domain')),
+            static fn(string $fqn): bool => $fqn === 'Fixtures\Domain\User',
+        );
+
+        self::assertCount(1, $users, 'Sources overlap by design; a symbol must not be offered twice');
+    }
+
+    public function testChildNamespacesAreMergedAcrossSources(): void
+    {
+        $children = $this->catalog->childrenOf('');
+
+        self::assertContains('Fixtures', $children->childNamespaces, 'From the autoload maps');
+        self::assertContains('Random', $children->childNamespaces, 'From the built-ins');
+    }
+
+    public function testWorkspaceEditsAreVisibleImmediately(): void
+    {
+        self::assertNotContains(
+            'Fixtures\Domain\Added',
+            self::fqns($this->catalog->childrenOf('Fixtures\Domain')),
+            'Not yet declared',
+        );
+
+        $this->index->add(new Symbol(
+            name: 'Added',
+            fullyQualifiedName: 'Fixtures\Domain\Added',
+            kind: SymbolKind::Class_,
+            location: new Location('file:///Added.php', 0, 0, 0, 1),
+        ));
+
+        self::assertContains(
+            'Fixtures\Domain\Added',
+            self::fqns($this->catalog->childrenOf('Fixtures\Domain')),
+            'A namespace already looked at must not be served stale after an edit',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function fqns(NamespaceContents $contents): array
+    {
+        return array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $contents->symbols,
+        );
+    }
+}

--- a/tests/Index/CountingNamespaceCatalog.php
+++ b/tests/Index/CountingNamespaceCatalog.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\NamespaceCatalog;
+use Firehed\PhpLsp\Index\NamespaceContents;
+
+/**
+ * Records how often it is asked about a namespace, so that caching and laziness
+ * can be asserted on rather than assumed.
+ */
+final class CountingNamespaceCatalog implements NamespaceCatalog
+{
+    public int $calls = 0;
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        $this->calls++;
+
+        return new NamespaceContents([$namespace . '\Child'], []);
+    }
+}

--- a/tests/Index/ReflectionNamespaceSourceTest.php
+++ b/tests/Index/ReflectionNamespaceSourceTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Index\ReflectionNamespaceSource;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ReflectionNamespaceSource::class)]
+#[CoversClass(CatalogSymbol::class)]
+#[CoversClass(NamespaceContents::class)]
+class ReflectionNamespaceSourceTest extends TestCase
+{
+    private ReflectionNamespaceSource $source;
+
+    protected function setUp(): void
+    {
+        $this->source = new ReflectionNamespaceSource();
+    }
+
+    public function testGlobalNamespaceContainsBuiltinClassesFunctionsAndConstants(): void
+    {
+        $contents = $this->source->childrenOf('');
+
+        self::assertContains(
+            'Exception',
+            self::symbolNames($contents, NameKind::ClassLike),
+            'Built-in classes are in the global namespace and must be discoverable',
+        );
+        self::assertContains(
+            'strlen',
+            self::symbolNames($contents, NameKind::Function_),
+            'Built-in functions must be discoverable',
+        );
+        self::assertContains(
+            'PHP_EOL',
+            self::symbolNames($contents, NameKind::Constant),
+            'Built-in constants must be discoverable',
+        );
+    }
+
+    public function testBuiltinInterfacesAreDiscoverable(): void
+    {
+        $contents = $this->source->childrenOf('');
+
+        self::assertContains(
+            'SessionHandlerInterface',
+            self::symbolNames($contents, NameKind::ClassLike),
+            'The interface from #308 that could never be offered before',
+        );
+    }
+
+    public function testInternalSymbolsAreNotAssumedToBeGlobal(): void
+    {
+        $global = $this->source->childrenOf('');
+
+        self::assertContains(
+            'Random',
+            $global->childNamespaces,
+            'Random\ is an internal namespace, so the global namespace has a child',
+        );
+        self::assertNotContains(
+            'Randomizer',
+            self::symbolNames($global, NameKind::ClassLike),
+            'Random\Randomizer is internal but namespaced; it does not belong to global',
+        );
+
+        self::assertContains(
+            'Random\Randomizer',
+            self::fqns($this->source->childrenOf('Random')),
+            'An internal namespaced class is filed under its real namespace',
+        );
+    }
+
+    public function testUserlandSymbolsAreExcluded(): void
+    {
+        $contents = $this->source->childrenOf('');
+
+        self::assertNotContains(
+            'Firehed',
+            $contents->childNamespaces,
+            'The language server\'s own classes are loaded in this process but are not built-ins',
+        );
+        self::assertNotContains(
+            'PhpParser',
+            $contents->childNamespaces,
+            'Vendored dependencies of the server are not built-ins either',
+        );
+    }
+
+    public function testUnknownNamespaceIsEmpty(): void
+    {
+        $contents = $this->source->childrenOf('No\Such\Namespace');
+
+        self::assertSame([], $contents->childNamespaces, 'An unknown namespace has no children');
+        self::assertSame([], $contents->symbols, 'An unknown namespace has no symbols');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function symbolNames(NamespaceContents $contents, NameKind $kind): array
+    {
+        $names = [];
+        foreach ($contents->symbols as $symbol) {
+            if ($symbol->kind === $kind) {
+                $names[] = $symbol->shortName();
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function fqns(NamespaceContents $contents): array
+    {
+        return array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $contents->symbols,
+        );
+    }
+}

--- a/tests/Index/SymbolIndexTest.php
+++ b/tests/Index/SymbolIndexTest.php
@@ -34,22 +34,46 @@ class SymbolIndexTest extends TestCase
         self::assertNull($index->findByFqn('Unknown\\Class'));
     }
 
-    public function testAllReturnsEverySymbol(): void
+    public function testInNamespaceReturnsSymbolsDeclaredThere(): void
     {
         $index = new SymbolIndex();
         $location = new Location('file:///test.php', 0, 0, 0, 10);
-        $index->add(new Symbol('MyClass', 'App\\MyClass', SymbolKind::Class_, $location));
-        $index->add(new Symbol('helper', 'App\\helper', SymbolKind::Function_, $location));
+        $index->add(new Symbol('Thing', 'App\\Thing', SymbolKind::Class_, $location));
+        $index->add(new Symbol('Deep', 'App\\Sub\\Deep', SymbolKind::Class_, $location));
 
         $fqns = array_map(
             static fn(Symbol $symbol): string => $symbol->fullyQualifiedName,
-            $index->all(),
+            $index->inNamespace('App'),
         );
 
         self::assertSame(
-            ['App\\MyClass', 'App\\helper'],
+            ['App\\Thing'],
             $fqns,
-            'Namespace discovery reads the whole index, since symbols are keyed by name, not namespace',
+            'Only symbols declared directly in the namespace, not those in a child of it',
+        );
+    }
+
+    public function testInNamespaceIsCaseInsensitive(): void
+    {
+        $index = new SymbolIndex();
+        $location = new Location('file:///test.php', 0, 0, 0, 10);
+        $index->add(new Symbol('Thing', 'App\\Thing', SymbolKind::Class_, $location));
+
+        self::assertCount(1, $index->inNamespace('app'), 'PHP namespaces are case-insensitive');
+    }
+
+    public function testNamespacesListsEachNamespaceOnceInRealCasing(): void
+    {
+        $index = new SymbolIndex();
+        $location = new Location('file:///test.php', 0, 0, 0, 10);
+        $index->add(new Symbol('Thing', 'App\\Model\\Thing', SymbolKind::Class_, $location));
+        $index->add(new Symbol('Other', 'App\\Model\\Other', SymbolKind::Class_, $location));
+        $index->add(new Symbol('globalHelper', 'globalHelper', SymbolKind::Function_, $location));
+
+        self::assertSame(
+            ['App\\Model', ''],
+            $index->namespaces(),
+            'One entry per namespace that has symbols, spelled as declared; child namespaces are derived elsewhere',
         );
     }
 
@@ -66,6 +90,38 @@ class SymbolIndexTest extends TestCase
 
         self::assertNull($index->findByFqn('ClassA'));
         self::assertNotNull($index->findByFqn('ClassB'));
+    }
+
+    public function testClearByUriRemovesFromTheNamespaceIndex(): void
+    {
+        $index = new SymbolIndex();
+        $index->add(new Symbol('Thing', 'App\\Thing', SymbolKind::Class_, new Location('file:///a.php', 0, 0, 0, 10)));
+        $index->add(new Symbol('Other', 'App\\Other', SymbolKind::Class_, new Location('file:///b.php', 0, 0, 0, 10)));
+
+        $index->clearByUri('file:///a.php');
+
+        $fqns = array_map(
+            static fn(Symbol $symbol): string => $symbol->fullyQualifiedName,
+            $index->inNamespace('App'),
+        );
+
+        self::assertSame(
+            ['App\\Other'],
+            $fqns,
+            'A removed symbol is gone from the namespace index; the ones sharing its namespace remain',
+        );
+        self::assertSame(['App'], $index->namespaces(), 'The namespace still has a symbol, so it stays');
+    }
+
+    public function testClearByUriDropsANamespaceLeftEmpty(): void
+    {
+        $index = new SymbolIndex();
+        $index->add(new Symbol('Only', 'App\\Only', SymbolKind::Class_, new Location('file:///a.php', 0, 0, 0, 10)));
+
+        $index->clearByUri('file:///a.php');
+
+        self::assertSame([], $index->namespaces(), 'A namespace with no symbols left is not reported');
+        self::assertSame([], $index->inNamespace('App'), 'Nor does it hold symbols');
     }
 
     public function testFindByName(): void

--- a/tests/Index/SymbolIndexTest.php
+++ b/tests/Index/SymbolIndexTest.php
@@ -34,6 +34,25 @@ class SymbolIndexTest extends TestCase
         self::assertNull($index->findByFqn('Unknown\\Class'));
     }
 
+    public function testAllReturnsEverySymbol(): void
+    {
+        $index = new SymbolIndex();
+        $location = new Location('file:///test.php', 0, 0, 0, 10);
+        $index->add(new Symbol('MyClass', 'App\\MyClass', SymbolKind::Class_, $location));
+        $index->add(new Symbol('helper', 'App\\helper', SymbolKind::Function_, $location));
+
+        $fqns = array_map(
+            static fn(Symbol $symbol): string => $symbol->fullyQualifiedName,
+            $index->all(),
+        );
+
+        self::assertSame(
+            ['App\\MyClass', 'App\\helper'],
+            $fqns,
+            'Namespace discovery reads the whole index, since symbols are keyed by name, not namespace',
+        );
+    }
+
     public function testClearByUri(): void
     {
         $index = new SymbolIndex();

--- a/tests/Index/WorkspaceNamespaceSourceTest.php
+++ b/tests/Index/WorkspaceNamespaceSourceTest.php
@@ -105,6 +105,25 @@ class WorkspaceNamespaceSourceTest extends TestCase
         );
     }
 
+    public function testSymbolsInUnrelatedNamespacesAreIgnored(): void
+    {
+        $this->add('Thing', 'App\Thing', SymbolKind::Class_);
+        $this->add('Other', 'Vendor\Package\Other', SymbolKind::Class_);
+
+        $contents = $this->source->childrenOf('App');
+
+        self::assertSame(
+            ['App\Thing'],
+            self::fqns($contents),
+            'A symbol outside the namespace is neither its content nor below it',
+        );
+        self::assertSame(
+            [],
+            $contents->childNamespaces,
+            'Nor does it imply a child namespace',
+        );
+    }
+
     public function testGlobalNamespaceSymbols(): void
     {
         $this->add('globalHelper', 'globalHelper', SymbolKind::Function_);

--- a/tests/Index/WorkspaceNamespaceSourceTest.php
+++ b/tests/Index/WorkspaceNamespaceSourceTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\Location;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Index\Symbol;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Index\WorkspaceNamespaceSource;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WorkspaceNamespaceSource::class)]
+#[CoversClass(CatalogSymbol::class)]
+#[CoversClass(NamespaceContents::class)]
+class WorkspaceNamespaceSourceTest extends TestCase
+{
+    private SymbolIndex $index;
+    private WorkspaceNamespaceSource $source;
+
+    protected function setUp(): void
+    {
+        $this->index = new SymbolIndex();
+        $this->source = new WorkspaceNamespaceSource($this->index);
+    }
+
+    public function testSymbolsAreFiledUnderTheirNamespace(): void
+    {
+        $this->add('Thing', 'App\Thing', SymbolKind::Class_);
+        $this->add('helper', 'App\helper', SymbolKind::Function_);
+
+        $contents = $this->source->childrenOf('App');
+
+        self::assertSame(
+            ['App\Thing', 'App\helper'],
+            self::fqns($contents),
+            'Symbols declared in a namespace are its contents',
+        );
+    }
+
+    public function testSymbolKindsMapToNameKinds(): void
+    {
+        $this->add('Thing', 'App\Thing', SymbolKind::Class_);
+        $this->add('Contract', 'App\Contract', SymbolKind::Interface_);
+        $this->add('Reusable', 'App\Reusable', SymbolKind::Trait_);
+        $this->add('Status', 'App\Status', SymbolKind::Enum_);
+        $this->add('helper', 'App\helper', SymbolKind::Function_);
+        $this->add('LIMIT', 'App\LIMIT', SymbolKind::Constant);
+
+        $kinds = [];
+        foreach ($this->source->childrenOf('App')->symbols as $symbol) {
+            $kinds[$symbol->shortName()] = $symbol->kind;
+        }
+
+        self::assertSame(
+            [
+                'Thing' => NameKind::ClassLike,
+                'Contract' => NameKind::ClassLike,
+                'Reusable' => NameKind::ClassLike,
+                'Status' => NameKind::ClassLike,
+                'helper' => NameKind::Function_,
+                'LIMIT' => NameKind::Constant,
+            ],
+            $kinds,
+            'Every class-like collapses to one kind; functions and constants keep their own',
+        );
+    }
+
+    public function testMembersAreNotSymbolsOfANamespace(): void
+    {
+        $this->add('Thing', 'App\Thing', SymbolKind::Class_);
+        $this->add('doIt', 'App\Thing::doIt', SymbolKind::Method);
+        $this->add('name', 'App\Thing::name', SymbolKind::Property);
+
+        self::assertSame(
+            ['App\Thing'],
+            self::fqns($this->source->childrenOf('App')),
+            'Members belong to a class, not to a namespace, and are never referenced by name',
+        );
+    }
+
+    public function testChildNamespacesAreDerivedFromSymbols(): void
+    {
+        $this->add('Repository', 'App\Model\User\Repository', SymbolKind::Class_);
+
+        self::assertSame(
+            ['App'],
+            $this->source->childrenOf('')->childNamespaces,
+            'A deeply nested symbol makes its root a child of the global namespace',
+        );
+        self::assertSame(
+            ['App\Model'],
+            $this->source->childrenOf('App')->childNamespaces,
+            'Intermediate namespaces exist even with no symbols of their own',
+        );
+        self::assertSame(
+            [],
+            $this->source->childrenOf('App')->symbols,
+            'An intermediate namespace holds no symbols itself',
+        );
+    }
+
+    public function testGlobalNamespaceSymbols(): void
+    {
+        $this->add('globalHelper', 'globalHelper', SymbolKind::Function_);
+
+        self::assertSame(
+            ['globalHelper'],
+            self::fqns($this->source->childrenOf('')),
+            'A symbol with no namespace belongs to the global namespace',
+        );
+    }
+
+    public function testNamespaceMatchingIsCaseInsensitive(): void
+    {
+        $this->add('Thing', 'App\Thing', SymbolKind::Class_);
+
+        self::assertSame(
+            ['App\Thing'],
+            self::fqns($this->source->childrenOf('app')),
+            'Namespaces are case-insensitive in PHP',
+        );
+    }
+
+    public function testReflectsLaterEdits(): void
+    {
+        $this->add('Thing', 'App\Thing', SymbolKind::Class_);
+        self::assertSame(['App\Thing'], self::fqns($this->source->childrenOf('App')));
+
+        $this->index->clearByUri('file:///App/Thing.php');
+
+        self::assertSame(
+            [],
+            self::fqns($this->source->childrenOf('App')),
+            'The workspace changes as documents are edited, so its contents cannot be cached',
+        );
+    }
+
+    private function add(string $name, string $fqn, SymbolKind $kind): void
+    {
+        $this->index->add(new Symbol(
+            name: $name,
+            fullyQualifiedName: $fqn,
+            kind: $kind,
+            location: new Location('file:///' . str_replace('\\', '/', $fqn) . '.php', 0, 0, 0, 1),
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function fqns(NamespaceContents $contents): array
+    {
+        return array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $contents->symbols,
+        );
+    }
+}

--- a/tests/Utility/NamespacePathTest.php
+++ b/tests/Utility/NamespacePathTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Utility;
+
+use Firehed\PhpLsp\Utility\NamespacePath;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NamespacePath::class)]
+class NamespacePathTest extends TestCase
+{
+    /**
+     * @param array<string, string> $expected
+     */
+    #[DataProvider('provideAncestors')]
+    public function testAncestors(string $namespace, array $expected): void
+    {
+        self::assertSame(
+            $expected,
+            NamespacePath::ancestors($namespace),
+            'Each ancestor maps to the child leading towards the namespace',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, array<string, string>}>
+     */
+    public static function provideAncestors(): iterable
+    {
+        yield 'global namespace has none' => ['', []];
+        yield 'single segment' => ['App', ['' => 'App']];
+        yield 'nested' => ['A\B\C', ['' => 'A', 'A' => 'A\B', 'A\B' => 'A\B\C']];
+    }
+
+    #[DataProvider('provideRelativeTo')]
+    public function testRelativeTo(string $namespace, string $ancestor, ?string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            NamespacePath::relativeTo($namespace, $ancestor),
+            'A namespace is only relative to one that strictly contains it',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string, ?string}>
+     */
+    public static function provideRelativeTo(): iterable
+    {
+        yield 'child of global' => ['App\Model', '', 'App\Model'];
+        yield 'child of a namespace' => ['App\Model\User', 'App', 'Model\User'];
+        yield 'identical namespaces are not relative' => ['App', 'App', null];
+        yield 'case-insensitive' => ['APP\Model', 'app', 'Model'];
+        yield 'unrelated' => ['Other\Thing', 'App', null];
+        yield 'partial segment is not a prefix' => ['App\Models\Thing', 'App\Model', null];
+        yield 'global is not below anything' => ['', 'App', null];
+    }
+
+    #[DataProvider('provideNames')]
+    public function testNamespaceAndShortNameSplitTheName(
+        string $fqn,
+        string $expectedNamespace,
+        string $expectedShortName,
+    ): void {
+        self::assertSame($expectedNamespace, NamespacePath::namespaceOf($fqn), 'Everything before the last separator');
+        self::assertSame($expectedShortName, NamespacePath::shortNameOf($fqn), 'Everything after it');
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function provideNames(): iterable
+    {
+        yield 'namespaced' => ['App\Model\User', 'App\Model', 'User'];
+        yield 'global' => ['Exception', '', 'Exception'];
+    }
+
+    #[DataProvider('provideFirstSegments')]
+    public function testFirstSegment(string $name, string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            NamespacePath::firstSegment($name),
+            'The leading segment is what an import binds',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideFirstSegments(): iterable
+    {
+        yield 'qualified' => ['Model\User\Repository', 'Model'];
+        yield 'unqualified' => ['User', 'User'];
+    }
+
+    public function testJoinSkipsEmptySegments(): void
+    {
+        self::assertSame(
+            'App\User',
+            NamespacePath::join('', 'App', '', 'User'),
+            'A symbol in the global namespace has no empty leading separator',
+        );
+    }
+}


### PR DESCRIPTION
Closes #328.

## What

Adds the discovery half of #308: a `NamespaceCatalog` that answers *"what is inside this
namespace?"* — the child namespaces, and the symbols declared directly in it.

Nothing could answer that before. `ClassRepository` and reflection do *lookup* (resolve one
known name), which is all hover and go-to-definition ever need. Completion needs
*enumeration*, and without it built-in and vendor symbols simply cannot be candidates:
`WorkspaceIndexer` skips `/vendor/` outright, and nothing seeds built-ins. This is why
`SessionHandlerInterface` can never be offered after `implements`.

Three sources, merged and deduplicated:

- **`WorkspaceNamespaceSource`** — from the existing `SymbolIndex`.
- **`ComposerNamespaceSource`** — from Composer's autoload maps.
- **`ReflectionNamespaceSource`** — the language's built-ins.

## `vendor/` is not indexed

Under PSR-4 a namespace maps to a directory, so a namespace's contents are a **directory
listing, not a parse** — and only the directories for the namespace being asked about are
read. Navigating to `Psr\Log\` costs one `scandir` no matter how large `vendor/` is.
Namespaces *above* a prefix are known from the prefix string alone: a prefix of
`Psr\Http\Message\` proves `Psr\Http` exists with no disk access at all.

The classmap is the exception — it has no namespace structure — so it is indexed once, on
first use.

## Two traps, both pinned by tests

- **Internal does not imply global.** `Random\Randomizer` is a built-in that lives in a
  namespace, so each symbol is filed under the namespace its reflected name actually
  carries. The global-namespace fallback in `ReferenceResolver` keys off *"namespace is
  empty"*, which is a different predicate from *"is internal"*.
- **`get_declared_classes()` sees this process.** It reports the language server's own
  classes and its vendored dependencies alongside the built-ins, so it is filtered to
  `isInternal()` — otherwise `PhpParser\*` would be offered as a built-in.

## Caching is a decorator, not a feature of the composite

`vendor/` and the built-ins are fixed for the life of the process; the workspace changes
with every keystroke. Caching the composite would cache the workspace too, and a stale
answer there is a just-renamed symbol still being offered. So `CachedNamespaceCatalog`
wraps only the stable sources, and the volatile one is always asked.

## Coarse kinds are deliberate

Discovery reports `NameKind` (class-like / function / constant), not which flavour of
class-like a symbol is: a PSR-4 directory listing yields `LoggerInterface.php` without
revealing what it declares, and finding out means parsing it. That is not a loss, because
it was never discovery's decision — whether a candidate is valid in a position is already
answered by the `CodeResolver` predicates, which resolve through the caching
`ClassRepository`. Discovery says what exists; resolution says what it is.

## Also here

- `NamespacePath` — namespace-string operations, extracted rather than copied a third time;
  `ReferenceResolver`'s private copies now point at it.
- `ComposerAutoloadMap` — the autoload-map reading `ComposerClassLocator` already did, now
  held in Composer's own `ClassLoader` so the maps live in one place; both the locator and
  `ComposerNamespaceSource` read them back through it. Still constructible from its data,
  which keeps the awkward cases (a prefix whose directory no longer exists, a malformed
  generated file) reachable in tests. Going through the loader also restores a
  root-namespace mapping (`"": ["src"]`), which Composer stores as a PSR-4 fallback dir and
  the raw-file read had dropped.
- `SymbolIndex` gains a namespace-keyed index, maintained in `add`/`clearByUri`, so the
  workspace source answers a namespace query without rescanning every symbol on each
  keystroke.

## Not wired in yet

`Server` does not construct the catalog: it has no consumer until #330 (navigation items)
and #331 (routing the existing sources through it), and wiring it now would add an object
nothing calls.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

