### PR TITLE
Add build procedure, slice manifest, and driver skills

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: do-next
+description: Implement the next build slice for the RFC-1 / Plan-0002 execution. Reads docs/architecture/build-manifest.md, computes the correct next slice from git/PR merge state (never a status field), enforces preconditions, and implements it under TDD on a slice/<id> branch. Invoke with /do-next.
+---
+
+# do-next — implement the next build slice
+
+Execute "Mode A" of `docs/architecture/build-procedure.md`. **Do not guess; halt and
+ask on any ambiguity.** The whole point is that a cold session picks the correct next
+slice from durable state, not from memory.
+
+## 1. Preconditions (halt and report if any fail)
+
+- `git status`: the **tracked** working tree must be clean. Untracked scratch files
+  (e.g. `notes.txt`, coverage output) are fine. If tracked files are modified, stop.
+- Switch to `main` and sync: `git fetch origin`; if `main` is behind, fast-forward;
+  if diverged, stop and report.
+- Verify the base is green: run `composer check`. If red, **stop** — do not build on
+  a red base.
+
+## 2. Compute the next slice X
+
+- Read `docs/architecture/build-manifest.md`; parse the slice table (ID, Step,
+  Depends on, Closes).
+- Compute each slice's status from **GitHub PR merge state** (not git commit
+  ancestry, and not any written status), checked in this order:
+  - `done` — a merged PR exists for the head branch:
+    `gh pr list --state merged --head slice/<ID> --json number` returns one.
+  - `in-flight` — an open PR exists: `gh pr list --state open --head slice/<ID>`.
+  - `todo` — neither.
+- `X` = the first `todo` slice whose every dependency is `done`.
+
+Deriving from PR merge state (not ancestry) is what keeps this correct under the
+project's **Squash and Merge**: a squash rewrites the branch into one new commit on
+`main`, so an ancestry check would report squashed slices as `todo` forever. Check
+`done` before `in-flight` so a squash-deleted branch is read as done, not unstarted.
+
+## 3. Safeguards (halt and report; do NOT proceed) if
+
+- No slice is unblocked — report done / blocked / in-flight counts and stop.
+- Any slice is `in-flight` and not `done` — one slice in flight at a time; finish or
+  review it first.
+- A slice's branch is merged while a dependency is not — surface the state drift.
+
+## 4. Implement X
+
+- Create `slice/<X>` off `main`.
+- Read X's plan step in `docs/architecture/0002-execution-plan.md` for its acceptance
+  criteria, and the RFC sections it cites in `0001-foundational-architecture.md`.
+- TDD:
+  - Behavior-preserving slice → add/extend the Step P parity fixtures **first**.
+  - Seam-introducing slice → add its §8.1 enforcement rule in this slice.
+  - Write failing tests, then implement to green.
+- Keep commits small and logical (project rule). Run `composer check` to green.
+- If you hit a fundamental design question the plan does not answer, **STOP and ask**
+  — do not invent an interpretation.
+
+## 5. Open the PR and report
+
+- PR title carries no issue number; the body cites the slice id, plan step, and RFC
+  section(s), and lists the acceptance criteria as a checklist.
+- List manifest `Closes` candidates as "Candidate closes (pending review
+  verification): #n" — do **not** wire `Closes #n` here; that is the reviewer's job
+  after reading the issue body.
+- Report the PR URL and the **next** computed slice, so a follow-up `/do-next` is
+  predictable.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: review-slice
+description: One cleanroom adversarial review pass (plus fixes) of a build slice branch for the RFC-1 / Plan-0002 execution. Reviews against the slice's acceptance criteria + RFC only, never the implementer's reasoning. Invoke with /review-slice [slice-id]; after /clear, re-run until a pass is clean, then land.
+---
+
+# review-slice — one cleanroom review pass (+ fix)
+
+Execute "Mode B" of `docs/architecture/build-procedure.md`. **One invocation = one
+pass.** If this pass fixes anything, the change needs another fresh pass — the user
+runs `/clear` then `/review-slice` again. Only a pass that finds nothing is "clean".
+
+## 1. Identify the slice
+
+- If a slice id / branch is given, use `slice/<id>`. Otherwise find the single
+  in-flight slice (an open, unmerged `slice/*` PR). If more than one, **STOP and ask**
+  which.
+- Check out the branch; ensure it is current with `main` (merge/rebase-free: if
+  behind, merge `main` in or report).
+- Compute the diff under review: `git diff main...slice/<id>`.
+
+## 2. Cleanroom review (this is the safeguard — keep it clean)
+
+Spawn independent reviewer subagents (the Agent tool) that see **only**: (a) the
+slice's acceptance criteria from `0002`, (b) the RFC sections it touches from `0001`,
+and (c) the diff. They **must not** be given this conversation, the commit messages'
+reasoning, or any implementer rationale — that is what makes it cleanroom. Run a small
+diverse panel in parallel:
+
+- **Acceptance** — is every acceptance criterion actually met, not just plausibly?
+- **Conformance** — §8.1 conformance for the invariants the slice touches (no
+  forbidden reflection/index access, no `instanceof` on a concrete `Type`, no branch
+  on a resolved kind, no raw `initialize` params outside the negotiation component,
+  as applicable).
+- **Coverage** — does the parity harness / enforcement rule actually **exercise** the
+  change? Green is not enough; an unexercised branch is a gap (Step P). Spot-check
+  that captured goldens assert the right values, not just that they diffed clean.
+
+Each returns structured findings; then have them adversarially try to break the
+change.
+
+## 3. Verify and fix
+
+- Keep only findings you can **confirm against the code**; discard speculation.
+- If any survive: fix them on the branch in small commits; run `composer check` to
+  green. Report: **"Pass found N issues, fixed and committed: [...]. Run /clear then
+  /review-slice again to verify."** STOP — do not land. A fix needs a fresh pass.
+
+## 4. If the pass is clean (no surviving findings)
+
+- For each `Closes` candidate in the manifest for this slice: `gh issue view <n>`,
+  confirm its acceptance criteria are met **by this change**; if so, add `Closes #<n>`
+  to the PR body with a one-line verification note. If not met, leave it and say why.
+- `gh pr ready` if the PR was a draft.
+- Report: **"Pass clean. Verified closes: #n. Ready to land — merge when ready."**
+  Do **not** auto-merge — merging is irreversible and outward-facing; the user lands.
+- Report the next computed slice for after landing.

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -1,0 +1,48 @@
+# Build Manifest (slice registry)
+
+    Status:   Draft — seeded through Wave 1 (Steps 0, 1, P, 2)
+    Driver:   build-procedure.md
+    Plan:     0002-execution-plan.md
+
+This is a **static** registry of build slices. It records *what* the slices are and
+how they depend on each other; it does **not** record progress — a slice's status is
+computed from whether its PR (`slice/<id>`) is merged (see `build-procedure.md`).
+
+Append later phases as they are reached; do not create the whole tree up front.
+
+## Columns
+
+- **ID** — stable slice id; the branch is `slice/<ID>`.
+- **Step** — the plan step in 0002 that owns the acceptance criteria.
+- **Depends on** — slice ids that must be `done` (merged) first.
+- **Closes** — pre-existing issues this slice closes, *after reviewer verification*.
+
+## Wave 1 — Steps 0, 1, P, 2
+
+    ID     Step  Title                                              Depends on        Closes
+    -----  ----  -------------------------------------------------  ----------------  -------
+    S0.1   0     Instrument parse count/time; run the spike         —                 —
+    S0.2   0     Request-scoped parse dedup (if spike warrants)     S0.1              —
+    S1.1   1     Read ClientCapabilities -> SessionCapabilities     —                 —
+    S1.2   1     Negotiate positionEncoding; convert at the edge    S1.1              #192
+    S1.3   1     Shape hover markup / snippets via capabilities     S1.1              #22
+    S1.4   1     Lifecycle state + malformed-frame robustness       S1.1              —
+    S1.5   1     Position round-trip corpus (regression net)        S1.2              —
+    SP.1   P     Per-surface parity harness + branch-coverage gate  —                 —
+    S2.1   2     Define SymbolSource/SymbolSink + delegating facade SP.1              —
+    S2.2   2     Migrate ClassCandidates -> search                  S2.1              —
+    S2.3   2     Migrate NamespaceCandidates -> childrenOf          S2.1              —
+    S2.4   2     Migrate SymbolResolver class lookups -> lookupClassLike  S2.1        —
+    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink      S2.1              —
+    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo) S2.2,S2.3,S2.4,S2.5  —
+
+Notes:
+
+- `NamespaceName` typed identifier is needed by S2.3 (`childrenOf`); land it within
+  that slice or as its immediate predecessor.
+- Steps 0, 1, and P are mutually independent and may run in any order; Step 2 is
+  gated on the parity harness (SP.1).
+- Wave 2 (Step 3a/3b sub-slices, Step 4 positional-layer units, Step 5, Step 6) is
+  appended when S2.* is `done`. Existing issues expected there: #239, #181, #317
+  (Step 3b); #268, #301, #303, #73, #74 (enabled, own feature PRs); #266/#264/#265
+  (later-step epics). #295 (Visibility enum) rides a cleanup slice.

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -27,15 +27,26 @@ happens outside the tool.
 - The **manifest** (`build-manifest.md`) is a *static* slice registry: id, step,
   title, dependencies, deterministic branch name, and which existing issues a slice
   closes. It is append-only as later phases are reached; it never records progress.
-- A slice's **status is computed**:
-  - `done` — the PR for its branch is merged.
-  - `in-flight` — its branch exists / its PR is open, not merged.
+- A slice's **status is computed**, checked in this order:
+  - `done` — a **merged PR** exists whose head ref is `slice/<id>`
+    (`gh pr list --state merged --head slice/<id>`).
+  - `in-flight` — an **open PR** exists for `slice/<id>`.
   - `todo` — neither.
 - The **next slice** = the first `todo` in the manifest whose dependencies are all
   `done`.
 
 Because status is computed from merge reality, a cold session cannot be misled by a
 stale field, and nothing needs updating by hand.
+
+**Squash-merge safety.** Status is derived from GitHub's **PR merge state**, which is
+set identically for squash, rebase, and merge-commit — not from git commit ancestry.
+This matters because the project lands everything via *Squash and Merge*, which
+rewrites a branch into one new commit on `main`: an ancestry check ("are the branch's
+commits in `main`?") would report every squashed slice as `todo` forever, whereas the
+merged-PR check is correct. Branch auto-deletion on merge is also fine — the merged PR
+record keeps its `headRefName` after the branch is gone, so it is still found by
+`slice/<id>`. Checking `done` (merged PR) *before* `in-flight` ensures a
+squash-deleted branch is never misread as unstarted.
 
 ## Conventions
 

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -1,0 +1,106 @@
+# Build Procedure (driving RFC 1 / Plan 0002 across sessions)
+
+    Status:   Draft (process)
+    Depends:  0001-foundational-architecture.md, 0002-execution-plan.md
+    Date:     2026-07-20
+
+## Purpose
+
+Execute the plan across many short sessions without holding state in your head.
+Two commands:
+
+- **"do the next step"** — implement the correct next slice.
+- **"review this step's branch"** — cleanroom-review and fix a slice, in a fresh
+  session.
+
+The safeguard that makes this usable when you are juggling other work: **the next
+step is computed, never remembered.** A session determines what to do from durable,
+checkable state and *halts and asks* when that state is ambiguous. This is one or
+two notches below hands-off autonomy by design.
+
+## Source of truth: git, not a status field
+
+Progress is **derived from git / PR merge state**, keyed by deterministic branch
+names — not from a hand-maintained "status" column, which drifts the moment a merge
+happens outside the tool.
+
+- The **manifest** (`build-manifest.md`) is a *static* slice registry: id, step,
+  title, dependencies, deterministic branch name, and which existing issues a slice
+  closes. It is append-only as later phases are reached; it never records progress.
+- A slice's **status is computed**:
+  - `done` — the PR for its branch is merged.
+  - `in-flight` — its branch exists / its PR is open, not merged.
+  - `todo` — neither.
+- The **next slice** = the first `todo` in the manifest whose dependencies are all
+  `done`.
+
+Because status is computed from merge reality, a cold session cannot be misled by a
+stale field, and nothing needs updating by hand.
+
+## Conventions
+
+- **One slice = one branch = one PR.** Branch name is fixed by the manifest:
+  `slice/<id>` (e.g. `slice/S2.1`). This is what lets a *review* session find "this
+  step's branch" unambiguously from the id alone.
+- **PR body** cites the slice id, its plan step, and the RFC section(s) it satisfies.
+- **`Closes #<n>`** is added to a PR **only after the reviewer has read that issue's
+  body and confirmed its acceptance criteria are met** — never inferred from a title
+  (per the project's review rules).
+- **Acceptance criteria** for a slice are its plan step's criteria in 0002; the
+  manifest points at the step, it does not restate them.
+
+## Mode A — "do the next step"
+
+1. **Preconditions (halt if unmet).** Working tree clean; on `main`; `main` synced
+   with origin; `composer check` green on `main`. If any fails, report and stop.
+2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
+   state; `X` = first `todo` whose dependencies are all `done`.
+3. **Safeguards (halt and ask, do not guess) if:**
+   - nothing is unblocked (report how many are `done` / blocked / in-flight);
+   - a slice is already `in-flight` that is not yet `done` (finish or review it
+     first — one slice in flight at a time);
+   - the manifest references a merged branch for a slice whose dependencies are not
+     merged (state drift — surface it).
+4. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
+   (for a behavior-preserving step: parity fixtures first; for a step that
+   introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
+   `composer check`; open a PR citing X.
+5. Stop. Report the PR and the *next* computed slice, so the human knows what a
+   follow-up "do the next step" would pick up.
+
+## Mode B — "review this step's branch"
+
+1. **Identify the slice.** The `in-flight` one, or the id given. Check out its
+   branch.
+2. **Cleanroom review.** A fresh reviewer (subagent) sees **only** the slice's
+   acceptance criteria, the relevant RFC sections, and the diff — **not** the
+   implementer's reasoning or this conversation. It adversarially verifies:
+   - every acceptance criterion is actually met (not just plausibly);
+   - §8.1 conformance for the invariants the slice touches;
+   - the parity harness / enforcement rule **actually covers** the change (green is
+     not enough — an unexercised branch is a gap, per Step P);
+   - it then tries to break the change.
+3. **Fix.** Apply fixes on the branch; re-run the cleanroom pass until clean.
+4. **Land.** Mark ready / merge. For each existing issue the manifest says this slice
+   closes, **read the issue body, confirm its criteria are met, then** wire
+   `Closes #<n>` (or close with a verification note).
+5. Stop. Report what merged and the next computed slice.
+
+## The "X is always correct" guarantee, in one place
+
+- Next step is **computed from git truth**, so a cold session cannot pick the wrong
+  one from a stale note.
+- The driver **halts and asks** at every fork it cannot resolve safely (unmet
+  precondition, nothing unblocked, a slice already in flight, state drift, a review
+  it cannot make clean).
+- **Deterministic branch names** mean the review session always finds the right
+  branch from the id.
+- **One slice in flight at a time** keeps "the next step" unambiguous.
+
+## Relationship to GitHub issues
+
+The manifest is the driver's source of truth. GitHub issues are the *human-facing*
+mirror and the mechanism for closing pre-existing issues (the `Closes` column).
+Create the per-slice issue when its phase is reached (just-in-time, one phase ahead
+— not the whole tree up front). Existing design epics (#264/#265/#266) are reused as
+the later-phase trackers, not duplicated.


### PR DESCRIPTION
## Summary

Adds the build infrastructure for executing the RFC 1 / Plan 0002 work across many
short sessions without holding state in your head.

- **`docs/architecture/build-procedure.md`** — the driver. Two modes ("do the next
  step", "review this step's branch"), with the safeguard that the next step is
  *computed*, not remembered, and the session *halts and asks* on ambiguity.
- **`docs/architecture/build-manifest.md`** — a static slice registry seeded through
  Wave 1 (Steps 0/1/P/2), with deterministic `slice/<id>` branches, dependency
  links, and the existing-issue `Closes` column (e.g. S1.2→#192, S1.3→#22).
- **`.claude/skills/do-next` + `.claude/skills/review-slice`** — the two slash
  commands wrapping the modes (force-added past the `.claude/` gitignore so they are
  versioned with the project).

## How "next" is tracked

Progress is **derived from GitHub PR merge state**, keyed by deterministic branch
names — not a status field (which drifts) and not git commit ancestry (which a squash
would break). The merged PR *is* the state transition. This is explicitly
**Squash-and-Merge-safe** (see `build-procedure.md` → "Squash-merge safety").

## Merge order

Third in the chain — land after:

    #356 (RFC 0001)  →  #357 (Plan 0002)  →  this

The procedure and manifest reference 0001/0002; land those first (or all together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
