### PR TITLE
Navigate relative-prefix names through the catalog

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -19,7 +19,7 @@ This document tracks the current state of code completion in php-lsp.
 | `catch` clause | `catch (Ba` or `catch (Foo \| Ba` | Throwable types only (from imports + workspace index): `Throwable` and any class or interface extending/implementing it. Multi-catch (`\|`-separated) supported; non-throwable types, functions, and keywords excluded | ✅ Working |
 | Attribute position | `#[Ro` | Attribute classes only (from imports + workspace index); classes, interfaces, traits, enums, and functions excluded. Grouped (`#[A, Ba`) supported; target-aware filtering is not yet (#252) | ✅ Working |
 | Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
-| Namespace navigation | `new \Ps`, `catch (\E`, `function f(\Ps` | Vendor/built-in class-likes and child namespaces from the catalog, walked one segment at a time. Absolute (`\`-rooted) names only; unqualified/imported prefixes are #339 | ✅ Working |
+| Namespace navigation | `new \Ps`, `catch (\E`, `function f(\Ps` | Vendor/built-in class-likes and child namespaces from the catalog, walked one segment at a time. Works on absolute (`\`-rooted) names and on imported prefixes that are also namespaces (`use App\Model\Env;` → `new Env\R`) | ✅ Working |
 
 All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
@@ -59,8 +59,13 @@ above nodes, and the result is capped with `isIncomplete` set so the client re-q
 the prefix narrows. Catalog candidates are resolved before being offered, so a
 `functions.php` picked up from a directory listing is never offered as a class.
 
-Navigation fires on **absolute** (`\`-rooted) names. Reaching a namespace by an unqualified
-or imported prefix (`new Env\R`) is #339.
+Navigation also works from an **imported prefix** that is itself a namespace: with
+`use App\Model\Env;`, the class in `App\Model\Env\Repository` is written `Env\Repository`,
+so `new Env`, `new Env\`, and `new Env\R` all offer it — catalog-sourced (no open file
+needed), inserted import-relative via `textEdit` so `new Env\R` never becomes
+`new Env\Env\Repository`. The position filter still applies (an interface child is offered
+as a type hint but not after `new`), and only the imported alias opens its namespace — an
+unrelated, unimported prefix reaches nothing.
 
 ## Limitations
 

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -19,7 +19,7 @@ This document tracks the current state of code completion in php-lsp.
 | `catch` clause | `catch (Ba` or `catch (Foo \| Ba` | Throwable types only (from imports + workspace index): `Throwable` and any class or interface extending/implementing it. Multi-catch (`\|`-separated) supported; non-throwable types, functions, and keywords excluded | ✅ Working |
 | Attribute position | `#[Ro` | Attribute classes only (from imports + workspace index); classes, interfaces, traits, enums, and functions excluded. Grouped (`#[A, Ba`) supported; target-aware filtering is not yet (#252) | ✅ Working |
 | Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
-| Namespace navigation | `new \Ps`, `catch (\E`, `function f(\Ps` | Vendor/built-in class-likes and child namespaces from the catalog, walked one segment at a time. Works on absolute (`\`-rooted) names and on imported prefixes that are also namespaces (`use App\Model\Env;` → `new Env\R`) | ✅ Working |
+| Namespace navigation | `new \Ps`, `catch (\E`, `function f(\Ps` | Vendor/built-in class-likes and child namespaces from the catalog, walked one segment at a time. Works on absolute (`\`-rooted) names and on relative prefixes resolved through a `use` import or the current namespace (`use App\Model\Env;` or being inside `App\Model` → `new Env\R`) | ✅ Working |
 
 All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
@@ -59,13 +59,21 @@ above nodes, and the result is capped with `isIncomplete` set so the client re-q
 the prefix narrows. Catalog candidates are resolved before being offered, so a
 `functions.php` picked up from a directory listing is never offered as a class.
 
-Navigation also works from an **imported prefix** that is itself a namespace: with
-`use App\Model\Env;`, the class in `App\Model\Env\Repository` is written `Env\Repository`,
-so `new Env`, `new Env\`, and `new Env\R` all offer it — catalog-sourced (no open file
-needed), inserted import-relative via `textEdit` so `new Env\R` never becomes
-`new Env\Env\Repository`. The position filter still applies (an interface child is offered
-as a type hint but not after `new`), and only the imported alias opens its namespace — an
-unrelated, unimported prefix reaches nothing.
+Navigation also works from a **relative prefix** whose first segment is a `use` import or a
+child of the current namespace. With `use App\Model\Env;` (or from inside `App\Model`),
+`new Env\` and `new Env\R` navigate `App\Model\Env` and offer its children, and `new Env`
+offers an `Env\` descent node. Discovery is catalog-sourced (no open file needed), and — as
+with absolute navigation — insertion is **leaf-relative**: at `new Env\R` only `Repository`
+is inserted, replacing the segment after the last `\`, so the typed `Env\` stands and is
+never duplicated (the FQCN is carried in the item's detail). The position filter still
+applies (an interface child is offered as a type hint but not after `new`), and only an
+imported alias or a real current-namespace child opens a namespace — an unrelated prefix
+reaches nothing.
+
+Leaf-relative insertion is also what keeps this working in editors that don't apply the LSP
+`textEdit` range and instead replace the word under the cursor (e.g. Vim/ale, see
+[dense-analysis/ale#4274](https://github.com/dense-analysis/ale/issues/4274)); the inserted
+text is aligned to that word boundary rather than spanning the whole qualified name.
 
 ## Limitations
 

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -43,6 +43,13 @@ final class NamespaceCandidates
      * are valid in the target position — matched by their next segment against
      * $prefix.
      *
+     * References default to the child's leaf name, for absolute navigation where the
+     * earlier segments are literally typed (`\Psr\Log\`). $referenceBase prepends an
+     * alias instead, for an imported prefix reached through a `use` (`Env\Repository`
+     * for a class in `App\Model\Env` imported as `Env`); $replaceRange then covers the
+     * whole typed alias so the insertion never duplicates it (#339). When omitted, the
+     * range is the partial leaf, the absolute-navigation default.
+     *
      * @return list<CompletionItem>
      */
     public function find(
@@ -51,10 +58,12 @@ final class NamespaceCandidates
         int $line,
         int $character,
         ClassCandidateFilter $filter,
+        string $referenceBase = '',
+        ?Range $replaceRange = null,
     ): array {
         $contents = $this->catalog->childrenOf($namespace);
         // The partial segment the user is typing; a selection replaces just it.
-        $replaceRange = Range::onLine($line, $character - strlen($prefix), $character);
+        $replaceRange ??= Range::onLine($line, $character - strlen($prefix), $character);
 
         $items = [];
         foreach ($contents->childNamespaces as $child) {
@@ -62,22 +71,29 @@ final class NamespaceCandidates
             if (!PrefixMatcher::matches($segment, $prefix)) {
                 continue;
             }
-            $items = array_merge($items, $this->offerChildNamespace($child, $segment, $filter, $replaceRange));
+            $reference = self::qualify($referenceBase, $segment);
+            $items = array_merge($items, $this->offerChildNamespace($child, $reference, $filter, $replaceRange));
         }
         // The classes declared directly in the navigated namespace, discovered on
-        // disk through the catalog. The reference is the leaf name — the earlier
-        // segments are already typed — and the textEdit replaces the partial one.
+        // disk through the catalog. The reference is the leaf name (or alias-qualified
+        // via $referenceBase), and the textEdit replaces the typed span.
         foreach ($contents->symbols as $symbol) {
             if (!PrefixMatcher::matches($symbol->shortName(), $prefix)) {
                 continue;
             }
-            $item = $this->offerSymbol($symbol, $symbol->shortName(), null, $filter, $replaceRange);
+            $reference = self::qualify($referenceBase, $symbol->shortName());
+            $item = $this->offerSymbol($symbol, $reference, $filter, $replaceRange);
             if ($item !== null) {
                 $items[] = $item;
             }
         }
 
         return $this->ranked($items);
+    }
+
+    private static function qualify(string $base, string $segment): string
+    {
+        return $base === '' ? $segment : $base . '\\' . $segment;
     }
 
     /**
@@ -110,7 +126,7 @@ final class NamespaceCandidates
      */
     private function offerChildNamespace(
         string $child,
-        string $segment,
+        string $reference,
         ClassCandidateFilter $filter,
         Range $range,
     ): array {
@@ -122,19 +138,17 @@ final class NamespaceCandidates
         $contents = $this->catalog->childrenOf($child);
         $elementCount = count($contents->childNamespaces) + count($contents->symbols);
         if ($elementCount === 0 || $elementCount > self::INLINE_THRESHOLD) {
-            return [CompletionItemFactory::forNamespace($segment, $child, $range)];
+            return [CompletionItemFactory::forNamespace($reference, $child, $range)];
         }
 
         $items = [];
         foreach ($contents->childNamespaces as $grandchild) {
-            $reference = $segment . '\\' . NamespacePath::shortNameOf($grandchild);
-            $items[] = CompletionItemFactory::forNamespace($reference, $grandchild, $range);
+            $grandReference = $reference . '\\' . NamespacePath::shortNameOf($grandchild);
+            $items[] = CompletionItemFactory::forNamespace($grandReference, $grandchild, $range);
         }
         foreach ($contents->symbols as $symbol) {
-            $reference = $segment . '\\' . $symbol->shortName();
-            // The user reaches an inlined entry by typing the parent segment, so it
-            // filters on the qualified reference rather than its leaf.
-            $item = $this->offerSymbol($symbol, $reference, $reference, $filter, $range);
+            $symbolReference = $reference . '\\' . $symbol->shortName();
+            $item = $this->offerSymbol($symbol, $symbolReference, $filter, $range);
             if ($item !== null) {
                 $items[] = $item;
             }
@@ -155,7 +169,6 @@ final class NamespaceCandidates
     private function offerSymbol(
         CatalogSymbol $symbol,
         string $reference,
-        ?string $filterText,
         ClassCandidateFilter $filter,
         Range $range,
     ): ?array {
@@ -172,6 +185,8 @@ final class NamespaceCandidates
             return null;
         }
 
-        return CompletionItemFactory::forClass($reference, $fqcn, $range, $filterText);
+        // The user reaches a navigation entry by typing its qualified reference, so
+        // it filters on that reference rather than on its bare leaf.
+        return CompletionItemFactory::forClass($reference, $fqcn, $range, $reference);
     }
 }

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
+use Firehed\PhpLsp\Resolution\NameContext;
 use Firehed\PhpLsp\Resolution\NameKind;
 use Firehed\PhpLsp\Utility\NamespacePath;
 
@@ -43,13 +44,6 @@ final class NamespaceCandidates
      * are valid in the target position — matched by their next segment against
      * $prefix.
      *
-     * References default to the child's leaf name, for absolute navigation where the
-     * earlier segments are literally typed (`\Psr\Log\`). $referenceBase prepends an
-     * alias instead, for an imported prefix reached through a `use` (`Env\Repository`
-     * for a class in `App\Model\Env` imported as `Env`); $replaceRange then covers the
-     * whole typed alias so the insertion never duplicates it (#339). When omitted, the
-     * range is the partial leaf, the absolute-navigation default.
-     *
      * @return list<CompletionItem>
      */
     public function find(
@@ -58,12 +52,10 @@ final class NamespaceCandidates
         int $line,
         int $character,
         ClassCandidateFilter $filter,
-        string $referenceBase = '',
-        ?Range $replaceRange = null,
     ): array {
         $contents = $this->catalog->childrenOf($namespace);
         // The partial segment the user is typing; a selection replaces just it.
-        $replaceRange ??= Range::onLine($line, $character - strlen($prefix), $character);
+        $replaceRange = Range::onLine($line, $character - strlen($prefix), $character);
 
         $items = [];
         foreach ($contents->childNamespaces as $child) {
@@ -71,18 +63,16 @@ final class NamespaceCandidates
             if (!PrefixMatcher::matches($segment, $prefix)) {
                 continue;
             }
-            $reference = self::qualify($referenceBase, $segment);
-            $items = array_merge($items, $this->offerChildNamespace($child, $reference, $filter, $replaceRange));
+            $items = array_merge($items, $this->offerChildNamespace($child, $segment, $filter, $replaceRange));
         }
         // The classes declared directly in the navigated namespace, discovered on
-        // disk through the catalog. The reference is the leaf name (or alias-qualified
-        // via $referenceBase), and the textEdit replaces the typed span.
+        // disk through the catalog. The reference is the leaf name — the earlier
+        // segments are already typed — and the textEdit replaces the partial one.
         foreach ($contents->symbols as $symbol) {
             if (!PrefixMatcher::matches($symbol->shortName(), $prefix)) {
                 continue;
             }
-            $reference = self::qualify($referenceBase, $symbol->shortName());
-            $item = $this->offerSymbol($symbol, $reference, $filter, $replaceRange);
+            $item = $this->offerSymbol($symbol, $symbol->shortName(), null, $filter, $replaceRange);
             if ($item !== null) {
                 $items[] = $item;
             }
@@ -91,9 +81,42 @@ final class NamespaceCandidates
         return $this->ranked($items);
     }
 
-    private static function qualify(string $base, string $segment): string
+    /**
+     * Descent nodes for a bare relative name: an `Env\` node for each `use` import
+     * or child of the current namespace whose name the typed $prefix begins and
+     * which is itself a navigable namespace. Imports win a name clash with a
+     * current-namespace child, matching PHP name resolution.
+     *
+     * @return list<CompletionItem>
+     */
+    public function descentNodes(NameContext $context, string $prefix, int $line, int $character): array
     {
-        return $base === '' ? $segment : $base . '\\' . $segment;
+        $range = Range::onLine($line, $character - strlen($prefix), $character);
+
+        $targets = [];
+        foreach ($this->catalog->childrenOf($context->namespace)->childNamespaces as $child) {
+            $targets[NamespacePath::shortNameOf($child)] = $child;
+        }
+        foreach ($context->classImports as $alias => $fqcn) {
+            $targets[$alias] = $fqcn;
+        }
+
+        $items = [];
+        foreach ($targets as $reference => $fqcn) {
+            if (!PrefixMatcher::matches($reference, $prefix) || !$this->isNavigable($fqcn)) {
+                continue;
+            }
+            $items[] = CompletionItemFactory::forNamespace($reference, $fqcn, $range);
+        }
+
+        return $this->ranked($items);
+    }
+
+    private function isNavigable(string $namespace): bool
+    {
+        $contents = $this->catalog->childrenOf($namespace);
+
+        return count($contents->childNamespaces) > 0 || count($contents->symbols) > 0;
     }
 
     /**
@@ -126,7 +149,7 @@ final class NamespaceCandidates
      */
     private function offerChildNamespace(
         string $child,
-        string $reference,
+        string $segment,
         ClassCandidateFilter $filter,
         Range $range,
     ): array {
@@ -138,17 +161,19 @@ final class NamespaceCandidates
         $contents = $this->catalog->childrenOf($child);
         $elementCount = count($contents->childNamespaces) + count($contents->symbols);
         if ($elementCount === 0 || $elementCount > self::INLINE_THRESHOLD) {
-            return [CompletionItemFactory::forNamespace($reference, $child, $range)];
+            return [CompletionItemFactory::forNamespace($segment, $child, $range)];
         }
 
         $items = [];
         foreach ($contents->childNamespaces as $grandchild) {
-            $grandReference = $reference . '\\' . NamespacePath::shortNameOf($grandchild);
-            $items[] = CompletionItemFactory::forNamespace($grandReference, $grandchild, $range);
+            $reference = $segment . '\\' . NamespacePath::shortNameOf($grandchild);
+            $items[] = CompletionItemFactory::forNamespace($reference, $grandchild, $range);
         }
         foreach ($contents->symbols as $symbol) {
-            $symbolReference = $reference . '\\' . $symbol->shortName();
-            $item = $this->offerSymbol($symbol, $symbolReference, $filter, $range);
+            $reference = $segment . '\\' . $symbol->shortName();
+            // The user reaches an inlined entry by typing the parent segment, so it
+            // filters on the qualified reference rather than its leaf.
+            $item = $this->offerSymbol($symbol, $reference, $reference, $filter, $range);
             if ($item !== null) {
                 $items[] = $item;
             }
@@ -169,6 +194,7 @@ final class NamespaceCandidates
     private function offerSymbol(
         CatalogSymbol $symbol,
         string $reference,
+        ?string $filterText,
         ClassCandidateFilter $filter,
         Range $range,
     ): ?array {
@@ -185,8 +211,6 @@ final class NamespaceCandidates
             return null;
         }
 
-        // The user reaches a navigation entry by typing its qualified reference, so
-        // it filters on that reference rather than on its bare leaf.
-        return CompletionItemFactory::forClass($reference, $fqcn, $range, $reference);
+        return CompletionItemFactory::forClass($reference, $fqcn, $range, $filterText);
     }
 }

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -40,6 +40,59 @@ final class NamespaceCandidates
     }
 
     /**
+     * Navigate the namespace tree for a class-position $prefix, dispatching on how
+     * the name is rooted so name resolution stays out of the handler:
+     *
+     * - absolute (`\Ps`) walks from the global namespace;
+     * - a bare relative name (`Env`) offers descent nodes for imports and children
+     *   of the current namespace;
+     * - a qualified relative name (`Env\R`) resolves its first segment through the
+     *   imports, else the current namespace, and walks from there.
+     *
+     * Every case inserts leaf-relative (see {@see find()}), so the typed segments
+     * stand and are never duplicated.
+     *
+     * @return list<CompletionItem>
+     */
+    public function navigate(
+        string $prefix,
+        NameContext $context,
+        int $line,
+        int $character,
+        ClassCandidateFilter $filter,
+    ): array {
+        if (str_starts_with($prefix, '\\')) {
+            $qualified = substr($prefix, 1);
+
+            return $this->find(
+                NamespacePath::namespaceOf($qualified),
+                NamespacePath::shortNameOf($qualified),
+                $line,
+                $character,
+                $filter,
+            );
+        }
+
+        if (!str_contains($prefix, '\\')) {
+            return $this->descentNodes($context, $prefix, $line, $character);
+        }
+
+        $alias = NamespacePath::firstSegment($prefix);
+        $base = array_key_exists($alias, $context->classImports)
+            ? $context->classImports[$alias]
+            : NamespacePath::join($context->namespace, $alias);
+        $rest = substr($prefix, strlen($alias) + 1);
+
+        return $this->find(
+            NamespacePath::join($base, NamespacePath::namespaceOf($rest)),
+            NamespacePath::shortNameOf($rest),
+            $line,
+            $character,
+            $filter,
+        );
+    }
+
+    /**
      * The child namespaces of $namespace, plus the class-likes declared in it that
      * are valid in the target position — matched by their next segment against
      * $prefix.

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -25,7 +25,6 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Resolution\CodeResolver;
-use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * @phpstan-import-type CompletionItem from CompletionItemFactory
@@ -276,9 +275,10 @@ final class CompletionHandler implements HandlerInterface
 
     /**
      * Class-name candidates valid for a position, from the workspace index and
-     * imports, plus namespace-navigation items when the cursor is on an absolute
-     * (`\`-rooted) name. Every class position routes through here, so navigation
-     * is offered consistently and filtered by the same predicate everywhere.
+     * imports, plus namespace navigation from the catalog. Every class position
+     * routes through here, so navigation is offered consistently and filtered by the
+     * same predicate everywhere. Name resolution (absolute vs import vs
+     * current-namespace) lives in {@see NamespaceCandidates::navigate()}, not here.
      *
      * @return list<CompletionItem>
      */
@@ -291,89 +291,16 @@ final class CompletionHandler implements HandlerInterface
     ): array {
         $items = array_merge(
             $this->classCandidates->find($prefix, $document, $line, $character, $filter),
-            $this->namespaceNavigationItems($prefix, $line, $character, $filter),
-            $this->relativePrefixNavigationItems($prefix, $document, $line, $character, $filter),
+            $this->namespaceCandidates->navigate(
+                $prefix,
+                $this->codeResolver->getNameContext($document, $line),
+                $line,
+                $character,
+                $filter,
+            ),
         );
 
         return $this->deduplicateCompletions($items);
-    }
-
-    /**
-     * Navigation into a name reached relative to the file — a `use` import that is
-     * also a namespace, or a child of the current namespace (#339). With
-     * `use App\Model\Env;` (or from inside `App\Model`), `App\Model\Env\Repository`
-     * is written `Env\Repository`, so `new Env\R` reaches it and `new Env` offers an
-     * `Env\` descent node. Discovery is catalog-sourced (on disk, no open file), and
-     * insertion is leaf-relative — the same model as absolute navigation — so the
-     * typed `Env\` stands and is never duplicated.
-     *
-     * @return list<CompletionItem>
-     */
-    private function relativePrefixNavigationItems(
-        string $prefix,
-        TextDocument $document,
-        int $line,
-        int $character,
-        ClassCandidateFilter $filter,
-    ): array {
-        // Absolute names are namespaceNavigationItems' job.
-        if (str_starts_with($prefix, '\\')) {
-            return [];
-        }
-        $context = $this->codeResolver->getNameContext($document, $line);
-
-        if (!str_contains($prefix, '\\')) {
-            // Bare name: offer a descent node for each import or current-namespace
-            // child whose name the prefix begins.
-            return $this->namespaceCandidates->descentNodes($context, $prefix, $line, $character);
-        }
-
-        // Qualified name: resolve the first segment through the imports, else
-        // relative to the current namespace, then navigate it. `find()` inserts the
-        // leaf, replacing only the segment after the last `\`.
-        $alias = NamespacePath::firstSegment($prefix);
-        $base = array_key_exists($alias, $context->classImports)
-            ? $context->classImports[$alias]
-            : NamespacePath::join($context->namespace, $alias);
-        $rest = substr($prefix, strlen($alias) + 1);
-
-        return $this->namespaceCandidates->find(
-            NamespacePath::join($base, NamespacePath::namespaceOf($rest)),
-            NamespacePath::shortNameOf($rest),
-            $line,
-            $character,
-            $filter,
-        );
-    }
-
-    /**
-     * Namespace nodes and classes when the cursor is on a fully-qualified name
-     * (`new \Ps`), so the user can walk the tree into vendor and built-in
-     * namespaces. The leading `\` roots the walk at the global namespace; the
-     * segment already typed filters the children, and $filter keeps the classes
-     * valid for the position.
-     *
-     * @return list<CompletionItem>
-     */
-    private function namespaceNavigationItems(
-        string $prefix,
-        int $line,
-        int $character,
-        ClassCandidateFilter $filter,
-    ): array {
-        if (!str_starts_with($prefix, '\\')) {
-            return [];
-        }
-
-        $qualified = substr($prefix, 1);
-
-        return $this->namespaceCandidates->find(
-            NamespacePath::namespaceOf($qualified),
-            NamespacePath::shortNameOf($qualified),
-            $line,
-            $character,
-            $filter,
-        );
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -24,7 +24,6 @@ use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Utility\NamespacePath;
 
@@ -293,51 +292,57 @@ final class CompletionHandler implements HandlerInterface
         $items = array_merge(
             $this->classCandidates->find($prefix, $document, $line, $character, $filter),
             $this->namespaceNavigationItems($prefix, $line, $character, $filter),
-            $this->importedPrefixNavigationItems($prefix, $document, $line, $character, $filter),
+            $this->relativePrefixNavigationItems($prefix, $document, $line, $character, $filter),
         );
 
         return $this->deduplicateCompletions($items);
     }
 
     /**
-     * Navigation into a `use` import that is also a namespace: `use App\Model\Env;`
-     * makes `App\Model\Env\Repository` writable as `Env\Repository`, so `new Env`,
-     * `new Env\`, and `new Env\R` all reach it (#339). The children are catalog-
-     * sourced (on disk, no open file needed) and written import-relative; the
-     * textEdit replaces the whole typed alias so the insertion never duplicates it.
+     * Navigation into a name reached relative to the file — a `use` import that is
+     * also a namespace, or a child of the current namespace (#339). With
+     * `use App\Model\Env;` (or from inside `App\Model`), `App\Model\Env\Repository`
+     * is written `Env\Repository`, so `new Env\R` reaches it and `new Env` offers an
+     * `Env\` descent node. Discovery is catalog-sourced (on disk, no open file), and
+     * insertion is leaf-relative — the same model as absolute navigation — so the
+     * typed `Env\` stands and is never duplicated.
      *
      * @return list<CompletionItem>
      */
-    private function importedPrefixNavigationItems(
+    private function relativePrefixNavigationItems(
         string $prefix,
         TextDocument $document,
         int $line,
         int $character,
         ClassCandidateFilter $filter,
     ): array {
-        // Absolute names are namespaceNavigationItems' job; here the first segment
-        // must be an unqualified import.
+        // Absolute names are namespaceNavigationItems' job.
         if (str_starts_with($prefix, '\\')) {
             return [];
         }
-        $alias = NamespacePath::firstSegment($prefix);
-        $imports = $this->codeResolver->getImports($document);
-        if ($alias === '' || !array_key_exists($alias, $imports)) {
-            return [];
+        $context = $this->codeResolver->getNameContext($document, $line);
+
+        if (!str_contains($prefix, '\\')) {
+            // Bare name: offer a descent node for each import or current-namespace
+            // child whose name the prefix begins.
+            return $this->namespaceCandidates->descentNodes($context, $prefix, $line, $character);
         }
 
-        // The path typed after the alias: `R` in `Env\R`, `Sub\R` in `Env\Sub\R`, ''.
-        $rest = str_contains($prefix, '\\') ? substr($prefix, strlen($alias) + 1) : '';
-        $middle = NamespacePath::namespaceOf($rest);
+        // Qualified name: resolve the first segment through the imports, else
+        // relative to the current namespace, then navigate it. `find()` inserts the
+        // leaf, replacing only the segment after the last `\`.
+        $alias = NamespacePath::firstSegment($prefix);
+        $base = array_key_exists($alias, $context->classImports)
+            ? $context->classImports[$alias]
+            : NamespacePath::join($context->namespace, $alias);
+        $rest = substr($prefix, strlen($alias) + 1);
 
         return $this->namespaceCandidates->find(
-            NamespacePath::join($imports[$alias], $middle),
+            NamespacePath::join($base, NamespacePath::namespaceOf($rest)),
             NamespacePath::shortNameOf($rest),
             $line,
             $character,
             $filter,
-            NamespacePath::join($alias, $middle),
-            Range::onLine($line, $character - strlen($prefix), $character),
         );
     }
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -24,6 +24,7 @@ use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Utility\NamespacePath;
 
@@ -292,9 +293,52 @@ final class CompletionHandler implements HandlerInterface
         $items = array_merge(
             $this->classCandidates->find($prefix, $document, $line, $character, $filter),
             $this->namespaceNavigationItems($prefix, $line, $character, $filter),
+            $this->importedPrefixNavigationItems($prefix, $document, $line, $character, $filter),
         );
 
         return $this->deduplicateCompletions($items);
+    }
+
+    /**
+     * Navigation into a `use` import that is also a namespace: `use App\Model\Env;`
+     * makes `App\Model\Env\Repository` writable as `Env\Repository`, so `new Env`,
+     * `new Env\`, and `new Env\R` all reach it (#339). The children are catalog-
+     * sourced (on disk, no open file needed) and written import-relative; the
+     * textEdit replaces the whole typed alias so the insertion never duplicates it.
+     *
+     * @return list<CompletionItem>
+     */
+    private function importedPrefixNavigationItems(
+        string $prefix,
+        TextDocument $document,
+        int $line,
+        int $character,
+        ClassCandidateFilter $filter,
+    ): array {
+        // Absolute names are namespaceNavigationItems' job; here the first segment
+        // must be an unqualified import.
+        if (str_starts_with($prefix, '\\')) {
+            return [];
+        }
+        $alias = NamespacePath::firstSegment($prefix);
+        $imports = $this->codeResolver->getImports($document);
+        if ($alias === '' || !array_key_exists($alias, $imports)) {
+            return [];
+        }
+
+        // The path typed after the alias: `R` in `Env\R`, `Sub\R` in `Env\Sub\R`, ''.
+        $rest = str_contains($prefix, '\\') ? substr($prefix, strlen($alias) + 1) : '';
+        $middle = NamespacePath::namespaceOf($rest);
+
+        return $this->namespaceCandidates->find(
+            NamespacePath::join($imports[$alias], $middle),
+            NamespacePath::shortNameOf($rest),
+            $line,
+            $character,
+            $filter,
+            NamespacePath::join($alias, $middle),
+            Range::onLine($line, $character - strlen($prefix), $character),
+        );
     }
 
     /**

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -311,7 +311,7 @@ class NamespaceCandidatesTest extends TestCase
 
         self::assertCount(1, $items);
         self::assertSame('Env\Repository', $items[0]['label'], 'The reference is written import-relative');
-        self::assertSame('App\Model\Env\Repository', $items[0]['detail'], 'The detail is the FQCN');
+        self::assertSame('App\Model\Env\Repository', $items[0]['detail'] ?? null, 'The detail is the FQCN');
         self::assertSame('Env\Repository', $items[0]['filterText'] ?? null, 'It filters on the qualified reference');
         self::assertSame(
             ['range' => $range->toArray(), 'newText' => 'Env\Repository'],

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -12,6 +12,7 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Resolution\NameKind;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -291,6 +292,50 @@ class NamespaceCandidatesTest extends TestCase
 
         self::assertContains('Small\Deep\\', $labels, 'An inlined namespace exposes a grandchild as a qualified node');
         self::assertNotContains('Small\\', $labels, 'The inlined namespace itself is not offered as a node');
+    }
+
+    public function testQualifiesSymbolReferencesWithTheReferenceBase(): void
+    {
+        // An imported prefix (`use App\Model\Env;`) roots enumeration at the import
+        // target but writes references import-relative (`Env\Repository`) and
+        // replaces the whole typed span, so `new Env\R` never duplicates `Env\`.
+        $catalog = self::catalog([
+            'App\Model\Env' => new NamespaceContents([], [
+                new CatalogSymbol('App\Model\Env\Repository', NameKind::ClassLike),
+            ]),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $range = Range::onLine(0, 4, 9);
+
+        $items = $candidates->find('App\Model\Env', 'R', 0, 9, ClassCandidateFilter::Any, 'Env', $range);
+
+        self::assertCount(1, $items);
+        self::assertSame('Env\Repository', $items[0]['label'], 'The reference is written import-relative');
+        self::assertSame('App\Model\Env\Repository', $items[0]['detail'], 'The detail is the FQCN');
+        self::assertSame('Env\Repository', $items[0]['filterText'] ?? null, 'It filters on the qualified reference');
+        self::assertSame(
+            ['range' => $range->toArray(), 'newText' => 'Env\Repository'],
+            $items[0]['textEdit'] ?? null,
+            'The textEdit inserts the qualified reference over the provided range',
+        );
+    }
+
+    public function testQualifiesNamespaceNodesWithTheReferenceBase(): void
+    {
+        $catalog = self::catalog([
+            'App\Model\Env' => new NamespaceContents(['App\Model\Env\Sub'], []),
+            'App\Model\Env\Sub' => new NamespaceContents([], self::manyClassLikes('App\Model\Env\Sub')),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $range = Range::onLine(0, 4, 8);
+
+        $items = $candidates->find('App\Model\Env', '', 0, 8, ClassCandidateFilter::Any, 'Env', $range);
+
+        self::assertContains(
+            'Env\Sub\\',
+            array_column($items, 'label'),
+            'A child namespace node is written import-relative',
+        );
     }
 
     public function testRanksSymbolsAboveNamespaceNodes(): void

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -12,8 +12,8 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceContents;
-use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
+use Firehed\PhpLsp\Resolution\NameContext;
 use Firehed\PhpLsp\Resolution\NameKind;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -294,48 +294,37 @@ class NamespaceCandidatesTest extends TestCase
         self::assertNotContains('Small\\', $labels, 'The inlined namespace itself is not offered as a node');
     }
 
-    public function testQualifiesSymbolReferencesWithTheReferenceBase(): void
+    public function testDescentNodesOfferImportsAndCurrentNamespaceChildren(): void
     {
-        // An imported prefix (`use App\Model\Env;`) roots enumeration at the import
-        // target but writes references import-relative (`Env\Repository`) and
-        // replaces the whole typed span, so `new Env\R` never duplicates `Env\`.
         $catalog = self::catalog([
-            'App\Model\Env' => new NamespaceContents([], [
-                new CatalogSymbol('App\Model\Env\Repository', NameKind::ClassLike),
-            ]),
+            'App' => new NamespaceContents(['App\Models'], []),
+            'App\Models' => new NamespaceContents([], [new CatalogSymbol('App\Models\User', NameKind::ClassLike)]),
+            'Vendor\Pkg' => new NamespaceContents([], [new CatalogSymbol('Vendor\Pkg\Thing', NameKind::ClassLike)]),
+            'Vendor\Plain' => new NamespaceContents([], []),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
-        $range = Range::onLine(0, 4, 9);
+        $candidates = new NamespaceCandidates($catalog, self::createStub(CodeResolver::class));
+        $context = new NameContext('App', ['Pkg' => 'Vendor\Pkg', 'Plain' => 'Vendor\Plain']);
 
-        $items = $candidates->find('App\Model\Env', 'R', 0, 9, ClassCandidateFilter::Any, 'Env', $range);
+        $labels = array_column($candidates->descentNodes($context, '', 0, 0), 'label');
 
-        self::assertCount(1, $items);
-        self::assertSame('Env\Repository', $items[0]['label'], 'The reference is written import-relative');
-        self::assertSame('App\Model\Env\Repository', $items[0]['detail'] ?? null, 'The detail is the FQCN');
-        self::assertSame('Env\Repository', $items[0]['filterText'] ?? null, 'It filters on the qualified reference');
-        self::assertSame(
-            ['range' => $range->toArray(), 'newText' => 'Env\Repository'],
-            $items[0]['textEdit'] ?? null,
-            'The textEdit inserts the qualified reference over the provided range',
-        );
+        self::assertContains('Models\\', $labels, 'A navigable child of the current namespace is a descent node');
+        self::assertContains('Pkg\\', $labels, 'A navigable import is a descent node');
+        self::assertNotContains('Plain\\', $labels, 'An import that is not a namespace is not a descent node');
     }
 
-    public function testQualifiesNamespaceNodesWithTheReferenceBase(): void
+    public function testDescentNodesFilterByPrefix(): void
     {
         $catalog = self::catalog([
-            'App\Model\Env' => new NamespaceContents(['App\Model\Env\Sub'], []),
-            'App\Model\Env\Sub' => new NamespaceContents([], self::manyClassLikes('App\Model\Env\Sub')),
+            'App' => new NamespaceContents([], []),
+            'Vendor\Mapping' => new NamespaceContents([], [new CatalogSymbol('Vendor\Mapping\Column', NameKind::ClassLike)]),
+            'Vendor\Other' => new NamespaceContents([], [new CatalogSymbol('Vendor\Other\Thing', NameKind::ClassLike)]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
-        $range = Range::onLine(0, 4, 8);
+        $candidates = new NamespaceCandidates($catalog, self::createStub(CodeResolver::class));
+        $context = new NameContext('App', ['Mapping' => 'Vendor\Mapping', 'Other' => 'Vendor\Other']);
 
-        $items = $candidates->find('App\Model\Env', '', 0, 8, ClassCandidateFilter::Any, 'Env', $range);
+        $labels = array_column($candidates->descentNodes($context, 'Map', 0, 3), 'label');
 
-        self::assertContains(
-            'Env\Sub\\',
-            array_column($items, 'label'),
-            'A child namespace node is written import-relative',
-        );
+        self::assertSame(['Mapping\\'], $labels, 'Only imports/children whose name begins with the prefix are offered');
     }
 
     public function testRanksSymbolsAboveNamespaceNodes(): void

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -316,8 +316,12 @@ class NamespaceCandidatesTest extends TestCase
     {
         $catalog = self::catalog([
             'App' => new NamespaceContents([], []),
-            'Vendor\Mapping' => new NamespaceContents([], [new CatalogSymbol('Vendor\Mapping\Column', NameKind::ClassLike)]),
-            'Vendor\Other' => new NamespaceContents([], [new CatalogSymbol('Vendor\Other\Thing', NameKind::ClassLike)]),
+            'Vendor\Mapping' => new NamespaceContents([], [
+                new CatalogSymbol('Vendor\Mapping\Column', NameKind::ClassLike),
+            ]),
+            'Vendor\Other' => new NamespaceContents([], [
+                new CatalogSymbol('Vendor\Other\Thing', NameKind::ClassLike),
+            ]),
         ]);
         $candidates = new NamespaceCandidates($catalog, self::createStub(CodeResolver::class));
         $context = new NameContext('App', ['Mapping' => 'Vendor\Mapping', 'Other' => 'Vendor\Other']);

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -331,6 +331,73 @@ class NamespaceCandidatesTest extends TestCase
         self::assertSame(['Mapping\\'], $labels, 'Only imports/children whose name begins with the prefix are offered');
     }
 
+    public function testNavigateWalksAbsoluteNames(): void
+    {
+        $catalog = self::catalog([
+            'Psr\Http' => new NamespaceContents([], [
+                new CatalogSymbol('Psr\Http\Message', NameKind::ClassLike),
+            ]),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+
+        $items = $candidates->navigate('\Psr\Http\M', new NameContext(''), 0, 12, ClassCandidateFilter::Any);
+
+        self::assertContains(
+            'Message',
+            array_column($items, 'label'),
+            'An absolute name walks from the global namespace',
+        );
+    }
+
+    public function testNavigateOffersDescentNodesForBareNames(): void
+    {
+        $catalog = self::catalog([
+            'App' => new NamespaceContents([], []),
+            'Vendor\Pkg' => new NamespaceContents([], [
+                new CatalogSymbol('Vendor\Pkg\Thing', NameKind::ClassLike),
+            ]),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $context = new NameContext('App', ['Pkg' => 'Vendor\Pkg']);
+
+        $items = $candidates->navigate('Pk', $context, 0, 2, ClassCandidateFilter::Any);
+
+        self::assertContains('Pkg\\', array_column($items, 'label'), 'A bare name offers descent nodes');
+    }
+
+    public function testNavigateResolvesQualifiedNamesThroughImports(): void
+    {
+        $catalog = self::catalog([
+            'Vendor\Pkg' => new NamespaceContents([], [
+                new CatalogSymbol('Vendor\Pkg\Thing', NameKind::ClassLike),
+            ]),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $context = new NameContext('App', ['Pkg' => 'Vendor\Pkg']);
+
+        $items = $candidates->navigate('Pkg\T', $context, 0, 5, ClassCandidateFilter::Any);
+
+        self::assertContains('Thing', array_column($items, 'label'), 'A qualified name resolves through the imports');
+    }
+
+    public function testNavigateResolvesQualifiedNamesRelativeToTheCurrentNamespace(): void
+    {
+        $catalog = self::catalog([
+            'App\Sub' => new NamespaceContents([], [
+                new CatalogSymbol('App\Sub\Thing', NameKind::ClassLike),
+            ]),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+
+        $items = $candidates->navigate('Sub\T', new NameContext('App'), 0, 5, ClassCandidateFilter::Any);
+
+        self::assertContains(
+            'Thing',
+            array_column($items, 'label'),
+            'A qualified name falls back to the current namespace',
+        );
+    }
+
     public function testRanksSymbolsAboveNamespaceNodes(): void
     {
         $catalog = self::catalog([

--- a/tests/Fixtures/Namespacing/CurrentNamespaceProbe.php
+++ b/tests/Fixtures/Namespacing/CurrentNamespaceProbe.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Model;
+
+/**
+ * A file whose own namespace is Fixtures\Model, where `Env` is a child namespace
+ * (not a `use` import). `new Env\R` resolves relative to the current namespace and
+ * reaches Fixtures\Model\Env\Repository (#339).
+ */
+class CurrentNamespaceProbe
+{
+    public function make(): void
+    {
+        new Env\R/*|current_ns_child*/
+    }
+}

--- a/tests/Fixtures/Namespacing/ImportedPrefix.php
+++ b/tests/Fixtures/Namespacing/ImportedPrefix.php
@@ -46,4 +46,9 @@ class ImportedPrefix
     {
         new Other\R/*|imported_unrelated*/
     }
+
+    public function deep(): void
+    {
+        new Env\Sub\T/*|imported_deep*/
+    }
 }

--- a/tests/Fixtures/Namespacing/ImportedPrefix.php
+++ b/tests/Fixtures/Namespacing/ImportedPrefix.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Fixtures\Model\Env;
+
+/**
+ * Completion of an imported name that is also a namespace prefix (#339). Each
+ * incomplete reference lives in its own method so parser recovery is not confused
+ * by multiple broken statements.
+ */
+class ImportedPrefix
+{
+    public function bare(): void
+    {
+        new Env/*|imported_bare*/
+    }
+
+    public function slash(): void
+    {
+        new Env\/*|imported_slash*/
+    }
+
+    public function partial(): void
+    {
+        new Env\R/*|imported_partial*/
+    }
+
+    public function noMatch(): void
+    {
+        new Env\Zz/*|imported_no_match*/
+    }
+
+    public function interfaceAfterNew(): void
+    {
+        new Env\H/*|imported_iface_new*/
+    }
+
+    public function interfaceAsType(Env\H/*|imported_iface_type*/ $handler): void
+    {
+    }
+
+    public function unrelated(): void
+    {
+        new Other\R/*|imported_unrelated*/
+    }
+}

--- a/tests/Fixtures/src/Model/Env.php
+++ b/tests/Fixtures/src/Model/Env.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Model;
+
+/**
+ * A class whose name is also a namespace prefix: `Env.php` sits beside an `Env/`
+ * directory, so `use Fixtures\Model\Env;` imports this class and opens the
+ * namespace holding Env\Repository (#339).
+ */
+class Env
+{
+}

--- a/tests/Fixtures/src/Model/Env/Handler.php
+++ b/tests/Fixtures/src/Model/Env/Handler.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Model\Env;
+
+/**
+ * An interface child of the imported Env namespace: valid as a type hint, but not
+ * after `new`.
+ */
+interface Handler
+{
+}

--- a/tests/Fixtures/src/Model/Env/Repository.php
+++ b/tests/Fixtures/src/Model/Env/Repository.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Model\Env;
+
+/**
+ * A child of the imported Env namespace, reachable as Env\Repository. Its method
+ * exists to prove members are never offered as `new`/class candidates.
+ */
+class Repository
+{
+    public function persist(): void
+    {
+    }
+}

--- a/tests/Fixtures/src/Model/Env/Sub/Thing.php
+++ b/tests/Fixtures/src/Model/Env/Sub/Thing.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Model\Env\Sub;
+
+/**
+ * A grandchild of the imported Env namespace, reachable as Env\Sub\Thing, so
+ * navigation from an imported prefix can descend more than one level.
+ */
+class Thing
+{
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -639,6 +639,23 @@ class CompletionHandlerTest extends TestCase
         self::assertSame([], array_values($envItems), 'No child matches `Env\\Zz`, so none is offered');
     }
 
+    public function testImportedPrefixNavigatesDeeperNamespaces(): void
+    {
+        // `Env\Sub\T` descends two levels below the import: the enumerated namespace
+        // is the import target plus the middle path, and the reference carries both.
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_deep');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $byLabel = array_column($result['items'], 'detail', 'label');
+        self::assertSame(
+            'Fixtures\Model\Env\Sub\Thing',
+            $byLabel['Env\Sub\Thing'] ?? null,
+            'A grandchild is reached and written import-relative',
+        );
+    }
+
     public function testUnimportedPrefixIsNotReached(): void
     {
         $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_unrelated');

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -534,12 +534,12 @@ class CompletionHandlerTest extends TestCase
         self::assertCount(100, $result['items'], 'Unranked completions are capped at the limit');
     }
 
-    #[DataProvider('provideImportedPrefixMarkers')]
-    public function testImportedPrefixOffersCatalogChild(string $marker): void
+    #[DataProvider('provideQualifiedImportedPrefixMarkers')]
+    public function testQualifiedImportedPrefixOffersLeafChild(string $marker): void
     {
         // Repository.php is NOT opened; it is discovered on disk through the catalog
-        // via the `use Fixtures\Model\Env;` import, whether typed as `Env`, `Env\`,
-        // or `Env\R`.
+        // via the `use Fixtures\Model\Env;` import. The child is offered by its leaf
+        // (Repository) with the FQCN as detail — the typed `Env\` stands.
         $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', $marker);
 
         $result = $this->handler->handle($this->completionRequestAt($cursor));
@@ -548,8 +548,8 @@ class CompletionHandlerTest extends TestCase
         $byLabel = array_column($result['items'], 'detail', 'label');
         self::assertSame(
             'Fixtures\Model\Env\Repository',
-            $byLabel['Env\Repository'] ?? null,
-            "The imported namespace's child is offered import-relative with its FQCN detail",
+            $byLabel['Repository'] ?? null,
+            "The imported namespace's child is offered by its leaf with the FQCN detail",
         );
     }
 
@@ -557,14 +557,30 @@ class CompletionHandlerTest extends TestCase
      * @codeCoverageIgnore
      * @return iterable<string, array{string}>
      */
-    public static function provideImportedPrefixMarkers(): iterable
+    public static function provideQualifiedImportedPrefixMarkers(): iterable
     {
-        yield 'bare import name' => ['imported_bare'];
         yield 'trailing slash' => ['imported_slash'];
         yield 'partial child' => ['imported_partial'];
     }
 
-    public function testImportedPrefixInsertsQualifiedReferenceWithoutDuplication(): void
+    public function testBareImportedPrefixOffersDescentNode(): void
+    {
+        // `new Env` offers an `Env\` node to step into the imported namespace, since
+        // the import target is itself a namespace.
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_bare');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $byLabel = array_column($result['items'], 'detail', 'label');
+        self::assertSame(
+            'Fixtures\Model\Env',
+            $byLabel['Env\\'] ?? null,
+            'The imported namespace is offered as an Env\\ descent node',
+        );
+    }
+
+    public function testQualifiedImportedPrefixInsertsLeafWithoutDuplication(): void
     {
         $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_partial');
 
@@ -576,9 +592,9 @@ class CompletionHandlerTest extends TestCase
             $byLabel[$item['label']] = $item['textEdit']['newText'] ?? null;
         }
         self::assertSame(
-            'Env\Repository',
-            $byLabel['Env\Repository'] ?? null,
-            'Accepting at `new Env\\R` inserts Env\\Repository, never Env\\Env\\Repository',
+            'Repository',
+            $byLabel['Repository'] ?? null,
+            'At `new Env\\R` only the leaf is inserted, so the typed `Env\\` is never duplicated',
         );
     }
 
@@ -590,7 +606,7 @@ class CompletionHandlerTest extends TestCase
 
         self::assertIsArray($result);
         self::assertNotContains(
-            'Env\Handler',
+            'Handler',
             array_column($result['items'], 'label'),
             'An interface child is not offered after `new`',
         );
@@ -604,7 +620,7 @@ class CompletionHandlerTest extends TestCase
 
         self::assertIsArray($result);
         self::assertContains(
-            'Env\Handler',
+            'Handler',
             array_column($result['items'], 'label'),
             'An interface child is offered in a type-hint position',
         );
@@ -621,7 +637,7 @@ class CompletionHandlerTest extends TestCase
 
         self::assertIsArray($result);
         $labels = array_column($result['items'], 'label');
-        self::assertContains('Env\Repository', $labels, 'The class child is still offered');
+        self::assertContains('Repository', $labels, 'The class child is still offered');
         self::assertNotContains('persist', $labels, "The child's method is not offered as a class candidate");
     }
 
@@ -632,17 +648,15 @@ class CompletionHandlerTest extends TestCase
         $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
-        $envItems = array_filter(
-            array_column($result['items'], 'label'),
-            static fn(string $label): bool => str_starts_with($label, 'Env\\'),
-        );
-        self::assertSame([], array_values($envItems), 'No child matches `Env\\Zz`, so none is offered');
+        $labels = array_column($result['items'], 'label');
+        self::assertNotContains('Repository', $labels, 'No child matches `Env\\Zz`, so none is offered');
+        self::assertNotContains('Handler', $labels, 'No child matches `Env\\Zz`, so none is offered');
     }
 
     public function testImportedPrefixNavigatesDeeperNamespaces(): void
     {
-        // `Env\Sub\T` descends two levels below the import: the enumerated namespace
-        // is the import target plus the middle path, and the reference carries both.
+        // `Env\Sub\T` descends two levels: the enumerated namespace is the import
+        // target plus the middle path, and only the leaf (Thing) is inserted.
         $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_deep');
 
         $result = $this->handler->handle($this->completionRequestAt($cursor));
@@ -651,12 +665,30 @@ class CompletionHandlerTest extends TestCase
         $byLabel = array_column($result['items'], 'detail', 'label');
         self::assertSame(
             'Fixtures\Model\Env\Sub\Thing',
-            $byLabel['Env\Sub\Thing'] ?? null,
-            'A grandchild is reached and written import-relative',
+            $byLabel['Thing'] ?? null,
+            'A grandchild is reached and offered by its leaf',
         );
     }
 
-    public function testUnimportedPrefixIsNotReached(): void
+    public function testCurrentNamespaceChildIsNavigableWithoutAnImport(): void
+    {
+        // In a file whose namespace is Fixtures\Model, `Env` is a child namespace,
+        // not an import. `new Env\R` still resolves it relative to the current
+        // namespace and offers Repository.
+        $cursor = $this->openFixtureAtCursor('Namespacing/CurrentNamespaceProbe.php', 'current_ns_child');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $byLabel = array_column($result['items'], 'detail', 'label');
+        self::assertSame(
+            'Fixtures\Model\Env\Repository',
+            $byLabel['Repository'] ?? null,
+            'A child of the current namespace is navigable without an import',
+        );
+    }
+
+    public function testUnimportedUnrelatedPrefixIsNotReached(): void
     {
         $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_unrelated');
 
@@ -665,9 +697,9 @@ class CompletionHandlerTest extends TestCase
         self::assertIsArray($result);
         $otherItems = array_filter(
             array_column($result['items'], 'label'),
-            static fn(string $label): bool => str_starts_with($label, 'Other\\'),
+            static fn(string $label): bool => str_starts_with($label, 'Other'),
         );
-        self::assertSame([], array_values($otherItems), 'An unimported prefix opens no namespace');
+        self::assertSame([], array_values($otherItems), 'A prefix that is neither imported nor a current-NS child reaches nothing');
     }
 
     public function testStaticCompletionResolvesImportedClassName(): void

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -534,6 +534,125 @@ class CompletionHandlerTest extends TestCase
         self::assertCount(100, $result['items'], 'Unranked completions are capped at the limit');
     }
 
+    #[DataProvider('provideImportedPrefixMarkers')]
+    public function testImportedPrefixOffersCatalogChild(string $marker): void
+    {
+        // Repository.php is NOT opened; it is discovered on disk through the catalog
+        // via the `use Fixtures\Model\Env;` import, whether typed as `Env`, `Env\`,
+        // or `Env\R`.
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', $marker);
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $byLabel = array_column($result['items'], 'detail', 'label');
+        self::assertSame(
+            'Fixtures\Model\Env\Repository',
+            $byLabel['Env\Repository'] ?? null,
+            "The imported namespace's child is offered import-relative with its FQCN detail",
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string}>
+     */
+    public static function provideImportedPrefixMarkers(): iterable
+    {
+        yield 'bare import name' => ['imported_bare'];
+        yield 'trailing slash' => ['imported_slash'];
+        yield 'partial child' => ['imported_partial'];
+    }
+
+    public function testImportedPrefixInsertsQualifiedReferenceWithoutDuplication(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_partial');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $byLabel = [];
+        foreach ($result['items'] as $item) {
+            $byLabel[$item['label']] = $item['textEdit']['newText'] ?? null;
+        }
+        self::assertSame(
+            'Env\Repository',
+            $byLabel['Env\Repository'] ?? null,
+            'Accepting at `new Env\\R` inserts Env\\Repository, never Env\\Env\\Repository',
+        );
+    }
+
+    public function testImportedPrefixExcludesInterfaceAfterNew(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_iface_new');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertNotContains(
+            'Env\Handler',
+            array_column($result['items'], 'label'),
+            'An interface child is not offered after `new`',
+        );
+    }
+
+    public function testImportedPrefixOffersInterfaceAsTypeHint(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_iface_type');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertContains(
+            'Env\Handler',
+            array_column($result['items'], 'label'),
+            'An interface child is offered in a type-hint position',
+        );
+    }
+
+    public function testImportedPrefixDoesNotLeakMembersWhenChildIsOpen(): void
+    {
+        // Opening the child's file must not cause its methods to be offered as
+        // class candidates — the reverted #331 attempt's regression.
+        $this->openFixture('src/Model/Env/Repository.php');
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_slash');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('Env\Repository', $labels, 'The class child is still offered');
+        self::assertNotContains('persist', $labels, "The child's method is not offered as a class candidate");
+    }
+
+    public function testImportedPrefixOffersNothingForUnmatchedChild(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_no_match');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $envItems = array_filter(
+            array_column($result['items'], 'label'),
+            static fn(string $label): bool => str_starts_with($label, 'Env\\'),
+        );
+        self::assertSame([], array_values($envItems), 'No child matches `Env\\Zz`, so none is offered');
+    }
+
+    public function testUnimportedPrefixIsNotReached(): void
+    {
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_unrelated');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $otherItems = array_filter(
+            array_column($result['items'], 'label'),
+            static fn(string $label): bool => str_starts_with($label, 'Other\\'),
+        );
+        self::assertSame([], array_values($otherItems), 'An unimported prefix opens no namespace');
+    }
+
     public function testStaticCompletionResolvesImportedClassName(): void
     {
         $cursor = $this->openFixtureAtCursor('Namespacing/MultiNamespaceImports.php', 'imported_static');

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -690,16 +690,19 @@ class CompletionHandlerTest extends TestCase
 
     public function testUnimportedUnrelatedPrefixIsNotReached(): void
     {
+        // `new Other\R`: Other is neither an import nor a child of the current
+        // namespace, so it resolves to a namespace that does not exist. Nothing is
+        // offered — in particular Env's children (Repository/Handler) do not leak in.
         $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_unrelated');
 
         $result = $this->handler->handle($this->completionRequestAt($cursor));
 
         self::assertIsArray($result);
-        $otherItems = array_filter(
-            array_column($result['items'], 'label'),
-            static fn(string $label): bool => str_starts_with($label, 'Other'),
+        self::assertSame(
+            [],
+            $result['items'],
+            'A prefix that is neither imported nor a current-namespace child reaches nothing',
         );
-        self::assertSame([], array_values($otherItems), 'A prefix that is neither imported nor a current-NS child reaches nothing');
     }
 
     public function testStaticCompletionResolvesImportedClassName(): void


### PR DESCRIPTION
Closes #339. Part of the namespace-correct completion epic (#308).

Extends namespace navigation to **relative prefixes** — a name whose first segment is a
`use` import or a child of the current namespace — building on the same catalog and
navigation machinery as absolute navigation (#330), with no duplicated logic.

## What it does

With `use App\Model\Env;` (or from inside `App\Model`, where `Env` is a child namespace):

- **Qualified (`new Env\`, `new Env\R`, `new Env\Sub\T`)** → navigates the resolved
  namespace and offers its children, catalog-sourced (on disk, no open file needed). The
  first segment resolves through the imports first, then relative to the current namespace.
- **Bare (`new Env`, `new M`)** → offers an `Env\` / `Mapping\` descent node for each import
  or current-namespace child that is itself a namespace.
- The position filter still applies (an interface child is a type hint, not a `new`
  candidate); members never leak (a directory listing has no members); an unrelated /
  non-namespace prefix reaches nothing.

## Insertion is leaf-relative (and why)

A selected child inserts only its **leaf** (`Repository`), replacing the segment after the
last `\`, so the typed `Env\` stands and is never duplicated — the FQCN is carried in the
item's `detail`. This is the same model #330 already uses, and it's the client-independent
choice: it's valid LSP *and* works in editors that don't apply the LSP `textEdit.range` and
instead replace the word under the cursor (Vim/ale — see
[dense-analysis/ale#4274](https://github.com/dense-analysis/ale/issues/4274)). A first pass
here inserted the full alias-qualified reference; that duplicated the prefix in such editors
and was reworked to leaf insertion after UAT.

## Scope

Fires in class/type-reference positions (`new`, `catch`, param/return/property types,
`implements`/`extends`, attributes). General expression start (`$x = Env\R`) does not
navigate, matching the absolute-navigation boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
