### PR TITLE
Test FQCN new offers global built-in class leaf

### DIFF
--- a/tests/Fixtures/Namespacing/UnqualifiedNewCompletion.php
+++ b/tests/Fixtures/Namespacing/UnqualifiedNewCompletion.php
@@ -29,4 +29,9 @@ class Trigger
     {
         new \Ps/*|nav_global*/
     }
+
+    public function navigateBuiltinClass(): void
+    {
+        new \Spl/*|nav_global_class*/
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -465,6 +465,30 @@ class CompletionHandlerTest extends TestCase
         self::assertFalse($result['isIncomplete'], 'A result set within the cap is complete');
     }
 
+    public function testBackslashNavigationOffersGlobalBuiltinClasses(): void
+    {
+        // Issue #38: typing an absolute name whose prefix matches a class declared
+        // directly in the global namespace (`new \Spl`) offers that built-in class as
+        // a leaf, not merely a namespace node. SplFixedArray is instantiable, so the
+        // `new` position's Instantiable filter keeps it.
+        $cursor = $this->openFixtureAtCursor('Namespacing/UnqualifiedNewCompletion.php', 'nav_global_class');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $classLeaves = [];
+        foreach ($result['items'] as $item) {
+            if (($item['kind'] ?? null) === CompletionItemKind::Class_->value) {
+                $classLeaves[] = $item['label'];
+            }
+        }
+        self::assertContains(
+            'SplFixedArray',
+            $classLeaves,
+            'Navigating `new \\Spl` offers the instantiable global built-in class as a leaf',
+        );
+    }
+
     public function testCapsResultsAndReportsIncompleteWhenNavigationOverflows(): void
     {
         // A namespace with far more children than the cap floods navigation. The


### PR DESCRIPTION
## Summary

FQCN completion — typing an absolute name after `new` (`new \Spl`) offering global built-in classes — was already implemented by the recent namespace-navigation work (#342, #344, #346). This adds an end-to-end handler test to prevent regressions, since the exact issue scenario was not directly covered.

The existing `testBackslashNavigationOffersNamespaceNodes` only asserts a namespace *node* (`Psr\Http\`). Nothing asserted that a class declared directly in the global namespace is offered as a **`Class` leaf** when its prefix is typed after `new \`.

## Changes

- Fixture: new `new \Spl/*|nav_global_class*/` marker in `UnqualifiedNewCompletion.php`.
- Test: `testBackslashNavigationOffersGlobalBuiltinClasses` drives the completion handler and asserts `SplFixedArray` is offered as a `Class` leaf. It uses `\Spl` → `SplFixedArray` because it is an instantiable global built-in that survives the `new` position's `Instantiable` filter.

The test passes against current `main` behavior; it is a coverage backfill guarding against regression, not a fix.

Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
