### PR TITLE
Negotiate positionEncoding and convert positions at the document boundary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.3",
+        "ext-mbstring": "*",
         "amphp/amp": "^3.0",
         "amphp/byte-stream": "^2.0",
         "nikic/php-parser": "^5.7"

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -149,6 +149,23 @@ encoding, plus dedicated multibyte cases. And Step 1 is not fully orthogonal to 
 4: Step 1's single internal representation has to be the one the Step 4 positional
 layer consumes, or the encoding work is silently redone — coordinate the two.
 
+**Interior consumers deferred from S1.2 to S1.5.** S1.2 fixed the conversion
+boundary (`TextDocument::offsetAt` / `positionAt`) and the negotiation, but left the
+interior sites that still slice line text by the raw wire `character` — a §4.9
+violation ("interior components MUST operate only on that representation") the corpus
+must drive out. S1.5 MUST correct these, and cover each with multibyte fixtures:
+
+- **Inbound reads** that do `substr($lineText, 0, $character)`, treating the wire
+  column as a byte length: `CompletionHandler` (text-before-cursor),
+  `SymbolResolver::resolveVariableAccessWithAst`, and
+  `TextFallbackHelper::getMemberAccessContext`. Each holds the `TextDocument`, so the
+  fix is a byte column from `offsetAt` (no encoding threading), and the repeated
+  pattern wants a shared `TextDocument` helper.
+- **Outbound completion `Range` columns** that compute `$character - strlen($prefix)`,
+  mixing a wire column with a byte length: `ClassCandidates` and `NamespaceCandidates`.
+  These need the negotiated `PositionEncoding` reachable at the completion sources, so
+  S1.5 threads it there — S1.2 deliberately kept it confined to the document boundary.
+
 ### Step P — Resolution & enumeration parity harness (gates Steps 2–4)
 
 New infrastructure that the strangler steps depend on. `TypeGraphParityTest` covers

--- a/src/Capability/CapabilityNegotiator.php
+++ b/src/Capability/CapabilityNegotiator.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Capability;
 use Firehed\PhpLsp\Protocol\InitializeResult;
 use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\PositionEncoding;
 use Firehed\PhpLsp\ServerInfo;
 
 /**
@@ -18,6 +19,15 @@ use Firehed\PhpLsp\ServerInfo;
  */
 final class CapabilityNegotiator
 {
+    /**
+     * The encodings the server can convert at the document boundary, in the
+     * server's own order of preference. UTF-16 is the [LSP] mandatory encoding;
+     * adding another is a new entry here plus a `PositionEncoding` case.
+     *
+     * @var list<PositionEncoding>
+     */
+    private const array SUPPORTED_ENCODINGS = [PositionEncoding::Utf16];
+
     private SessionCapabilities $sessionCapabilities;
 
     public function __construct(
@@ -43,14 +53,38 @@ final class CapabilityNegotiator
 
     private function resolveSessionCapabilities(Message $message): SessionCapabilities
     {
-        $capabilities = self::readMap($message->params ?? [], 'capabilities');
+        $params = $message->params ?? [];
+        $capabilities = self::readMap($params, 'capabilities');
         $textDocument = self::readMap($capabilities, 'textDocument');
         $completionItem = self::readMap(self::readMap($textDocument, 'completion'), 'completionItem');
 
         return new SessionCapabilities(
             hoverMarkupKind: self::negotiateHoverMarkupKind(self::readMap($textDocument, 'hover')),
             snippetSupport: ($completionItem['snippetSupport'] ?? false) === true,
+            positionEncoding: self::negotiatePositionEncoding(self::readMap($params, 'general')),
         );
+    }
+
+    /**
+     * Per [LSP] `InitializeParams`, `general.positionEncodings` lists the
+     * encodings the client supports; the server returns the first of its own
+     * supported encodings the client offered. UTF-16 is always assumable, so a
+     * client that offers nothing the server supports still resolves to it
+     * (RFC 1 §4.9).
+     *
+     * @param array<array-key, mixed> $general
+     */
+    private static function negotiatePositionEncoding(array $general): PositionEncoding
+    {
+        $offered = self::readMap($general, 'positionEncodings');
+
+        foreach (self::SUPPORTED_ENCODINGS as $encoding) {
+            if (in_array($encoding->value, $offered, true)) {
+                return $encoding;
+            }
+        }
+
+        return PositionEncoding::Utf16;
     }
 
     /**
@@ -95,6 +129,7 @@ final class CapabilityNegotiator
     private function advertisedCapabilities(): array
     {
         return [
+            'positionEncoding' => $this->sessionCapabilities->positionEncoding->value,
             'textDocumentSync' => [
                 'openClose' => true,
                 'change' => 1, // TextDocumentSyncKind.Full

--- a/src/Capability/SessionCapabilities.php
+++ b/src/Capability/SessionCapabilities.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Capability;
 
 use Firehed\PhpLsp\Protocol\MarkupKind;
+use Firehed\PhpLsp\Protocol\PositionEncoding;
 
 /**
  * The client's declared capabilities, resolved once during `initialize` into an
@@ -23,6 +24,7 @@ final readonly class SessionCapabilities
     public function __construct(
         public MarkupKind $hoverMarkupKind = MarkupKind::PlainText,
         public bool $snippetSupport = false,
+        public PositionEncoding $positionEncoding = PositionEncoding::Utf16,
     ) {
     }
 }

--- a/src/Document/TextDocument.php
+++ b/src/Document/TextDocument.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Document;
 
+use Firehed\PhpLsp\Protocol\PositionEncoding;
+
 final class TextDocument
 {
     /** @var list<int> Byte offsets of line starts */
@@ -14,6 +16,7 @@ final class TextDocument
         public readonly string $languageId,
         public readonly int $version,
         private readonly string $content,
+        private readonly PositionEncoding $encoding = PositionEncoding::Utf16,
     ) {
         $this->lineOffsets = $this->computeLineOffsets();
     }
@@ -25,7 +28,7 @@ final class TextDocument
 
     public function withContent(string $content, int $version): self
     {
-        return new self($this->uri, $this->languageId, $version, $content);
+        return new self($this->uri, $this->languageId, $version, $content, $this->encoding);
     }
 
     public function getLine(int $line): string
@@ -48,12 +51,11 @@ final class TextDocument
             return 0;
         }
 
-        $lineStart = $this->lineOffsets[$line];
-        $lineEnd = $line + 1 < count($this->lineOffsets)
-            ? $this->lineOffsets[$line + 1]
-            : strlen($this->content);
-
-        return min($lineStart + $character, $lineEnd);
+        // The negotiated encoding measures `character`; the interior is bytes.
+        // Converting against the line content also clamps an over-long column
+        // to the line's byte length, so no separate line-end clamp is needed.
+        return $this->lineOffsets[$line]
+            + $this->encoding->characterToByteOffset($this->getLine($line), $character);
     }
 
     /**
@@ -73,7 +75,10 @@ final class TextDocument
 
         return [
             'line' => $line,
-            'character' => $offset - $this->lineOffsets[$line],
+            'character' => $this->encoding->byteToCharacterOffset(
+                $this->getLine($line),
+                $offset - $this->lineOffsets[$line],
+            ),
         ];
     }
 

--- a/src/Protocol/InitializeResult.php
+++ b/src/Protocol/InitializeResult.php
@@ -11,6 +11,7 @@ use JsonSerializable;
  * The `initialize` response, per [LSP] "Server lifecycle" (`InitializeResult`).
  *
  * @phpstan-type ServerCapabilities array{
+ *   positionEncoding: string,
  *   textDocumentSync: array{
  *     openClose: bool,
  *     change: int,

--- a/src/Protocol/PositionEncoding.php
+++ b/src/Protocol/PositionEncoding.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+/**
+ * A negotiated position encoding, per [LSP] "Basic JSON Structures"
+ * (`PositionEncodingKind`) and RFC 1 §4.9.
+ *
+ * An LSP `Position`'s `character` is measured in code units of the negotiated
+ * encoding. The interior of the server operates on byte offsets (the AST's own
+ * unit), so each encoding knows how to map a `character` column within a line to
+ * a byte offset and back — the conversion RFC 1 §4.9 confines to the document
+ * boundary.
+ *
+ * UTF-16 is the only encoding the server currently negotiates; it is also the
+ * [LSP] mandatory default. A further encoding is a new case plus the match arm
+ * PHPStan then requires, not a rewrite of the boundary.
+ */
+enum PositionEncoding: string
+{
+    case Utf16 = 'utf-16';
+
+    /**
+     * The byte offset within `$line` at the given `character` column, measured
+     * in this encoding's code units. A column past the line's end clamps to its
+     * byte length; a column landing inside a multi-unit codepoint rounds up to
+     * that codepoint's boundary.
+     */
+    public function characterToByteOffset(string $line, int $character): int
+    {
+        return match ($this) {
+            self::Utf16 => self::utf16ToByteOffset($line, $character),
+        };
+    }
+
+    /**
+     * The `character` column, in this encoding's code units, at the given byte
+     * offset within `$line` — the inverse of {@see characterToByteOffset()}.
+     */
+    public function byteToCharacterOffset(string $line, int $byteOffset): int
+    {
+        return match ($this) {
+            self::Utf16 => self::byteOffsetToUtf16($line, $byteOffset),
+        };
+    }
+
+    /**
+     * A UTF-8 codepoint occupies two UTF-16 code units (a surrogate pair) iff
+     * its UTF-8 encoding is four bytes long; every shorter codepoint is a single
+     * BMP code unit.
+     */
+    private static function utf16Units(string $codepoint): int
+    {
+        return strlen($codepoint) === 4 ? 2 : 1;
+    }
+
+    private static function utf16ToByteOffset(string $line, int $character): int
+    {
+        $byteOffset = 0;
+        $units = 0;
+
+        foreach (mb_str_split($line, 1, 'UTF-8') as $codepoint) {
+            if ($units >= $character) {
+                break;
+            }
+            $units += self::utf16Units($codepoint);
+            $byteOffset += strlen($codepoint);
+        }
+
+        return $byteOffset;
+    }
+
+    private static function byteOffsetToUtf16(string $line, int $byteOffset): int
+    {
+        $bytes = 0;
+        $units = 0;
+
+        foreach (mb_str_split($line, 1, 'UTF-8') as $codepoint) {
+            if ($bytes >= $byteOffset) {
+                break;
+            }
+            $units += self::utf16Units($codepoint);
+            $bytes += strlen($codepoint);
+        }
+
+        return $units;
+    }
+}

--- a/tests/Architecture/RawInitializeCapabilitiesRule.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRule.php
@@ -16,16 +16,18 @@ use PHPStan\Type\MixedType;
  * The RFC 1 §8.1 mechanism for §4.8: the raw `initialize` parameters are
  * reachable only within the negotiation component.
  *
- * `capabilities` is the [LSP] `InitializeParams` field that carries them
- * ("Server lifecycle" → `initialize`), so reading that key anywhere else is a
- * component re-inspecting the raw parameters instead of querying the
- * `SessionCapabilities` value resolved once during negotiation.
+ * `capabilities` (client capabilities, §4.8) and `general` (which carries
+ * `positionEncodings`, §4.9) are the [LSP] `InitializeParams` fields the
+ * negotiation reads ("Server lifecycle" → `initialize`), so reading either key
+ * anywhere else is a component re-inspecting the raw parameters instead of
+ * querying the `SessionCapabilities` value resolved once during negotiation.
  *
  * @implements Rule<ArrayDimFetch>
  */
 final class RawInitializeCapabilitiesRule implements Rule
 {
-    private const string CAPABILITIES_FIELD = 'capabilities';
+    /** @var list<string> */
+    private const array CONFINED_FIELDS = ['capabilities', 'general'];
     private const string NEGOTIATION_NAMESPACE = 'Firehed\PhpLsp\Capability';
 
     public function getNodeType(): string
@@ -36,7 +38,7 @@ final class RawInitializeCapabilitiesRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         $dim = $node->dim;
-        if (!$dim instanceof String_ || $dim->value !== self::CAPABILITIES_FIELD) {
+        if (!$dim instanceof String_ || !in_array($dim->value, self::CONFINED_FIELDS, true)) {
             return [];
         }
 
@@ -55,7 +57,7 @@ final class RawInitializeCapabilitiesRule implements Rule
 
         $message = sprintf(
             'Raw initialize %s must not be read outside %s; query SessionCapabilities instead (RFC 1 §4.8).',
-            self::CAPABILITIES_FIELD,
+            $dim->value,
             self::NEGOTIATION_NAMESPACE,
         );
 

--- a/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRuleTest.php
@@ -17,12 +17,22 @@ class RawInitializeCapabilitiesRuleTest extends RuleTestCase
 {
     private const string EXPECTED_MESSAGE = 'Raw initialize capabilities must not be read outside '
         . 'Firehed\PhpLsp\Capability; query SessionCapabilities instead (RFC 1 §4.8).';
+    private const string EXPECTED_GENERAL_MESSAGE = 'Raw initialize general must not be read outside '
+        . 'Firehed\PhpLsp\Capability; query SessionCapabilities instead (RFC 1 §4.8).';
 
     public function testReadingRawCapabilitiesElsewhereIsReported(): void
     {
         $this->analyse(
             [__DIR__ . '/data/reads-raw-capabilities.php'],
             [[self::EXPECTED_MESSAGE, 18]],
+        );
+    }
+
+    public function testReadingRawGeneralElsewhereIsReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/reads-raw-general.php'],
+            [[self::EXPECTED_GENERAL_MESSAGE, 19]],
         );
     }
 

--- a/tests/Architecture/data/negotiates-raw-capabilities.php
+++ b/tests/Architecture/data/negotiates-raw-capabilities.php
@@ -19,4 +19,12 @@ final class NegotiatesRawCapabilities
 
         return $capabilities !== [];
     }
+
+    public function offersAnEncoding(Message $message): bool
+    {
+        $params = $message->params ?? [];
+        $general = $params['general'] ?? [];
+
+        return $general !== [];
+    }
 }

--- a/tests/Architecture/data/reads-raw-general.php
+++ b/tests/Architecture/data/reads-raw-general.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Protocol\Message;
+
+/**
+ * A component outside the negotiation package re-inspecting the raw
+ * `initialize` `general` parameters (position encoding), which RFC 1 §4.9
+ * confines to the negotiation component.
+ */
+final class ReadsRawGeneral
+{
+    public function prefersUtf8(Message $message): bool
+    {
+        $params = $message->params ?? [];
+        $general = $params['general'] ?? [];
+
+        return $general !== [];
+    }
+}

--- a/tests/Capability/CapabilityNegotiatorTest.php
+++ b/tests/Capability/CapabilityNegotiatorTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Capability;
 use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Capability\SessionCapabilities;
 use Firehed\PhpLsp\Protocol\MarkupKind;
+use Firehed\PhpLsp\Protocol\PositionEncoding;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\ServerInfo;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -80,6 +81,7 @@ class CapabilityNegotiatorTest extends TestCase
 
         self::assertSame(
             [
+                'positionEncoding',
                 'textDocumentSync',
                 'definitionProvider',
                 'hoverProvider',
@@ -96,6 +98,34 @@ class CapabilityNegotiatorTest extends TestCase
             ['(', ','],
             $capabilities['signatureHelpProvider']['triggerCharacters'],
             'signature help re-fires as arguments are typed',
+        );
+    }
+
+    public function testAdvertisesTheNegotiatedPositionEncoding(): void
+    {
+        $negotiator = new CapabilityNegotiator(new ServerInfo('test', '1.0'));
+
+        $capabilities = $negotiator->negotiate(self::initializeWith([]))->capabilities;
+
+        self::assertSame(
+            'utf-16',
+            $capabilities['positionEncoding'],
+            'the server returns the single negotiated encoding as [LSP] ServerCapabilities.positionEncoding',
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $general
+     */
+    #[DataProvider('positionEncodingCases')]
+    public function testPositionEncodingIsNegotiated(array $general, PositionEncoding $expected): void
+    {
+        $message = new RequestMessage(id: 1, method: 'initialize', params: ['general' => $general]);
+
+        self::assertSame(
+            $expected,
+            self::resolve($message)->positionEncoding,
+            'the server selects a supported encoding the client offered, else the [LSP] mandatory UTF-16',
         );
     }
 
@@ -184,6 +214,26 @@ class CapabilityNegotiatorTest extends TestCase
             MarkupKind::PlainText,
         ];
         yield 'textDocument not a map' => [['textDocument' => 'nonsense'], MarkupKind::PlainText];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{array<array-key, mixed>, PositionEncoding}>
+     */
+    public static function positionEncodingCases(): iterable
+    {
+        yield 'no general capability' => [[], PositionEncoding::Utf16];
+        yield 'utf-16 offered' => [['positionEncodings' => ['utf-16']], PositionEncoding::Utf16];
+        yield 'only unsupported offered falls back to mandatory utf-16' => [
+            ['positionEncodings' => ['utf-8']],
+            PositionEncoding::Utf16,
+        ];
+        yield 'server prefers its own support order over the client list' => [
+            ['positionEncodings' => ['utf-8', 'utf-16']],
+            PositionEncoding::Utf16,
+        ];
+        yield 'positionEncodings not a list' => [['positionEncodings' => 'nonsense'], PositionEncoding::Utf16];
     }
 
     /**

--- a/tests/Capability/SessionCapabilitiesTest.php
+++ b/tests/Capability/SessionCapabilitiesTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Capability;
 
 use Firehed\PhpLsp\Capability\SessionCapabilities;
 use Firehed\PhpLsp\Protocol\MarkupKind;
+use Firehed\PhpLsp\Protocol\PositionEncoding;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -29,6 +30,11 @@ class SessionCapabilitiesTest extends TestCase
         self::assertFalse(
             $capabilities->snippetSupport,
             'snippet syntax is inserted literally by a client that cannot expand it',
+        );
+        self::assertSame(
+            PositionEncoding::Utf16,
+            $capabilities->positionEncoding,
+            'UTF-16 is the [LSP] mandatory default a client that offers no encoding must get',
         );
     }
 }

--- a/tests/Document/TextDocumentTest.php
+++ b/tests/Document/TextDocumentTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Document;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(TextDocument::class)]
@@ -82,5 +83,44 @@ class TextDocumentTest extends TestCase
         self::assertSame(['line' => 1, 'character' => 0], $doc->positionAt(6));
         // Offset 10 = line 1, char 4
         self::assertSame(['line' => 1, 'character' => 4], $doc->positionAt(10));
+    }
+
+    /**
+     * "é" is one UTF-16 code unit but two UTF-8 bytes; "😀" is two UTF-16 units
+     * (a surrogate pair) but four bytes. The interior works in byte offsets, so
+     * a UTF-16 character column must be converted, not read as a byte column
+     * (RFC 1 §4.9, issue #192). Line 1 is `$s = 'é😀';`.
+     *
+     * @param int<0, max> $character
+     * @param int<0, max> $byteOffset
+     */
+    #[DataProvider('multibyteRoundTripCases')]
+    public function testOffsetAndPositionConvertUtf16CharactersToBytes(int $character, int $byteOffset): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, "<?php\n\$s = 'é😀';");
+
+        self::assertSame(
+            $byteOffset,
+            $doc->offsetAt(line: 1, character: $character),
+            'a UTF-16 column must resolve to the byte offset the AST uses, past any multibyte characters',
+        );
+        self::assertSame(
+            ['line' => 1, 'character' => $character],
+            $doc->positionAt($byteOffset),
+            'a byte offset must resolve back to the UTF-16 column the client sent',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{int<0, max>, int<0, max>}>
+     */
+    public static function multibyteRoundTripCases(): iterable
+    {
+        // Line 1 begins at byte 6 (after "<?php\n").
+        yield 'before the multibyte content' => [6, 12];  // the é
+        yield 'after a two-byte BMP char' => [7, 14];      // the 😀, past é
+        yield 'after a four-byte astral char' => [9, 18];  // the closing quote, past 😀
     }
 }

--- a/tests/Protocol/InitializeResultTest.php
+++ b/tests/Protocol/InitializeResultTest.php
@@ -16,6 +16,7 @@ class InitializeResultTest extends TestCase
     {
         $result = new InitializeResult(
             capabilities: [
+                'positionEncoding' => 'utf-16',
                 'textDocumentSync' => [
                     'openClose' => true,
                     'change' => 1,
@@ -38,6 +39,7 @@ class InitializeResultTest extends TestCase
 
         self::assertSame([
             'capabilities' => [
+                'positionEncoding' => 'utf-16',
                 'textDocumentSync' => [
                     'openClose' => true,
                     'change' => 1,

--- a/tests/Protocol/PositionEncodingTest.php
+++ b/tests/Protocol/PositionEncodingTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\PositionEncoding;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PositionEncoding::class)]
+class PositionEncodingTest extends TestCase
+{
+    public function testUtf16CarriesTheLspEncodingKind(): void
+    {
+        self::assertSame(
+            'utf-16',
+            PositionEncoding::Utf16->value,
+            'the value is advertised verbatim as the ServerCapabilities positionEncoding',
+        );
+    }
+
+    #[DataProvider('characterToByteCases')]
+    public function testCharacterToByteOffset(string $line, int $character, int $expected): void
+    {
+        self::assertSame(
+            $expected,
+            PositionEncoding::Utf16->characterToByteOffset($line, $character),
+            'a UTF-16 character column must map to the byte offset the AST uses internally',
+        );
+    }
+
+    #[DataProvider('byteToCharacterCases')]
+    public function testByteToCharacterOffset(string $line, int $byteOffset, int $expected): void
+    {
+        self::assertSame(
+            $expected,
+            PositionEncoding::Utf16->byteToCharacterOffset($line, $byteOffset),
+            'an internal byte offset must map back to the UTF-16 column the client sent',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{string, int, int}>
+     */
+    public static function characterToByteCases(): iterable
+    {
+        yield 'ascii is identity' => ['abc', 2, 2];
+        yield 'ascii start' => ['abc', 0, 0];
+        yield 'column past end clamps to byte length' => ['abc', 5, 3];
+        yield 'bmp multibyte counts one unit, two bytes' => ['é', 1, 2];
+        yield 'column before a multibyte char' => ['aéb', 1, 1];
+        yield 'column after a multibyte char' => ['aéb', 2, 3];
+        yield 'column at end after multibyte' => ['aéb', 3, 4];
+        yield 'astral char is two units, four bytes' => ['😀', 2, 4];
+        yield 'column inside a surrogate pair rounds up' => ['😀', 1, 4];
+        yield 'column after an astral char' => ['a😀b', 3, 5];
+        yield 'column at end after astral' => ['a😀b', 4, 6];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{string, int, int}>
+     */
+    public static function byteToCharacterCases(): iterable
+    {
+        yield 'ascii is identity' => ['abc', 2, 2];
+        yield 'ascii start' => ['abc', 0, 0];
+        yield 'byte before a multibyte char' => ['aéb', 1, 1];
+        yield 'byte after a multibyte char' => ['aéb', 3, 2];
+        yield 'byte inside a multibyte char rounds up' => ['aéb', 2, 2];
+        yield 'byte at end after multibyte' => ['aéb', 4, 3];
+        yield 'astral char is two units' => ['😀', 4, 2];
+        yield 'byte after an astral char' => ['a😀b', 5, 3];
+        yield 'byte at end after astral' => ['a😀b', 6, 4];
+    }
+}


### PR DESCRIPTION
## Slice S1.2 — Negotiate positionEncoding; convert at the edge

- **Slice:** S1.2 (`build-manifest.md`)
- **Plan step:** Step 1 — Capability negotiation + encoding edge (`0002-execution-plan.md`)
- **RFC sections:** §4.8 (capability negotiation), §4.9 (position encoding), §5.4 (session capabilities), §8.1 (enforcement)

### What this does

Stands up `positionEncoding` negotiation and fixes position conversion at the single
document boundary, so a UTF-16 `character` column is no longer read as a byte offset.

- `PositionEncoding` (`Utf16` case) owns the character↔byte mapping via `match($this)`,
  so a future encoding is a new case plus the arm PHPStan then requires — not a rewrite.
  A codepoint's UTF-16 width is derived from its UTF-8 byte length (4 bytes ⇒ surrogate
  pair), so no `mb_ord`.
- `CapabilityNegotiator` reads `general.positionEncodings`, selects the first supported
  encoding the client offered (UTF-16 is always assumable, so a client that offers none
  supported still resolves to it), stores it on `SessionCapabilities`, and advertises it
  as `ServerCapabilities.positionEncoding`.
- `TextDocument::offsetAt` / `positionAt` — the single transport/document boundary —
  convert UTF-16↔byte through the encoding. The interior keeps operating on byte offsets
  (the AST's unit); the negotiated value is only carried, not threaded, since the sole
  supported encoding is UTF-16.
- The §8.1 rule `RawInitializeCapabilitiesRule` now confines the `general` field too, not
  just `capabilities`: reading either raw `initialize` field outside the negotiation
  component fails PHPStan.

### Acceptance criteria (S1.2 slice of Step 1)

- [x] `initialize` negotiates `positionEncoding` with a UTF-16 default
- [x] advertised `ServerCapabilities.positionEncoding` derives from the server's
      supported set
- [x] encoding conversion occurs at the transport/document boundary, into one internal
      representation (byte offsets)
- [x] a multibyte fixture round-trips positions correctly through that representation
      (`é` + `😀` in `TextDocumentTest`)
- [x] a rule confines the raw `initialize` params (now including `general`) to the
      negotiation component

### Deferred to S1.5 (documented in the plan)

Per the plan's S1.2/S1.5 split, S1.2 fixes the boundary and negotiation; the interior
consumers that still slice line text by the raw wire `character` are corrected under
S1.5 (the position round-trip corpus), and are enumerated in `0002-execution-plan.md`
(Step 1). They are: the inbound `substr($lineText, 0, $character)` reads in
`CompletionHandler`, `SymbolResolver::resolveVariableAccessWithAst`, and
`TextFallbackHelper::getMemberAccessContext`; and the outbound completion `Range`
columns in `ClassCandidates` / `NamespaceCandidates`, which need the encoding threaded
to the completion sources. This is a conscious, recorded deferral, not a silent gap.

Pre-existing (not introduced here): `TextDocument::getLine` / `offsetAt` out-of-range
guards remain uncovered as on `main`.

### Candidate closes (pending review verification)

- #192 (multibyte/unicode handling) — the boundary is fixed here; full interior coverage
  lands with S1.5, so verify against the issue's acceptance before wiring `Closes`.
