### PR TITLE
Complete namespaces and classes in use statements

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -81,11 +81,12 @@ imports, so `use Ps` and `use Psr\Http\` navigate the tree exactly as `new \Ps` 
 `new \Psr\Http\` do, offering any kind of class-like (a `use` can import a class, interface,
 trait, or enum). `use function` and `use const` are out of scope here (#239, #317).
 
-Only a **top-level** `use` is an import. A `use` inside a class body is a trait
-application — an unrelated construct that shares the keyword — and resolves relative to the
-file like any class reference, so it keeps the ordinary expression-position behavior and
-never enters absolute import navigation. The two are indistinguishable on a single line, so
-the import/trait distinction is made structurally from the whole document.
+Only a **top-level** `use` is an import. The keyword is shared by two unrelated constructs
+that are not: a `use` inside a class body is a trait application, and resolves relative to
+the file like any class reference (the ordinary expression-position behavior); a `use` after
+a closure's parameter list (`function () use (`) is a capture list, a variable position.
+Neither enters absolute import navigation. The three are indistinguishable on a single line,
+so the distinction is made structurally from the whole document.
 
 Leaf-relative insertion is also what keeps this working in editors that don't apply the LSP
 `textEdit` range and instead replace the word under the cursor (e.g. Vim/ale, see

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -21,7 +21,7 @@ This document tracks the current state of code completion in php-lsp.
 | Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
 | `instanceof` right-hand side | `$x instanceof Ba` | Class-likes valid as a type (classes, interfaces, enums) from imports + workspace index; traits excluded (a trait `instanceof` check is always false), as are scalar type keywords and functions | ✅ Working |
 | Namespace navigation | `new \Ps`, `catch (\E`, `function f(\Ps` | Vendor/built-in class-likes and child namespaces from the catalog, walked one segment at a time. Works on absolute (`\`-rooted) names and on relative prefixes resolved through a `use` import or the current namespace (`use App\Model\Env;` or being inside `App\Model` → `new Env\R`) | ✅ Working |
-| `use` import statement | `use Psr\Lo` | Namespaces and class-likes (any kind) from the catalog, walked one segment at a time. The name is **absolute** — resolved from the global namespace regardless of the file's own namespace or imports — so it navigates the same tree as `new \Ps`. `use function` / `use const` are not yet offered (#239, #317) | ✅ Working |
+| `use` import statement | `use Psr\Lo` | Namespaces and class-likes (any kind) from the catalog, walked one segment at a time. The name is **absolute** — resolved from the global namespace regardless of the file's own namespace or imports — so it navigates the same tree as `new \Ps`. Applies to top-level imports only; a `use` in a class body is a trait application (see below). `use function` / `use const` are not yet offered (#239, #317) | ✅ Working |
 
 All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
@@ -80,6 +80,12 @@ a `use` name resolves from the global namespace regardless of the file's own nam
 imports, so `use Ps` and `use Psr\Http\` navigate the tree exactly as `new \Ps` and
 `new \Psr\Http\` do, offering any kind of class-like (a `use` can import a class, interface,
 trait, or enum). `use function` and `use const` are out of scope here (#239, #317).
+
+Only a **top-level** `use` is an import. A `use` inside a class body is a trait
+application — an unrelated construct that shares the keyword — and resolves relative to the
+file like any class reference, so it keeps the ordinary expression-position behavior and
+never enters absolute import navigation. The two are indistinguishable on a single line, so
+the import/trait distinction is made structurally from the whole document.
 
 Leaf-relative insertion is also what keeps this working in editors that don't apply the LSP
 `textEdit` range and instead replace the word under the cursor (e.g. Vim/ale, see

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -21,6 +21,7 @@ This document tracks the current state of code completion in php-lsp.
 | Attribute arguments | `#[Route(` | Constructor named arguments, like a normal call (an attribute is a constructor call on its class); signature help shows the constructor | ✅ Working |
 | `instanceof` right-hand side | `$x instanceof Ba` | Class-likes valid as a type (classes, interfaces, enums) from imports + workspace index; traits excluded (a trait `instanceof` check is always false), as are scalar type keywords and functions | ✅ Working |
 | Namespace navigation | `new \Ps`, `catch (\E`, `function f(\Ps` | Vendor/built-in class-likes and child namespaces from the catalog, walked one segment at a time. Works on absolute (`\`-rooted) names and on relative prefixes resolved through a `use` import or the current namespace (`use App\Model\Env;` or being inside `App\Model` → `new Env\R`) | ✅ Working |
+| `use` import statement | `use Psr\Lo` | Namespaces and class-likes (any kind) from the catalog, walked one segment at a time. The name is **absolute** — resolved from the global namespace regardless of the file's own namespace or imports — so it navigates the same tree as `new \Ps`. `use function` / `use const` are not yet offered (#239, #317) | ✅ Working |
 
 All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
@@ -73,6 +74,12 @@ never duplicated (the FQCN is carried in the item's detail). The position filter
 applies (an interface child is offered as a type hint but not after `new`), and only an
 imported alias or a real current-namespace child opens a namespace — an unrelated prefix
 reaches nothing.
+
+A **`use` import statement** enters the same machinery, always through the absolute walk:
+a `use` name resolves from the global namespace regardless of the file's own namespace or
+imports, so `use Ps` and `use Psr\Http\` navigate the tree exactly as `new \Ps` and
+`new \Psr\Http\` do, offering any kind of class-like (a `use` can import a class, interface,
+trait, or enum). `use function` and `use const` are out of scope here (#239, #317).
 
 Leaf-relative insertion is also what keeps this working in editors that don't apply the LSP
 `textEdit` range and instead replace the word under the cursor (e.g. Vim/ale, see

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -58,6 +58,14 @@ final class CompletionClassifier
     private const ATTRIBUTE_PATTERN =
         '/#\[\s*(?:[\w\\\\]+\s*(?:\([^)]*\))?\s*,\s*)*' . self::QUALIFIED_TAIL . '$/';
 
+    // Matches a `use` import statement's name: "use ", an optional leading `\`, and
+    // the qualified name typed so far. A `use` name is always fully qualified — it
+    // resolves from the global namespace regardless of the file's own namespace or
+    // imports — so the whole path is captured for an absolute walk. `use function`
+    // and `use const` are deliberately not matched: they import functions and
+    // constants, which are out of this position's scope (#239, #317).
+    private const USE_PATTERN = '/\buse\s+' . self::QUALIFIED_TAIL . '$/';
+
     public static function classify(string $textBeforeCursor): CompletionClassification
     {
         // Variable completion
@@ -145,6 +153,14 @@ final class CompletionClassifier
                 return new CompletionClassification(CompletionKind::ClassBody, $matches[1]);
             }
             return new CompletionClassification(CompletionKind::None, '');
+        }
+
+        // `use` import statement. Checked after the class-body block (a same-line
+        // trait `use` is consumed there) and before the expression fallback, which
+        // would otherwise claim `use Fo` as an Expression. The name is navigated
+        // absolutely; see USE_PATTERN.
+        if (preg_match(self::USE_PATTERN, $textBeforeCursor, $matches) === 1) {
+            return new CompletionClassification(CompletionKind::Use_, $matches[1]);
         }
 
         // Function/class/keyword completion (at start of expression or after operators)

--- a/src/Completion/CompletionKind.php
+++ b/src/Completion/CompletionKind.php
@@ -48,6 +48,9 @@ enum CompletionKind
     /** On the right of `instanceof`, e.g. `$x instanceof Ba` — class-likes except traits */
     case Instanceof_;
 
+    /** In a `use` import statement, e.g. `use Psr\Lo` — namespaces and class-likes, named absolutely */
+    case Use_;
+
     /** Directly inside a class body — class-level keywords only */
     case ClassBody;
 

--- a/src/Completion/ContextDetector.php
+++ b/src/Completion/ContextDetector.php
@@ -112,6 +112,20 @@ final class ContextDetector
     }
 
     /**
+     * Whether $offset sits in a closure's `use (...)` capture list, where a `use`
+     * captures variables from the enclosing scope rather than importing a namespace
+     * — again two unrelated constructs that share the keyword. The capture list is
+     * the only place a `use` follows a `)` (a closing parameter list); an import or
+     * trait `use` follows a statement boundary. Token-based and whole-document, so
+     * it survives mid-edit breakage and sees a `)` on an earlier line.
+     */
+    public static function isClosureUse(string $code, int $offset): bool
+    {
+        // `) use` — the closure's parameter list closes, then the capture keyword.
+        return array_slice(self::significantTokensBefore($code, $offset), -2) === [')', T_USE];
+    }
+
+    /**
      * The significant tokens (whitespace, comments, and docblocks removed) that
      * begin before $offset, each reduced to its token id (array tokens) or literal
      * text (single-character tokens). Only code up to the cursor defines its scope,

--- a/src/Completion/ContextDetector.php
+++ b/src/Completion/ContextDetector.php
@@ -69,6 +69,74 @@ final class ContextDetector
         return CompletionContext::Full;
     }
 
+    /**
+     * Whether $offset sits directly inside a class-like body (class, interface,
+     * trait, or enum), where a `use` is a trait application rather than a namespace
+     * import — two unrelated constructs that share the keyword. Token-based so it
+     * survives mid-edit breakage, like the rest of this detector, and structural so
+     * it can tell the two `use` forms apart, which the single line the classifier
+     * sees cannot.
+     */
+    public static function isInsideClassBody(string $code, int $offset): bool
+    {
+        $tokens = token_get_all($code);
+        // One entry per open brace, true when that brace opened a class-like body.
+        // The innermost (last) entry is the scope the cursor sits directly in.
+        $braceOpensClassBody = [];
+        $nextBraceOpensClassBody = false;
+        $previousSignificant = null;
+        $position = 0;
+
+        foreach ($tokens as $token) {
+            // Only code up to the cursor defines its scope; stop before it.
+            if ($position >= $offset) {
+                break;
+            }
+
+            if (is_array($token)) {
+                $position += strlen($token[1]);
+                $id = $token[0];
+
+                if ($id === T_WHITESPACE || $id === T_COMMENT || $id === T_DOC_COMMENT) {
+                    continue;
+                }
+
+                // Interpolation braces (`"{$x}"`, `"${x}"`) open a scope closed by a
+                // plain `}`, so they are tracked to keep the brace stack balanced.
+                if ($id === T_CURLY_OPEN || $id === T_DOLLAR_OPEN_CURLY_BRACES) {
+                    $braceOpensClassBody[] = false;
+                    $nextBraceOpensClassBody = false;
+                    $previousSignificant = $id;
+                    continue;
+                }
+
+                // A class-like declaration marks the next `{` as a class body. The
+                // `::class` constant reference is not a declaration and is excluded.
+                if (
+                    ($id === T_CLASS || $id === T_INTERFACE || $id === T_TRAIT || $id === T_ENUM)
+                    && $previousSignificant !== T_DOUBLE_COLON
+                ) {
+                    $nextBraceOpensClassBody = true;
+                }
+
+                $previousSignificant = $id;
+                continue;
+            }
+
+            $position += strlen($token);
+            $previousSignificant = $token;
+
+            if ($token === '{') {
+                $braceOpensClassBody[] = $nextBraceOpensClassBody;
+                $nextBraceOpensClassBody = false;
+            } elseif ($token === '}') {
+                array_pop($braceOpensClassBody);
+            }
+        }
+
+        return $braceOpensClassBody !== [] && end($braceOpensClassBody) === true;
+    }
+
     private static function contextForToken(int $tokenType, string $tokenText, bool $inNowdoc): CompletionContext
     {
         if (in_array($tokenType, self::NO_COMPLETION_TOKENS, true)) {

--- a/src/Completion/ContextDetector.php
+++ b/src/Completion/ContextDetector.php
@@ -79,16 +79,53 @@ final class ContextDetector
      */
     public static function isInsideClassBody(string $code, int $offset): bool
     {
-        $tokens = token_get_all($code);
         // One entry per open brace, true when that brace opened a class-like body.
         // The innermost (last) entry is the scope the cursor sits directly in.
         $braceOpensClassBody = [];
         $nextBraceOpensClassBody = false;
         $previousSignificant = null;
+
+        foreach (self::significantTokensBefore($code, $offset) as $token) {
+            // Interpolation braces (`"{$x}"`, `"${x}"`) open a scope closed by a
+            // plain `}`, so they are tracked to keep the brace stack balanced.
+            if ($token === T_CURLY_OPEN || $token === T_DOLLAR_OPEN_CURLY_BRACES) {
+                $braceOpensClassBody[] = false;
+                $nextBraceOpensClassBody = false;
+            } elseif (
+                // A class-like declaration marks the next `{` as a class body. The
+                // `::class` constant reference is not a declaration and is excluded.
+                ($token === T_CLASS || $token === T_INTERFACE || $token === T_TRAIT || $token === T_ENUM)
+                && $previousSignificant !== T_DOUBLE_COLON
+            ) {
+                $nextBraceOpensClassBody = true;
+            } elseif ($token === '{') {
+                $braceOpensClassBody[] = $nextBraceOpensClassBody;
+                $nextBraceOpensClassBody = false;
+            } elseif ($token === '}') {
+                array_pop($braceOpensClassBody);
+            }
+
+            $previousSignificant = $token;
+        }
+
+        return $braceOpensClassBody !== [] && end($braceOpensClassBody) === true;
+    }
+
+    /**
+     * The significant tokens (whitespace, comments, and docblocks removed) that
+     * begin before $offset, each reduced to its token id (array tokens) or literal
+     * text (single-character tokens). Only code up to the cursor defines its scope,
+     * so scanning stops there. Shared by the structural `use`-disambiguation checks
+     * so they walk the document identically.
+     *
+     * @return list<int|string>
+     */
+    private static function significantTokensBefore(string $code, int $offset): array
+    {
+        $significant = [];
         $position = 0;
 
-        foreach ($tokens as $token) {
-            // Only code up to the cursor defines its scope; stop before it.
+        foreach (token_get_all($code) as $token) {
             if ($position >= $offset) {
                 break;
             }
@@ -96,45 +133,18 @@ final class ContextDetector
             if (is_array($token)) {
                 $position += strlen($token[1]);
                 $id = $token[0];
-
                 if ($id === T_WHITESPACE || $id === T_COMMENT || $id === T_DOC_COMMENT) {
                     continue;
                 }
-
-                // Interpolation braces (`"{$x}"`, `"${x}"`) open a scope closed by a
-                // plain `}`, so they are tracked to keep the brace stack balanced.
-                if ($id === T_CURLY_OPEN || $id === T_DOLLAR_OPEN_CURLY_BRACES) {
-                    $braceOpensClassBody[] = false;
-                    $nextBraceOpensClassBody = false;
-                    $previousSignificant = $id;
-                    continue;
-                }
-
-                // A class-like declaration marks the next `{` as a class body. The
-                // `::class` constant reference is not a declaration and is excluded.
-                if (
-                    ($id === T_CLASS || $id === T_INTERFACE || $id === T_TRAIT || $id === T_ENUM)
-                    && $previousSignificant !== T_DOUBLE_COLON
-                ) {
-                    $nextBraceOpensClassBody = true;
-                }
-
-                $previousSignificant = $id;
+                $significant[] = $id;
                 continue;
             }
 
             $position += strlen($token);
-            $previousSignificant = $token;
-
-            if ($token === '{') {
-                $braceOpensClassBody[] = $nextBraceOpensClassBody;
-                $nextBraceOpensClassBody = false;
-            } elseif ($token === '}') {
-                array_pop($braceOpensClassBody);
-            }
+            $significant[] = $token;
         }
 
-        return $braceOpensClassBody !== [] && end($braceOpensClassBody) === true;
+        return $significant;
     }
 
     private static function contextForToken(int $tokenType, string $tokenText, bool $inNowdoc): CompletionContext

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -63,15 +63,7 @@ final class NamespaceCandidates
         ClassCandidateFilter $filter,
     ): array {
         if (str_starts_with($prefix, '\\')) {
-            $qualified = substr($prefix, 1);
-
-            return $this->find(
-                NamespacePath::namespaceOf($qualified),
-                NamespacePath::shortNameOf($qualified),
-                $line,
-                $character,
-                $filter,
-            );
+            return $this->findAbsolute(substr($prefix, 1), $line, $character, $filter);
         }
 
         if (!str_contains($prefix, '\\')) {
@@ -91,6 +83,24 @@ final class NamespaceCandidates
             $character,
             $filter,
         );
+    }
+
+    /**
+     * Navigate the namespace tree for a `use` import, whose name is fully qualified
+     * — resolved from the global namespace regardless of the file's own namespace or
+     * imports. An optional leading `\` is accepted and ignored (`use Foo` and
+     * `use \Foo` name the same symbol). Unlike {@see navigate()}, no
+     * {@see NameContext} is consulted: nothing in a `use` statement is relative.
+     *
+     * @return list<CompletionItem>
+     */
+    public function useStatement(
+        string $prefix,
+        int $line,
+        int $character,
+        ClassCandidateFilter $filter,
+    ): array {
+        return $this->findAbsolute(ltrim($prefix, '\\'), $line, $character, $filter);
     }
 
     /**
@@ -171,6 +181,29 @@ final class NamespaceCandidates
         }
 
         return $this->ranked($items);
+    }
+
+    /**
+     * Walk absolutely from the global namespace for a $qualified name (no leading
+     * separator), offering the child namespaces and class-likes reached at its
+     * final typed segment. Shared by absolute (`\`-rooted) navigation and by `use`
+     * imports, which name symbols from the global namespace the same way.
+     *
+     * @return list<CompletionItem>
+     */
+    private function findAbsolute(
+        string $qualified,
+        int $line,
+        int $character,
+        ClassCandidateFilter $filter,
+    ): array {
+        return $this->find(
+            NamespacePath::namespaceOf($qualified),
+            NamespacePath::shortNameOf($qualified),
+            $line,
+            $character,
+            $filter,
+        );
     }
 
     private function isNavigable(string $namespace): bool

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -264,6 +264,7 @@ final class CompletionHandler implements HandlerInterface
                 $character,
                 ClassCandidateFilter::TypeHint,
             ),
+            CompletionKind::Use_ => $this->getUseCompletions($prefix, $line, $character),
             CompletionKind::ClassBody => $this->keywordCandidates->find($prefix, KeywordGroup::ClassBody),
             CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document, $line, $character),
             CompletionKind::None => [],
@@ -308,6 +309,25 @@ final class CompletionHandler implements HandlerInterface
         );
 
         return $this->deduplicateCompletions($items);
+    }
+
+    /**
+     * Suggest namespaces and class-likes for a `use` import statement. A `use` name
+     * is fully qualified — resolved from the global namespace regardless of the
+     * file's own namespace or imports — so navigation walks the tree absolutely
+     * rather than through the current-namespace/import resolution the other class
+     * positions use. Any class-like is importable, so no position filter narrows it.
+     *
+     * @return list<CompletionItem>
+     */
+    private function getUseCompletions(string $prefix, int $line, int $character): array
+    {
+        return $this->namespaceCandidates->useStatement(
+            $prefix,
+            $line,
+            $character,
+            ClassCandidateFilter::Any,
+        );
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -264,7 +264,7 @@ final class CompletionHandler implements HandlerInterface
                 $character,
                 ClassCandidateFilter::TypeHint,
             ),
-            CompletionKind::Use_ => $this->getUseCompletions($prefix, $line, $character),
+            CompletionKind::Use_ => $this->getUseCompletions($prefix, $document, $line, $character),
             CompletionKind::ClassBody => $this->keywordCandidates->find($prefix, KeywordGroup::ClassBody),
             CompletionKind::Expression => $this->getExpressionCompletions($prefix, $document, $line, $character),
             CompletionKind::None => [],
@@ -312,16 +312,31 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * Suggest namespaces and class-likes for a `use` import statement. A `use` name
-     * is fully qualified — resolved from the global namespace regardless of the
-     * file's own namespace or imports — so navigation walks the tree absolutely
-     * rather than through the current-namespace/import resolution the other class
-     * positions use. Any class-like is importable, so no position filter narrows it.
+     * Suggest completions for a `use` keyword, which names two unrelated constructs
+     * that happen to share it. A top-level `use` is an import: its name is fully
+     * qualified — resolved from the global namespace regardless of the file's own
+     * namespace or imports — so it navigates the namespace tree absolutely, and any
+     * class-like is importable (no position filter). A `use` inside a class body is
+     * a trait application, resolved relative to the file like any class reference;
+     * it keeps the ordinary expression-position behavior until trait-specific
+     * completion exists, and must never enter absolute import navigation.
+     *
+     * The two are indistinguishable on the single line the classifier sees, so the
+     * structural check reads the whole document here.
      *
      * @return list<CompletionItem>
      */
-    private function getUseCompletions(string $prefix, int $line, int $character): array
-    {
+    private function getUseCompletions(
+        string $prefix,
+        TextDocument $document,
+        int $line,
+        int $character,
+    ): array {
+        $offset = $document->offsetAt($line, $character);
+        if (ContextDetector::isInsideClassBody($document->getContent(), $offset)) {
+            return $this->getExpressionCompletions($prefix, $document, $line, $character);
+        }
+
         return $this->namespaceCandidates->useStatement(
             $prefix,
             $line,

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -312,17 +312,19 @@ final class CompletionHandler implements HandlerInterface
     }
 
     /**
-     * Suggest completions for a `use` keyword, which names two unrelated constructs
-     * that happen to share it. A top-level `use` is an import: its name is fully
-     * qualified — resolved from the global namespace regardless of the file's own
-     * namespace or imports — so it navigates the namespace tree absolutely, and any
-     * class-like is importable (no position filter). A `use` inside a class body is
-     * a trait application, resolved relative to the file like any class reference;
-     * it keeps the ordinary expression-position behavior until trait-specific
-     * completion exists, and must never enter absolute import navigation.
+     * Suggest completions for a `use` keyword, which names three unrelated
+     * constructs that happen to share it. A top-level `use` is an import: its name
+     * is fully qualified — resolved from the global namespace regardless of the
+     * file's own namespace or imports — so it navigates the namespace tree
+     * absolutely, and any class-like is importable (no position filter). A `use`
+     * inside a class body is a trait application, resolved relative to the file like
+     * any class reference; it keeps the ordinary expression-position behavior until
+     * trait-specific completion exists. A `use` after a closure's parameter list is
+     * a capture list, offering the variables in the enclosing scope. Only the import
+     * enters absolute namespace navigation.
      *
-     * The two are indistinguishable on the single line the classifier sees, so the
-     * structural check reads the whole document here.
+     * The three are indistinguishable on the single line the classifier sees, so the
+     * structural checks read the whole document here.
      *
      * @return list<CompletionItem>
      */
@@ -333,8 +335,12 @@ final class CompletionHandler implements HandlerInterface
         int $character,
     ): array {
         $offset = $document->offsetAt($line, $character);
-        if (ContextDetector::isInsideClassBody($document->getContent(), $offset)) {
+        $content = $document->getContent();
+        if (ContextDetector::isInsideClassBody($content, $offset)) {
             return $this->getExpressionCompletions($prefix, $document, $line, $character);
+        }
+        if (ContextDetector::isClosureUse($content, $offset)) {
+            return $this->variableCandidates->find($prefix, $document, $line, $character);
         }
 
         return $this->namespaceCandidates->useStatement(

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -210,6 +210,10 @@ class CompletionClassifierTest extends TestCase
         yield 'use trailing separator' => ['use Psr\\', CompletionKind::Use_, 'Psr\\'];
         yield 'use absolute' => ['use \\Ru', CompletionKind::Use_, '\\Ru'];
         yield 'use indented' => ['    use Fo', CompletionKind::Use_, 'Fo'];
+        // A closure capture list shares the keyword; the single-line classifier
+        // cannot tell it from an import, so it classifies broadly as Use_ and the
+        // handler disambiguates structurally from the whole document.
+        yield 'closure use classifies broadly' => ['$f = function () use ', CompletionKind::Use_, ''];
         // `use function` / `use const` import functions and constants, out of this
         // position's scope, so they are not classified as a class-like `use`.
         yield 'use function is not a class-like use' => [

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -201,6 +201,23 @@ class CompletionClassifierTest extends TestCase
             '\\App\\Ba',
         ];
 
+        // A `use` import statement names a symbol absolutely, so the whole qualified
+        // prefix (including a leading `\`) is captured for navigation from the global
+        // namespace (#40).
+        yield 'use with prefix' => ['use Fo', CompletionKind::Use_, 'Fo'];
+        yield 'use bare' => ['use ', CompletionKind::Use_, ''];
+        yield 'use qualified' => ['use Psr\\Log', CompletionKind::Use_, 'Psr\\Log'];
+        yield 'use trailing separator' => ['use Psr\\', CompletionKind::Use_, 'Psr\\'];
+        yield 'use absolute' => ['use \\Ru', CompletionKind::Use_, '\\Ru'];
+        yield 'use indented' => ['    use Fo', CompletionKind::Use_, 'Fo'];
+        // `use function` / `use const` import functions and constants, out of this
+        // position's scope, so they are not classified as a class-like `use`.
+        yield 'use function is not a class-like use' => [
+            'use function Foo\\ba',
+            CompletionKind::None,
+            '',
+        ];
+
         yield 'expression at start' => ['fo', CompletionKind::Expression, 'fo'];
         yield 'expression after assignment' => ['$x = fo', CompletionKind::Expression, 'fo'];
         yield 'expression inside method body' => [

--- a/tests/Completion/ContextDetectorTest.php
+++ b/tests/Completion/ContextDetectorTest.php
@@ -227,6 +227,64 @@ class ContextDetectorTest extends TestCase
     }
 
     // =========================================================================
+    // Class-body detection - telling a trait `use` apart from an import `use`
+    // =========================================================================
+
+    #[DataProvider('provideClassBodyScenarios')]
+    public function testIsInsideClassBody(string $code, bool $expected): void
+    {
+        self::assertSame(
+            $expected,
+            ContextDetector::isInsideClassBody($code, strlen($code)),
+            'The cursor position should be recognised as (not) directly inside a class-like body',
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     * @codeCoverageIgnore
+     */
+    public static function provideClassBodyScenarios(): iterable
+    {
+        // A top-level import is not in a class body — the case that must navigate.
+        yield 'top-level import' => ["<?php\nnamespace App;\nuse Psr\\Log\\Lo", false];
+        yield 'import after a closed class' => ["<?php\nclass A {}\nuse Ha", false];
+        // A braced namespace's brace is not a class body: the `use` is still an import.
+        yield 'import in a braced namespace' => ["<?php\nnamespace App {\n    use Ha", false];
+        // `::class` is a constant reference, not a declaration; it opens no class body.
+        yield 'class constant reference is not a declaration' => ["<?php\n\$c = Foo::class;\nuse Ha", false];
+
+        // A `use` directly in any class-like body is a trait application, not an import.
+        yield 'class body' => ["<?php\nclass A\n{\n    use Ha", true];
+        yield 'interface body' => ["<?php\ninterface I\n{\n    use Ha", true];
+        yield 'trait body' => ["<?php\ntrait T\n{\n    use Ha", true];
+        yield 'enum body' => ["<?php\nenum E\n{\n    use Ha", true];
+        yield 'anonymous class body' => ["<?php\n\$x = new class {\n    use Ha", true];
+
+        // Inside a method the innermost scope is the method, not the class body.
+        yield 'method body' => ["<?php\nclass A {\n    function m() {\n        use Ha", false];
+        // Interpolation braces must be balanced so a later top-level `use` is not
+        // mistaken for a trait application.
+        yield 'top-level import after interpolation braces' => [
+            "<?php\nclass A { function m() { echo \"{\$x->y}\"; } }\nuse Ha",
+            false,
+        ];
+    }
+
+    public function testIsInsideClassBodyIgnoresCodeAfterCursor(): void
+    {
+        // Only code up to the cursor defines its scope; a class opened further down
+        // the file must not leak in and turn a top-level import into a trait `use`.
+        $code = "<?php\nuse Ha\n\nclass Widget\n{\n}\n";
+        $offset = strpos($code, 'Ha');
+        self::assertIsInt($offset);
+        self::assertFalse(
+            ContextDetector::isInsideClassBody($code, $offset + 2),
+            'A class declared after the cursor does not enclose it',
+        );
+    }
+
+    // =========================================================================
     // Robustness - handles edge cases without throwing
     // =========================================================================
 

--- a/tests/Completion/ContextDetectorTest.php
+++ b/tests/Completion/ContextDetectorTest.php
@@ -285,6 +285,41 @@ class ContextDetectorTest extends TestCase
     }
 
     // =========================================================================
+    // Closure-use detection - telling a capture list apart from an import `use`
+    // =========================================================================
+
+    #[DataProvider('provideClosureUseScenarios')]
+    public function testIsClosureUse(string $code, bool $expected): void
+    {
+        self::assertSame(
+            $expected,
+            ContextDetector::isClosureUse($code, strlen($code)),
+            'The cursor position should be recognised as (not) a closure `use()` capture list',
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     * @codeCoverageIgnore
+     */
+    public static function provideClosureUseScenarios(): iterable
+    {
+        // A closure capture list is the only `use` that follows a closing `)`.
+        yield 'closure use' => ["<?php\n\$f = function () use ", true];
+        // The `)` may sit on an earlier line; the whole-document walk still sees it.
+        yield 'closure use across lines' => ["<?php\n\$f = function ()\n    use ", true];
+
+        // An import or trait `use` follows a statement boundary, never a `)`.
+        yield 'top-level import' => ["<?php\nuse ", false];
+        yield 'import with a prefix' => ["<?php\nuse Psr\\Lo", false];
+        yield 'trait use in a class body' => ["<?php\nclass A {\n    use ", false];
+
+        // Degenerate inputs must not read past the start of the token stream.
+        yield 'empty document' => ['', false];
+        yield 'no use keyword' => ['<?php', false];
+    }
+
+    // =========================================================================
     // Robustness - handles edge cases without throwing
     // =========================================================================
 

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -398,6 +398,61 @@ class NamespaceCandidatesTest extends TestCase
         );
     }
 
+    public function testUseStatementWalksQualifiedNameFromGlobal(): void
+    {
+        $catalog = self::catalog([
+            'Psr\Http' => new NamespaceContents([], [
+                new CatalogSymbol('Psr\Http\Message', NameKind::ClassLike),
+            ]),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+
+        $items = $candidates->useStatement('Psr\Http\M', 0, 10, ClassCandidateFilter::Any);
+
+        self::assertContains(
+            'Message',
+            array_column($items, 'label'),
+            'A `use` name walks from the global namespace, offering the leaf at the final segment',
+        );
+    }
+
+    public function testUseStatementIgnoresOptionalLeadingBackslash(): void
+    {
+        $catalog = self::catalog([
+            'Psr\Http' => new NamespaceContents([], [
+                new CatalogSymbol('Psr\Http\Message', NameKind::ClassLike),
+            ]),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+
+        $items = $candidates->useStatement('\Psr\Http\M', 0, 11, ClassCandidateFilter::Any);
+
+        self::assertContains(
+            'Message',
+            array_column($items, 'label'),
+            'A leading `\` is accepted and ignored: `use \Foo` names the same symbol as `use Foo`',
+        );
+    }
+
+    public function testUseStatementNavigatesFirstSegmentFromGlobal(): void
+    {
+        // A single typed segment (no separator) walks the global namespace's
+        // children, so a root namespace is offered as a node to step into.
+        $catalog = self::catalog([
+            '' => new NamespaceContents(['Psr'], []),
+            'Psr' => new NamespaceContents([], self::manyClassLikes('Psr')),
+        ]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+
+        $labels = array_column($candidates->useStatement('Ps', 0, 2, ClassCandidateFilter::Any), 'label');
+
+        self::assertContains(
+            'Psr\\',
+            $labels,
+            'A bare first segment navigates the global namespace, not the current one',
+        );
+    }
+
     public function testRanksSymbolsAboveNamespaceNodes(): void
     {
         $catalog = self::catalog([

--- a/tests/Fixtures/Namespacing/ClosureUseCompletion.php
+++ b/tests/Fixtures/Namespacing/ClosureUseCompletion.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+// A closure's `use (...)` clause captures variables from the enclosing scope; it
+// shares the `use` keyword with an import but is an unrelated construct. Like a
+// trait `use`, it must never enter the absolute namespace navigation an import
+// `use` triggers (#40): it is a variable position, not a class-reference one.
+function makeGreeter(): callable
+{
+    $greeting = 'hello';
+
+    return function () use /*|closure_capture*/($greeting) {
+        return $greeting;
+    };
+}

--- a/tests/Fixtures/Namespacing/TraitUseCompletion.php
+++ b/tests/Fixtures/Namespacing/TraitUseCompletion.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Fixtures\Traits\HasTimestamps;
+
+// A `use` inside a class body is a trait application, an unrelated construct that
+// merely shares the keyword with an import. It must keep the ordinary
+// class-reference behavior (resolving through imports/the current namespace), never
+// the absolute namespace navigation an import `use` triggers (#40).
+class Widget
+{
+    use HasT/*|trait_use*/
+}

--- a/tests/Fixtures/Namespacing/UseCompletion.php
+++ b/tests/Fixtures/Namespacing/UseCompletion.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+// A `use` import names its symbol absolutely (from the global namespace), so the
+// file's own `App` namespace must not affect what is offered here (#40). Each
+// incomplete `use` is navigated from the catalog, not the current document's AST.
+use Ps/*|use_first_segment*/
+use Fixtures\Domain\/*|use_workspace_class*/

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -535,6 +535,32 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testClosureUseCaptureIsNotImportNavigation(): void
+    {
+        // A closure's `use (...)` clause captures variables from the enclosing
+        // scope; it shares the `use` keyword with an import but is an unrelated
+        // construct. Like a trait `use`, it must never enter the absolute namespace
+        // navigation an import `use` triggers — no namespaces, no class-likes.
+        $cursor = $this->openFixtureAtCursor('Namespacing/ClosureUseCompletion.php', 'closure_capture');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $navigation = array_filter(
+            $result['items'],
+            static fn(array $item): bool => in_array(
+                $item['kind'] ?? null,
+                [CompletionItemKind::Module->value, CompletionItemKind::Class_->value],
+                true,
+            ),
+        );
+        self::assertSame(
+            [],
+            $navigation,
+            'A closure `use` offers no namespace or class navigation; it is not import navigation',
+        );
+    }
+
     public function testBackslashNavigationOffersGlobalBuiltinClasses(): void
     {
         // Issue #38: typing an absolute name whose prefix matches a class declared

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -465,6 +465,47 @@ class CompletionHandlerTest extends TestCase
         self::assertFalse($result['isIncomplete'], 'A result set within the cap is complete');
     }
 
+    public function testUseStatementNavigatesFromGlobalNamespace(): void
+    {
+        // Issue #40: typing a `use` import offers namespaces from the global
+        // namespace, even in a file whose own namespace is `App` — a `use` name is
+        // absolute. The fixtures install only psr/http-message, so Psr has a single
+        // child (Http) and inlines to its Http node, exactly as `new \Ps` does.
+        $cursor = $this->openFixtureAtCursor('Namespacing/UseCompletion.php', 'use_first_segment');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $modules = [];
+        foreach ($result['items'] as $item) {
+            if (($item['kind'] ?? null) === CompletionItemKind::Module->value) {
+                $modules[] = $item['label'];
+            }
+        }
+        self::assertContains(
+            'Psr\\Http\\',
+            $modules,
+            'A `use` import navigates the global namespace absolutely, ignoring the file\'s own `App` namespace',
+        );
+    }
+
+    public function testUseStatementOffersWorkspaceClassLeaf(): void
+    {
+        // A `use` import navigates workspace/vendor namespaces through the catalog:
+        // Fixtures\Domain\ is a PSR-4 namespace on disk, so its classes are offered
+        // by their leaf name without the file being open.
+        $cursor = $this->openFixtureAtCursor('Namespacing/UseCompletion.php', 'use_workspace_class');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertContains(
+            'User',
+            array_column($result['items'], 'label'),
+            'A class in a navigated workspace namespace is offered by its leaf name in a `use` import',
+        );
+    }
+
     public function testBackslashNavigationOffersGlobalBuiltinClasses(): void
     {
         // Issue #38: typing an absolute name whose prefix matches a class declared

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -506,6 +506,35 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testTraitUseInClassBodyIsNotImportNavigation(): void
+    {
+        // A `use` inside a class body is a trait application, not an import: it must
+        // resolve like any class reference (through the file's imports), not enter
+        // the absolute namespace navigation an import `use` triggers. The imported
+        // trait is offered by its short name — which absolute import navigation,
+        // walking the global namespace, would never surface.
+        $cursor = $this->openFixtureAtCursor('Namespacing/TraitUseCompletion.php', 'trait_use');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains(
+            'HasTimestamps',
+            $labels,
+            'A trait `use` keeps class-reference behavior, offering the imported trait by its short name',
+        );
+        $modules = array_filter(
+            $result['items'],
+            static fn(array $item): bool => ($item['kind'] ?? null) === CompletionItemKind::Module->value,
+        );
+        self::assertSame(
+            [],
+            $modules,
+            'A trait `use` offers no namespace-navigation nodes; it is not import navigation',
+        );
+    }
+
     public function testBackslashNavigationOffersGlobalBuiltinClasses(): void
     {
         // Issue #38: typing an absolute name whose prefix matches a class declared


### PR DESCRIPTION
Completes namespaces and class-likes when typing a `use` import statement, on the #308
navigation foundation.

## What it does

- Detects the `use` import position (new `CompletionKind::Use_` in the text-based
  `CompletionClassifier`).
- Navigates the namespace tree **absolutely**: a `use` name resolves from the global
  namespace regardless of the file's own namespace or imports, so `use Ps` and
  `use Psr\Http\` walk the same tree as `new \Ps`. Sourcing reuses the existing
  `NamespaceCandidates` navigation via a shared `findAbsolute` helper (extracted from
  the `\`-rooted path), and leaf-relative insertion keeps the typed prefix intact.
- Any class-like is importable, so no position filter narrows the results.

## Keeping trait `use` out of it

A top-level `use Foo\Bar;` (import) and a class-body `use SomeTrait;` (trait
application) are unrelated constructs that share the keyword and look identical on the
single line the classifier sees. A new token-based
`ContextDetector::isInsideClassBody()` (whole-document, resilient to mid-edit breakage)
distinguishes them: a class-body `use` keeps its prior expression-position behavior and
never enters import navigation. Trait-specific completion is tracked in #316, which
plugs into this seam.

## Scope

Top-level, single-line imports. `use function` / `use const` (#239, #317), group `use`
declarations (#350, blocked on #310), and class-body trait completion (#316) are
tracked separately.

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
