### PR TITLE
Complete class-likes after instanceof

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -19,6 +19,7 @@ This document tracks the current state of code completion in php-lsp.
 | `catch` clause | `catch (Ba` or `catch (Foo \| Ba` | Throwable types only (from imports + workspace index): `Throwable` and any class or interface extending/implementing it. Multi-catch (`\|`-separated) supported; non-throwable types, functions, and keywords excluded | ✅ Working |
 | Attribute position | `#[Ro` | Attribute classes only (from imports + workspace index); classes, interfaces, traits, enums, and functions excluded. Grouped (`#[A, Ba`) supported; target-aware filtering is not yet (#252) | ✅ Working |
 | Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
+| `instanceof` right-hand side | `$x instanceof Ba` | Class-likes valid as a type (classes, interfaces, enums) from imports + workspace index; traits excluded (a trait `instanceof` check is always false), as are scalar type keywords and functions | ✅ Working |
 | Namespace navigation | `new \Ps`, `catch (\E`, `function f(\Ps` | Vendor/built-in class-likes and child namespaces from the catalog, walked one segment at a time. Works on absolute (`\`-rooted) names and on relative prefixes resolved through a `use` import or the current namespace (`use App\Model\Env;` or being inside `App\Model` → `new Env\R`) | ✅ Working |
 
 All of the above work identically in class methods, free functions, and

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -72,6 +72,13 @@ final class CompletionClassifier
             return new CompletionClassification(CompletionKind::New_, $matches[1]);
         }
 
+        // instanceof right-hand side. Checked before the broader operator/expression
+        // fallbacks, which would otherwise claim `instanceof Ba` as an Expression. The
+        // prefix keeps a leading `\` so absolute navigation reaches the handler intact.
+        if (preg_match('/\binstanceof\s+' . self::QUALIFIED_TAIL . '$/', $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::Instanceof_, $matches[1]);
+        }
+
         // Attribute position (#[). Checked early: the "#[" delimiter is unambiguous,
         // and attributes appear in class bodies and type-hint-adjacent positions that
         // later, broader patterns would otherwise claim.

--- a/src/Completion/CompletionKind.php
+++ b/src/Completion/CompletionKind.php
@@ -45,6 +45,9 @@ enum CompletionKind
     /** In an attribute position, e.g. `#[Ba` — attribute classes only */
     case Attribute;
 
+    /** On the right of `instanceof`, e.g. `$x instanceof Ba` — class-likes except traits */
+    case Instanceof_;
+
     /** Directly inside a class body — class-level keywords only */
     case ClassBody;
 

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -257,6 +257,13 @@ final class CompletionHandler implements HandlerInterface
                 $character,
                 ClassCandidateFilter::Attribute,
             ),
+            CompletionKind::Instanceof_ => $this->getClassCompletions(
+                $prefix,
+                $document,
+                $line,
+                $character,
+                ClassCandidateFilter::TypeHint,
+            ),
             CompletionKind::ClassBody => $this->keywordCandidates->find($prefix, KeywordGroup::ClassBody),
             CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document, $line, $character),
             CompletionKind::None => [],

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -189,6 +189,18 @@ class CompletionClassifierTest extends TestCase
             'e',
         ];
 
+        // The right-hand side of `instanceof` is a class-like position (classes,
+        // interfaces, enums), so it classifies distinctly from the surrounding
+        // expression and keeps a leading `\` for navigation (#315).
+        yield 'instanceof with prefix' => ['        if ($x instanceof Ba', CompletionKind::Instanceof_, 'Ba'];
+        yield 'instanceof bare' => ['        if ($x instanceof ', CompletionKind::Instanceof_, ''];
+        yield 'instanceof absolute' => ['        if ($x instanceof \\Ba', CompletionKind::Instanceof_, '\\Ba'];
+        yield 'instanceof absolute qualified' => [
+            '        if ($x instanceof \\App\\Ba',
+            CompletionKind::Instanceof_,
+            '\\App\\Ba',
+        ];
+
         yield 'expression at start' => ['fo', CompletionKind::Expression, 'fo'];
         yield 'expression after assignment' => ['$x = fo', CompletionKind::Expression, 'fo'];
         yield 'expression inside method body' => [

--- a/tests/Fixtures/src/Completion/InstanceofCompletion.php
+++ b/tests/Fixtures/src/Completion/InstanceofCompletion.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+use Fixtures\Domain\Entity;
+use Fixtures\Domain\User;
+use Fixtures\Enum\Status;
+use Fixtures\Traits\SingletonTrait;
+
+class InstanceofCompletion
+{
+    public function trigger(object $value): void
+    {
+        if ($value instanceof /*|instanceof_empty*/) {
+            return;
+        }
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -3519,6 +3519,35 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testInstanceofOffersClassLikesNotTraits(): void
+    {
+        // Issue #315: the right-hand side of `instanceof` accepts classes, interfaces,
+        // and enums, but not traits — `$x instanceof SomeTrait` is always false. Scalar
+        // type keywords and functions are not valid there either.
+        $cursor = $this->openFixtureAtCursor('src/Completion/InstanceofCompletion.php', 'instanceof_empty');
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('User', $labels, 'A class is valid on the right of instanceof');
+        self::assertContains('Entity', $labels, 'An interface is valid on the right of instanceof');
+        self::assertContains('Status', $labels, 'An enum is valid on the right of instanceof');
+        self::assertNotContains('SingletonTrait', $labels, 'A trait instanceof check is always false');
+        self::assertNotContains('string', $labels, 'A scalar type keyword is not valid after instanceof');
+
+        $kinds = array_column($result['items'], 'kind');
+        self::assertNotContains(
+            CompletionItemKind::Function->value,
+            $kinds,
+            'Functions must not be offered on the right of instanceof',
+        );
+        self::assertNotContains(
+            CompletionItemKind::Keyword->value,
+            $kinds,
+            'Keywords must not be offered on the right of instanceof',
+        );
+    }
+
     public function testImplementsAcrossMultipleLinesOffersInterfaces(): void
     {
         self::markTestSkipped(


### PR DESCRIPTION
## Summary

Completion now fires on the right-hand side of `instanceof`, offering class-likes valid as a type — classes, interfaces, and enums — while excluding traits (an `instanceof` check against a trait is always false), scalar type keywords, and functions.

This is the low-cost path the issue described: the valid set is identical to a type-hint, so it reuses the existing `ClassCandidateFilter::TypeHint`.

## Changes

- `CompletionKind::Instanceof_` — new enum case.
- `CompletionClassifier` — one regex (`\binstanceof\s+…`), placed before the broad expression fallback so `instanceof Ba` does not degrade to `Expression`. It keeps a leading `\`, so absolute namespace navigation (`instanceof \App\Ba`) works like the other class positions.
- `CompletionHandler` — dispatches to `getClassCompletions` with `ClassCandidateFilter::TypeHint`. This intentionally uses `getClassCompletions`, not `getTypeHintCompletions`: the latter also offers scalar type keywords (`int`, `string`), which are not valid after `instanceof`.

## Tests

- Classifier rows for the prefix, bare, absolute, and absolute-qualified forms.
- An end-to-end handler test asserting a class, interface, and enum are offered; a trait and a scalar keyword are not; and no function/keyword kinds leak.

## Notes

The enum case, classifier arm, and dispatch arm are committed together because they are mutually dependent — the handler's `match` is exhaustive (so the arm is required) and the classifier test references the enum case, so any smaller split would produce a broken intermediate commit. Documentation is a separate commit.

Closes #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
