### PR TITLE
Insert completion references via textEdit and filterText

### DIFF
--- a/src/Completion/ClassCandidates.php
+++ b/src/Completion/ClassCandidates.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Resolution\NameContext;
 use Firehed\PhpLsp\Resolution\NameKind;
@@ -36,19 +37,30 @@ final class ClassCandidates
     /**
      * @return list<CompletionItem>
      */
-    public function find(string $prefix, TextDocument $document, int $line, ClassCandidateFilter $filter): array
-    {
+    public function find(
+        string $prefix,
+        TextDocument $document,
+        int $line,
+        int $character,
+        ClassCandidateFilter $filter,
+    ): array {
         $context = $this->codeResolver->getNameContext($document, $line);
+        // What a selected item replaces: the token the cursor sits at the end of.
+        $replaceRange = Range::onLine($line, $character - strlen($prefix), $character);
 
-        $items = $this->fromImports($prefix, $document, $filter);
-        return array_merge($items, $this->fromIndex($prefix, $filter, $context));
+        $items = $this->fromImports($prefix, $document, $filter, $replaceRange);
+        return array_merge($items, $this->fromIndex($prefix, $filter, $context, $replaceRange));
     }
 
     /**
      * @return list<CompletionItem>
      */
-    private function fromImports(string $prefix, TextDocument $document, ClassCandidateFilter $filter): array
-    {
+    private function fromImports(
+        string $prefix,
+        TextDocument $document,
+        ClassCandidateFilter $filter,
+        Range $replaceRange,
+    ): array {
         $items = [];
         foreach ($this->codeResolver->getImports($document) as $shortName => $fqcn) {
             if (!PrefixMatcher::matches($shortName, $prefix)) {
@@ -58,7 +70,7 @@ final class ClassCandidates
             if (!$this->passesResolutionFilter(new ClassName($fqcn), $filter)) {
                 continue;
             }
-            $items[] = CompletionItemFactory::forClass($shortName, $fqcn);
+            $items[] = CompletionItemFactory::forClass($shortName, $fqcn, $replaceRange);
         }
 
         return $items;
@@ -67,8 +79,12 @@ final class ClassCandidates
     /**
      * @return list<CompletionItem>
      */
-    private function fromIndex(string $prefix, ClassCandidateFilter $filter, NameContext $context): array
-    {
+    private function fromIndex(
+        string $prefix,
+        ClassCandidateFilter $filter,
+        NameContext $context,
+        Range $replaceRange,
+    ): array {
         $symbols = $this->symbolIndex->findByPrefix($prefix, $this->indexKinds($filter));
         $items = [];
 
@@ -86,7 +102,7 @@ final class ClassCandidates
             if (!$reference->isReachable()) {
                 continue;
             }
-            $items[] = CompletionItemFactory::forClass($reference->text, $fqcn);
+            $items[] = CompletionItemFactory::forClass($reference->text, $fqcn, $replaceRange);
         }
 
         return $items;

--- a/src/Completion/CompletionItemFactory.php
+++ b/src/Completion/CompletionItemFactory.php
@@ -6,23 +6,28 @@ namespace Firehed\PhpLsp\Completion;
 
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\ParameterInfo;
+use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\ResolvedConstant;
 use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Utility\DocblockParser;
+use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * Builds LSP completion items. Centralizing construction here keeps item shape,
  * kind assignment, and documentation extraction consistent across every
  * completion source.
  *
+ * @phpstan-import-type LspRange from Range
  * @phpstan-type CompletionItem array{
  *   label: string,
  *   kind?: int,
  *   detail?: string,
  *   documentation?: string,
+ *   filterText?: string,
+ *   textEdit?: array{range: LspRange, newText: string},
  * }
  */
 final class CompletionItemFactory
@@ -82,12 +87,21 @@ final class CompletionItemFactory
     /**
      * @return CompletionItem
      */
-    public static function forClass(string $shortName, string $fullyQualifiedName): array
+    public static function forClass(string $reference, string $fullyQualifiedName, Range $replaceRange): array
     {
         return [
-            'label' => $shortName,
+            'label' => $reference,
             'kind' => CompletionItemKind::Class_->value,
             'detail' => $fullyQualifiedName,
+            // Clients filter on the short name, so a relative reference like
+            // `Sub\Thing` still matches when only `Thing` has been typed.
+            'filterText' => NamespacePath::shortNameOf($reference),
+            // Replace the whole typed token with the reference, so a qualified
+            // name never duplicates the segments already on screen.
+            'textEdit' => [
+                'range' => $replaceRange->toArray(),
+                'newText' => $reference,
+            ],
         ];
     }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -148,7 +148,7 @@ final class CompletionHandler implements HandlerInterface
                 $items = array_merge($items, $this->keywordCandidates->find($prefix, KeywordGroup::Expression));
                 $items = array_merge(
                     $items,
-                    $this->classCandidates->find($prefix, $document, $line, ClassCandidateFilter::Any),
+                    $this->classCandidates->find($prefix, $document, $line, $character, ClassCandidateFilter::Any),
                 );
             }
 
@@ -162,52 +162,64 @@ final class CompletionHandler implements HandlerInterface
 
         return match ($classification->kind) {
             CompletionKind::Variable => $this->variableCandidates->find($prefix, $document, $line, $character),
-            CompletionKind::New_ => $this->getNewCompletions($prefix, $document, $line),
-            CompletionKind::AfterVisibility => $this->getAfterVisibilityCompletions($prefix, $document, $line),
+            CompletionKind::New_ => $this->getNewCompletions($prefix, $document, $line, $character),
+            CompletionKind::AfterVisibility => $this->getAfterVisibilityCompletions(
+                $prefix,
+                $document,
+                $line,
+                $character,
+            ),
             CompletionKind::ReturnType => $this->getTypeHintCompletions(
                 $prefix,
                 $document,
                 $line,
+                $character,
                 TypeHintContext::ReturnType,
             ),
             CompletionKind::PropertyType => $this->getTypeHintCompletions(
                 $prefix,
                 $document,
                 $line,
+                $character,
                 TypeHintContext::Property,
             ),
             CompletionKind::ParameterType => $this->getTypeHintCompletions(
                 $prefix,
                 $document,
                 $line,
+                $character,
                 TypeHintContext::Parameter,
             ),
             CompletionKind::InterfaceList => $this->classCandidates->find(
                 $prefix,
                 $document,
                 $line,
+                $character,
                 ClassCandidateFilter::Interface_,
             ),
             CompletionKind::ExtendableClass => $this->classCandidates->find(
                 $prefix,
                 $document,
                 $line,
+                $character,
                 ClassCandidateFilter::ExtendableClass,
             ),
             CompletionKind::Throwable => $this->classCandidates->find(
                 $prefix,
                 $document,
                 $line,
+                $character,
                 ClassCandidateFilter::Throwable,
             ),
             CompletionKind::Attribute => $this->classCandidates->find(
                 $prefix,
                 $document,
                 $line,
+                $character,
                 ClassCandidateFilter::Attribute,
             ),
             CompletionKind::ClassBody => $this->keywordCandidates->find($prefix, KeywordGroup::ClassBody),
-            CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document, $line),
+            CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document, $line, $character),
             CompletionKind::None => [],
         };
     }
@@ -217,10 +229,10 @@ final class CompletionHandler implements HandlerInterface
      *
      * @return list<CompletionItem>
      */
-    private function getNewCompletions(string $prefix, TextDocument $document, int $line): array
+    private function getNewCompletions(string $prefix, TextDocument $document, int $line, int $character): array
     {
         return $this->deduplicateCompletions(
-            $this->classCandidates->find($prefix, $document, $line, ClassCandidateFilter::Instantiable),
+            $this->classCandidates->find($prefix, $document, $line, $character, ClassCandidateFilter::Instantiable),
         );
     }
 
@@ -229,12 +241,16 @@ final class CompletionHandler implements HandlerInterface
      *
      * @return list<CompletionItem>
      */
-    private function getAfterVisibilityCompletions(string $prefix, TextDocument $document, int $line): array
-    {
+    private function getAfterVisibilityCompletions(
+        string $prefix,
+        TextDocument $document,
+        int $line,
+        int $character,
+    ): array {
         $items = $this->keywordCandidates->find($prefix, KeywordGroup::AfterVisibility);
         $items = array_merge(
             $items,
-            $this->getTypeHintCompletions($prefix, $document, $line, TypeHintContext::Property),
+            $this->getTypeHintCompletions($prefix, $document, $line, $character, TypeHintContext::Property),
         );
         return $this->deduplicateCompletions($items);
     }
@@ -244,13 +260,17 @@ final class CompletionHandler implements HandlerInterface
      *
      * @return list<CompletionItem>
      */
-    private function getExpressionCompletions(string $prefix, TextDocument $document, int $line): array
-    {
+    private function getExpressionCompletions(
+        string $prefix,
+        TextDocument $document,
+        int $line,
+        int $character,
+    ): array {
         $items = $this->keywordCandidates->find($prefix, KeywordGroup::All);
         $items = array_merge($items, $this->functionCandidates->find($prefix, $document));
         $items = array_merge(
             $items,
-            $this->classCandidates->find($prefix, $document, $line, ClassCandidateFilter::Any),
+            $this->classCandidates->find($prefix, $document, $line, $character, ClassCandidateFilter::Any),
         );
         return $this->deduplicateCompletions($items);
     }
@@ -286,6 +306,7 @@ final class CompletionHandler implements HandlerInterface
         string $prefix,
         TextDocument $document,
         int $line,
+        int $character,
         TypeHintContext $context,
     ): array {
         $items = $this->builtinTypeCandidates->find($prefix, $context);
@@ -293,7 +314,7 @@ final class CompletionHandler implements HandlerInterface
         // Class-likes valid as type hints (traits excluded)
         $items = array_merge(
             $items,
-            $this->classCandidates->find($prefix, $document, $line, ClassCandidateFilter::TypeHint),
+            $this->classCandidates->find($prefix, $document, $line, $character, ClassCandidateFilter::TypeHint),
         );
 
         return $this->deduplicateCompletions($items);

--- a/src/Protocol/Range.php
+++ b/src/Protocol/Range.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+/**
+ * An LSP range: a start and end position, each a zero-based line and character
+ * offset. Serializes to the `{ start, end }` shape LSP uses for textEdits,
+ * locations, diagnostics, and the like, so callers never hand-build that nested
+ * array.
+ *
+ * @phpstan-type LspRange array{
+ *   start: array{line: int, character: int},
+ *   end: array{line: int, character: int},
+ * }
+ */
+final readonly class Range
+{
+    public function __construct(
+        public int $startLine,
+        public int $startCharacter,
+        public int $endLine,
+        public int $endCharacter,
+    ) {
+    }
+
+    /**
+     * A span within a single line, from $startCharacter up to $endCharacter — the
+     * common case when replacing a token the user has typed.
+     */
+    public static function onLine(int $line, int $startCharacter, int $endCharacter): self
+    {
+        return new self($line, $startCharacter, $line, $endCharacter);
+    }
+
+    /**
+     * @return LspRange
+     */
+    public function toArray(): array
+    {
+        return [
+            'start' => ['line' => $this->startLine, 'character' => $this->startCharacter],
+            'end' => ['line' => $this->endLine, 'character' => $this->endCharacter],
+        ];
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -265,7 +265,7 @@ class CompletionHandlerTest extends TestCase
         self::assertIsArray($result);
         $item = null;
         foreach ($result['items'] as $candidate) {
-            if (($candidate['label'] ?? null) === 'Sub\Thing') {
+            if ($candidate['label'] === 'Sub\Thing') {
                 $item = $candidate;
                 break;
             }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -255,6 +255,41 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testQualifiedClassCarriesFilterTextAndTextEdit(): void
+    {
+        $this->openFixture('Namespacing/SubNamespaceClass.php');
+        $cursor = $this->openFixtureAtCursor('Namespacing/UnqualifiedNewCompletion.php', 'subnamespace_new');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $item = null;
+        foreach ($result['items'] as $candidate) {
+            if (($candidate['label'] ?? null) === 'Sub\Thing') {
+                $item = $candidate;
+                break;
+            }
+        }
+        self::assertIsArray($item, 'The sub-namespace class is offered as `Sub\Thing`');
+
+        self::assertSame(
+            'Thing',
+            $item['filterText'] ?? null,
+            'The short name is the filter text, so the client keeps the item when the short prefix is typed',
+        );
+        self::assertSame(
+            [
+                'range' => [
+                    'start' => ['line' => $cursor['line'], 'character' => $cursor['character'] - 2],
+                    'end' => ['line' => $cursor['line'], 'character' => $cursor['character']],
+                ],
+                'newText' => 'Sub\Thing',
+            ],
+            $item['textEdit'] ?? null,
+            'The textEdit replaces the whole typed prefix (`Th`) with the reference, so it never duplicates',
+        );
+    }
+
     public function testSameShortNameInTwoNamespacesEachResolvesDistinctly(): void
     {
         $this->openFixture('Namespacing/SubNamespaceClass.php');

--- a/tests/Protocol/RangeTest.php
+++ b/tests/Protocol/RangeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\Range;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Range::class)]
+class RangeTest extends TestCase
+{
+    public function testOnLineIsASingleLineSpan(): void
+    {
+        $range = Range::onLine(4, 8, 10);
+
+        self::assertSame(
+            [
+                'start' => ['line' => 4, 'character' => 8],
+                'end' => ['line' => 4, 'character' => 10],
+            ],
+            $range->toArray(),
+            'A single-line span shares its line between start and end',
+        );
+    }
+
+    public function testAMultiLineRangeSerializes(): void
+    {
+        $range = new Range(2, 5, 7, 1);
+
+        self::assertSame(
+            [
+                'start' => ['line' => 2, 'character' => 5],
+                'end' => ['line' => 7, 'character' => 1],
+            ],
+            $range->toArray(),
+            'Start and end may sit on different lines',
+        );
+    }
+}


### PR DESCRIPTION
Closes #338.

## What

Completion items now insert via an explicit `textEdit` and filter via `filterText`,
instead of relying on the client to replace "the current word" with the label. This is the
foundation namespace-correct completion needs — and it makes the relabel that landed in
#337 actually usable in a real client.

## Why label-only items aren't enough

- **Insertion.** A relabelled reference like `Sub\Thing` inserted at a typed `Th` depends
  on the client's word-boundary rules; for a qualified name it can duplicate the already-
  typed prefix (`Sub\Sub\Thing`-style). A `textEdit` with an explicit range replaces the
  exact token, unambiguously and portably.
- **Filtering.** Clients filter items by matching the typed text against the label, and
  `Sub\Thing` does not start with `Th` — so strict-prefix clients drop it and fuzzy clients
  keep it only by luck. `filterText` (the short name) makes it match reliably while the
  label and inserted text stay the qualified reference. Without this, #337's relabel may
  not even *display*.

## Changes

- New `Protocol\Range` value object serializing to the LSP `{ start, end }` shape, so
  callers never hand-build the nested range array. `Location` and the handlers can adopt it
  later (they build the same shape inline today).
- `CompletionItemFactory::forClass` emits `filterText` (the short name) and a `textEdit`
  (range = the typed token, `newText` = the reference).
- `ClassCandidates` computes the replacement range from the cursor; `CompletionHandler`
  threads the cursor character down to it, mirroring how the line is already threaded.

## Scope

Class candidates only — the sources that produce qualified references today. Namespace
navigation nodes and catalog symbols (#330) and imported-prefix children (#339) will reuse
the same `Range` / `textEdit` / `filterText` machinery when they land; that's why this is
split out as its own foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
