### PR TITLE
Unify relative and absolute namespace navigation

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -62,7 +62,10 @@ the prefix narrows. Catalog candidates are resolved before being offered, so a
 Navigation also works from a **relative prefix** whose first segment is a `use` import or a
 child of the current namespace. With `use App\Model\Env;` (or from inside `App\Model`),
 `new Env\` and `new Env\R` navigate `App\Model\Env` and offer its children, and `new Env`
-offers an `Env\` descent node. Discovery is catalog-sourced (no open file needed), and — as
+descends into it directly. A relative name behaves **identically to the absolute form** once
+the first segment is resolved — the `\` only changes how the root is qualified — so `new Env`
+inlines a small target (offering `Env\Repository` …) and nodes a large one (`Env\`), exactly
+as `new \App\Model\Env` would. Discovery is catalog-sourced (no open file needed), and — as
 with absolute navigation — insertion is **leaf-relative**: at `new Env\R` only `Repository`
 is inserted, replacing the segment after the last `\`, so the typed `Env\` stands and is
 never duplicated (the FQCN is carried in the item's detail). The position filter still

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -44,8 +44,9 @@ final class NamespaceCandidates
      * the name is rooted so name resolution stays out of the handler:
      *
      * - absolute (`\Ps`) walks from the global namespace;
-     * - a bare relative name (`Env`) offers descent nodes for imports and children
-     *   of the current namespace;
+     * - a bare relative name (`Env`) descends into imports and children of the
+     *   current namespace, inlining a small target and noding a large one, exactly
+     *   as the absolute form would once the first segment is resolved;
      * - a qualified relative name (`Env\R`) resolves its first segment through the
      *   imports, else the current namespace, and walks from there.
      *

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -74,7 +74,7 @@ final class NamespaceCandidates
         }
 
         if (!str_contains($prefix, '\\')) {
-            return $this->descentNodes($context, $prefix, $line, $character);
+            return $this->descend($context, $prefix, $line, $character, $filter);
         }
 
         $alias = NamespacePath::firstSegment($prefix);
@@ -135,15 +135,22 @@ final class NamespaceCandidates
     }
 
     /**
-     * Descent nodes for a bare relative name: an `Env\` node for each `use` import
-     * or child of the current namespace whose name the typed $prefix begins and
-     * which is itself a navigable namespace. Imports win a name clash with a
-     * current-namespace child, matching PHP name resolution.
+     * Candidates for a bare relative name: each `use` import or child of the current
+     * namespace whose name the typed $prefix begins and which is itself a navigable
+     * namespace. Each is offered through the same {@see offerChildNamespace()} as
+     * absolute navigation, so a small target inlines and a large one is a node —
+     * identically, whichever way the namespace was reached. Imports win a name clash
+     * with a current-namespace child, matching PHP name resolution.
      *
      * @return list<CompletionItem>
      */
-    public function descentNodes(NameContext $context, string $prefix, int $line, int $character): array
-    {
+    public function descend(
+        NameContext $context,
+        string $prefix,
+        int $line,
+        int $character,
+        ClassCandidateFilter $filter,
+    ): array {
         $range = Range::onLine($line, $character - strlen($prefix), $character);
 
         $targets = [];
@@ -159,7 +166,7 @@ final class NamespaceCandidates
             if (!PrefixMatcher::matches($reference, $prefix) || !$this->isNavigable($fqcn)) {
                 continue;
             }
-            $items[] = CompletionItemFactory::forNamespace($reference, $fqcn, $range);
+            $items = array_merge($items, $this->offerChildNamespace($fqcn, $reference, $filter, $range));
         }
 
         return $this->ranked($items);

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -294,41 +294,43 @@ class NamespaceCandidatesTest extends TestCase
         self::assertNotContains('Small\\', $labels, 'The inlined namespace itself is not offered as a node');
     }
 
-    public function testDescentNodesOfferImportsAndCurrentNamespaceChildren(): void
+    public function testDescendInlinesSmallTargetsAndNodesLargeOnes(): void
     {
+        // A bare name reaches its candidates through the same offerChildNamespace as
+        // absolute navigation, so a small one inlines and a large one is a node.
         $catalog = self::catalog([
-            'App' => new NamespaceContents(['App\Models'], []),
-            'App\Models' => new NamespaceContents([], [new CatalogSymbol('App\Models\User', NameKind::ClassLike)]),
-            'Vendor\Pkg' => new NamespaceContents([], [new CatalogSymbol('Vendor\Pkg\Thing', NameKind::ClassLike)]),
+            'App' => new NamespaceContents(['App\Small'], []),
+            'App\Small' => new NamespaceContents([], [new CatalogSymbol('App\Small\Thing', NameKind::ClassLike)]),
+            'Vendor\Big' => new NamespaceContents([], self::manyClassLikes('Vendor\Big')),
             'Vendor\Plain' => new NamespaceContents([], []),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::createStub(CodeResolver::class));
-        $context = new NameContext('App', ['Pkg' => 'Vendor\Pkg', 'Plain' => 'Vendor\Plain']);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $context = new NameContext('App', ['Big' => 'Vendor\Big', 'Plain' => 'Vendor\Plain']);
 
-        $labels = array_column($candidates->descentNodes($context, '', 0, 0), 'label');
+        $labels = array_column($candidates->descend($context, '', 0, 0, ClassCandidateFilter::Any), 'label');
 
-        self::assertContains('Models\\', $labels, 'A navigable child of the current namespace is a descent node');
-        self::assertContains('Pkg\\', $labels, 'A navigable import is a descent node');
-        self::assertNotContains('Plain\\', $labels, 'An import that is not a namespace is not a descent node');
+        self::assertContains(
+            'Small\Thing',
+            $labels,
+            'A small current-namespace child inlines, like absolute navigation',
+        );
+        self::assertContains('Big\\', $labels, 'A large import is a node');
+        self::assertNotContains('Plain\\', $labels, 'An import that is not a namespace is skipped');
     }
 
-    public function testDescentNodesFilterByPrefix(): void
+    public function testDescendFiltersByPrefix(): void
     {
         $catalog = self::catalog([
             'App' => new NamespaceContents([], []),
-            'Vendor\Mapping' => new NamespaceContents([], [
-                new CatalogSymbol('Vendor\Mapping\Column', NameKind::ClassLike),
-            ]),
-            'Vendor\Other' => new NamespaceContents([], [
-                new CatalogSymbol('Vendor\Other\Thing', NameKind::ClassLike),
-            ]),
+            'Vendor\Mapping' => new NamespaceContents([], self::manyClassLikes('Vendor\Mapping')),
+            'Vendor\Other' => new NamespaceContents([], self::manyClassLikes('Vendor\Other')),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::createStub(CodeResolver::class));
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
         $context = new NameContext('App', ['Mapping' => 'Vendor\Mapping', 'Other' => 'Vendor\Other']);
 
-        $labels = array_column($candidates->descentNodes($context, 'Map', 0, 3), 'label');
+        $labels = array_column($candidates->descend($context, 'Map', 0, 3, ClassCandidateFilter::Any), 'label');
 
-        self::assertSame(['Mapping\\'], $labels, 'Only imports/children whose name begins with the prefix are offered');
+        self::assertSame(['Mapping\\'], $labels, 'Only imports whose name begins with the prefix are offered');
     }
 
     public function testNavigateWalksAbsoluteNames(): void
@@ -349,20 +351,18 @@ class NamespaceCandidatesTest extends TestCase
         );
     }
 
-    public function testNavigateOffersDescentNodesForBareNames(): void
+    public function testNavigateDescendsForBareNames(): void
     {
         $catalog = self::catalog([
             'App' => new NamespaceContents([], []),
-            'Vendor\Pkg' => new NamespaceContents([], [
-                new CatalogSymbol('Vendor\Pkg\Thing', NameKind::ClassLike),
-            ]),
+            'Vendor\Pkg' => new NamespaceContents([], self::manyClassLikes('Vendor\Pkg')),
         ]);
         $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
         $context = new NameContext('App', ['Pkg' => 'Vendor\Pkg']);
 
         $items = $candidates->navigate('Pk', $context, 0, 2, ClassCandidateFilter::Any);
 
-        self::assertContains('Pkg\\', array_column($items, 'label'), 'A bare name offers descent nodes');
+        self::assertContains('Pkg\\', array_column($items, 'label'), 'A bare name descends into an imported namespace');
     }
 
     public function testNavigateResolvesQualifiedNamesThroughImports(): void

--- a/tests/Fixtures/Namespacing/ImportedPrefix.php
+++ b/tests/Fixtures/Namespacing/ImportedPrefix.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App;
 
 use Fixtures\Model\Env;
+use Psr\Http\Message;
 
 /**
  * Completion of an imported name that is also a namespace prefix (#339). Each
@@ -50,5 +51,10 @@ class ImportedPrefix
     public function deep(): void
     {
         new Env\Sub\T/*|imported_deep*/
+    }
+
+    public function large(): void
+    {
+        new Message/*|imported_large*/
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -563,10 +563,10 @@ class CompletionHandlerTest extends TestCase
         yield 'partial child' => ['imported_partial'];
     }
 
-    public function testBareImportedPrefixOffersDescentNode(): void
+    public function testBareImportedPrefixInlinesSmallTarget(): void
     {
-        // `new Env` offers an `Env\` node to step into the imported namespace, since
-        // the import target is itself a namespace.
+        // `new Env` reaches the same offerChildNamespace path as `new \Fixtures\Model\Env`,
+        // so a small imported namespace inlines its members rather than offering a node.
         $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_bare');
 
         $result = $this->handler->handle($this->completionRequestAt($cursor));
@@ -574,9 +574,27 @@ class CompletionHandlerTest extends TestCase
         self::assertIsArray($result);
         $byLabel = array_column($result['items'], 'detail', 'label');
         self::assertSame(
-            'Fixtures\Model\Env',
-            $byLabel['Env\\'] ?? null,
-            'The imported namespace is offered as an Env\\ descent node',
+            'Fixtures\Model\Env\Repository',
+            $byLabel['Env\Repository'] ?? null,
+            'A small imported namespace inlines its members, identically to absolute navigation',
+        );
+        self::assertArrayNotHasKey('Env\\', $byLabel, 'A small target is not also offered as a bare node');
+    }
+
+    public function testBareImportedPrefixNodesLargeTarget(): void
+    {
+        // `use Psr\Http\Message;` then `new Message`: the target has many members, so
+        // it stays a `Message\` node to step into — the Doctrine\ORM\Mapping case.
+        $cursor = $this->openFixtureAtCursor('Namespacing/ImportedPrefix.php', 'imported_large');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $byLabel = array_column($result['items'], 'detail', 'label');
+        self::assertSame(
+            'Psr\Http\Message',
+            $byLabel['Message\\'] ?? null,
+            'A large imported namespace stays a descent node',
         );
     }
 


### PR DESCRIPTION
Closes #345. Last sub-issue of the namespace-navigation epic (#308).

Makes relative navigation (`new Env`, imported or current-namespace) behave **identically**
to absolute navigation (`new \App\Model\Env`) once the first segment is resolved. The `\` only
changes how the root is qualified; everything downstream now shares one code path.

## Change

`NamespaceCandidates::descend()` (the bare-relative entry) previously always emitted a plain
`Foo\` node. It now routes each candidate namespace through the same `offerChildNamespace()`
that absolute navigation uses, so:

- a **small** target (≤ `INLINE_THRESHOLD`) inlines its members — `new Env` offers
  `Env\Repository` directly, exactly as `new \App\Model\Env` does;
- a **large** target stays a `Foo\` node to step into — `use Psr\Http\Message;` / `new Message`
  (or your `Doctrine\ORM\Mapping`) is still `Message\` / `Mapping\`.

The position filter and leaf-relative insertion carry through unchanged (they already lived in
`offerChildNamespace`).

## UAT

- `new Env` on a **small** imported/current-NS namespace → its members inline (`Env\Repository`),
  no bare `Env\` node.
- `new M` on a **large** one (`Doctrine\ORM\Mapping`) → still the `Mapping\` node.
- Both match what the absolute `new \…` form already did for the same namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
