### PR TITLE
Make Visibility enum string-backed

### DIFF
--- a/src/Domain/Visibility.php
+++ b/src/Domain/Visibility.php
@@ -7,11 +7,11 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Member visibility level.
  */
-enum Visibility: int implements Formattable
+enum Visibility: string implements Formattable
 {
-    case Private = 0;
-    case Protected = 1;
-    case Public = 2;
+    case Private = 'private';
+    case Protected = 'protected';
+    case Public = 'public';
 
     /**
      * Raises this visibility to the given floor, returning whichever is more
@@ -19,21 +19,17 @@ enum Visibility: int implements Formattable
      */
     public function atLeast(self $floor): self
     {
-        return self::from(max($this->value, $floor->value));
+        return $this->rank() >= $floor->rank() ? $this : $floor;
     }
 
     public function isAccessibleFrom(self $minimumRequired): bool
     {
-        return $this->value >= $minimumRequired->value;
+        return $this->rank() >= $minimumRequired->rank();
     }
 
     public function format(): string
     {
-        return match ($this) {
-            self::Private => 'private',
-            self::Protected => 'protected',
-            self::Public => 'public',
-        };
+        return $this->value;
     }
 
     public static function fromString(string $visibility): self
@@ -42,6 +38,18 @@ enum Visibility: int implements Formattable
             'private' => self::Private,
             'protected' => self::Protected,
             default => self::Public,
+        };
+    }
+
+    /**
+     * Ordinal ranking used for accessibility comparisons: more public is higher.
+     */
+    private function rank(): int
+    {
+        return match ($this) {
+            self::Private => 0,
+            self::Protected => 1,
+            self::Public => 2,
         };
     }
 }

--- a/src/Domain/Visibility.php
+++ b/src/Domain/Visibility.php
@@ -13,6 +13,15 @@ enum Visibility: int implements Formattable
     case Protected = 1;
     case Public = 2;
 
+    /**
+     * Raises this visibility to the given floor, returning whichever is more
+     * restrictive (more public).
+     */
+    public function atLeast(self $floor): self
+    {
+        return self::from(max($this->value, $floor->value));
+    }
+
     public function isAccessibleFrom(self $minimumRequired): bool
     {
         return $this->value >= $minimumRequired->value;

--- a/src/Domain/Visibility.php
+++ b/src/Domain/Visibility.php
@@ -32,15 +32,6 @@ enum Visibility: string implements Formattable
         return $this->value;
     }
 
-    public static function fromString(string $visibility): self
-    {
-        return match (strtolower($visibility)) {
-            'private' => self::Private,
-            'protected' => self::Protected,
-            default => self::Public,
-        };
-    }
-
     /**
      * Ordinal ranking used for accessibility comparisons: more public is higher.
      */

--- a/src/Resolution/TextFallbackHelper.php
+++ b/src/Resolution/TextFallbackHelper.php
@@ -657,7 +657,7 @@ final class TextFallbackHelper
         // A subclass cannot access its parent's private members, so never query the
         // parent below Protected visibility (while still honoring an external Public
         // access level).
-        $inheritedVisibility = Visibility::from(max($minVisibility->value, Visibility::Protected->value));
+        $inheritedVisibility = $minVisibility->atLeast(Visibility::Protected);
 
         $methods = $this->memberResolver->getMethods($parentClassName, $inheritedVisibility, $filter);
         foreach ($methods as $methodInfo) {

--- a/src/Resolution/TextFallbackHelper.php
+++ b/src/Resolution/TextFallbackHelper.php
@@ -695,7 +695,7 @@ final class TextFallbackHelper
         $pattern = '/^\s*(public|protected|private)\s+(static\s+)?function\s+(\w+)\s*\(/m';
         if (preg_match_all($pattern, $classContent, $matches, PREG_SET_ORDER) > 0) {
             foreach ($matches as $match) {
-                $visibility = Visibility::fromString($match[1]);
+                $visibility = Visibility::from($match[1]);
                 if (!$visibility->isAccessibleFrom($minVisibility)) {
                     continue;
                 }
@@ -740,7 +740,7 @@ final class TextFallbackHelper
         $pattern = '/^\s*(public|protected|private)\s+(static\s+)?(readonly\s+)?(?:[\w\\\\|?]+\s+)?\$(\w+)/m';
         if (preg_match_all($pattern, $classContent, $matches, PREG_SET_ORDER) > 0) {
             foreach ($matches as $match) {
-                $visibility = Visibility::fromString($match[1]);
+                $visibility = Visibility::from($match[1]);
                 if (!$visibility->isAccessibleFrom($minVisibility)) {
                     continue;
                 }
@@ -782,7 +782,7 @@ final class TextFallbackHelper
         $pattern = '/^\s*(public|protected|private)?\s*const\s+(?:[\w\\\\|?]+\s+)?(\w+)\s*=/m';
         if (preg_match_all($pattern, $classContent, $matches, PREG_SET_ORDER) > 0) {
             foreach ($matches as $match) {
-                $visibility = ($match[1] !== '') ? Visibility::fromString($match[1]) : Visibility::Public;
+                $visibility = ($match[1] !== '') ? Visibility::from($match[1]) : Visibility::Public;
                 if (!$visibility->isAccessibleFrom($minVisibility)) {
                     continue;
                 }

--- a/tests/Domain/VisibilityTest.php
+++ b/tests/Domain/VisibilityTest.php
@@ -45,12 +45,24 @@ class VisibilityTest extends TestCase
     public static function atLeastProvider(): array
     {
         return [
-            'private raised to protected' => [Visibility::Private, Visibility::Protected, Visibility::Protected],
-            'protected floored at protected' => [Visibility::Protected, Visibility::Protected, Visibility::Protected],
-            'public unaffected by protected floor' => [Visibility::Public, Visibility::Protected, Visibility::Public],
-            'private raised to public' => [Visibility::Private, Visibility::Public, Visibility::Public],
-            'private unaffected by private floor' => [Visibility::Private, Visibility::Private, Visibility::Private],
-            'protected unaffected by private floor' => [Visibility::Protected, Visibility::Private, Visibility::Protected],
+            'private raised to protected' => [
+                Visibility::Private, Visibility::Protected, Visibility::Protected,
+            ],
+            'protected floored at protected' => [
+                Visibility::Protected, Visibility::Protected, Visibility::Protected,
+            ],
+            'public unaffected by protected floor' => [
+                Visibility::Public, Visibility::Protected, Visibility::Public,
+            ],
+            'private raised to public' => [
+                Visibility::Private, Visibility::Public, Visibility::Public,
+            ],
+            'private unaffected by private floor' => [
+                Visibility::Private, Visibility::Private, Visibility::Private,
+            ],
+            'protected unaffected by private floor' => [
+                Visibility::Protected, Visibility::Private, Visibility::Protected,
+            ],
         ];
     }
 

--- a/tests/Domain/VisibilityTest.php
+++ b/tests/Domain/VisibilityTest.php
@@ -93,29 +93,4 @@ class VisibilityTest extends TestCase
     {
         self::assertSame($expected, $visibility->format());
     }
-
-    /**
-     * @return array<string, array{string, Visibility}>
-     * @codeCoverageIgnore
-     */
-    public static function fromStringProvider(): array
-    {
-        return [
-            'private lowercase' => ['private', Visibility::Private],
-            'private uppercase' => ['PRIVATE', Visibility::Private],
-            'private mixed' => ['Private', Visibility::Private],
-            'protected lowercase' => ['protected', Visibility::Protected],
-            'protected uppercase' => ['PROTECTED', Visibility::Protected],
-            'public lowercase' => ['public', Visibility::Public],
-            'public uppercase' => ['PUBLIC', Visibility::Public],
-            'empty string defaults to public' => ['', Visibility::Public],
-            'unknown defaults to public' => ['unknown', Visibility::Public],
-        ];
-    }
-
-    #[DataProvider('fromStringProvider')]
-    public function testFromString(string $input, Visibility $expected): void
-    {
-        self::assertSame($expected, Visibility::fromString($input));
-    }
 }

--- a/tests/Domain/VisibilityTest.php
+++ b/tests/Domain/VisibilityTest.php
@@ -39,6 +39,31 @@ class VisibilityTest extends TestCase
     }
 
     /**
+     * @return array<string, array{Visibility, Visibility, Visibility}>
+     * @codeCoverageIgnore
+     */
+    public static function atLeastProvider(): array
+    {
+        return [
+            'private raised to protected' => [Visibility::Private, Visibility::Protected, Visibility::Protected],
+            'protected floored at protected' => [Visibility::Protected, Visibility::Protected, Visibility::Protected],
+            'public unaffected by protected floor' => [Visibility::Public, Visibility::Protected, Visibility::Public],
+            'private raised to public' => [Visibility::Private, Visibility::Public, Visibility::Public],
+            'private unaffected by private floor' => [Visibility::Private, Visibility::Private, Visibility::Private],
+            'protected unaffected by private floor' => [Visibility::Protected, Visibility::Private, Visibility::Protected],
+        ];
+    }
+
+    #[DataProvider('atLeastProvider')]
+    public function testAtLeast(
+        Visibility $visibility,
+        Visibility $floor,
+        Visibility $expected,
+    ): void {
+        self::assertSame($expected, $visibility->atLeast($floor));
+    }
+
+    /**
      * @return array<string, array{Visibility, string}>
      * @codeCoverageIgnore
      */


### PR DESCRIPTION
Closes #295.

`Visibility` was `int`-backed solely to make `isAccessibleFrom` a `>=` comparison, despite significant adjacent string handling (`format()`, `fromString()`, and a raw `->value` `max()` in `TextFallbackHelper`).

## Changes

- Flip the backing from `int` to `string` (`'private'`/`'protected'`/`'public'`). Accessibility ordering now lives in a private `rank()`.
- Add `Visibility::atLeast()`, replacing the raw `Visibility::from(max($minVisibility->value, Visibility::Protected->value))` arithmetic in the text fallback.
- `format()` collapses to `return $this->value;`, removing the duplicated literals.
- Delete `Visibility::fromString()` in favor of native `Visibility::from()`. The three call sites parse a regex capture group that only ever matches the lowercase `public|protected|private` literals, which are now exactly the enum values; the empty-constant case keeps its existing explicit ternary.

The `fromString` test was removed alongside the method it covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)