### PR TITLE
Adjust local+ci rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-
-      - name: PHPStan
-        run: composer phpstan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --working-dir=tests/Fixtures
 
       - name: Run PHPUnit
-        run: composer phpunit
+        run: composer unit
           --
           --coverage-clover coverage.xml
           --log-junit junit.xml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,4 +23,4 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PHPStan
-        run: composer phpstan
+        run: composer phpstan -- --error-format=github

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
 
 jobs:
-  test:
+  phpstan:
     runs-on: ubuntu-latest
-    name: PHP ${{ matrix.php }}
+    name: PHPStan
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,26 @@
+name: Static Analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: PHP ${{ matrix.php }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: pcov
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: PHPStan
+        run: composer phpstan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ on:
   pull_request:
 
 jobs:
-  test:
+  unit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php: ['8.3', '8.4', '8.5']
-    name: PHP ${{ matrix.php }}
+    name: Unit Tests - ${{ matrix.php }}
     steps:
       - uses: actions/checkout@v7
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Quick Start
 
 ```bash
-composer check # PHPStan + tests + PHPCS (run before commits)
-composer phpunit -- --filter X # Run specific tests
+composer test # PHPStan + tests + PHPCS (run before commits)
+composer unit -- --filter X # Run specific tests
 composer phpstan -- --error-format=raw --no-progress # run phpstan
 composer phpstan -- --error-format=raw --no-progress path/to/analyze # run phpstan on a specific path
 composer phpcs -- -q --report=emacs # run code style checks (PSR-12)

--- a/README.md
+++ b/README.md
@@ -36,14 +36,17 @@ composer install
 # Generate test fixture autoload
 composer dump-autoload --working-dir=tests/Fixtures
 
-# Run tests and static analysis
-composer check
+# Run tests, static analysis, and linters
+composer test
 
 # Run just tests
-composer phpunit
+composer unit
 
 # Run just static analysis
 composer phpstan
+
+# Run just linters
+composer phpcs
 ```
 
 ## Editor Integration

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
     },
     "scripts": {
         "phpcs": "phpcs",
-        "phpunit": "phpunit",
+        "unit": "phpunit",
         "phpstan": "phpstan analyze",
-        "check": [
+        "test": [
             "@phpstan",
-            "@phpunit",
+            "@unit",
             "@phpcs"
         ]
     },


### PR DESCRIPTION
This project got scaffolded in a different way than most other projects (including my own) with regard to various QA tools. I'm bringing them back in line:

- `composer unit` -> run unit tests
- `composer check` renamed to `composer test`, still runs all tools
- Split PHPStan GHA into own workflow, rather than in the PHPUnit matrix
- Update README/Claude instructions

Non-code adjustment to the branch protection rules to match new names/structure