### PR TITLE
Narrow review-slice scope and pin subagent commands

### DIFF
--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -31,12 +31,53 @@ diverse panel in parallel:
   forbidden reflection/index access, no `instanceof` on a concrete `Type`, no branch
   on a resolved kind, no raw `initialize` params outside the negotiation component,
   as applicable).
-- **Coverage** — does the parity harness / enforcement rule actually **exercise** the
-  change? Green is not enough; an unexercised branch is a gap (Step P). Spot-check
-  that captured goldens assert the right values, not just that they diffed clean.
+- **Test strength** — would the tests actually **catch** the defect they imply? Name a
+  mutation of the implementation (move a statement out of a `finally`, shorten a timed
+  span, return a constant) and check whether anything fails. Spot-check that captured
+  goldens assert the right values, not just that they diffed clean.
 
 Each returns structured findings; then have them adversarially try to break the
 change.
+
+### Do not re-do CI's job
+
+CI already runs the suite, PHPStan, PHPCS, and coverage on every push. A finding whose
+evidence is "the suite passes", "coverage is N%", or "this line is uncovered" is out of
+scope — drop it. Reviewers must not run a coverage driver or report per-file
+percentages.
+
+What CI *cannot* judge is what the panel is for: whether a recorded claim is true,
+whether an assertion would survive a mutation, whether an acceptance criterion is
+genuinely met. An unexercised branch is still worth raising — but as "nothing would
+catch X", with the mutation named, not as a coverage number.
+
+### Constrain the subagents' commands
+
+State in every subagent prompt that it may run **only** the project's composer scripts:
+
+```
+composer test                                        # full check
+composer unit -- --filter X                          # one test
+composer phpstan -- --error-format=raw --no-progress
+composer phpcs -- -q --report=emacs
+```
+
+Raw equivalents (`vendor/bin/phpunit`, `php -d … vendor/bin/phpunit`) bypass the
+approved-command list and fire a permission prompt per call.
+
+Reviewers already receive `CLAUDE.md` automatically and default to these scripts on
+their own. They defect in two specific situations, so head both off:
+
+- **Throwaway measurement harnesses.** Put them in `tests/`, run them with
+  `composer unit -- --filter <name>`, and delete them before reporting. Do not write
+  them to the scratchpad, which forces a positional path and a raw invocation.
+- **Interpreter-level flags** (`php -d pcov.enabled=0 …`). `composer unit` runs PHP
+  through Composer's own process, so an `-d` override cannot reach the child. There is
+  no approved route to this — if a finding needs one, **report that and stop** rather
+  than invoking the binary. Keeping coverage out of scope removes most of the motive.
+
+Scale the panel to the diff. A docs-and-one-class slice does not need agents that each
+burn 75k+ tokens re-deriving the whole measurement.
 
 ## 3. Verify and fix
 

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -88,9 +88,15 @@ squash-deleted branch is never misread as unstarted.
    implementer's reasoning or this conversation. It adversarially verifies:
    - every acceptance criterion is actually met (not just plausibly);
    - §8.1 conformance for the invariants the slice touches;
-   - the parity harness / enforcement rule **actually covers** the change (green is
-     not enough — an unexercised branch is a gap, per Step P);
+   - the parity harness / enforcement rule would **actually catch a regression in**
+     the change — name a mutation of the implementation and check that something
+     fails (per Step P);
    - it then tries to break the change.
+
+   The reviewer does **not** re-check what CI already enforces: a green suite,
+   PHPStan, PHPCS, coverage percentages. Those run on every push. Review effort goes
+   where CI is blind — unverified claims, assertions that survive mutation,
+   acceptance criteria met only in appearance.
 3. **Fix.** Apply fixes on the branch; re-run the cleanroom pass until clean.
 4. **Land.** Mark ready / merge. For each existing issue the manifest says this slice
    closes, **read the issue body, confirm its criteria are met, then** wire


### PR DESCRIPTION
Process-instruction changes only; no source or test files touched.

Both come from running `/review-slice` on S0.1, where the panel produced good findings but at disproportionate cost: three subagents burned ~275k tokens, and their permission prompts were more disruptive than the review was worth.

## Review scope

`build-procedure.md` Mode B told the reviewer that "the parity harness actually **covers** the change (green is not enough)". Read literally that is an instruction to go measure coverage — which CI already does. `test.yml` runs `composer unit` under pcov and uploads clover to Codecov on every push and PR; PHPStan and PHPCS have their own workflows on the same triggers.

Reframed to what CI cannot do: name a mutation of the implementation and check that something fails. Findings evidenced by a green suite, a coverage percentage, or an uncovered line are now explicitly out of scope, and reviewers must not run a coverage driver.

This is a narrowing, not a removal. The S0.1 pass found a timer assertion that stayed green when the timed span was mutated to exclude the parse entirely — that class of finding is still in scope, because CI cannot see it.

## Subagent commands

Reviewers went raw (`vendor/bin/phpunit`, `php -d pcov.enabled=0 vendor/bin/phpunit`), which bypasses the approved-command list and prompts per call.

Worth recording why, since my first guess was wrong: subagents **do** receive `CLAUDE.md` automatically and did default to the composer scripts. They defected in exactly two situations, both now headed off in the skill:

- Throwaway measurement harnesses written to the scratchpad, which forces a positional path. They belong in `tests/`, run via `composer unit -- --filter`, deleted before reporting.
- Interpreter-level `-d` flags. `composer unit` invokes PHP through Composer's own process, so an ini override cannot reach the child. There is no approved route, so the reviewer must report and stop.

Also added: scale the panel to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
