### PR TITLE
Resolve client capabilities into an immutable session value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,9 @@ composer phpcs -- -q --report=emacs # run code style checks (PSR-12)
 - `src/Parser/` — `ParserService` (the only place an AST is produced; memoizes by content for the duration of one handled LSP message, discarded by `Server`'s message loop) and `ParseMetrics` (parse count/time, which every parse is metered through)
 - `src/Utility/` — AST helpers (ScopeFinder, Scope, TypeFactory, DocblockParser)
 - `src/Completion/` — Completion context detection (`ContextDetector`, `CompletionClassifier`) and per-kind sources (`*Candidates`, `CompletionItemFactory`)
+- `src/Capability/` — Protocol capability negotiation (see Capability Negotiation below)
 - `docs/features/` — Feature status documentation
+- `tests/Architecture/` — PHPStan rules enforcing RFC 1 §8.1 invariants, and their `RuleTestCase` tests
 - `tests/Fixtures/` — Test fixture files (see Testing section)
 
 ## Architecture
@@ -128,6 +130,27 @@ Key methods:
 
 **Never store types as strings.** Use `TypeFactory::fromNode()` or `TypeFactory::fromReflection()` to create Type objects at parse time. Use `Type::format()` only for display.
 
+### Capability Negotiation
+
+`src/Capability/` is the protocol-negotiation tier (RFC 1 §4.8, §5.4). It is the
+**only** place the raw `initialize` parameters are read.
+
+- **`CapabilityNegotiator`** owns the `initialize` exchange: it resolves the client's
+  declared capabilities into a `SessionCapabilities` value, and returns the
+  `InitializeResult` carrying the advertised `ServerCapabilities`. `LifecycleHandler`
+  delegates to it and shapes nothing itself.
+- **`SessionCapabilities`** is immutable and resolved once. Every capability the client
+  did not declare resolves to the value's own default state — safe defaults live in the
+  constructor, never in a branch at the point of use, so a minimal client needs no
+  dedicated code path.
+- **Advertised capabilities are a hand-maintained list** in `CapabilityNegotiator`.
+  Add to it when a handler starts implementing a new LSP method; never advertise a
+  capability the server does not implement.
+
+Anything that shapes an outgoing message by client support (hover markup kind, snippet
+support, …) queries `SessionCapabilities`. `RawInitializeCapabilitiesRule`
+(`tests/Architecture/`) fails PHPStan if any other package reads a `capabilities` key.
+
 ### Guidelines for New Code
 
 - **Keep code DRY.** Be on the lookout for existing tools that will solve your problem; NEVER copy-and-paste. Extract repeated logic aggressively.
@@ -178,6 +201,12 @@ per-member-kind walk. Adding an edge to the graph is a change to `supertypes()`.
 members PHP exposes at runtime (reflection is the oracle), across every shape —
 extends, implements, interface-extends-interface, trait-using-trait, and interfaces
 reached via a parent. A traversal that misses an edge fails it.
+
+**All client-capability reads go through `SessionCapabilities`.**
+
+The raw `initialize` parameters are read once, in `src/Capability/`. No other package
+may re-inspect them; output shaped by client support queries `SessionCapabilities`
+instead. `RawInitializeCapabilitiesRule` enforces this in PHPStan (RFC 1 §4.8, §8.1).
 
 **Adding support for a new AST node type:**
 1. Add handling in `SymbolResolver` (ONE place)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,9 @@ Key methods:
 - **`SessionCapabilities`** is immutable and resolved once. Every capability the client
   did not declare resolves to the value's own default state — safe defaults live in the
   constructor, never in a branch at the point of use, so a minimal client needs no
-  dedicated code path.
+  dedicated code path. It carries only already-resolved values and offers no way to
+  build itself from a `Message`, so the raw parameters cannot be re-read through it —
+  the confinement holds by construction, not merely by rule.
 - **Advertised capabilities are a hand-maintained list** in `CapabilityNegotiator`.
   Add to it when a handler starts implementing a new LSP method; never advertise a
   capability the server does not implement.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,12 @@ parameters:
         - tests
     excludePaths:
         - tests/Fixtures
+        # Deliberate rule violations, analysed only by RuleTestCase.
+        - tests/Architecture/data
+
+services:
+    # RFC 1 §8.1 enforcement mechanisms.
+    -
+        class: Firehed\PhpLsp\Tests\Architecture\RawInitializeCapabilitiesRule
+        tags:
+            - phpstan.rules.rule

--- a/src/Capability/CapabilityNegotiator.php
+++ b/src/Capability/CapabilityNegotiator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Capability;
 
 use Firehed\PhpLsp\Protocol\InitializeResult;
+use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\ServerInfo;
 
@@ -32,12 +33,55 @@ final class CapabilityNegotiator
 
     public function negotiate(Message $message): InitializeResult
     {
-        $this->sessionCapabilities = SessionCapabilities::fromMessage($message);
+        $this->sessionCapabilities = $this->resolveSessionCapabilities($message);
 
         return new InitializeResult(
             capabilities: $this->advertisedCapabilities(),
             serverInfo: $this->serverInfo,
         );
+    }
+
+    private function resolveSessionCapabilities(Message $message): SessionCapabilities
+    {
+        $capabilities = self::readMap($message->params ?? [], 'capabilities');
+        $textDocument = self::readMap($capabilities, 'textDocument');
+        $completionItem = self::readMap(self::readMap($textDocument, 'completion'), 'completionItem');
+
+        return new SessionCapabilities(
+            hoverMarkupKind: self::negotiateHoverMarkupKind(self::readMap($textDocument, 'hover')),
+            snippetSupport: ($completionItem['snippetSupport'] ?? false) === true,
+        );
+    }
+
+    /**
+     * Per [LSP] `HoverClientCapabilities`, `contentFormat` lists the kinds the
+     * client supports in the order it prefers them; the first the server also
+     * supports wins.
+     *
+     * @param array<array-key, mixed> $hover
+     */
+    private static function negotiateHoverMarkupKind(array $hover): MarkupKind
+    {
+        foreach (self::readMap($hover, 'contentFormat') as $format) {
+            $kind = is_string($format) ? MarkupKind::tryFrom($format) : null;
+            if ($kind !== null) {
+                return $kind;
+            }
+        }
+
+        return MarkupKind::PlainText;
+    }
+
+    /**
+     * @param array<array-key, mixed> $source
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function readMap(array $source, string $key): array
+    {
+        $value = $source[$key] ?? null;
+
+        return is_array($value) ? $value : [];
     }
 
     /**

--- a/src/Capability/CapabilityNegotiator.php
+++ b/src/Capability/CapabilityNegotiator.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Capability;
+
+use Firehed\PhpLsp\Protocol\InitializeResult;
+use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\ServerInfo;
+
+/**
+ * The protocol negotiation component (RFC 1 §4.8): the one place that reads the
+ * raw `initialize` parameters, and the source of the `SessionCapabilities` that
+ * every output-shaping decision queries instead.
+ *
+ * @phpstan-import-type ServerCapabilities from InitializeResult
+ */
+final class CapabilityNegotiator
+{
+    private SessionCapabilities $sessionCapabilities;
+
+    public function __construct(
+        private readonly ServerInfo $serverInfo,
+    ) {
+        $this->sessionCapabilities = new SessionCapabilities();
+    }
+
+    public function getSessionCapabilities(): SessionCapabilities
+    {
+        return $this->sessionCapabilities;
+    }
+
+    public function negotiate(Message $message): InitializeResult
+    {
+        $this->sessionCapabilities = SessionCapabilities::fromMessage($message);
+
+        return new InitializeResult(
+            capabilities: $this->advertisedCapabilities(),
+            serverInfo: $this->serverInfo,
+        );
+    }
+
+    /**
+     * Only capabilities the server implements are advertised. A client that did
+     * not declare support for one simply will not invoke it; per RFC 1 §4.8 the
+     * shaping of each response is decided by `SessionCapabilities`, not by this
+     * list.
+     *
+     * @return ServerCapabilities
+     */
+    private function advertisedCapabilities(): array
+    {
+        return [
+            'textDocumentSync' => [
+                'openClose' => true,
+                'change' => 1, // TextDocumentSyncKind.Full
+                'save' => false,
+            ],
+            'definitionProvider' => true,
+            'hoverProvider' => true,
+            'signatureHelpProvider' => [
+                'triggerCharacters' => ['(', ','],
+            ],
+            'completionProvider' => [
+                // Note: ':' omitted - fires prematurely on first ':' of '::'
+                'triggerCharacters' => ['>', '$', '\\'],
+            ],
+        ];
+    }
+}

--- a/src/Capability/SessionCapabilities.php
+++ b/src/Capability/SessionCapabilities.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Capability;
+
+use Firehed\PhpLsp\Protocol\MarkupKind;
+use Firehed\PhpLsp\Protocol\Message;
+
+/**
+ * The client's declared capabilities, resolved once during `initialize` into an
+ * immutable value (RFC 1 §4.8, §5.4).
+ *
+ * Every capability the client did not declare resolves to this value's own
+ * default state, so a minimal or older client is served by the default
+ * configuration rather than by a branch at the point of use.
+ *
+ * This is the only place the raw `initialize` parameters are read.
+ */
+final readonly class SessionCapabilities
+{
+    public function __construct(
+        public MarkupKind $hoverMarkupKind = MarkupKind::PlainText,
+        public bool $snippetSupport = false,
+    ) {
+    }
+
+    public static function fromMessage(Message $message): self
+    {
+        $capabilities = self::readMap($message->params ?? [], 'capabilities');
+        $textDocument = self::readMap($capabilities, 'textDocument');
+        $completionItem = self::readMap(self::readMap($textDocument, 'completion'), 'completionItem');
+
+        return new self(
+            hoverMarkupKind: self::negotiateHoverMarkupKind(self::readMap($textDocument, 'hover')),
+            snippetSupport: ($completionItem['snippetSupport'] ?? false) === true,
+        );
+    }
+
+    /**
+     * Per [LSP] `HoverClientCapabilities`, `contentFormat` lists the kinds the
+     * client supports in the order it prefers them; the first the server also
+     * supports wins.
+     *
+     * @param array<array-key, mixed> $hover
+     */
+    private static function negotiateHoverMarkupKind(array $hover): MarkupKind
+    {
+        foreach (self::readMap($hover, 'contentFormat') as $format) {
+            $kind = is_string($format) ? MarkupKind::tryFrom($format) : null;
+            if ($kind !== null) {
+                return $kind;
+            }
+        }
+
+        return MarkupKind::PlainText;
+    }
+
+    /**
+     * @param array<array-key, mixed> $source
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function readMap(array $source, string $key): array
+    {
+        $value = $source[$key] ?? null;
+
+        return is_array($value) ? $value : [];
+    }
+}

--- a/src/Capability/SessionCapabilities.php
+++ b/src/Capability/SessionCapabilities.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Capability;
 
 use Firehed\PhpLsp\Protocol\MarkupKind;
-use Firehed\PhpLsp\Protocol\Message;
 
 /**
  * The client's declared capabilities, resolved once during `initialize` into an
@@ -15,7 +14,9 @@ use Firehed\PhpLsp\Protocol\Message;
  * default state, so a minimal or older client is served by the default
  * configuration rather than by a branch at the point of use.
  *
- * This is the only place the raw `initialize` parameters are read.
+ * The value carries only already-resolved capabilities: it exposes no way to
+ * build itself from a `Message`, so no component outside `CapabilityNegotiator`
+ * can re-read the raw `initialize` parameters through it.
  */
 final readonly class SessionCapabilities
 {
@@ -23,48 +24,5 @@ final readonly class SessionCapabilities
         public MarkupKind $hoverMarkupKind = MarkupKind::PlainText,
         public bool $snippetSupport = false,
     ) {
-    }
-
-    public static function fromMessage(Message $message): self
-    {
-        $capabilities = self::readMap($message->params ?? [], 'capabilities');
-        $textDocument = self::readMap($capabilities, 'textDocument');
-        $completionItem = self::readMap(self::readMap($textDocument, 'completion'), 'completionItem');
-
-        return new self(
-            hoverMarkupKind: self::negotiateHoverMarkupKind(self::readMap($textDocument, 'hover')),
-            snippetSupport: ($completionItem['snippetSupport'] ?? false) === true,
-        );
-    }
-
-    /**
-     * Per [LSP] `HoverClientCapabilities`, `contentFormat` lists the kinds the
-     * client supports in the order it prefers them; the first the server also
-     * supports wins.
-     *
-     * @param array<array-key, mixed> $hover
-     */
-    private static function negotiateHoverMarkupKind(array $hover): MarkupKind
-    {
-        foreach (self::readMap($hover, 'contentFormat') as $format) {
-            $kind = is_string($format) ? MarkupKind::tryFrom($format) : null;
-            if ($kind !== null) {
-                return $kind;
-            }
-        }
-
-        return MarkupKind::PlainText;
-    }
-
-    /**
-     * @param array<array-key, mixed> $source
-     *
-     * @return array<array-key, mixed>
-     */
-    private static function readMap(array $source, string $key): array
-    {
-        $value = $source[$key] ?? null;
-
-        return is_array($value) ? $value : [];
     }
 }

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Handler;
 
+use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\ServerInfo;
 
 final class LifecycleHandler implements HandlerInterface
 {
@@ -20,7 +20,7 @@ final class LifecycleHandler implements HandlerInterface
     private ?int $exitCode = null;
 
     public function __construct(
-        private readonly ServerInfo $serverInfo,
+        private readonly CapabilityNegotiator $negotiator,
     ) {
     }
 
@@ -32,7 +32,7 @@ final class LifecycleHandler implements HandlerInterface
     public function handle(Message $message): mixed
     {
         return match ($message->method) {
-            'initialize' => $this->handleInitialize(),
+            'initialize' => $this->negotiator->negotiate($message),
             'initialized' => null,
             'shutdown' => $this->handleShutdown(),
             'exit' => $this->handleExit(),
@@ -48,32 +48,6 @@ final class LifecycleHandler implements HandlerInterface
     public function getExitCode(): ?int
     {
         return $this->exitCode;
-    }
-
-    /**
-     * @return array{capabilities: array<string, mixed>, serverInfo: array{name: string, version: string}}
-     */
-    private function handleInitialize(): array
-    {
-        return [
-            'capabilities' => [
-                'textDocumentSync' => [
-                    'openClose' => true,
-                    'change' => 1, // TextDocumentSyncKind.Full
-                    'save' => false,
-                ],
-                'definitionProvider' => true,
-                'hoverProvider' => true,
-                'signatureHelpProvider' => [
-                    'triggerCharacters' => ['(', ','],
-                ],
-                'completionProvider' => [
-                    // Note: ':' omitted - fires prematurely on first ':' of '::'
-                    'triggerCharacters' => ['>', '$', '\\'],
-                ],
-            ],
-            'serverInfo' => $this->serverInfo->toArray(),
-        ];
     }
 
     private function handleShutdown(): null

--- a/src/Protocol/InitializeResult.php
+++ b/src/Protocol/InitializeResult.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+use Firehed\PhpLsp\ServerInfo;
+use JsonSerializable;
+
+/**
+ * The `initialize` response, per [LSP] "Server lifecycle" (`InitializeResult`).
+ *
+ * @phpstan-type ServerCapabilities array{
+ *   textDocumentSync: array{
+ *     openClose: bool,
+ *     change: int,
+ *     save: bool,
+ *   },
+ *   definitionProvider: bool,
+ *   hoverProvider: bool,
+ *   signatureHelpProvider: array{
+ *     triggerCharacters: list<string>,
+ *   },
+ *   completionProvider: array{
+ *     triggerCharacters: list<string>,
+ *   },
+ * }
+ */
+final readonly class InitializeResult implements JsonSerializable
+{
+    /**
+     * @param ServerCapabilities $capabilities
+     */
+    public function __construct(
+        public array $capabilities,
+        public ServerInfo $serverInfo,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   capabilities: ServerCapabilities,
+     *   serverInfo: array{name: string, version: string},
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'capabilities' => $this->capabilities,
+            'serverInfo' => $this->serverInfo->toArray(),
+        ];
+    }
+}

--- a/src/Protocol/MarkupKind.php
+++ b/src/Protocol/MarkupKind.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+/**
+ * The content formats a client can render in result literals such as `Hover`
+ * and `CompletionItem`, per [LSP] "Basic JSON Structures" (`MarkupContent`).
+ */
+enum MarkupKind: string
+{
+    case Markdown = 'markdown';
+    case PlainText = 'plaintext';
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp;
 
+use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
@@ -79,7 +80,7 @@ final class Server
             $functionRepository,
         );
 
-        $this->lifecycleHandler = new LifecycleHandler($serverInfo);
+        $this->lifecycleHandler = new LifecycleHandler(new CapabilityNegotiator($serverInfo));
         $this->handlers[] = $this->lifecycleHandler;
         $this->handlers[] = new TextDocumentSyncHandler(
             $this->documentManager,

--- a/tests/Architecture/RawInitializeCapabilitiesRule.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRule.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * The RFC 1 §8.1 mechanism for §4.8: the raw `initialize` parameters are
+ * reachable only within the negotiation component.
+ *
+ * `capabilities` is the [LSP] `InitializeParams` field that carries them
+ * ("Server lifecycle" → `initialize`), so reading that key anywhere else is a
+ * component re-inspecting the raw parameters instead of querying the
+ * `SessionCapabilities` value resolved once during negotiation.
+ *
+ * @implements Rule<ArrayDimFetch>
+ */
+final class RawInitializeCapabilitiesRule implements Rule
+{
+    private const string CAPABILITIES_FIELD = 'capabilities';
+    private const string NEGOTIATION_NAMESPACE = 'Firehed\PhpLsp\Capability';
+
+    public function getNodeType(): string
+    {
+        return ArrayDimFetch::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $dim = $node->dim;
+        if (!$dim instanceof String_ || $dim->value !== self::CAPABILITIES_FIELD) {
+            return [];
+        }
+
+        if ($scope->getNamespace() === self::NEGOTIATION_NAMESPACE) {
+            return [];
+        }
+
+        $message = sprintf(
+            'Raw initialize %s must not be read outside %s; query SessionCapabilities instead (RFC 1 §4.8).',
+            self::CAPABILITIES_FIELD,
+            self::NEGOTIATION_NAMESPACE,
+        );
+
+        return [
+            RuleErrorBuilder::message($message)
+                ->identifier('phpLsp.rawInitializeCapabilities')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Architecture/RawInitializeCapabilitiesRule.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRule.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\MixedType;
 
 /**
  * The RFC 1 §8.1 mechanism for §4.8: the raw `initialize` parameters are
@@ -40,6 +41,15 @@ final class RawInitializeCapabilitiesRule implements Rule
         }
 
         if ($scope->getNamespace() === self::NEGOTIATION_NAMESPACE) {
+            return [];
+        }
+
+        // The raw params are `array<array-key, mixed>`, so a genuine read of
+        // them yields `mixed`. A read that resolves to a concrete type is
+        // indexing one of the server's own typed structures — the `capabilities`
+        // of an outgoing InitializeResult, say — which is not an initialize
+        // parameter at all and which §4.8 says nothing about.
+        if (!$scope->getType($node) instanceof MixedType) {
             return [];
         }
 

--- a/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
@@ -31,6 +31,11 @@ class RawInitializeCapabilitiesRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/negotiates-raw-capabilities.php'], []);
     }
 
+    public function testReadingTheServersOwnAdvertisedCapabilitiesIsAllowed(): void
+    {
+        $this->analyse([__DIR__ . '/data/reads-own-result-capabilities.php'], []);
+    }
+
     protected function getRule(): Rule
     {
         return new RawInitializeCapabilitiesRule();

--- a/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @extends RuleTestCase<RawInitializeCapabilitiesRule>
+ */
+#[CoversClass(RawInitializeCapabilitiesRule::class)]
+class RawInitializeCapabilitiesRuleTest extends RuleTestCase
+{
+    private const string EXPECTED_MESSAGE = 'Raw initialize capabilities must not be read outside '
+        . 'Firehed\PhpLsp\Capability; query SessionCapabilities instead (RFC 1 §4.8).';
+
+    public function testReadingRawCapabilitiesElsewhereIsReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/reads-raw-capabilities.php'],
+            [[self::EXPECTED_MESSAGE, 18]],
+        );
+    }
+
+    public function testTheNegotiationPackageMayReadRawCapabilities(): void
+    {
+        $this->analyse([__DIR__ . '/data/negotiates-raw-capabilities.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new RawInitializeCapabilitiesRule();
+    }
+}

--- a/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
@@ -6,12 +6,13 @@ namespace Firehed\PhpLsp\Tests\Architecture;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
+ * No `#[CoversClass]`: the rule under test is dev tooling under `tests/`, not a
+ * coverage target, and naming it as one is a PHPUnit error.
+ *
  * @extends RuleTestCase<RawInitializeCapabilitiesRule>
  */
-#[CoversClass(RawInitializeCapabilitiesRule::class)]
 class RawInitializeCapabilitiesRuleTest extends RuleTestCase
 {
     private const string EXPECTED_MESSAGE = 'Raw initialize capabilities must not be read outside '

--- a/tests/Architecture/data/negotiates-raw-capabilities.php
+++ b/tests/Architecture/data/negotiates-raw-capabilities.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Capability;
+
+use Firehed\PhpLsp\Protocol\Message;
+
+/**
+ * The negotiation package is the one place RFC 1 §4.8 allows the raw
+ * `initialize` parameters to be read.
+ */
+final class NegotiatesRawCapabilities
+{
+    public function declaresAnything(Message $message): bool
+    {
+        $params = $message->params ?? [];
+        $capabilities = $params['capabilities'] ?? [];
+
+        return $capabilities !== [];
+    }
+}

--- a/tests/Architecture/data/reads-own-result-capabilities.php
+++ b/tests/Architecture/data/reads-own-result-capabilities.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Protocol\InitializeResult;
+
+/**
+ * Reading the server's *own* advertised capabilities off a typed
+ * `InitializeResult` is not a read of the raw `initialize` parameters, so RFC 1
+ * §4.8 does not forbid it. The key name is the same; the provenance is not.
+ */
+final class ReadsOwnResultCapabilities
+{
+    public function advertisesHover(InitializeResult $result): bool
+    {
+        $serialized = $result->jsonSerialize();
+
+        return $serialized['capabilities']['hoverProvider'];
+    }
+}

--- a/tests/Architecture/data/reads-raw-capabilities.php
+++ b/tests/Architecture/data/reads-raw-capabilities.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Protocol\Message;
+
+/**
+ * A component outside the negotiation package re-inspecting the raw
+ * `initialize` parameters, which RFC 1 §4.8 forbids.
+ */
+final class ReadsRawCapabilities
+{
+    public function prefersMarkdown(Message $message): bool
+    {
+        $params = $message->params ?? [];
+        $capabilities = $params['capabilities'] ?? [];
+
+        return $capabilities !== [];
+    }
+}

--- a/tests/Capability/CapabilityNegotiatorTest.php
+++ b/tests/Capability/CapabilityNegotiatorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Capability;
+
+use Firehed\PhpLsp\Capability\CapabilityNegotiator;
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Protocol\MarkupKind;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\ServerInfo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CapabilityNegotiator::class)]
+class CapabilityNegotiatorTest extends TestCase
+{
+    public function testSessionCapabilitiesDefaultBeforeInitialize(): void
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('test', '1.0'));
+
+        self::assertEquals(
+            new SessionCapabilities(),
+            $negotiator->getSessionCapabilities(),
+            'components must have a usable value before initialize rather than a null to branch on',
+        );
+    }
+
+    public function testNegotiateResolvesTheSessionCapabilitiesOnce(): void
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('test', '1.0'));
+
+        $negotiator->negotiate(self::initializeWith([
+            'textDocument' => [
+                'hover' => ['contentFormat' => ['markdown', 'plaintext']],
+                'completion' => ['completionItem' => ['snippetSupport' => true]],
+            ],
+        ]));
+
+        $capabilities = $negotiator->getSessionCapabilities();
+
+        self::assertSame(
+            MarkupKind::Markdown,
+            $capabilities->hoverMarkupKind,
+            'the declared hover format must be readable without re-inspecting the initialize params',
+        );
+        self::assertTrue(
+            $capabilities->snippetSupport,
+            'the declared snippet support must be readable without re-inspecting the initialize params',
+        );
+    }
+
+    public function testNegotiateReportsServerInfo(): void
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('php-lsp', '0.1.0'));
+
+        $result = $negotiator->negotiate(self::initializeWith([]));
+
+        self::assertSame('php-lsp', $result->serverInfo->name, 'serverInfo comes from the injected value');
+        self::assertSame('0.1.0', $result->serverInfo->version, 'serverInfo comes from the injected value');
+    }
+
+    public function testAdvertisesTextDocumentSyncAsOptions(): void
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('test', '1.0'));
+
+        $sync = $negotiator->negotiate(self::initializeWith([]))->capabilities['textDocumentSync'];
+
+        self::assertTrue($sync['openClose'], 'the server tracks open and close notifications');
+        self::assertSame(1, $sync['change'], 'the server only supports full-document sync (TextDocumentSyncKind.Full)');
+        self::assertFalse($sync['save'], 'the server does not act on save notifications');
+    }
+
+    public function testAdvertisesOnlyImplementedProviders(): void
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('test', '1.0'));
+
+        $capabilities = $negotiator->negotiate(self::initializeWith([]))->capabilities;
+
+        self::assertTrue($capabilities['definitionProvider'], 'DefinitionHandler implements textDocument/definition');
+        self::assertTrue($capabilities['hoverProvider'], 'HoverHandler implements textDocument/hover');
+        self::assertSame(
+            ['(', ','],
+            $capabilities['signatureHelpProvider']['triggerCharacters'],
+            'signature help re-fires as arguments are typed',
+        );
+    }
+
+    public function testCompletionTriggerCharactersExcludeColon(): void
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('test', '1.0'));
+
+        $capabilities = $negotiator->negotiate(self::initializeWith([]))->capabilities;
+        $triggers = $capabilities['completionProvider']['triggerCharacters'];
+
+        self::assertNotContains(':', $triggers, "':' fires prematurely on the first ':' of '::'");
+        self::assertContains('>', $triggers, 'member access completion triggers on the > of ->');
+        self::assertContains('$', $triggers, 'variable completion triggers on $');
+        self::assertContains('\\', $triggers, 'namespaced class completion triggers on a separator');
+    }
+
+    /**
+     * @param array<array-key, mixed> $clientCapabilities
+     */
+    private static function initializeWith(array $clientCapabilities): RequestMessage
+    {
+        return new RequestMessage(
+            id: 1,
+            method: 'initialize',
+            params: ['capabilities' => $clientCapabilities],
+        );
+    }
+}

--- a/tests/Capability/CapabilityNegotiatorTest.php
+++ b/tests/Capability/CapabilityNegotiatorTest.php
@@ -77,6 +77,18 @@ class CapabilityNegotiatorTest extends TestCase
 
         $capabilities = $negotiator->negotiate(self::initializeWith([]))->capabilities;
 
+        self::assertSame(
+            [
+                'textDocumentSync',
+                'definitionProvider',
+                'hoverProvider',
+                'signatureHelpProvider',
+                'completionProvider',
+            ],
+            array_keys($capabilities),
+            'RFC 1 §4.8 forbids advertising a capability the server does not implement; '
+                . 'extend this list only together with the handler that answers the method',
+        );
         self::assertTrue($capabilities['definitionProvider'], 'DefinitionHandler implements textDocument/definition');
         self::assertTrue($capabilities['hoverProvider'], 'HoverHandler implements textDocument/hover');
         self::assertSame(

--- a/tests/Capability/CapabilityNegotiatorTest.php
+++ b/tests/Capability/CapabilityNegotiatorTest.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\ServerInfo;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(CapabilityNegotiator::class)]
@@ -114,6 +115,119 @@ class CapabilityNegotiatorTest extends TestCase
     /**
      * @param array<array-key, mixed> $clientCapabilities
      */
+    #[DataProvider('hoverMarkupKindCases')]
+    public function testHoverMarkupKindIsNegotiated(array $clientCapabilities, MarkupKind $expected): void
+    {
+        $capabilities = self::resolve(self::initializeWith($clientCapabilities));
+
+        self::assertSame(
+            $expected,
+            $capabilities->hoverMarkupKind,
+            'contentFormat order describes the client preference, per [LSP] HoverClientCapabilities',
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $clientCapabilities
+     */
+    #[DataProvider('snippetSupportCases')]
+    public function testSnippetSupportIsRead(array $clientCapabilities, bool $expected): void
+    {
+        $capabilities = self::resolve(self::initializeWith($clientCapabilities));
+
+        self::assertSame(
+            $expected,
+            $capabilities->snippetSupport,
+            'snippetSupport is only true when the client declares it as a boolean true',
+        );
+    }
+
+    public function testMissingParamsResolveToDefaults(): void
+    {
+        $message = new RequestMessage(id: 1, method: 'initialize', params: null);
+
+        self::assertEquals(
+            new SessionCapabilities(),
+            self::resolve($message),
+            'a client that sends no params must be served the default configuration',
+        );
+    }
+
+    public function testNonArrayCapabilitiesResolveToDefaults(): void
+    {
+        $message = new RequestMessage(id: 1, method: 'initialize', params: ['capabilities' => 'nonsense']);
+
+        self::assertEquals(
+            new SessionCapabilities(),
+            self::resolve($message),
+            'a malformed capabilities value must degrade to defaults, not crash negotiation',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{array<array-key, mixed>, MarkupKind}>
+     */
+    public static function hoverMarkupKindCases(): iterable
+    {
+        yield 'no capabilities declared' => [[], MarkupKind::PlainText];
+        yield 'no hover capability' => [['textDocument' => []], MarkupKind::PlainText];
+        yield 'no contentFormat' => [['textDocument' => ['hover' => []]], MarkupKind::PlainText];
+        yield 'empty contentFormat' => [self::hover([]), MarkupKind::PlainText];
+        yield 'markdown preferred' => [self::hover(['markdown', 'plaintext']), MarkupKind::Markdown];
+        yield 'plaintext preferred' => [self::hover(['plaintext', 'markdown']), MarkupKind::PlainText];
+        yield 'unsupported kind skipped' => [self::hover(['$reserved', 'markdown']), MarkupKind::Markdown];
+        yield 'non-string entry skipped' => [self::hover([42, 'markdown']), MarkupKind::Markdown];
+        yield 'contentFormat not a list' => [
+            ['textDocument' => ['hover' => ['contentFormat' => 'markdown']]],
+            MarkupKind::PlainText,
+        ];
+        yield 'textDocument not a map' => [['textDocument' => 'nonsense'], MarkupKind::PlainText];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{array<array-key, mixed>, bool}>
+     */
+    public static function snippetSupportCases(): iterable
+    {
+        yield 'no capabilities declared' => [[], false];
+        yield 'no completion capability' => [['textDocument' => []], false];
+        yield 'no completionItem capability' => [['textDocument' => ['completion' => []]], false];
+        yield 'declared true' => [self::completionItem(['snippetSupport' => true]), true];
+        yield 'declared false' => [self::completionItem(['snippetSupport' => false]), false];
+        yield 'declared as a non-boolean' => [self::completionItem(['snippetSupport' => 'yes']), false];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param list<mixed> $contentFormat
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function hover(array $contentFormat): array
+    {
+        return ['textDocument' => ['hover' => ['contentFormat' => $contentFormat]]];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param array<string, mixed> $completionItem
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function completionItem(array $completionItem): array
+    {
+        return ['textDocument' => ['completion' => ['completionItem' => $completionItem]]];
+    }
+
+    /**
+     * @param array<array-key, mixed> $clientCapabilities
+     */
     private static function initializeWith(array $clientCapabilities): RequestMessage
     {
         return new RequestMessage(
@@ -121,5 +235,13 @@ class CapabilityNegotiatorTest extends TestCase
             method: 'initialize',
             params: ['capabilities' => $clientCapabilities],
         );
+    }
+
+    private static function resolve(RequestMessage $message): SessionCapabilities
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('test', '1.0'));
+        $negotiator->negotiate($message);
+
+        return $negotiator->getSessionCapabilities();
     }
 }

--- a/tests/Capability/SessionCapabilitiesTest.php
+++ b/tests/Capability/SessionCapabilitiesTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Capability;
+
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Protocol\MarkupKind;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SessionCapabilities::class)]
+class SessionCapabilitiesTest extends TestCase
+{
+    public function testDefaultsAreTheSafeValues(): void
+    {
+        $capabilities = new SessionCapabilities();
+
+        self::assertSame(
+            MarkupKind::PlainText,
+            $capabilities->hoverMarkupKind,
+            'plaintext is the only markup every client renders, so it is the safe default',
+        );
+        self::assertFalse(
+            $capabilities->snippetSupport,
+            'snippet syntax is inserted literally by a client that cannot expand it',
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $clientCapabilities
+     */
+    #[DataProvider('hoverMarkupKindCases')]
+    public function testHoverMarkupKindIsNegotiated(array $clientCapabilities, MarkupKind $expected): void
+    {
+        $capabilities = SessionCapabilities::fromMessage(self::initializeWith($clientCapabilities));
+
+        self::assertSame(
+            $expected,
+            $capabilities->hoverMarkupKind,
+            'contentFormat order describes the client preference, per [LSP] HoverClientCapabilities',
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $clientCapabilities
+     */
+    #[DataProvider('snippetSupportCases')]
+    public function testSnippetSupportIsRead(array $clientCapabilities, bool $expected): void
+    {
+        $capabilities = SessionCapabilities::fromMessage(self::initializeWith($clientCapabilities));
+
+        self::assertSame(
+            $expected,
+            $capabilities->snippetSupport,
+            'snippetSupport is only true when the client declares it as a boolean true',
+        );
+    }
+
+    public function testMissingParamsResolveToDefaults(): void
+    {
+        $message = new RequestMessage(id: 1, method: 'initialize', params: null);
+
+        $capabilities = SessionCapabilities::fromMessage($message);
+
+        self::assertEquals(
+            new SessionCapabilities(),
+            $capabilities,
+            'a client that sends no params must be served the default configuration',
+        );
+    }
+
+    public function testNonArrayCapabilitiesResolveToDefaults(): void
+    {
+        $message = new RequestMessage(id: 1, method: 'initialize', params: ['capabilities' => 'nonsense']);
+
+        $capabilities = SessionCapabilities::fromMessage($message);
+
+        self::assertEquals(
+            new SessionCapabilities(),
+            $capabilities,
+            'a malformed capabilities value must degrade to defaults, not crash negotiation',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{array<array-key, mixed>, MarkupKind}>
+     */
+    public static function hoverMarkupKindCases(): iterable
+    {
+        yield 'no capabilities declared' => [[], MarkupKind::PlainText];
+        yield 'no hover capability' => [['textDocument' => []], MarkupKind::PlainText];
+        yield 'no contentFormat' => [['textDocument' => ['hover' => []]], MarkupKind::PlainText];
+        yield 'empty contentFormat' => [self::hover([]), MarkupKind::PlainText];
+        yield 'markdown preferred' => [self::hover(['markdown', 'plaintext']), MarkupKind::Markdown];
+        yield 'plaintext preferred' => [self::hover(['plaintext', 'markdown']), MarkupKind::PlainText];
+        yield 'unsupported kind skipped' => [self::hover(['$reserved', 'markdown']), MarkupKind::Markdown];
+        yield 'non-string entry skipped' => [self::hover([42, 'markdown']), MarkupKind::Markdown];
+        yield 'contentFormat not a list' => [['textDocument' => ['hover' => ['contentFormat' => 'markdown']]], MarkupKind::PlainText];
+        yield 'textDocument not a map' => [['textDocument' => 'nonsense'], MarkupKind::PlainText];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{array<array-key, mixed>, bool}>
+     */
+    public static function snippetSupportCases(): iterable
+    {
+        yield 'no capabilities declared' => [[], false];
+        yield 'no completion capability' => [['textDocument' => []], false];
+        yield 'no completionItem capability' => [['textDocument' => ['completion' => []]], false];
+        yield 'declared true' => [self::completionItem(['snippetSupport' => true]), true];
+        yield 'declared false' => [self::completionItem(['snippetSupport' => false]), false];
+        yield 'declared as a non-boolean' => [self::completionItem(['snippetSupport' => 'yes']), false];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param list<mixed> $contentFormat
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function hover(array $contentFormat): array
+    {
+        return ['textDocument' => ['hover' => ['contentFormat' => $contentFormat]]];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param array<string, mixed> $completionItem
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function completionItem(array $completionItem): array
+    {
+        return ['textDocument' => ['completion' => ['completionItem' => $completionItem]]];
+    }
+
+    /**
+     * @param array<array-key, mixed> $clientCapabilities
+     */
+    private static function initializeWith(array $clientCapabilities): RequestMessage
+    {
+        return new RequestMessage(
+            id: 1,
+            method: 'initialize',
+            params: ['capabilities' => $clientCapabilities],
+        );
+    }
+}

--- a/tests/Capability/SessionCapabilitiesTest.php
+++ b/tests/Capability/SessionCapabilitiesTest.php
@@ -6,11 +6,14 @@ namespace Firehed\PhpLsp\Tests\Capability;
 
 use Firehed\PhpLsp\Capability\SessionCapabilities;
 use Firehed\PhpLsp\Protocol\MarkupKind;
-use Firehed\PhpLsp\Protocol\RequestMessage;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Resolving a client's declared capabilities into this value is
+ * `CapabilityNegotiator`'s job, and is covered by `CapabilityNegotiatorTest`;
+ * the value itself only has to carry safe defaults.
+ */
 #[CoversClass(SessionCapabilities::class)]
 class SessionCapabilitiesTest extends TestCase
 {
@@ -26,135 +29,6 @@ class SessionCapabilitiesTest extends TestCase
         self::assertFalse(
             $capabilities->snippetSupport,
             'snippet syntax is inserted literally by a client that cannot expand it',
-        );
-    }
-
-    /**
-     * @param array<array-key, mixed> $clientCapabilities
-     */
-    #[DataProvider('hoverMarkupKindCases')]
-    public function testHoverMarkupKindIsNegotiated(array $clientCapabilities, MarkupKind $expected): void
-    {
-        $capabilities = SessionCapabilities::fromMessage(self::initializeWith($clientCapabilities));
-
-        self::assertSame(
-            $expected,
-            $capabilities->hoverMarkupKind,
-            'contentFormat order describes the client preference, per [LSP] HoverClientCapabilities',
-        );
-    }
-
-    /**
-     * @param array<array-key, mixed> $clientCapabilities
-     */
-    #[DataProvider('snippetSupportCases')]
-    public function testSnippetSupportIsRead(array $clientCapabilities, bool $expected): void
-    {
-        $capabilities = SessionCapabilities::fromMessage(self::initializeWith($clientCapabilities));
-
-        self::assertSame(
-            $expected,
-            $capabilities->snippetSupport,
-            'snippetSupport is only true when the client declares it as a boolean true',
-        );
-    }
-
-    public function testMissingParamsResolveToDefaults(): void
-    {
-        $message = new RequestMessage(id: 1, method: 'initialize', params: null);
-
-        $capabilities = SessionCapabilities::fromMessage($message);
-
-        self::assertEquals(
-            new SessionCapabilities(),
-            $capabilities,
-            'a client that sends no params must be served the default configuration',
-        );
-    }
-
-    public function testNonArrayCapabilitiesResolveToDefaults(): void
-    {
-        $message = new RequestMessage(id: 1, method: 'initialize', params: ['capabilities' => 'nonsense']);
-
-        $capabilities = SessionCapabilities::fromMessage($message);
-
-        self::assertEquals(
-            new SessionCapabilities(),
-            $capabilities,
-            'a malformed capabilities value must degrade to defaults, not crash negotiation',
-        );
-    }
-
-    /**
-     * @codeCoverageIgnore
-     *
-     * @return iterable<string, array{array<array-key, mixed>, MarkupKind}>
-     */
-    public static function hoverMarkupKindCases(): iterable
-    {
-        yield 'no capabilities declared' => [[], MarkupKind::PlainText];
-        yield 'no hover capability' => [['textDocument' => []], MarkupKind::PlainText];
-        yield 'no contentFormat' => [['textDocument' => ['hover' => []]], MarkupKind::PlainText];
-        yield 'empty contentFormat' => [self::hover([]), MarkupKind::PlainText];
-        yield 'markdown preferred' => [self::hover(['markdown', 'plaintext']), MarkupKind::Markdown];
-        yield 'plaintext preferred' => [self::hover(['plaintext', 'markdown']), MarkupKind::PlainText];
-        yield 'unsupported kind skipped' => [self::hover(['$reserved', 'markdown']), MarkupKind::Markdown];
-        yield 'non-string entry skipped' => [self::hover([42, 'markdown']), MarkupKind::Markdown];
-        yield 'contentFormat not a list' => [
-            ['textDocument' => ['hover' => ['contentFormat' => 'markdown']]],
-            MarkupKind::PlainText,
-        ];
-        yield 'textDocument not a map' => [['textDocument' => 'nonsense'], MarkupKind::PlainText];
-    }
-
-    /**
-     * @codeCoverageIgnore
-     *
-     * @return iterable<string, array{array<array-key, mixed>, bool}>
-     */
-    public static function snippetSupportCases(): iterable
-    {
-        yield 'no capabilities declared' => [[], false];
-        yield 'no completion capability' => [['textDocument' => []], false];
-        yield 'no completionItem capability' => [['textDocument' => ['completion' => []]], false];
-        yield 'declared true' => [self::completionItem(['snippetSupport' => true]), true];
-        yield 'declared false' => [self::completionItem(['snippetSupport' => false]), false];
-        yield 'declared as a non-boolean' => [self::completionItem(['snippetSupport' => 'yes']), false];
-    }
-
-    /**
-     * @codeCoverageIgnore
-     *
-     * @param list<mixed> $contentFormat
-     *
-     * @return array<array-key, mixed>
-     */
-    private static function hover(array $contentFormat): array
-    {
-        return ['textDocument' => ['hover' => ['contentFormat' => $contentFormat]]];
-    }
-
-    /**
-     * @codeCoverageIgnore
-     *
-     * @param array<string, mixed> $completionItem
-     *
-     * @return array<array-key, mixed>
-     */
-    private static function completionItem(array $completionItem): array
-    {
-        return ['textDocument' => ['completion' => ['completionItem' => $completionItem]]];
-    }
-
-    /**
-     * @param array<array-key, mixed> $clientCapabilities
-     */
-    private static function initializeWith(array $clientCapabilities): RequestMessage
-    {
-        return new RequestMessage(
-            id: 1,
-            method: 'initialize',
-            params: ['capabilities' => $clientCapabilities],
         );
     }
 }

--- a/tests/Capability/SessionCapabilitiesTest.php
+++ b/tests/Capability/SessionCapabilitiesTest.php
@@ -100,7 +100,10 @@ class SessionCapabilitiesTest extends TestCase
         yield 'plaintext preferred' => [self::hover(['plaintext', 'markdown']), MarkupKind::PlainText];
         yield 'unsupported kind skipped' => [self::hover(['$reserved', 'markdown']), MarkupKind::Markdown];
         yield 'non-string entry skipped' => [self::hover([42, 'markdown']), MarkupKind::Markdown];
-        yield 'contentFormat not a list' => [['textDocument' => ['hover' => ['contentFormat' => 'markdown']]], MarkupKind::PlainText];
+        yield 'contentFormat not a list' => [
+            ['textDocument' => ['hover' => ['contentFormat' => 'markdown']]],
+            MarkupKind::PlainText,
+        ];
         yield 'textDocument not a map' => [['textDocument' => 'nonsense'], MarkupKind::PlainText];
     }
 

--- a/tests/Handler/LifecycleHandlerTest.php
+++ b/tests/Handler/LifecycleHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Handler;
 
+use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
@@ -17,7 +18,7 @@ class LifecycleHandlerTest extends TestCase
 {
     public function testSupportsLifecycleMethods(): void
     {
-        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+        $handler = self::handler();
 
         self::assertTrue($handler->supports('initialize'));
         self::assertTrue($handler->supports('initialized'));
@@ -26,9 +27,10 @@ class LifecycleHandlerTest extends TestCase
         self::assertFalse($handler->supports('textDocument/hover'));
     }
 
-    public function testInitializeReturnsCapabilities(): void
+    public function testInitializeDelegatesToTheNegotiator(): void
     {
-        $handler = new LifecycleHandler(new ServerInfo('php-lsp', '0.1.0'));
+        $negotiator = new CapabilityNegotiator(new ServerInfo('php-lsp', '0.1.0'));
+        $handler = new LifecycleHandler($negotiator);
 
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -39,55 +41,16 @@ class LifecycleHandlerTest extends TestCase
 
         $result = $handler->handle($request);
 
-        self::assertIsArray($result);
-        self::assertArrayHasKey('capabilities', $result);
-        self::assertArrayHasKey('serverInfo', $result);
-        self::assertIsArray($result['serverInfo']);
-        self::assertSame('php-lsp', $result['serverInfo']['name']);
-        self::assertSame('0.1.0', $result['serverInfo']['version']);
-
-        // Verify textDocumentSync uses options object, not bare number
-        $capabilities = $result['capabilities'];
-        self::assertIsArray($capabilities);
-        $sync = $capabilities['textDocumentSync'];
-        self::assertIsArray($sync);
-        self::assertTrue($sync['openClose']);
-        self::assertSame(1, $sync['change']);
-        self::assertFalse($sync['save']);
-    }
-
-    public function testCompletionTriggerCharactersExcludeColon(): void
-    {
-        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
-
-        $request = RequestMessage::fromArray([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'initialize',
-            'params' => [],
-        ]);
-
-        $result = $handler->handle($request);
-
-        self::assertIsArray($result);
-        $capabilities = $result['capabilities'];
-        self::assertIsArray($capabilities);
-        $completion = $capabilities['completionProvider'];
-        self::assertIsArray($completion);
-        $triggers = $completion['triggerCharacters'];
-        self::assertIsArray($triggers);
-
-        // ':' should NOT be a trigger - it fires prematurely on first ':' of '::'
-        self::assertNotContains(':', $triggers);
-        // These should still be triggers
-        self::assertContains('>', $triggers);
-        self::assertContains('$', $triggers);
-        self::assertContains('\\', $triggers);
+        self::assertEquals(
+            $negotiator->negotiate($request),
+            $result,
+            'the handler must return the negotiator result rather than shape one itself',
+        );
     }
 
     public function testInitializedReturnsNull(): void
     {
-        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+        $handler = self::handler();
 
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -102,7 +65,7 @@ class LifecycleHandlerTest extends TestCase
 
     public function testShutdownSetsFlag(): void
     {
-        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+        $handler = self::handler();
 
         self::assertFalse($handler->isShutdownRequested());
 
@@ -120,7 +83,7 @@ class LifecycleHandlerTest extends TestCase
 
     public function testExitCodeAfterShutdown(): void
     {
-        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+        $handler = self::handler();
 
         // Shutdown first
         $handler->handle(RequestMessage::fromArray([
@@ -141,7 +104,7 @@ class LifecycleHandlerTest extends TestCase
 
     public function testExitCodeWithoutShutdown(): void
     {
-        $handler = new LifecycleHandler(new ServerInfo('test', '1.0'));
+        $handler = self::handler();
 
         $notification = NotificationMessage::fromArray([
             'jsonrpc' => '2.0',
@@ -151,5 +114,10 @@ class LifecycleHandlerTest extends TestCase
         $result = $handler->handle($notification);
 
         self::assertSame(1, $handler->getExitCode());
+    }
+
+    private static function handler(): LifecycleHandler
+    {
+        return new LifecycleHandler(new CapabilityNegotiator(new ServerInfo('test', '1.0')));
     }
 }

--- a/tests/Handler/LifecycleHandlerTest.php
+++ b/tests/Handler/LifecycleHandlerTest.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Tests\Handler;
 
 use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
+use Firehed\PhpLsp\Protocol\InitializeResult;
+use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\ServerInfo;
@@ -36,15 +38,33 @@ class LifecycleHandlerTest extends TestCase
             'jsonrpc' => '2.0',
             'id' => 1,
             'method' => 'initialize',
-            'params' => ['processId' => 1234, 'capabilities' => []],
+            'params' => [
+                'processId' => 1234,
+                'capabilities' => [
+                    'textDocument' => ['hover' => ['contentFormat' => ['markdown']]],
+                ],
+            ],
         ]);
 
         $result = $handler->handle($request);
 
-        self::assertEquals(
-            $negotiator->negotiate($request),
+        // Observing the injected negotiator's resolved value, rather than
+        // comparing against a second negotiate() call, is what makes this fail
+        // if the handler shapes its own result or builds its own negotiator.
+        self::assertSame(
+            MarkupKind::Markdown,
+            $negotiator->getSessionCapabilities()->hoverMarkupKind,
+            'the handler must route initialize through the injected negotiator so the client params are resolved',
+        );
+        self::assertInstanceOf(
+            InitializeResult::class,
             $result,
-            'the handler must return the negotiator result rather than shape one itself',
+            'initialize must be answered with the negotiated result',
+        );
+        self::assertSame(
+            'php-lsp',
+            $result->serverInfo->name,
+            'the result must carry the server info the negotiator was constructed with',
         );
     }
 

--- a/tests/Protocol/InitializeResultTest.php
+++ b/tests/Protocol/InitializeResultTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\InitializeResult;
+use Firehed\PhpLsp\ServerInfo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InitializeResult::class)]
+class InitializeResultTest extends TestCase
+{
+    public function testSerializesToTheLspResultShape(): void
+    {
+        $result = new InitializeResult(
+            capabilities: [
+                'textDocumentSync' => [
+                    'openClose' => true,
+                    'change' => 1,
+                    'save' => false,
+                ],
+                'definitionProvider' => true,
+                'hoverProvider' => true,
+                'signatureHelpProvider' => [
+                    'triggerCharacters' => ['('],
+                ],
+                'completionProvider' => [
+                    'triggerCharacters' => ['>'],
+                ],
+            ],
+            serverInfo: new ServerInfo('php-lsp', '0.1.0'),
+        );
+
+        $encoded = json_encode($result, JSON_THROW_ON_ERROR);
+        $decoded = json_decode($encoded, true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame([
+            'capabilities' => [
+                'textDocumentSync' => [
+                    'openClose' => true,
+                    'change' => 1,
+                    'save' => false,
+                ],
+                'definitionProvider' => true,
+                'hoverProvider' => true,
+                'signatureHelpProvider' => [
+                    'triggerCharacters' => ['('],
+                ],
+                'completionProvider' => [
+                    'triggerCharacters' => ['>'],
+                ],
+            ],
+            'serverInfo' => [
+                'name' => 'php-lsp',
+                'version' => '0.1.0',
+            ],
+        ], $decoded, 'the wire shape must match [LSP] InitializeResult');
+    }
+}


### PR DESCRIPTION
Slice **S1.1** of the RFC 1 / Plan 0002 build (`docs/architecture/build-manifest.md`).

- **Plan step:** 0002 Step 1 — Capability negotiation + encoding edge
- **RFC sections:** 0001 §4.8 (Protocol Capability Negotiation), §5.4 (Session
  Capabilities), §8.1 (enforcement mechanism for §4.8)

## What this does

Stands up the protocol-negotiation tier. `src/Capability/` becomes the one place the
raw `initialize` parameters are read; everything that will later shape output by client
support queries an immutable `SessionCapabilities` instead.

- `CapabilityNegotiator` owns the `initialize` exchange. `LifecycleHandler` delegates to
  it and no longer shapes the response itself.
- `SessionCapabilities` is resolved once and immutable. Both queries it exposes —
  `hoverMarkupKind` and `snippetSupport` — come from constructor defaults when the
  client declares nothing, so an older or minimal client is served by the default
  configuration with no branch at the point of use (§4.8). It carries only
  already-resolved values and exposes no `Message`-based constructor, so the raw params
  cannot be re-read through it: that confinement holds **by construction**, not by rule.
  Reading the raw params lives entirely in `CapabilityNegotiator`.
- `InitializeResult` replaces the untyped response array, and the advertised
  `ServerCapabilities` move into the negotiator unchanged.
- `RawInitializeCapabilitiesRule` is the §8.1 mechanism for §4.8: a custom PHPStan rule,
  active repo-wide with **no allowlist**, that reports reads of a raw `capabilities` key
  outside `Firehed\PhpLsp\Capability`. It fires only where the read resolves to `mixed`
  — i.e. genuinely untyped decoded JSON — so indexing the server's *own* typed
  `InitializeResult` is not a false positive. Its remaining scope gaps are tracked in
  #365.

Spec citations: `contentFormat` and its preference ordering are
[LSP] "Language Features → Hover" (`HoverClientCapabilities`); `snippetSupport` is
[LSP] "Language Features → Completion" (`CompletionClientCapabilities.completionItem`);
`MarkupKind` is [LSP] "Basic JSON Structures" (`MarkupContent`).

## Acceptance criteria (Step 1, the parts S1.1 owns)

- [x] `initialize` reads `ClientCapabilities` into an immutable `SessionCapabilities`
- [x] Every capability the client did not declare resolves to the value's own default
      state, not a special-cased branch at the point of use
- [x] Advertised `ServerCapabilities` derive from the implemented set (hand-maintained
      list, moved into the negotiation component; nothing unimplemented is advertised)
- [x] A rule confines raw `initialize` params to the negotiation component

## Deliberately not in this slice

Per the manifest's Step 1 split: `positionEncoding` negotiation and edge conversion
(S1.2), hover markup / snippet *consumption* (S1.3), lifecycle state and malformed-frame
robustness (S1.4), and the position round-trip corpus (S1.5). `SessionCapabilities`
therefore exposes two queries that production code does not read yet — S1.3 wires them.

Note for S1.3: the safe default for `hoverMarkupKind` is `plaintext`. `HoverHandler`
currently emits markdown unconditionally, so S1.3 must decide what a client that
declares no `contentFormat` is sent.

Second note for S1.3 — an injection trap found in review. `Server` constructs every
handler in its own constructor, i.e. *before* any `initialize` arrives, and
`CapabilityNegotiator::$sessionCapabilities` is reassigned when `negotiate()` runs. A
consumer that takes a `SessionCapabilities` by constructor injection would therefore
capture the pre-`initialize` default permanently and silently. S1.3 should inject the
**negotiator** and call `getSessionCapabilities()` per use. Enforcing single resolution
is left to S1.4, which owns lifecycle state (a duplicate `initialize` is an
`InvalidRequest`).

## Design decisions worth a reviewer's attention

- **Advertised capabilities stay a hand-maintained list.** §4.8's binding requirement is
  that responses are shaped by declared client support, not that the advertised set is
  derived; deriving it from the wired handlers would push LSP wire details
  (`triggerCharacters`, sync options) into handlers, against §4.1. Confirmed with the
  repo owner; no follow-up slice is scheduled for derivation.
- **`capabilities` as the rule's predicate.** The rule keys on the [LSP]
  `InitializeParams.capabilities` field name because that is what identifies the raw
  params. Framing it instead as "no `Message::$params` access outside a parser" would
  have needed an allowlist entry for the pre-existing `TextDocumentSyncHandler` /
  `TextDocumentPositionParams` readers, which Step Z forbids carrying.
- **`InitializeResult` is typed** rather than `array{capabilities: array<string, mixed>}`.
  Because it is typed, a read of its `capabilities` resolves to a concrete array shape
  rather than `mixed`, which is exactly what lets the rule tell the server's own
  outgoing structure apart from raw client params without an allowlist.
- **Negotiation lives in the negotiator, not on the value.** An earlier shape had
  `SessionCapabilities::fromMessage()`; review showed that a `public static` factory
  taking a `Message` is itself a bypass — any component could re-resolve the session
  value from raw params while appearing to go through the negotiation tier. Guarding it
  with a second static rule immediately collided with the value's own unit test, which
  is the usual sign that a rule is patching a design problem. Removing the factory
  closes the hole by construction instead, which §8.1 prefers over a static rule.

## Mutation check

Commenting out the `excludePaths` entry for `tests/Architecture/data` makes the
repo-wide PHPStan run report the seeded violation with identifier
`phpLsp.rawInitializeCapabilities`, confirming the rule is live in `composer test` and
not only inside `RuleTestCase`. Removing the namespace exemption makes
`testTheNegotiationPackageMayReadRawCapabilities` fail; removing the report makes
`testReadingRawCapabilitiesElsewhereIsReported` fail.

## Tests moved, not dropped

`LifecycleHandlerTest`'s `testInitializeReturnsCapabilities` and
`testCompletionTriggerCharactersExcludeColon` asserted on the advertised set, which now
lives in `CapabilityNegotiator`. Their assertions moved to `CapabilityNegotiatorTest`
(and gained the `signatureHelpProvider` and `definitionProvider` cases they lacked);
`LifecycleHandlerTest` keeps a test that `initialize` delegates to the negotiator.

`SessionCapabilitiesTest`'s negotiation cases — both data providers and the
malformed-input cases — moved to `CapabilityNegotiatorTest` along with the parsing they
cover. `SessionCapabilitiesTest` keeps the one test that still belongs to the value: its
safe defaults.

## Fixed in review

- `LifecycleHandlerTest`'s delegation test computed its expectation by calling
  `negotiate()` a second time, so it passed even when the handler ignored the injected
  negotiator entirely (verified: the whole suite stayed green under that mutation). It
  now observes the injected negotiator's resolved value instead.
- `testAdvertisesOnlyImplementedProviders` asserted presence but never absence, so
  advertising an unimplemented provider passed both the suite and PHPStan at `level:
  max`. It now pins the complete advertised key set, which is what §4.8's "MUST NOT
  advertise a capability it does not implement" actually needs.

## Candidate closes

The manifest lists no `Closes` candidates for S1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

