### PR TITLE
Extract FunctionRepository for function resolution

### DIFF
--- a/src/Repository/DefaultFunctionRepository.php
+++ b/src/Repository/DefaultFunctionRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Repository;
+
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use ReflectionException;
+use ReflectionFunction;
+
+final class DefaultFunctionRepository implements FunctionRepository
+{
+    public function get(string $functionName, array $ast): ?FunctionInfo
+    {
+        $node = $this->findFunctionInAst($functionName, $ast);
+        if ($node !== null) {
+            return FunctionInfo::fromNode($node);
+        }
+
+        try {
+            return FunctionInfo::fromReflection(new ReflectionFunction($functionName));
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    /**
+     * Match a user-defined function whose short name or fully-qualified
+     * (namespaced) name equals the query.
+     *
+     * @param array<Stmt> $ast
+     */
+    private function findFunctionInAst(string $functionName, array $ast): ?Stmt\Function_
+    {
+        $finder = new class ($functionName) extends NodeVisitorAbstract {
+            public ?Stmt\Function_ $found = null;
+
+            public function __construct(private readonly string $functionName)
+            {
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if (!$node instanceof Stmt\Function_) {
+                    return null;
+                }
+
+                $shortName = $node->name->toString();
+                $fqn = $node->namespacedName?->toString();
+                if ($shortName === $this->functionName || $fqn === $this->functionName) {
+                    $this->found = $node;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($finder);
+        $traverser->traverse($ast);
+
+        return $finder->found;
+    }
+}

--- a/src/Repository/FunctionRepository.php
+++ b/src/Repository/FunctionRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Repository;
+
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use PhpParser\Node\Stmt;
+
+/**
+ * Repository for resolving standalone function metadata from multiple sources.
+ */
+interface FunctionRepository
+{
+    /**
+     * Resolve a function by name.
+     *
+     * Resolution order: user-defined function in the given AST -> reflection
+     * fallback for built-ins.
+     *
+     * @param array<Stmt> $ast
+     */
+    public function get(string $functionName, array $ast): ?FunctionInfo;
+}

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Repository\FunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
 use Firehed\PhpLsp\Domain\ClassKind;
@@ -46,8 +47,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Stmt;
 use LogicException;
-use ReflectionException;
-use ReflectionFunction;
 use Throwable;
 
 /**
@@ -79,6 +78,7 @@ final class SymbolResolver implements CodeResolver
         private readonly ClassRepository $classRepository,
         private readonly MemberResolver $memberResolver,
         private readonly TypeResolverInterface $typeResolver,
+        private readonly FunctionRepository $functionRepository,
     ) {
         $this->textFallback = new TextFallbackHelper($memberResolver);
     }
@@ -1443,19 +1443,12 @@ final class SymbolResolver implements CodeResolver
      */
     private function resolveFunctionByName(string $functionName, array $ast): ?ResolvedFunction
     {
-        // Try user-defined function first
-        $funcNode = ScopeFinder::findFunction($functionName, $ast);
-        if ($funcNode !== null) {
-            return new ResolvedFunction(FunctionInfo::fromNode($funcNode));
-        }
-
-        // Fall back to built-in function via reflection
-        try {
-            $funcInfo = FunctionInfo::fromReflection(new ReflectionFunction($functionName));
-            return new ResolvedFunction($funcInfo);
-        } catch (ReflectionException) {
+        $funcInfo = $this->functionRepository->get($functionName, $ast);
+        if ($funcInfo === null) {
             return null;
         }
+
+        return new ResolvedFunction($funcInfo);
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -70,7 +70,7 @@ final class Server
         $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
         $functionRepository = new DefaultFunctionRepository();
         $memberResolver = new MemberResolver($classRepository);
-        $typeResolver = new BasicTypeResolver($memberResolver);
+        $typeResolver = new BasicTypeResolver($memberResolver, $functionRepository);
         $symbolResolver = new SymbolResolver(
             $parser,
             $classRepository,

--- a/src/Server.php
+++ b/src/Server.php
@@ -28,6 +28,7 @@ use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
@@ -67,9 +68,16 @@ final class Server
 
         $classInfoFactory = new DefaultClassInfoFactory();
         $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
+        $functionRepository = new DefaultFunctionRepository();
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver);
-        $symbolResolver = new SymbolResolver($parser, $classRepository, $memberResolver, $typeResolver);
+        $symbolResolver = new SymbolResolver(
+            $parser,
+            $classRepository,
+            $memberResolver,
+            $typeResolver,
+            $functionRepository,
+        );
 
         $this->lifecycleHandler = new LifecycleHandler($serverInfo);
         $this->handlers[] = $this->lifecycleHandler;

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Repository\FunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Utility\Scope;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -33,6 +34,7 @@ final class BasicTypeResolver implements TypeResolverInterface
 {
     public function __construct(
         private readonly MemberResolver $memberResolver,
+        private readonly FunctionRepository $functionRepository,
     ) {
     }
     public function resolveExpressionType(
@@ -270,60 +272,30 @@ final class BasicTypeResolver implements TypeResolverInterface
     {
         $shortName = $functionName->toString();
 
-        // If NameResolver provided a FQN, use it directly
+        // Candidates follow PHP's name resolution: an explicit resolved FQN, then
+        // the enclosing namespace, then the global fallback. FunctionRepository
+        // handles both the user-defined lookup and the built-in reflection fallback.
+        $candidates = [];
+
         $resolvedName = $functionName->getAttribute('resolvedName');
         if ($resolvedName instanceof Node\Name) {
-            $func = $this->findFunctionInAst($resolvedName->toString(), $ast);
-            if ($func !== null) {
-                return TypeFactory::fromNode($func->returnType);
-            }
+            $candidates[] = $resolvedName->toString();
         }
 
-        // For unqualified names, try the enclosing namespace first (PHP's fallback behavior)
         $namespace = ScopeFinder::findEnclosingNamespace($functionName);
         if ($namespace !== null && $namespace->name !== null) {
-            $namespacedFqn = $namespace->name->toString() . '\\' . $shortName;
-            $func = $this->findFunctionInAst($namespacedFqn, $ast);
-            if ($func !== null) {
-                return TypeFactory::fromNode($func->returnType);
+            $candidates[] = $namespace->name->toString() . '\\' . $shortName;
+        }
+
+        $candidates[] = $shortName;
+
+        foreach ($candidates as $candidate) {
+            $function = $this->functionRepository->get($candidate, $ast);
+            if ($function !== null) {
+                return $function->returnType;
             }
         }
 
-        // Try global namespace
-        $func = $this->findFunctionInAst($shortName, $ast);
-        if ($func !== null) {
-            return TypeFactory::fromNode($func->returnType);
-        }
-
-        // Try reflection for built-in functions
-        try {
-            $reflection = new \ReflectionFunction($shortName);
-            return TypeFactory::fromReflection($reflection->getReturnType());
-        } catch (\ReflectionException) {
-            return null;
-        }
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function findFunctionInAst(string $functionFqn, array $ast): ?Stmt\Function_
-    {
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Function_ && $stmt->name->toString() === $functionFqn) {
-                return $stmt;
-            }
-            if ($stmt instanceof Stmt\Namespace_) {
-                foreach ($stmt->stmts as $nsStmt) {
-                    if ($nsStmt instanceof Stmt\Function_) {
-                        $fqn = $nsStmt->namespacedName?->toString() ?? $nsStmt->name->toString();
-                        if ($fqn === $functionFqn) {
-                            return $nsStmt;
-                        }
-                    }
-                }
-            }
-        }
         return null;
     }
 

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -240,37 +240,6 @@ final class ScopeFinder
     }
 
     /**
-     * Find a user-defined function by name in the AST.
-     *
-     * @param array<Stmt> $ast
-     */
-    public static function findFunction(string $functionName, array $ast): ?Stmt\Function_
-    {
-        $visitor = new class ($functionName) extends NodeVisitorAbstract {
-            public ?Stmt\Function_ $found = null;
-
-            public function __construct(private readonly string $functionName)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Function_ && $node->name->toString() === $this->functionName) {
-                    $this->found = $node;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($visitor);
-        $traverser->traverse($ast);
-
-        return $visitor->found;
-    }
-
-    /**
      * Extract all class imports from `use` statements as short name => FQCN.
      *
      * Superseded by {@see NameContextFactory}, which is type-aware and scoped to

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -76,7 +76,7 @@ class CompletionHandlerTest extends TestCase
             $this->parser,
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
-        $typeResolver = new BasicTypeResolver($this->memberResolver);
+        $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());
         $this->symbolResolver = new SymbolResolver(
             $this->parser,
             $this->classRepository,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -32,6 +32,7 @@ use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
@@ -81,6 +82,7 @@ class CompletionHandlerTest extends TestCase
             $this->classRepository,
             $this->memberResolver,
             $typeResolver,
+            new DefaultFunctionRepository(),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
         $this->handler = $this->makeHandler(

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -15,6 +15,7 @@ use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
@@ -50,6 +51,7 @@ class DefinitionHandlerTest extends TestCase
             $this->classRepository,
             $memberResolver,
             $typeResolver,
+            new DefaultFunctionRepository(),
         );
         $this->handler = new DefinitionHandler(
             $this->documents,

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -45,7 +45,7 @@ class DefinitionHandlerTest extends TestCase
             $this->parser,
         );
         $memberResolver = new MemberResolver($this->classRepository);
-        $typeResolver = new BasicTypeResolver($memberResolver);
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
         $symbolResolver = new SymbolResolver(
             $this->parser,
             $this->classRepository,

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -47,7 +47,7 @@ class HoverHandlerTest extends TestCase
             $this->parser,
         );
         $memberResolver = new MemberResolver($this->classRepository);
-        $typeResolver = new BasicTypeResolver($memberResolver);
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
         $symbolResolver = new SymbolResolver(
             $this->parser,
             $this->classRepository,

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -16,6 +16,7 @@ use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
@@ -52,6 +53,7 @@ class HoverHandlerTest extends TestCase
             $this->classRepository,
             $memberResolver,
             $typeResolver,
+            new DefaultFunctionRepository(),
         );
         $this->handler = new HoverHandler(
             $this->documents,

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -46,7 +46,7 @@ class SignatureHelpHandlerTest extends TestCase
             $this->parser,
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
-        $typeResolver = new BasicTypeResolver($this->memberResolver);
+        $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());
         $symbolResolver = new SymbolResolver(
             $this->parser,
             $this->classRepository,

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
@@ -51,6 +52,7 @@ class SignatureHelpHandlerTest extends TestCase
             $this->classRepository,
             $this->memberResolver,
             $typeResolver,
+            new DefaultFunctionRepository(),
         );
         $this->handler = new SignatureHelpHandler(
             $this->documents,

--- a/tests/Repository/DefaultFunctionRepositoryTest.php
+++ b/tests/Repository/DefaultFunctionRepositoryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Repository;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
+use PhpParser\Node\Stmt;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DefaultFunctionRepository::class)]
+class DefaultFunctionRepositoryTest extends TestCase
+{
+    use LoadsFixturesTrait;
+
+    private DefaultFunctionRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = new DefaultFunctionRepository();
+    }
+
+    /**
+     * @param ?string $expectedName Short name of the resolved function, or null
+     */
+    #[DataProvider('resolutionProvider')]
+    public function testGet(string $fixturePath, string $query, ?string $expectedName): void
+    {
+        $ast = $this->parseFixture($fixturePath);
+
+        $result = $this->repository->get($query, $ast);
+
+        self::assertSame(
+            $expectedName,
+            $result?->name,
+            'Resolved function name should match the expected result',
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string, ?string}>
+     * @codeCoverageIgnore
+     */
+    public static function resolutionProvider(): iterable
+    {
+        yield 'global user function by name' => [
+            'TypeInference/GlobalFunction.php',
+            'getGlobalConfig',
+            'getGlobalConfig',
+        ];
+        yield 'namespaced user function by FQN' => [
+            'src/Completion/FunctionCompletion.php',
+            'Fixtures\\Completion\\calculateSum',
+            'calculateSum',
+        ];
+        yield 'namespaced user function by short name' => [
+            'src/Completion/FunctionCompletion.php',
+            'calculateSum',
+            'calculateSum',
+        ];
+        yield 'built-in function via reflection' => [
+            'TypeInference/GlobalFunction.php',
+            'strlen',
+            'strlen',
+        ];
+        yield 'unknown function' => [
+            'TypeInference/GlobalFunction.php',
+            'nonexistent_function_xyz',
+            null,
+        ];
+    }
+
+    public function testGetReturnsFullMetadata(): void
+    {
+        $ast = $this->parseFixture('src/Completion/FunctionCompletion.php');
+
+        $result = $this->repository->get('Fixtures\\Completion\\calculateSum', $ast);
+
+        self::assertNotNull($result, 'calculateSum should resolve from the fixture');
+        self::assertCount(2, $result->parameters, 'calculateSum declares two parameters');
+        self::assertNotNull($result->returnType, 'calculateSum declares a return type');
+        self::assertSame('int', $result->returnType->format(), 'Return type should be int');
+        self::assertNotNull($result->docblock, 'calculateSum carries a docblock');
+        self::assertStringContainsString(
+            'Adds two numbers',
+            $result->docblock,
+            'Docblock content should be preserved',
+        );
+    }
+
+    public function testGetResolvesReturnTypeToClassName(): void
+    {
+        $ast = $this->parseFixture('src/TypeInference/FunctionTypes.php');
+
+        $result = $this->repository->get('Fixtures\\TypeInference\\getUser', $ast);
+
+        self::assertNotNull($result, 'getUser should resolve from the fixture');
+        self::assertInstanceOf(ClassName::class, $result->returnType);
+        self::assertSame('Fixtures\\Domain\\User', $result->returnType->fqn);
+    }
+
+    /**
+     * @return array<Stmt>
+     */
+    private function parseFixture(string $fixturePath): array
+    {
+        $parser = new ParserService();
+        $document = new TextDocument('file:///test.php', 'php', 1, $this->loadFixture($fixturePath));
+        return $parser->parse($document) ?? [];
+    }
+}

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -13,6 +13,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\NameContextFactory;
 use Firehed\PhpLsp\Resolution\ResolvedClass;
@@ -76,6 +77,7 @@ final class SymbolResolverTest extends TestCase
             classRepository: $this->classRepository,
             memberResolver: $memberResolver,
             typeResolver: $typeResolver,
+            functionRepository: new DefaultFunctionRepository(),
         );
 
         $this->syncHandler = new TextDocumentSyncHandler(

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -69,7 +69,7 @@ final class SymbolResolverTest extends TestCase
             $this->parser,
         );
         $memberResolver = new MemberResolver($this->classRepository);
-        $typeResolver = new BasicTypeResolver($memberResolver);
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
 
         $this->resolver = new SymbolResolver(

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -17,6 +17,7 @@ use Throwable;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
@@ -42,7 +43,7 @@ class BasicTypeResolverTest extends TestCase
         $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
         $memberResolver = new MemberResolver($classRepository);
 
-        $this->resolver = new BasicTypeResolver($memberResolver);
+        $this->resolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
     }
 
     public function testResolveNewExpression(): void
@@ -936,6 +937,6 @@ class BasicTypeResolverTest extends TestCase
         $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
         $memberResolver = new MemberResolver($classRepository);
 
-        return new BasicTypeResolver($memberResolver);
+        return new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
     }
 }

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -355,36 +355,6 @@ class ScopeFinderTest extends TestCase
         self::assertSame('Second', $statements[1]->name?->toString());
     }
 
-    public function testFindFunctionReturnsNullWhenNotFound(): void
-    {
-        $code = $this->loadFixture('src/Utility/GlobalScope.php');
-        $ast = self::parseWithParents($code);
-
-        self::assertNull(ScopeFinder::findFunction('nonexistent', $ast));
-    }
-
-    public function testFindFunctionReturnsMatchingFunction(): void
-    {
-        $code = $this->loadFixture('TypeInference/GlobalFunction.php');
-        $ast = self::parseWithParents($code);
-
-        $found = ScopeFinder::findFunction('testGlobalFunction', $ast);
-
-        self::assertNotNull($found);
-        self::assertSame('testGlobalFunction', $found->name->toString());
-    }
-
-    public function testFindFunctionWorksWithNamespace(): void
-    {
-        $code = $this->loadFixture('src/Utility/GlobalScope.php');
-        $ast = self::parseWithParents($code);
-
-        $found = ScopeFinder::findFunction('utilityFunction', $ast);
-
-        self::assertNotNull($found);
-        self::assertSame('utilityFunction', $found->name->toString());
-    }
-
     public function testResolveClassNameDelegatesToResolveName(): void
     {
         $code = $this->loadFixture('src/Utility/ImportedExtends.php');


### PR DESCRIPTION
Consolidates standalone-function resolution behind a `FunctionRepository`,
mirroring the existing `ClassRepository` pattern. The "find a user function in
the AST → fall back to `ReflectionFunction` → build a `FunctionInfo`" logic was
duplicated across `SymbolResolver` and `BasicTypeResolver` (with two divergent
AST matchers); it now lives in one place.

Closes #171.

## Changes

- New `FunctionRepository` interface + `DefaultFunctionRepository`
  (`get(string $functionName, array $ast): ?FunctionInfo`). The AST match is
  namespace-aware — it matches a declared function by its short name **or** its
  `namespacedName`, a superset that preserves both previous callers.
- `SymbolResolver::resolveFunctionByName` and
  `BasicTypeResolver::getFunctionReturnType` now route through the repository.
  `BasicTypeResolver` keeps its PHP name-resolution candidate order
  (resolved → enclosing namespace → global); the repository owns the reflection
  fallback.
- Removed the now-dead `ScopeFinder::findFunction` and its three dedicated tests
  (coverage is superseded by `DefaultFunctionRepositoryTest`).

## Scope

Point-lookup consolidation only. Function *completion* namespace resolution
(#239) and cross-file/workspace user-function lookup are intentionally left as
follow-ups — the name-resolution foundation for #239 already exists and this
change does not block it.

## Verification

- `DefaultFunctionRepositoryTest` covers global, namespaced-by-FQN,
  namespaced-by-short-name, built-in-via-reflection, and not-found cases;
  `DefaultFunctionRepository` is at 100% coverage.
- Existing `SymbolResolverTest` / `BasicTypeResolverTest` remain green,
  confirming behavior was preserved through the matcher unification.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
