### PR TITLE
Reference composer test instead of a nonexistent check script

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -15,7 +15,7 @@ slice from durable state, not from memory.
   (e.g. `notes.txt`, coverage output) are fine. If tracked files are modified, stop.
 - Switch to `main` and sync: `git fetch origin`; if `main` is behind, fast-forward;
   if diverged, stop and report.
-- Verify the base is green: run `composer check`. If red, **stop** — do not build on
+- Verify the base is green: run `composer test`. If red, **stop** — do not build on
   a red base.
 
 ## 2. Compute the next slice X
@@ -51,7 +51,7 @@ project's **Squash and Merge**: a squash rewrites the branch into one new commit
   - Behavior-preserving slice → add/extend the Step P parity fixtures **first**.
   - Seam-introducing slice → add its §8.1 enforcement rule in this slice.
   - Write failing tests, then implement to green.
-- Keep commits small and logical (project rule). Run `composer check` to green.
+- Keep commits small and logical (project rule). Run `composer test` to green.
 - If you hit a fundamental design question the plan does not answer, **STOP and ask**
   — do not invent an interpretation.
 

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -41,7 +41,7 @@ change.
 ## 3. Verify and fix
 
 - Keep only findings you can **confirm against the code**; discard speculation.
-- If any survive: fix them on the branch in small commits; run `composer check` to
+- If any survive: fix them on the branch in small commits; run `composer test` to
   green. Report: **"Pass found N issues, fixed and committed: [...]. Run /clear then
   /review-slice again to verify."** STOP — do not land. A fix needs a fresh pass.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Note: `MemberAccessResolver` was removed in #262 — instance/static member acce
   - Before starting on a feature, verify that it hasn't already been impemented
   - Resolve any ambiguity or conflict BEFORE starting to write a line of code
 - Update `docs/features/*.md` when merging features
-- Run `composer check` before commits
+- Run `composer test` before commits
 - `composer.lock` is gitignored — do not attempt to stage or commit it
 - Debugging: use the testing framework to debug code paths. DO NOT write arbitrary PHP scripts.
 

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -63,7 +63,7 @@ squash-deleted branch is never misread as unstarted.
 ## Mode A — "do the next step"
 
 1. **Preconditions (halt if unmet).** Working tree clean; on `main`; `main` synced
-   with origin; `composer check` green on `main`. If any fails, report and stop.
+   with origin; `composer test` green on `main`. If any fails, report and stop.
 2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
    state; `X` = first `todo` whose dependencies are all `done`.
 3. **Safeguards (halt and ask, do not guess) if:**
@@ -75,7 +75,7 @@ squash-deleted branch is never misread as unstarted.
 4. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
    (for a behavior-preserving step: parity fixtures first; for a step that
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
-   `composer check`; open a PR citing X.
+   `composer test`; open a PR citing X.
 5. Stop. Report the PR and the *next* computed slice, so the human knows what a
    follow-up "do the next step" would pick up.
 

--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -139,7 +139,6 @@ agnostic to the parsing strategy. Detection stays text/token-based (`ContextDete
 ## Testing
 
 ```bash
-composer test                    # Run all tests
-composer test -- --filter Completion  # Run completion tests only
-composer check                   # PHPStan + tests
+composer test                    # PHPStan + tests + PHPCS
+composer unit -- --filter Completion  # Run completion tests only
 ```


### PR DESCRIPTION
`composer check` is not a script in this project. Composer resolves the abbreviation to its built-in `check-platform-reqs`, which verifies installed PHP extension versions and runs no tests, no static analysis, and no style checks — so it exits 0 on a codebase that is thoroughly broken. Anything following the instruction to "run `composer check` before commits" was verifying nothing.

The real gate is `composer test` (`@phpstan` + `@unit` + `@phpcs`). All seven references now say so.

- `CLAUDE.md` — the pre-commit instruction (the Quick Start block above it already said `composer test`)
- `docs/architecture/build-procedure.md` — Mode A's precondition and its implement step
- `.claude/skills/do-next/SKILL.md` — the green-base precondition and the to-green step
- `.claude/skills/review-slice/SKILL.md` — the fix step

The second commit also corrects two adjacent errors in `docs/features/completion.md`'s testing block, which were the same mistake in another form:

- `composer check  # PHPStan + tests` was a wrongly-named duplicate of the `composer test` line directly above it, and understated what that script runs — removed, with the surviving line relabelled `PHPStan + tests + PHPCS`.
- `composer test -- --filter Completion` does not filter. `test` is an array script, so the trailing arguments do not reach PHPUnit. Changed to `composer unit -- --filter Completion`, which is the form `CLAUDE.md` documents.

Found while running slice S0.1 (#360), where the driver skill's "verify the base is green" step passed without testing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
