### PR TITLE
Shape hover markup and completion snippets by client capabilities

### DIFF
--- a/docs/features/completion.md
+++ b/docs/features/completion.md
@@ -27,6 +27,14 @@ All of the above work identically in class methods, free functions, and
 file-level (procedural) code — variable and member resolution use the enclosing
 lexical scope, which includes global scope.
 
+Completing a **callable** (method or function) inserts `name($0)` — the
+parentheses typed for you with the cursor between them — as an LSP snippet, but
+only when the client declared `completionItem.snippetSupport` during
+`initialize`. A client without snippet support gets the bare name inserted, since
+it would show the `$0` tab stop literally. The decision is shaped by
+`SessionCapabilities` (RFC 1 §4.8), read through `SessionCapabilitiesProvider`;
+non-callable members (properties, constants, enum cases) never gain parentheses.
+
 Member completions cover the full type graph: members declared on the type itself,
 plus those inherited through the parent chain, used traits (including traits that
 use other traits), and implemented or extended interfaces at any depth. This holds
@@ -105,7 +113,7 @@ text is aligned to that word boundary rather than spanning the whole qualified n
 |---------|---------|-------|
 | Array keys | `$config['` | No key suggestions from array shapes |
 | Docblock tags | `@par` → `@param` | No PHPDoc completion |
-| Snippets | Method inserting `()` | No snippet support in completion items |
+| Parameter placeholders | `setName(${1:$name})` | Snippets insert `()` with the cursor between the parens; per-parameter tab stops are not yet emitted (#22) |
 | Auto-import | Suggesting FQCN with use statement insertion | No additional text edits |
 
 ## Architecture

--- a/src/Capability/CapabilityNegotiator.php
+++ b/src/Capability/CapabilityNegotiator.php
@@ -17,7 +17,7 @@ use Firehed\PhpLsp\ServerInfo;
  *
  * @phpstan-import-type ServerCapabilities from InitializeResult
  */
-final class CapabilityNegotiator
+final class CapabilityNegotiator implements SessionCapabilitiesProvider
 {
     /**
      * The encodings the server can convert at the document boundary, in the

--- a/src/Capability/SessionCapabilitiesProvider.php
+++ b/src/Capability/SessionCapabilitiesProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Capability;
+
+/**
+ * Read-only access to the resolved {@see SessionCapabilities} for the components
+ * that shape output by client support (RFC 1 §4.8, §5.4).
+ *
+ * Output-shaping components are constructed before `initialize` runs, so they
+ * cannot receive the resolved value directly; they depend on this interface and
+ * read the current value when they handle a message. Exposing only the read keeps
+ * the raw `initialize` parameters confined to {@see CapabilityNegotiator} — a
+ * consumer cannot reach `negotiate()` or the parameters through it.
+ */
+interface SessionCapabilitiesProvider
+{
+    public function getSessionCapabilities(): SessionCapabilities;
+}

--- a/src/Completion/CompletionItemFactory.php
+++ b/src/Completion/CompletionItemFactory.php
@@ -73,11 +73,13 @@ final class CompletionItemFactory
      */
     public static function forFunction(FunctionInfo $function, bool $snippetSupport = false): array
     {
-        return self::withCallableSnippet(self::withDocumentation([
+        $item = self::withDocumentation([
             'label' => $function->name,
             'kind' => CompletionItemKind::Function->value,
             'detail' => $function->format(),
-        ], $function->docblock), $snippetSupport);
+        ], $function->docblock);
+
+        return self::withCallableSnippet($item, $snippetSupport);
     }
 
     /**

--- a/src/Completion/CompletionItemFactory.php
+++ b/src/Completion/CompletionItemFactory.php
@@ -28,6 +28,8 @@ use Firehed\PhpLsp\Utility\NamespacePath;
  *   documentation?: string,
  *   filterText?: string,
  *   sortText?: string,
+ *   insertText?: string,
+ *   insertTextFormat?: int,
  *   textEdit?: array{range: LspRange, newText: string},
  * }
  */
@@ -36,7 +38,7 @@ final class CompletionItemFactory
     /**
      * @return CompletionItem
      */
-    public static function forResolvedMember(ResolvedMember $member): array
+    public static function forResolvedMember(ResolvedMember $member, bool $snippetSupport = false): array
     {
         $kind = match (true) {
             $member instanceof ResolvedMethod => CompletionItemKind::Method,
@@ -59,30 +61,34 @@ final class CompletionItemFactory
             $item['documentation'] = $doc;
         }
 
+        if ($member instanceof ResolvedMethod) {
+            $item = self::withCallableSnippet($item, $snippetSupport);
+        }
+
         return $item;
     }
 
     /**
      * @return CompletionItem
      */
-    public static function forFunction(FunctionInfo $function): array
+    public static function forFunction(FunctionInfo $function, bool $snippetSupport = false): array
     {
-        return self::withDocumentation([
+        return self::withCallableSnippet(self::withDocumentation([
             'label' => $function->name,
             'kind' => CompletionItemKind::Function->value,
             'detail' => $function->format(),
-        ], $function->docblock);
+        ], $function->docblock), $snippetSupport);
     }
 
     /**
      * @return CompletionItem
      */
-    public static function forBuiltinFunction(string $name): array
+    public static function forBuiltinFunction(string $name, bool $snippetSupport = false): array
     {
-        return [
+        return self::withCallableSnippet([
             'label' => $name,
             'kind' => CompletionItemKind::Function->value,
-        ];
+        ], $snippetSupport);
     }
 
     /**
@@ -200,6 +206,28 @@ final class CompletionItemFactory
             'kind' => CompletionItemKind::Constant->value,
             'detail' => 'string (fully qualified class name)',
         ];
+    }
+
+    /**
+     * Insert `name($0)` for a callable so the parentheses are typed for the user
+     * and the cursor lands between them. Emitted only when the client declared
+     * snippet support (RFC 1 §4.8); otherwise the item inserts its bare label, as
+     * a plaintext client would show `$0` literally. The label is an identifier, so
+     * it needs no snippet escaping.
+     *
+     * @param CompletionItem $item
+     * @return CompletionItem
+     */
+    private static function withCallableSnippet(array $item, bool $snippetSupport): array
+    {
+        if (!$snippetSupport) {
+            return $item;
+        }
+
+        $item['insertText'] = $item['label'] . '($0)';
+        $item['insertTextFormat'] = InsertTextFormat::Snippet->value;
+
+        return $item;
     }
 
     /**

--- a/src/Completion/FunctionCandidates.php
+++ b/src/Completion/FunctionCandidates.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Completion;
 
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
@@ -18,6 +19,7 @@ final class FunctionCandidates
 {
     public function __construct(
         private readonly CodeResolver $codeResolver,
+        private readonly SessionCapabilitiesProvider $capabilities,
     ) {
     }
 
@@ -26,17 +28,19 @@ final class FunctionCandidates
      */
     public function find(string $prefix, TextDocument $document): array
     {
+        $snippetSupport = $this->capabilities->getSessionCapabilities()->snippetSupport;
+
         $items = [];
 
         foreach ($this->codeResolver->getFileFunctions($document) as $function) {
             if (PrefixMatcher::matches($function->name, $prefix)) {
-                $items[] = CompletionItemFactory::forFunction($function);
+                $items[] = CompletionItemFactory::forFunction($function, $snippetSupport);
             }
         }
 
         foreach (get_defined_functions()['internal'] as $name) {
             if (PrefixMatcher::matches($name, $prefix)) {
-                $items[] = CompletionItemFactory::forBuiltinFunction($name);
+                $items[] = CompletionItemFactory::forBuiltinFunction($name, $snippetSupport);
             }
         }
 

--- a/src/Completion/InsertTextFormat.php
+++ b/src/Completion/InsertTextFormat.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Completion;
+
+/**
+ * How a completion item's inserted text is interpreted, per [LSP] "Language
+ * Features → Completion" (`InsertTextFormat`). `Snippet` enables tab-stop syntax
+ * such as `$0`; it is only emitted when the client declares snippet support
+ * (RFC 1 §4.8).
+ */
+enum InsertTextFormat: int
+{
+    case PlainText = 1;
+    case Snippet = 2;
+}

--- a/src/Completion/MemberCandidates.php
+++ b/src/Completion/MemberCandidates.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Completion;
 
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Resolution\MemberAccessContext;
@@ -25,6 +26,7 @@ final class MemberCandidates
 {
     public function __construct(
         private readonly CodeResolver $codeResolver,
+        private readonly SessionCapabilitiesProvider $capabilities,
     ) {
     }
 
@@ -59,13 +61,15 @@ final class MemberCandidates
             $filter,
         );
 
+        $snippetSupport = $this->capabilities->getSessionCapabilities()->snippetSupport;
+
         $items = [];
         foreach ($members as $member) {
             if ($context->kind === MemberAccessKind::Parent && !$member instanceof ResolvedMethod) {
                 continue;
             }
             if (PrefixMatcher::matches($member->getName()->name, $context->prefix)) {
-                $items[] = CompletionItemFactory::forResolvedMember($member);
+                $items[] = CompletionItemFactory::forResolvedMember($member, $snippetSupport);
             }
         }
 

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -4,17 +4,24 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Handler;
 
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Protocol\MarkupContent;
+use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\TextDocumentPositionParams;
 use Firehed\PhpLsp\Resolution\ResolvedSymbol;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
+/**
+ * @phpstan-import-type LspMarkupContent from MarkupContent
+ */
 final class HoverHandler implements HandlerInterface
 {
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
+        private readonly SessionCapabilitiesProvider $capabilities,
     ) {
     }
 
@@ -24,7 +31,7 @@ final class HoverHandler implements HandlerInterface
     }
 
     /**
-     * @return array{contents: string}|null
+     * @return array{contents: LspMarkupContent}|null
      */
     public function handle(Message $message): ?array
     {
@@ -43,10 +50,12 @@ final class HoverHandler implements HandlerInterface
             return null;
         }
 
-        return ['contents' => $this->formatHover($symbol)];
+        $kind = $this->capabilities->getSessionCapabilities()->hoverMarkupKind;
+
+        return ['contents' => (new MarkupContent($kind, $this->formatHover($symbol, $kind)))->toArray()];
     }
 
-    private function formatHover(ResolvedSymbol $symbol): string
+    private function formatHover(ResolvedSymbol $symbol, MarkupKind $kind): string
     {
         $parts = [];
 
@@ -55,7 +64,13 @@ final class HoverHandler implements HandlerInterface
             $parts[] = $doc;
         }
 
-        $parts[] = '```php' . "\n" . $symbol->format() . "\n```";
+        // A markdown client renders the signature as a fenced PHP block; a
+        // plaintext client would show the fences literally, so give it the bare
+        // signature instead.
+        $signature = $symbol->format();
+        $parts[] = $kind === MarkupKind::Markdown
+            ? '```php' . "\n" . $signature . "\n```"
+            : $signature;
 
         return implode("\n\n", $parts);
     }

--- a/src/Protocol/MarkupContent.php
+++ b/src/Protocol/MarkupContent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Protocol;
+
+/**
+ * A `MarkupContent` result literal per [LSP] "Basic JSON Structures": a value
+ * paired with the {@see MarkupKind} the client should render it as. The kind is
+ * chosen from the client's declared support (RFC 1 §4.8), so a plaintext-only
+ * client is never sent markdown.
+ *
+ * @phpstan-type LspMarkupContent array{kind: string, value: string}
+ */
+final readonly class MarkupContent
+{
+    public function __construct(
+        public MarkupKind $kind,
+        public string $value,
+    ) {
+    }
+
+    /**
+     * @return LspMarkupContent
+     */
+    public function toArray(): array
+    {
+        return [
+            'kind' => $this->kind->value,
+            'value' => $this->value,
+        ];
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -111,10 +111,10 @@ final class Server
                 NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot),
                 $symbolResolver,
             ),
-            new FunctionCandidates($symbolResolver),
+            new FunctionCandidates($symbolResolver, $negotiator),
             new KeywordCandidates(),
             new VariableCandidates($symbolResolver),
-            new MemberCandidates($symbolResolver),
+            new MemberCandidates($symbolResolver, $negotiator),
             new NamedArgumentCandidates(),
             new BuiltinTypeCandidates(),
         );

--- a/src/Server.php
+++ b/src/Server.php
@@ -80,7 +80,8 @@ final class Server
             $functionRepository,
         );
 
-        $this->lifecycleHandler = new LifecycleHandler(new CapabilityNegotiator($serverInfo));
+        $negotiator = new CapabilityNegotiator($serverInfo);
+        $this->lifecycleHandler = new LifecycleHandler($negotiator);
         $this->handlers[] = $this->lifecycleHandler;
         $this->handlers[] = new TextDocumentSyncHandler(
             $this->documentManager,
@@ -96,6 +97,7 @@ final class Server
         $this->handlers[] = new HoverHandler(
             $this->documentManager,
             $symbolResolver,
+            $negotiator,
         );
         $this->handlers[] = new SignatureHelpHandler(
             $this->documentManager,

--- a/tests/Fixtures/src/Completion/FunctionCompletion.php
+++ b/tests/Fixtures/src/Completion/FunctionCompletion.php
@@ -29,4 +29,9 @@ class FunctionCompletionTriggers
         $config = getConfig();
         $config->/*|function_return_chain*/
     }
+
+    public function triggerUserFunction(): void
+    {
+        $y = calc/*|user_function*/
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Handler;
 
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\CompletionItemFactory;
 use Firehed\PhpLsp\Completion\CompletionItemKind;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
+use Firehed\PhpLsp\Completion\InsertTextFormat;
 use Firehed\PhpLsp\Completion\KeywordCandidates;
 use Firehed\PhpLsp\Completion\MemberCandidates;
 use Firehed\PhpLsp\Completion\NamedArgumentCandidates;
@@ -40,6 +43,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-import-type CompletionItem from CompletionItemFactory
+ */
 #[CoversClass(CompletionHandler::class)]
 #[CoversClass(BuiltinTypeCandidates::class)]
 #[CoversClass(ClassCandidates::class)]
@@ -60,6 +66,7 @@ class CompletionHandlerTest extends TestCase
     private DefaultClassInfoFactory $classInfoFactory;
     private MemberResolver $memberResolver;
     private SymbolResolver $symbolResolver;
+    private NamespaceCatalog $catalog;
     private CompletionHandler $handler;
     private TextDocumentSyncHandler $syncHandler;
 
@@ -85,9 +92,8 @@ class CompletionHandlerTest extends TestCase
             new DefaultFunctionRepository(),
         );
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
-        $this->handler = $this->makeHandler(
-            NamespaceCatalogFactory::forProject($this->symbolIndex, __DIR__ . '/../Fixtures'),
-        );
+        $this->catalog = NamespaceCatalogFactory::forProject($this->symbolIndex, __DIR__ . '/../Fixtures');
+        $this->handler = $this->makeHandler($this->catalog);
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
             $this->parser,
@@ -97,20 +103,40 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
-    private function makeHandler(NamespaceCatalog $catalog): CompletionHandler
+    private function makeHandler(NamespaceCatalog $catalog, bool $snippetSupport = false): CompletionHandler
     {
+        $capabilities = self::createStub(SessionCapabilitiesProvider::class);
+        $capabilities->method('getSessionCapabilities')
+            ->willReturn(new SessionCapabilities(snippetSupport: $snippetSupport));
+
         return new CompletionHandler(
             $this->documents,
             $this->symbolResolver,
             new ClassCandidates($this->symbolIndex, $this->symbolResolver),
             new NamespaceCandidates($catalog, $this->symbolResolver),
-            new FunctionCandidates($this->symbolResolver),
+            new FunctionCandidates($this->symbolResolver, $capabilities),
             new KeywordCandidates(),
             new VariableCandidates($this->symbolResolver),
-            new MemberCandidates($this->symbolResolver),
+            new MemberCandidates($this->symbolResolver, $capabilities),
             new NamedArgumentCandidates(),
             new BuiltinTypeCandidates(),
         );
+    }
+
+    /**
+     * @param array{items: list<CompletionItem>} $result
+     *
+     * @return CompletionItem
+     */
+    private static function itemFor(array $result, string $label): array
+    {
+        foreach ($result['items'] as $item) {
+            if ($item['label'] === $label) {
+                return $item;
+            }
+        }
+
+        self::fail("no completion item labelled {$label}");
     }
 
     public function testSupports(): void
@@ -960,6 +986,80 @@ class CompletionHandlerTest extends TestCase
         // Should include built-in functions starting with "arr"
         self::assertContains('array_map', $labels);
         self::assertContains('array_filter', $labels);
+    }
+
+    /**
+     * @param non-empty-string $fixture
+     * @param non-empty-string $marker
+     */
+    #[DataProvider('callableSnippetCases')]
+    public function testCallableCompletionInsertsSnippetWhenClientSupportsIt(
+        string $fixture,
+        string $marker,
+        string $label,
+    ): void {
+        $handler = $this->makeHandler($this->catalog, snippetSupport: true);
+        $cursor = $this->openFixtureAtCursor($fixture, $marker);
+
+        $result = $handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $item = self::itemFor($result, $label);
+        self::assertSame(
+            $label . '($0)',
+            $item['insertText'] ?? null,
+            'a snippet-capable client gets the parentheses typed with the cursor between them',
+        );
+        self::assertSame(
+            InsertTextFormat::Snippet->value,
+            $item['insertTextFormat'] ?? null,
+            'insertText is only interpreted as a snippet when tagged as one',
+        );
+    }
+
+    public function testCallableCompletionOmitsSnippetWithoutClientSupport(): void
+    {
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'this_empty');
+
+        // The default handler is built with snippetSupport off.
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $item = self::itemFor($result, 'setName');
+        self::assertArrayNotHasKey(
+            'insertText',
+            $item,
+            'a client without snippet support inserts the bare label, so no snippet text is emitted',
+        );
+        self::assertArrayNotHasKey('insertTextFormat', $item, 'nothing marks the item as a snippet');
+    }
+
+    public function testNonCallableMemberNeverInsertsSnippet(): void
+    {
+        $handler = $this->makeHandler($this->catalog, snippetSupport: true);
+        $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'this_empty');
+
+        $result = $handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $property = self::itemFor($result, 'name');
+        self::assertArrayNotHasKey(
+            'insertText',
+            $property,
+            'a property is not callable, so no parentheses are inserted even when snippets are supported',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{non-empty-string, non-empty-string, string}>
+     */
+    public static function callableSnippetCases(): iterable
+    {
+        yield 'method' => ['src/Completion/MethodAccess.php', 'this_empty', 'setName'];
+        yield 'user function' => ['src/Completion/FunctionCompletion.php', 'user_function', 'calculateSum'];
+        yield 'builtin function' => ['src/Completion/FunctionCompletion.php', 'builtin_function', 'array_map'];
     }
 
     public function testExpressionCompletionIncludesImportedClasses(): void

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Handler;
 
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\HoverHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
@@ -11,6 +13,7 @@ use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
@@ -32,6 +35,7 @@ class HoverHandlerTest extends TestCase
     private ParserService $parser;
     private DefaultClassRepository $classRepository;
     private DefaultClassInfoFactory $classInfoFactory;
+    private SymbolResolver $symbolResolver;
     private HoverHandler $handler;
     private TextDocumentSyncHandler $syncHandler;
 
@@ -48,17 +52,17 @@ class HoverHandlerTest extends TestCase
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
-        $symbolResolver = new SymbolResolver(
+        $this->symbolResolver = new SymbolResolver(
             $this->parser,
             $this->classRepository,
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
         );
-        $this->handler = new HoverHandler(
-            $this->documents,
-            $symbolResolver,
-        );
+        // The default markup kind is plaintext (the pre-initialize default a
+        // minimal client is served); the fenced-markdown path is exercised
+        // explicitly below.
+        $this->handler = $this->handlerFor(MarkupKind::PlainText);
         $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
@@ -75,6 +79,57 @@ class HoverHandlerTest extends TestCase
         self::assertFalse($this->handler->supports('textDocument/definition'));
     }
 
+    public function testHoverContentsAdvertiseTheNegotiatedMarkupKind(): void
+    {
+        $handler = $this->handlerFor(MarkupKind::Markdown);
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'setName');
+
+        $result = $handler->handle($this->hoverRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame(
+            'markdown',
+            $result['contents']['kind'],
+            'the MarkupContent kind must reflect the client-negotiated hover format',
+        );
+    }
+
+    public function testMarkdownHoverFencesTheSignatureAsPhp(): void
+    {
+        $handler = $this->handlerFor(MarkupKind::Markdown);
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'setName');
+
+        $result = $handler->handle($this->hoverRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertStringContainsString(
+            '```php',
+            $result['contents']['value'],
+            'a markdown client renders the signature inside a fenced PHP block',
+        );
+    }
+
+    public function testPlainTextHoverOmitsTheMarkdownFences(): void
+    {
+        $handler = $this->handlerFor(MarkupKind::PlainText);
+        $cursor = $this->openFixtureAtHoverMarker('src/Domain/User.php', 'setName');
+
+        $result = $handler->handle($this->hoverRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertSame('plaintext', $result['contents']['kind'], 'the kind must degrade with the client');
+        self::assertStringNotContainsString(
+            '```',
+            $result['contents']['value'],
+            'a plaintext client would show markdown fences literally, so they must not be emitted',
+        );
+        self::assertStringContainsString(
+            'setName',
+            $result['contents']['value'],
+            'the signature itself is still present, just unfenced',
+        );
+    }
+
     public function testHoverOnClassWithDocblock(): void
     {
         $this->openFixture('src/Domain/User.php');
@@ -83,8 +138,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('User', $result['contents']);
-        self::assertStringContainsString('Represents a system user', $result['contents']);
+        self::assertStringContainsString('User', $result['contents']['value']);
+        self::assertStringContainsString('Represents a system user', $result['contents']['value']);
     }
 
     public function testHoverReturnsNullForUnknownPosition(): void
@@ -114,9 +169,9 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('signatureHelpAdd', $result['contents']);
-        self::assertStringContainsString('int', $result['contents']);
-        self::assertStringContainsString('Adds two numbers together', $result['contents']);
+        self::assertStringContainsString('signatureHelpAdd', $result['contents']['value']);
+        self::assertStringContainsString('int', $result['contents']['value']);
+        self::assertStringContainsString('Adds two numbers together', $result['contents']['value']);
     }
 
     public function testHoverOnMethod(): void
@@ -126,8 +181,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('setName', $result['contents']);
-        self::assertStringContainsString('Updates the user', $result['contents']);
+        self::assertStringContainsString('setName', $result['contents']['value']);
+        self::assertStringContainsString('Updates the user', $result['contents']['value']);
     }
 
     public function testHoverOnMethodCallInGlobalScope(): void
@@ -138,7 +193,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('getName', $result['contents']);
+        self::assertStringContainsString('getName', $result['contents']['value']);
     }
 
     public function testHoverOnProperty(): void
@@ -148,8 +203,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$manager', $result['contents']);
-        self::assertStringContainsString('User', $result['contents']);
+        self::assertStringContainsString('$manager', $result['contents']['value']);
+        self::assertStringContainsString('User', $result['contents']['value']);
     }
 
     public function testHoverOnBuiltinFunction(): void
@@ -159,7 +214,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('sort', $result['contents']);
+        self::assertStringContainsString('sort', $result['contents']['value']);
     }
 
     public function testHoverOnStaticMethod(): void
@@ -169,7 +224,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('create', $result['contents']);
+        self::assertStringContainsString('create', $result['contents']['value']);
     }
 
     public function testHoverOnTypedVariableMethodCall(): void
@@ -180,8 +235,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('setName', $result['contents']);
-        self::assertStringContainsString('Updates the user', $result['contents']);
+        self::assertStringContainsString('setName', $result['contents']['value']);
+        self::assertStringContainsString('Updates the user', $result['contents']['value']);
     }
 
     public function testHoverOnAssignedVariableMethodCall(): void
@@ -192,8 +247,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('setName', $result['contents']);
-        self::assertStringContainsString('Updates the user', $result['contents']);
+        self::assertStringContainsString('setName', $result['contents']['value']);
+        self::assertStringContainsString('Updates the user', $result['contents']['value']);
     }
 
     public function testHoverOnInheritedMethod(): void
@@ -205,8 +260,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('parentMethod', $result['contents']);
-        self::assertStringContainsString('Parent method documentation', $result['contents']);
+        self::assertStringContainsString('parentMethod', $result['contents']['value']);
+        self::assertStringContainsString('Parent method documentation', $result['contents']['value']);
     }
 
     public function testHoverOnInheritedProperty(): void
@@ -218,8 +273,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$parentProperty', $result['contents']);
-        self::assertStringContainsString('Parent property', $result['contents']);
+        self::assertStringContainsString('$parentProperty', $result['contents']['value']);
+        self::assertStringContainsString('Parent property', $result['contents']['value']);
     }
 
     public function testHoverOnMultiLevelInheritedMethod(): void
@@ -231,8 +286,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('grandparentMethod', $result['contents']);
-        self::assertStringContainsString('Grandparent method documentation', $result['contents']);
+        self::assertStringContainsString('grandparentMethod', $result['contents']['value']);
+        self::assertStringContainsString('Grandparent method documentation', $result['contents']['value']);
     }
 
     public function testHoverOnMultiLevelInheritedProperty(): void
@@ -244,8 +299,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$grandparentProperty', $result['contents']);
-        self::assertStringContainsString('Grandparent property', $result['contents']);
+        self::assertStringContainsString('$grandparentProperty', $result['contents']['value']);
+        self::assertStringContainsString('Grandparent property', $result['contents']['value']);
     }
 
     public function testHoverOnTraitMethod(): void
@@ -256,7 +311,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('markCreated', $result['contents']);
+        self::assertStringContainsString('markCreated', $result['contents']['value']);
     }
 
     public function testHoverOnTraitProperty(): void
@@ -266,8 +321,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$displayName', $result['contents']);
-        self::assertStringContainsString('Display name for the entity', $result['contents']);
+        self::assertStringContainsString('$displayName', $result['contents']['value']);
+        self::assertStringContainsString('Display name for the entity', $result['contents']['value']);
     }
 
     public function testHoverOnInterfaceMethod(): void
@@ -277,8 +332,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('getName', $result['contents']);
-        self::assertStringContainsString("Gets the person's name", $result['contents']);
+        self::assertStringContainsString('getName', $result['contents']['value']);
+        self::assertStringContainsString("Gets the person's name", $result['contents']['value']);
     }
 
     public function testHoverOnInheritedMethodAcrossNamespaces(): void
@@ -291,8 +346,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('baseMethod', $result['contents']);
-        self::assertStringContainsString('Method from Base namespace', $result['contents']);
+        self::assertStringContainsString('baseMethod', $result['contents']['value']);
+        self::assertStringContainsString('Method from Base namespace', $result['contents']['value']);
     }
 
     public function testHoverOnPrivateInheritedMethodReturnsNull(): void
@@ -326,9 +381,9 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('overriddenMethod', $result['contents']);
-        self::assertStringContainsString('Child implementation', $result['contents']);
-        self::assertStringNotContainsString('Parent implementation', $result['contents']);
+        self::assertStringContainsString('overriddenMethod', $result['contents']['value']);
+        self::assertStringContainsString('Child implementation', $result['contents']['value']);
+        self::assertStringNotContainsString('Parent implementation', $result['contents']['value']);
     }
 
     public function testHoverOnOverriddenPropertyShowsChildVersion(): void
@@ -340,9 +395,9 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$sharedProperty', $result['contents']);
-        self::assertStringContainsString('Child override', $result['contents']);
-        self::assertStringNotContainsString('Shared property from parent', $result['contents']);
+        self::assertStringContainsString('$sharedProperty', $result['contents']['value']);
+        self::assertStringContainsString('Child override', $result['contents']['value']);
+        self::assertStringNotContainsString('Shared property from parent', $result['contents']['value']);
     }
 
     public function testHoverOnStaticProperty(): void
@@ -353,9 +408,9 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$staticProperty', $result['contents']);
-        self::assertStringContainsString('static', $result['contents']);
-        self::assertStringContainsString('Static property documentation', $result['contents']);
+        self::assertStringContainsString('$staticProperty', $result['contents']['value']);
+        self::assertStringContainsString('static', $result['contents']['value']);
+        self::assertStringContainsString('Static property documentation', $result['contents']['value']);
     }
 
     public function testHoverOnBuiltinClassMethod(): void
@@ -365,7 +420,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('getArrayCopy', $result['contents']);
+        self::assertStringContainsString('getArrayCopy', $result['contents']['value']);
     }
 
     public function testHoverOnBuiltinClassProperty(): void
@@ -375,7 +430,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$message', $result['contents']);
+        self::assertStringContainsString('$message', $result['contents']['value']);
     }
 
     public function testHoverOnMethodWithVariadicParameter(): void
@@ -385,7 +440,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('...$items', $result['contents']);
+        self::assertStringContainsString('...$items', $result['contents']['value']);
     }
 
     public function testHoverOnMethodWithOptionalParameter(): void
@@ -395,8 +450,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$count = 0', $result['contents']);
-        self::assertStringNotContainsString('$name = ...', $result['contents']);
+        self::assertStringContainsString('$count = 0', $result['contents']['value']);
+        self::assertStringNotContainsString('$name = ...', $result['contents']['value']);
     }
 
     public function testHoverOnNullsafeMethodCall(): void
@@ -406,8 +461,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('setName', $result['contents']);
-        self::assertStringContainsString('Updates the user', $result['contents']);
+        self::assertStringContainsString('setName', $result['contents']['value']);
+        self::assertStringContainsString('Updates the user', $result['contents']['value']);
     }
 
     public function testHoverOnNullsafePropertyFetch(): void
@@ -417,8 +472,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$manager', $result['contents']);
-        self::assertStringContainsString('User', $result['contents']);
+        self::assertStringContainsString('$manager', $result['contents']['value']);
+        self::assertStringContainsString('User', $result['contents']['value']);
     }
 
     public function testHoverOnNullsafeTypedVariableMethodCall(): void
@@ -429,8 +484,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('setName', $result['contents']);
-        self::assertStringContainsString('Updates the user', $result['contents']);
+        self::assertStringContainsString('setName', $result['contents']['value']);
+        self::assertStringContainsString('Updates the user', $result['contents']['value']);
     }
 
     public function testHoverOnMultilineChainMethod(): void
@@ -441,8 +496,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('withName', $result['contents']);
-        self::assertStringContainsString('Sets the name fluently', $result['contents']);
+        self::assertStringContainsString('withName', $result['contents']['value']);
+        self::assertStringContainsString('Sets the name fluently', $result['contents']['value']);
     }
 
     public function testHoverOnMultilineChainProperty(): void
@@ -453,8 +508,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$team', $result['contents']);
-        self::assertStringContainsString('Team', $result['contents']);
+        self::assertStringContainsString('$team', $result['contents']['value']);
+        self::assertStringContainsString('Team', $result['contents']['value']);
     }
 
     public function testHoverOnMultilineChainCrossType(): void
@@ -465,8 +520,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('getLeader', $result['contents']);
-        self::assertStringContainsString('Gets the team leader', $result['contents']);
+        self::assertStringContainsString('getLeader', $result['contents']['value']);
+        self::assertStringContainsString('Gets the team leader', $result['contents']['value']);
     }
 
     public function testHoverOnMultilineChainBackToUser(): void
@@ -477,8 +532,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$manager', $result['contents']);
-        self::assertStringContainsString('User', $result['contents']);
+        self::assertStringContainsString('$manager', $result['contents']['value']);
+        self::assertStringContainsString('User', $result['contents']['value']);
     }
 
     public function testHoverOnMultilineChainNullsafe(): void
@@ -489,8 +544,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('withAge', $result['contents']);
-        self::assertStringContainsString('Sets the age fluently', $result['contents']);
+        self::assertStringContainsString('withAge', $result['contents']['value']);
+        self::assertStringContainsString('Sets the age fluently', $result['contents']['value']);
     }
 
     public function testHoverOnSelfStaticMethod(): void
@@ -502,8 +557,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('staticMethod', $result['contents']);
-        self::assertStringContainsString('Static method documentation', $result['contents']);
+        self::assertStringContainsString('staticMethod', $result['contents']['value']);
+        self::assertStringContainsString('Static method documentation', $result['contents']['value']);
     }
 
     public function testHoverOnStaticStaticMethod(): void
@@ -515,8 +570,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('staticMethod', $result['contents']);
-        self::assertStringContainsString('Static method documentation', $result['contents']);
+        self::assertStringContainsString('staticMethod', $result['contents']['value']);
+        self::assertStringContainsString('Static method documentation', $result['contents']['value']);
     }
 
     public function testHoverOnParentMethod(): void
@@ -528,8 +583,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('parentMethod', $result['contents']);
-        self::assertStringContainsString('Parent method documentation', $result['contents']);
+        self::assertStringContainsString('parentMethod', $result['contents']['value']);
+        self::assertStringContainsString('Parent method documentation', $result['contents']['value']);
     }
 
     public function testHoverOnSelfStaticProperty(): void
@@ -541,8 +596,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$staticProperty', $result['contents']);
-        self::assertStringContainsString('Static property documentation', $result['contents']);
+        self::assertStringContainsString('$staticProperty', $result['contents']['value']);
+        self::assertStringContainsString('Static property documentation', $result['contents']['value']);
     }
 
     public function testHoverOnStaticStaticProperty(): void
@@ -554,8 +609,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$staticProperty', $result['contents']);
-        self::assertStringContainsString('Static property documentation', $result['contents']);
+        self::assertStringContainsString('$staticProperty', $result['contents']['value']);
+        self::assertStringContainsString('Static property documentation', $result['contents']['value']);
     }
 
     public function testHoverOnParentStaticProperty(): void
@@ -567,8 +622,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$staticProperty', $result['contents']);
-        self::assertStringContainsString('Static property documentation', $result['contents']);
+        self::assertStringContainsString('$staticProperty', $result['contents']['value']);
+        self::assertStringContainsString('Static property documentation', $result['contents']['value']);
     }
 
     public function testHoverOnSelfMethodOutsideClassReturnsNull(): void
@@ -617,7 +672,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('PARENT_CONST', $result['contents']);
+        self::assertStringContainsString('PARENT_CONST', $result['contents']['value']);
     }
 
     /**
@@ -630,8 +685,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$typed', $result['contents']);
-        self::assertStringContainsString('User', $result['contents']);
+        self::assertStringContainsString('$typed', $result['contents']['value']);
+        self::assertStringContainsString('User', $result['contents']['value']);
     }
 
     /**
@@ -644,9 +699,9 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$id', $result['contents']);
-        self::assertStringContainsString('string', $result['contents']);
-        self::assertStringContainsString('readonly', $result['contents']);
+        self::assertStringContainsString('$id', $result['contents']['value']);
+        self::assertStringContainsString('string', $result['contents']['value']);
+        self::assertStringContainsString('readonly', $result['contents']['value']);
     }
 
     /**
@@ -660,8 +715,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result);
-        self::assertStringContainsString('$createdAt', $result['contents']);
-        self::assertStringContainsString('DateTimeImmutable', $result['contents']);
+        self::assertStringContainsString('$createdAt', $result['contents']['value']);
+        self::assertStringContainsString('DateTimeImmutable', $result['contents']['value']);
     }
 
     // =========================================================================
@@ -678,8 +733,8 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result, 'Hover should work on property in if condition');
-        self::assertStringContainsString('$name', $result['contents']);
-        self::assertStringContainsString('string', $result['contents']);
+        self::assertStringContainsString('$name', $result['contents']['value']);
+        self::assertStringContainsString('string', $result['contents']['value']);
     }
 
     public function testHoverOnMethodInWhileCondition(): void
@@ -692,7 +747,7 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result, 'Hover should work on method in while condition');
-        self::assertStringContainsString('getName', $result['contents']);
+        self::assertStringContainsString('getName', $result['contents']['value']);
     }
 
     public function testHoverOnAttributeClass(): void
@@ -703,7 +758,16 @@ class HoverHandlerTest extends TestCase
         $result = $this->handler->handle($this->hoverRequestAt($cursor));
 
         self::assertIsArray($result, 'Hover should resolve the class in a #[Attribute] usage');
-        self::assertStringContainsString('Route', $result['contents']);
-        self::assertStringContainsString('Defines a route', $result['contents']);
+        self::assertStringContainsString('Route', $result['contents']['value']);
+        self::assertStringContainsString('Defines a route', $result['contents']['value']);
+    }
+
+    private function handlerFor(MarkupKind $hoverMarkupKind): HoverHandler
+    {
+        $capabilities = self::createStub(SessionCapabilitiesProvider::class);
+        $capabilities->method('getSessionCapabilities')
+            ->willReturn(new SessionCapabilities(hoverMarkupKind: $hoverMarkupKind));
+
+        return new HoverHandler($this->documents, $this->symbolResolver, $capabilities);
     }
 }

--- a/tests/Protocol/MarkupContentTest.php
+++ b/tests/Protocol/MarkupContentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\MarkupContent;
+use Firehed\PhpLsp\Protocol\MarkupKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MarkupContent::class)]
+class MarkupContentTest extends TestCase
+{
+    /**
+     * @param array{kind: string, value: string} $expected
+     */
+    #[DataProvider('cases')]
+    public function testToArrayRendersTheLspLiteral(MarkupKind $kind, string $value, array $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new MarkupContent($kind, $value))->toArray(),
+            'MarkupContent serializes as the [LSP] {kind, value} literal',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{MarkupKind, string, array{kind: string, value: string}}>
+     */
+    public static function cases(): iterable
+    {
+        yield 'markdown' => [
+            MarkupKind::Markdown,
+            '```php' . "\n" . 'function f(): void' . "\n" . '```',
+            ['kind' => 'markdown', 'value' => '```php' . "\n" . 'function f(): void' . "\n" . '```'],
+        ];
+        yield 'plaintext' => [
+            MarkupKind::PlainText,
+            'function f(): void',
+            ['kind' => 'plaintext', 'value' => 'function f(): void'],
+        ];
+    }
+}


### PR DESCRIPTION
## Slice

**S1.3 — Shape hover markup / snippets via capabilities** (build-manifest.md).
Plan step: **Step 1 — Capability negotiation + encoding edge** (0002-execution-plan.md §4).
RFC sections: **§4.8** (output shaped by client support must query the resolved
capabilities value, not the raw `initialize` params), **§5.4** (a single immutable
`SessionCapabilities` exposing named queries — hover markup kind, snippet support).

Depends on S1.1 (merged), which resolved `ClientCapabilities` into `SessionCapabilities`.
Until now nothing *consumed* the resolved value; this slice wires it into the two
surfaces that shape output by client support.

## What changed

- **Wiring seam.** New read-only `SessionCapabilitiesProvider` interface
  (`getSessionCapabilities()`), implemented by `CapabilityNegotiator`. Output-shaping
  components are built before `initialize` runs, so they depend on the provider and
  read the current value at handle-time. The raw `initialize` params stay confined to
  `src/Capability/` (`RawInitializeCapabilitiesRule` stays green). This is the seam
  S1.5 will reuse to reach `positionEncoding` at the completion sources.
- **Hover markup.** `HoverHandler` now emits an LSP `MarkupContent {kind, value}`
  shaped by the negotiated `hoverMarkupKind`: markdown fences the signature as a PHP
  block; plaintext sends the bare signature (fences would render literally).
- **Completion snippets.** Completing a callable (method or function) inserts
  `name($0)` with `insertTextFormat: Snippet` when the client declared
  `completionItem.snippetSupport`; otherwise the bare name. Non-callable members
  (properties, constants, enum cases) never gain parentheses. Per-parameter
  placeholders are intentionally out of scope for this slice (parens + a single final
  tab stop only).

## Acceptance criteria

- [x] Hover markup kind is shaped via `SessionCapabilities` and emitted as
  `MarkupContent` (markdown → fenced, plaintext → unfenced).
- [x] Completion snippet output is shaped via `SessionCapabilities`
  (`insertTextFormat: Snippet` + `name($0)` when supported; bare name otherwise).
- [x] Reads go through `SessionCapabilitiesProvider`; no component re-inspects the raw
  `initialize` params (§4.8 confinement rule green).
- [x] Non-callable members never receive snippet parentheses.
- [x] `composer test` green; new code covered (the only sub-100% file, `HoverHandler`,
  is its two pre-existing `return null` guards, matching sibling handlers).

## Closes

Closes #22 — its required acceptance criteria are met: `insertTextFormat: 2` (Snippet)
is set on callable completion items, `()` is inserted after method/function names, and
the cursor is positioned inside the parens via `$0` — the issue's stated minimum bar.
The *optional* per-parameter placeholder criterion (`${1:param1}`) is deferred and
documented in `docs/features/completion.md`; reopen #22 if placeholders are wanted as a
follow-up.

👨 : I couldn't actually hands-on UAT #22; Vim+Ale doesn't support snippet expansion, at least as of the version I use. Tests should reasonably cover that it behaves per the LSP spec. If that turns out to not be true, we can reopen/refile the issue.

---

Written by AI (Claude), reviewed by a human before submission.
