### PR TITLE
Extract TextDocumentPositionParams value object

### DIFF
--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -24,6 +24,7 @@ use Firehed\PhpLsp\Completion\VariableCandidates;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\TextDocumentPositionParams;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
 /**
@@ -63,28 +64,14 @@ final class CompletionHandler implements HandlerInterface
      */
     public function handle(Message $message): ?array
     {
-        $params = $message->params ?? [];
+        $position = TextDocumentPositionParams::tryFromMessage($message);
+        if ($position === null) {
+            return null;
+        }
+        $line = $position->line;
+        $character = $position->character;
 
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-        $uri = $textDocument['uri'] ?? '';
-        if (!is_string($uri)) {
-            return null;
-        }
-
-        $position = $params['position'] ?? [];
-        if (!is_array($position)) {
-            return null;
-        }
-        $line = $position['line'] ?? 0;
-        $character = $position['character'] ?? 0;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        $document = $this->documentManager->get($uri);
+        $document = $this->documentManager->get($position->uri);
         if ($document === null) {
             return null;
         }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\TextDocumentPositionParams;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
 final class DefinitionHandler implements HandlerInterface
@@ -32,33 +33,17 @@ final class DefinitionHandler implements HandlerInterface
      */
     public function handle(Message $message): ?array
     {
-        $params = $message->params ?? [];
-
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-        $uri = $textDocument['uri'] ?? '';
-        if (!is_string($uri)) {
+        $position = TextDocumentPositionParams::tryFromMessage($message);
+        if ($position === null) {
             return null;
         }
 
-        $position = $params['position'] ?? [];
-        if (!is_array($position)) {
-            return null;
-        }
-        $line = $position['line'] ?? 0;
-        $character = $position['character'] ?? 0;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        $document = $this->documentManager->get($uri);
+        $document = $this->documentManager->get($position->uri);
         if ($document === null) {
             return null;
         }
 
-        $symbol = $this->codeResolver->resolveAtPosition($document, $line, $character);
+        $symbol = $this->codeResolver->resolveAtPosition($document, $position->line, $position->character);
 
         return $symbol?->getDefinitionLocation()?->toLspLocation();
     }

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\TextDocumentPositionParams;
 use Firehed\PhpLsp\Resolution\ResolvedSymbol;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
@@ -27,33 +28,17 @@ final class HoverHandler implements HandlerInterface
      */
     public function handle(Message $message): ?array
     {
-        $params = $message->params ?? [];
-
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-        $uri = $textDocument['uri'] ?? '';
-        if (!is_string($uri)) {
+        $position = TextDocumentPositionParams::tryFromMessage($message);
+        if ($position === null) {
             return null;
         }
 
-        $position = $params['position'] ?? [];
-        if (!is_array($position)) {
-            return null;
-        }
-        $line = $position['line'] ?? 0;
-        $character = $position['character'] ?? 0;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        $document = $this->documentManager->get($uri);
+        $document = $this->documentManager->get($position->uri);
         if ($document === null) {
             return null;
         }
 
-        $symbol = $this->codeResolver->resolveAtPosition($document, $line, $character);
+        $symbol = $this->codeResolver->resolveAtPosition($document, $position->line, $position->character);
         if ($symbol === null) {
             return null;
         }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\TextDocumentPositionParams;
 use Firehed\PhpLsp\Resolution\CallContext;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
@@ -35,33 +36,17 @@ final class SignatureHelpHandler implements HandlerInterface
      */
     public function handle(Message $message): ?array
     {
-        $params = $message->params ?? [];
-
-        $textDocument = $params['textDocument'] ?? [];
-        if (!is_array($textDocument)) {
-            return null;
-        }
-        $uri = $textDocument['uri'] ?? '';
-        if (!is_string($uri)) {
+        $position = TextDocumentPositionParams::tryFromMessage($message);
+        if ($position === null) {
             return null;
         }
 
-        $position = $params['position'] ?? [];
-        if (!is_array($position)) {
-            return null;
-        }
-        $line = $position['line'] ?? 0;
-        $character = $position['character'] ?? 0;
-        if (!is_int($line) || !is_int($character)) {
-            return null;
-        }
-
-        $document = $this->documentManager->get($uri);
+        $document = $this->documentManager->get($position->uri);
         if ($document === null) {
             return null;
         }
 
-        $context = $this->codeResolver->getCallContext($document, $line, $character);
+        $context = $this->codeResolver->getCallContext($document, $position->line, $position->character);
         if ($context === null) {
             return null;
         }

--- a/src/Protocol/TextDocumentPositionParams.php
+++ b/src/Protocol/TextDocumentPositionParams.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+/**
+ * Shared `textDocument/position` request parameters used by point-query
+ * handlers (definition, hover, completion, signature help).
+ */
+final readonly class TextDocumentPositionParams
+{
+    public function __construct(
+        public string $uri,
+        public int $line,
+        public int $character,
+    ) {
+    }
+
+    public static function tryFromMessage(Message $message): ?self
+    {
+        $params = $message->params ?? [];
+
+        $textDocument = $params['textDocument'] ?? [];
+        if (!is_array($textDocument)) {
+            return null;
+        }
+        $uri = $textDocument['uri'] ?? '';
+        if (!is_string($uri)) {
+            return null;
+        }
+
+        $position = $params['position'] ?? [];
+        if (!is_array($position)) {
+            return null;
+        }
+        $line = $position['line'] ?? 0;
+        $character = $position['character'] ?? 0;
+        if (!is_int($line) || !is_int($character)) {
+            return null;
+        }
+
+        return new self($uri, $line, $character);
+    }
+}

--- a/tests/Protocol/TextDocumentPositionParamsTest.php
+++ b/tests/Protocol/TextDocumentPositionParamsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Protocol\TextDocumentPositionParams;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TextDocumentPositionParams::class)]
+class TextDocumentPositionParamsTest extends TestCase
+{
+    public function testParsesValidParams(): void
+    {
+        $message = new RequestMessage(
+            id: 1,
+            method: 'textDocument/hover',
+            params: [
+                'textDocument' => ['uri' => 'file:///foo.php'],
+                'position' => ['line' => 3, 'character' => 7],
+            ],
+        );
+
+        $params = TextDocumentPositionParams::tryFromMessage($message);
+
+        self::assertNotNull($params, 'A well-formed message should parse');
+        self::assertSame('file:///foo.php', $params->uri);
+        self::assertSame(3, $params->line);
+        self::assertSame(7, $params->character);
+    }
+
+    public function testDefaultsWhenParamsAbsent(): void
+    {
+        $message = new RequestMessage(
+            id: 1,
+            method: 'textDocument/hover',
+            params: null,
+        );
+
+        $params = TextDocumentPositionParams::tryFromMessage($message);
+
+        self::assertNotNull($params, 'Absent params should fall back to defaults, not fail');
+        self::assertSame('', $params->uri, 'Missing uri defaults to empty string');
+        self::assertSame(0, $params->line, 'Missing line defaults to 0');
+        self::assertSame(0, $params->character, 'Missing character defaults to 0');
+    }
+
+    public function testDefaultsWhenKeysAbsent(): void
+    {
+        $message = new RequestMessage(
+            id: 1,
+            method: 'textDocument/hover',
+            params: [
+                'textDocument' => [],
+                'position' => [],
+            ],
+        );
+
+        $params = TextDocumentPositionParams::tryFromMessage($message);
+
+        self::assertNotNull($params, 'Empty sub-arrays should fall back to defaults');
+        self::assertSame('', $params->uri);
+        self::assertSame(0, $params->line);
+        self::assertSame(0, $params->character);
+    }
+
+    /**
+     * @param array<array-key, mixed> $params
+     */
+    #[DataProvider('malformedParamsProvider')]
+    public function testReturnsNullForMalformedParams(array $params, string $why): void
+    {
+        $message = new RequestMessage(
+            id: 1,
+            method: 'textDocument/hover',
+            params: $params,
+        );
+
+        self::assertNull(
+            TextDocumentPositionParams::tryFromMessage($message),
+            $why,
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{array<array-key, mixed>, string}>
+     */
+    public static function malformedParamsProvider(): iterable
+    {
+        yield 'textDocument not array' => [
+            ['textDocument' => 'nope', 'position' => ['line' => 0, 'character' => 0]],
+            'A non-array textDocument cannot be parsed',
+        ];
+        yield 'uri not string' => [
+            ['textDocument' => ['uri' => 42], 'position' => ['line' => 0, 'character' => 0]],
+            'A non-string uri cannot be parsed',
+        ];
+        yield 'position not array' => [
+            ['textDocument' => ['uri' => 'file:///foo.php'], 'position' => 'nope'],
+            'A non-array position cannot be parsed',
+        ];
+        yield 'line not int' => [
+            ['textDocument' => ['uri' => 'file:///foo.php'], 'position' => ['line' => 1.5, 'character' => 0]],
+            'A non-int line cannot be parsed',
+        ];
+        yield 'character not int' => [
+            ['textDocument' => ['uri' => 'file:///foo.php'], 'position' => ['line' => 0, 'character' => 1.5]],
+            'A non-int character cannot be parsed',
+        ];
+    }
+}


### PR DESCRIPTION
Closes #136.

The four point-query handlers (`Definition`, `Hover`, `Completion`, `SignatureHelp`) each opened `handle()` with an identical block extracting and validating `textDocument/position` params. This extracts that logic into a `TextDocumentPositionParams` value object with `tryFromMessage(Message): ?self`, and migrates each handler to it.

## Notes

- Scope is param extraction only (per the issue). The subsequent `DocumentManager::get($uri)` + null-check is also duplicated across the four handlers — a reasonable follow-up, left in place here to keep the change focused.
- `CompletionHandler` keeps local `$line`/`$character` to avoid churning its many downstream references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)