### PR TITLE
Enforce lifecycle state and survive malformed frames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,10 +192,12 @@ fails in the writer rather than in `handle()`.
 `LifecycleHandler` owns lifecycle state and gates every inbound message through
 `lifecycleErrorFor()` (RFC 1 §4.8): requests before `initialize` get
 `ServerNotInitialized`, requests after `shutdown` get `InvalidRequest`, and `exit` is
-always honored so the server can terminate. A gated message is never dispatched; a
-gated notification has no id, so its error is dropped rather than sent — which is
-what LSP "Server lifecycle" means by notifications being *dropped*. The gate opens
-only once `initialize` has produced a result.
+always honored so the server can terminate. `initialize` "may only be sent once"
+(LSP), so a second one is gated with `InvalidRequest` rather than re-negotiating over
+the already-resolved session. A gated message is never dispatched; a gated
+notification has no id, so its error is dropped rather than sent — which is what LSP
+"Server lifecycle" means by notifications being *dropped*. The gate opens only once
+`initialize` has produced a result.
 
 `Server` takes the `LifecycleHandler` separately from the other handlers and
 prepends it to the dispatch list itself, so the instance the gate consults cannot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,15 +164,36 @@ means stop. Do not collapse these back into `?Message`.
 **Malformed input never terminates the process** (RFC 1 §9). `MessageReader`
 classifies an unparseable body as `ParseError` and a structurally invalid message as
 `InvalidRequest` — it does *not* rely on the `assert()`s in the message factories,
-which are disabled in production. `Server` answers a throwing handler with
-`InternalError`. A malformed frame is answered with the JSON-RPC null id, since no id
-can be recovered from it.
+which are disabled in production.
+
+A rejected frame is answered at whatever id the reader could recover from it, and at
+the JSON-RPC null id only when it could recover none (JSON-RPC 2.0 §5) — answering a
+recoverable id at null leaves the client's request pending forever. A frame that is
+recognisably a *Notification* (a JSON object naming a method, with no `id`) is
+consumed and dropped instead: §4.1 forbids replying to one, so `read()` skips it and
+reports the next frame.
+
+`Content-Length` must be a run of decimal digits. A bare `(int)` cast accepts `-5`,
+which makes `substr()` consume from the wrong end and destroys the frames behind it,
+so an unusable value is rejected without touching the buffer. Every failure path
+consumes its own bytes, so one bad frame costs one error and never turns a body into
+framing.
+
+`Server` answers a throwing handler with `InternalError` — including a failure in
+`supports()` during handler lookup, and a result the encoder cannot represent, which
+fails in the writer rather than in `handle()`.
 
 `LifecycleHandler` owns lifecycle state and gates every inbound message through
 `lifecycleErrorFor()` (RFC 1 §4.8): requests before `initialize` get
 `ServerNotInitialized`, requests after `shutdown` get `InvalidRequest`, and `exit` is
 always honored so the server can terminate. A gated message is never dispatched; a
-gated notification has no id, so its error is dropped rather than sent.
+gated notification has no id, so its error is dropped rather than sent — which is
+what LSP "Server lifecycle" means by notifications being *dropped*. The gate opens
+only once `initialize` has produced a result.
+
+`Server` takes the `LifecycleHandler` separately from the other handlers and
+prepends it to the dispatch list itself, so the instance the gate consults cannot
+diverge from the one that handles `initialize`/`shutdown`.
 
 ### Guidelines for New Code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,8 @@ means stop. Do not collapse these back into `?Message`.
 **Malformed input never terminates the process** (RFC 1 §9). `MessageReader`
 classifies an unparseable body as `ParseError` and a structurally invalid message as
 `InvalidRequest` — it does *not* rely on the `assert()`s in the message factories,
-which are disabled in production.
+which are disabled in production. A message must carry `"jsonrpc":"2.0"` (JSON-RPC 2.0
+§4); a frame missing it or naming another version is `InvalidRequest`.
 
 A rejected frame is answered at whatever id the reader could recover from it, and at
 the JSON-RPC null id only when it could recover none (JSON-RPC 2.0 §5) — answering a
@@ -173,11 +174,16 @@ recognisably a *Notification* (a JSON object naming a method, with no `id`) is
 consumed and dropped instead: §4.1 forbids replying to one, so `read()` skips it and
 reports the next frame.
 
-`Content-Length` must be a run of decimal digits. A bare `(int)` cast accepts `-5`,
-which makes `substr()` consume from the wrong end and destroys the frames behind it,
-so an unusable value is rejected without touching the buffer. Every failure path
-consumes its own bytes, so one bad frame costs one error and never turns a body into
-framing.
+`Content-Length` must be a run of decimal digits (RFC 7230 §3.3.2, which LSP binds
+via §3.2), and repeated headers must agree (§3.3.3). A bare `(int)` cast accepted `-5`,
+which makes `substr()` consume from the wrong end. When the value is unusable the
+frame's extent is unknown, so `read()` hands the rest of the buffer to the decoder
+rather than rescanning it as the next header block: a content part is JSON, so a client
+that merely mis-declared the length is served and anything else costs one `ParseError`.
+Either way the buffer is emptied, so no failure path leaves bytes to be re-read as
+framing. A conformant `Content-Length` still frames exactly, which is what tells a
+truncated body from a complete one and separates two coalesced frames — the fallback is
+the error path only.
 
 `Server` answers a throwing handler with `InternalError` — including a failure in
 `supports()` during handler lookup, and a result the encoder cannot represent, which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,27 @@ Anything that shapes an outgoing message by client support (hover markup kind, s
 support, …) queries `SessionCapabilities`. `RawInitializeCapabilitiesRule`
 (`tests/Architecture/`) fails PHPStan if any other package reads a `capabilities` key.
 
+### Transport and Lifecycle
+
+`TransportInterface::read()` reports one of three outcomes, never a nullable message:
+a `Message`, a `MalformedFrame` (carrying the `ResponseError` to answer with), or
+`EndOfStream`. RFC 1 §9 requires a frame lacking a required header to be
+distinguishable from a closed stream — one means answer and keep serving, the other
+means stop. Do not collapse these back into `?Message`.
+
+**Malformed input never terminates the process** (RFC 1 §9). `MessageReader`
+classifies an unparseable body as `ParseError` and a structurally invalid message as
+`InvalidRequest` — it does *not* rely on the `assert()`s in the message factories,
+which are disabled in production. `Server` answers a throwing handler with
+`InternalError`. A malformed frame is answered with the JSON-RPC null id, since no id
+can be recovered from it.
+
+`LifecycleHandler` owns lifecycle state and gates every inbound message through
+`lifecycleErrorFor()` (RFC 1 §4.8): requests before `initialize` get
+`ServerNotInitialized`, requests after `shutdown` get `InvalidRequest`, and `exit` is
+always honored so the server can terminate. A gated message is never dispatched; a
+gated notification has no id, so its error is dropped rather than sent.
+
 ### Guidelines for New Code
 
 - **Keep code DRY.** Be on the lookout for existing tools that will solve your problem; NEVER copy-and-paste. Extract repeated logic aggressively.

--- a/bin/php-lsp
+++ b/bin/php-lsp
@@ -5,12 +5,17 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use Amp\ByteStream\ReadableResourceStream;
+use Amp\ByteStream\WritableResourceStream;
 use Firehed\PhpLsp\Server;
 use Firehed\PhpLsp\ServerInfo;
-use Firehed\PhpLsp\Transport\StdioTransport;
+use Firehed\PhpLsp\Transport\StreamTransport;
 
 $serverInfo = new ServerInfo('php-lsp', '0.1.0');
-$transport = new StdioTransport();
+$transport = new StreamTransport(
+    new ReadableResourceStream(STDIN),
+    new WritableResourceStream(STDOUT),
+);
 $server = Server::forProject($transport, $serverInfo);
 
 exit($server->run());

--- a/bin/php-lsp
+++ b/bin/php-lsp
@@ -11,6 +11,6 @@ use Firehed\PhpLsp\Transport\StdioTransport;
 
 $serverInfo = new ServerInfo('php-lsp', '0.1.0');
 $transport = new StdioTransport();
-$server = new Server($transport, $serverInfo);
+$server = Server::forProject($transport, $serverInfo);
 
 exit($server->run());

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -46,9 +46,10 @@ final class LifecycleHandler implements HandlerInterface
     /**
      * The lifecycle error an inbound message must be answered with given the
      * current state, or null if it is permitted (LSP "Server lifecycle",
-     * RFC 1 §4.8). `exit` is always honored so the server can terminate; the
-     * `initialize` request is the only other message allowed before the server
-     * is initialized.
+     * RFC 1 §4.8). `exit` is always honored so the server can terminate. Before
+     * the server is initialized, `initialize` is the only message allowed; it
+     * "may only be sent once" (LSP), so a second one is rejected rather than
+     * re-running negotiation over the already-resolved session.
      */
     public function lifecycleErrorFor(Message $message): ?ResponseError
     {
@@ -58,7 +59,10 @@ final class LifecycleHandler implements HandlerInterface
         if ($this->shutdownRequested) {
             return ResponseError::invalidRequest();
         }
-        if (!$this->initialized && $message->method !== 'initialize') {
+        if ($message->method === 'initialize') {
+            return $this->initialized ? ResponseError::invalidRequest() : null;
+        }
+        if (!$this->initialized) {
             return ResponseError::serverNotInitialized();
         }
         return null;

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -74,10 +74,18 @@ final class LifecycleHandler implements HandlerInterface
         return $this->exitCode;
     }
 
+    /**
+     * The gate opens only once negotiation has produced a result. A negotiation
+     * that failed would be answered with InternalError, so the client never
+     * receives an InitializeResult and by LSP "Server lifecycle" is still
+     * pre-initialize; the flag must not claim otherwise.
+     */
     private function handleInitialize(Message $message): InitializeResult
     {
+        $result = $this->negotiator->negotiate($message);
         $this->initialized = true;
-        return $this->negotiator->negotiate($message);
+
+        return $result;
     }
 
     private function handleShutdown(): null

--- a/src/Handler/LifecycleHandler.php
+++ b/src/Handler/LifecycleHandler.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Capability\CapabilityNegotiator;
+use Firehed\PhpLsp\Protocol\InitializeResult;
 use Firehed\PhpLsp\Protocol\Message;
+use Firehed\PhpLsp\Protocol\ResponseError;
 
 final class LifecycleHandler implements HandlerInterface
 {
@@ -16,6 +18,7 @@ final class LifecycleHandler implements HandlerInterface
         'exit',
     ];
 
+    private bool $initialized = false;
     private bool $shutdownRequested = false;
     private ?int $exitCode = null;
 
@@ -32,12 +35,33 @@ final class LifecycleHandler implements HandlerInterface
     public function handle(Message $message): mixed
     {
         return match ($message->method) {
-            'initialize' => $this->negotiator->negotiate($message),
+            'initialize' => $this->handleInitialize($message),
             'initialized' => null,
             'shutdown' => $this->handleShutdown(),
             'exit' => $this->handleExit(),
             default => null,
         };
+    }
+
+    /**
+     * The lifecycle error an inbound message must be answered with given the
+     * current state, or null if it is permitted (LSP "Server lifecycle",
+     * RFC 1 §4.8). `exit` is always honored so the server can terminate; the
+     * `initialize` request is the only other message allowed before the server
+     * is initialized.
+     */
+    public function lifecycleErrorFor(Message $message): ?ResponseError
+    {
+        if ($message->method === 'exit') {
+            return null;
+        }
+        if ($this->shutdownRequested) {
+            return ResponseError::invalidRequest();
+        }
+        if (!$this->initialized && $message->method !== 'initialize') {
+            return ResponseError::serverNotInitialized();
+        }
+        return null;
     }
 
     public function isShutdownRequested(): bool
@@ -48,6 +72,12 @@ final class LifecycleHandler implements HandlerInterface
     public function getExitCode(): ?int
     {
         return $this->exitCode;
+    }
+
+    private function handleInitialize(Message $message): InitializeResult
+    {
+        $this->initialized = true;
+        return $this->negotiator->negotiate($message);
     }
 
     private function handleShutdown(): null

--- a/src/Protocol/ResponseError.php
+++ b/src/Protocol/ResponseError.php
@@ -25,6 +25,11 @@ final readonly class ResponseError implements JsonSerializable
         return new self(-32600, 'Invalid Request', $data);
     }
 
+    public static function serverNotInitialized(?string $data = null): self
+    {
+        return new self(-32002, 'Server not initialized', $data);
+    }
+
     public static function methodNotFound(?string $method = null): self
     {
         $message = $method !== null

--- a/src/Server.php
+++ b/src/Server.php
@@ -186,6 +186,14 @@ final class Server
                     // (RFC 1 §9): an editor session that dies on one bad request
                     // loses all unsaved server state. Notifications have no id to
                     // answer, so their failure is contained and dropped.
+                    //
+                    // Forwarding the raw message crosses no trust boundary: the
+                    // client is the editor that spawned this process over its own
+                    // stdio pipe, and it already has the server's whole filesystem
+                    // view. Paths it may carry are the user's own, bound for the
+                    // user's own LSP log, which is what makes an unreproducible
+                    // crash diagnosable. `message` stays generic; per [LSP] "Base
+                    // Protocol", ResponseError.data is where detail belongs.
                     $error = ResponseError::internalError($e->getMessage());
                 } finally {
                     // The parse memo is scoped to one handled message — this loop
@@ -234,6 +242,10 @@ final class Server
      * both of which are known-encodable, so answering cannot fail the same way.
      * The frame is encoded before any bytes are written, so the failed response
      * leaves nothing half-written on the wire.
+     *
+     * The forwarded message discloses nothing: json_encode's failures come from
+     * PHP's fixed json_last_error_msg table ("Malformed UTF-8 characters…",
+     * "Recursion detected", …), which interpolate none of the value that failed.
      */
     private function writeResponse(int|string $id, ResponseMessage $response): void
     {

--- a/src/Server.php
+++ b/src/Server.php
@@ -158,10 +158,11 @@ final class Server
             }
 
             if ($message instanceof MalformedFrame) {
-                // The id cannot be recovered from a frame that would not decode,
-                // so it is answered with the JSON-RPC null id (RFC 1 §9). The
-                // loop continues: one bad frame must not end the session.
-                $this->transport->write(ResponseMessage::error(null, $message->error));
+                // Answered at whatever id the reader could correlate the frame
+                // to, and at the JSON-RPC null id when it could recover none
+                // (RFC 1 §9). The loop continues: one bad frame must not end
+                // the session.
+                $this->transport->write(ResponseMessage::error($message->id, $message->error));
                 continue;
             }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -174,9 +174,13 @@ final class Server
             $error = $this->lifecycleHandler->lifecycleErrorFor($message);
 
             if ($error === null) {
-                $handler = $this->findHandler($message->method);
-
                 try {
+                    // Inside the try because `supports()` is part of the
+                    // handler contract: a failure selecting a handler is a
+                    // handler failure, and must be answered rather than
+                    // crashing the read loop (RFC 1 §9).
+                    $handler = $this->findHandler($message->method);
+
                     if ($handler !== null) {
                         $result = $handler->handle($message);
                     } elseif ($message instanceof RequestMessage) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -208,7 +208,7 @@ final class Server
                 } else {
                     $response = ResponseMessage::success($message->id, $result);
                 }
-                $this->transport->write($response);
+                $this->writeResponse($message->id, $response);
             }
 
             // Check for exit
@@ -221,6 +221,29 @@ final class Server
 
         $this->transport->close();
         return 1;
+    }
+
+    /**
+     * A result a handler produced but the encoder cannot represent fails here
+     * rather than in `handle()`, so the dispatch catch never sees it. It is
+     * still a handler failure and must not take the read loop down with it
+     * (RFC 1 §9); text lifted from a file that is not valid UTF-8 reaches the
+     * writer exactly this way.
+     *
+     * The replacement carries only the exception message and the decoded id,
+     * both of which are known-encodable, so answering cannot fail the same way.
+     * The frame is encoded before any bytes are written, so the failed response
+     * leaves nothing half-written on the wire.
+     */
+    private function writeResponse(int|string $id, ResponseMessage $response): void
+    {
+        try {
+            $this->transport->write($response);
+        } catch (\JsonException $e) {
+            $this->transport->write(
+                ResponseMessage::error($id, ResponseError::internalError($e->getMessage())),
+            );
+        }
     }
 
     private function findHandler(string $method): ?HandlerInterface

--- a/src/Server.php
+++ b/src/Server.php
@@ -178,8 +178,8 @@ final class Server
                     //
                     // In a finally so the scope closes on every exit from the
                     // dispatch, not just the ones that return normally: a handler
-                    // that throws is fatal today, but S1.4 makes it survivable, and
-                    // a memo that outlived a message would then be standing.
+                    // that throws is caught just above and the loop keeps serving,
+                    // so a memo outliving its message would become standing.
                     $this->parser->discardScopedParses();
                 }
             }

--- a/src/Server.php
+++ b/src/Server.php
@@ -42,19 +42,25 @@ use Firehed\PhpLsp\Transport\TransportInterface;
 
 final class Server
 {
+    /** @var list<HandlerInterface> */
+    private readonly array $handlers;
+
     /**
-     * @param list<HandlerInterface> $handlers Consulted in order; the first that
-     *        supports a method answers it.
-     * @param LifecycleHandler $lifecycleHandler Also expected to appear in
-     *        $handlers. It is named separately because the loop asks it for the
-     *        lifecycle gate and the exit code, which are not dispatch.
+     * @param LifecycleHandler $lifecycleHandler Named separately because the
+     *        loop asks it for the lifecycle gate and the exit code, which are
+     *        not dispatch. It is prepended to the dispatch list here rather
+     *        than passed in twice, so the instance the gate consults and the
+     *        instance that handles `initialize`/`shutdown` cannot diverge.
+     * @param list<HandlerInterface> $handlers Consulted after it, in order;
+     *        the first that supports a method answers it.
      */
     public function __construct(
-        private TransportInterface $transport,
-        private array $handlers,
-        private LifecycleHandler $lifecycleHandler,
+        private readonly TransportInterface $transport,
+        private readonly LifecycleHandler $lifecycleHandler,
+        array $handlers,
         private readonly ParserService $parser,
     ) {
+        $this->handlers = [$lifecycleHandler, ...$handlers];
     }
 
     /**
@@ -102,7 +108,6 @@ final class Server
         $lifecycleHandler = new LifecycleHandler($negotiator);
 
         $handlers = [
-            $lifecycleHandler,
             new TextDocumentSyncHandler(
                 $documentManager,
                 $parser,
@@ -140,7 +145,7 @@ final class Server
             ),
         ];
 
-        return new self($transport, $handlers, $lifecycleHandler, $parser);
+        return new self($transport, $lifecycleHandler, $handlers, $parser);
     }
 
     public function run(): int

--- a/src/Server.php
+++ b/src/Server.php
@@ -42,23 +42,34 @@ use Firehed\PhpLsp\Transport\TransportInterface;
 
 final class Server
 {
-    private LifecycleHandler $lifecycleHandler;
-    private DocumentManager $documentManager;
-
-    /** @var list<HandlerInterface> */
-    private array $handlers = [];
-
     /**
-     * @param list<HandlerInterface> $additionalHandlers Registered after the
-     *        built-in handlers, so they answer only methods none of those claim.
+     * @param list<HandlerInterface> $handlers Consulted in order; the first that
+     *        supports a method answers it.
+     * @param LifecycleHandler $lifecycleHandler Also expected to appear in
+     *        $handlers. It is named separately because the loop asks it for the
+     *        lifecycle gate and the exit code, which are not dispatch.
      */
     public function __construct(
         private TransportInterface $transport,
+        private array $handlers,
+        private LifecycleHandler $lifecycleHandler,
+        private readonly ParserService $parser,
+    ) {
+    }
+
+    /**
+     * Wires the server against a project on disk.
+     *
+     * Construction lives here rather than in the constructor so the constructor
+     * stays injectable: the dispatch loop can then be exercised against a
+     * handler set a test chooses, without standing up the whole project.
+     */
+    public static function forProject(
+        TransportInterface $transport,
         ServerInfo $serverInfo,
         ?string $projectRoot = null,
-        private readonly ParserService $parser = new ParserService(),
-        array $additionalHandlers = [],
-    ) {
+        ParserService $parser = new ParserService(),
+    ): self {
         if ($projectRoot === null) {
             $cwd = getcwd();
             if ($cwd === false) {
@@ -69,18 +80,18 @@ final class Server
             $projectRoot = $cwd;
         }
 
-        $this->documentManager = new DocumentManager();
+        $documentManager = new DocumentManager();
         $symbolIndex = new SymbolIndex();
-        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $symbolIndex);
+        $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
         $classLocator = new ComposerClassLocator($projectRoot);
 
         $classInfoFactory = new DefaultClassInfoFactory();
-        $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $this->parser);
+        $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
         $functionRepository = new DefaultFunctionRepository();
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, $functionRepository);
         $symbolResolver = new SymbolResolver(
-            $this->parser,
+            $parser,
             $classRepository,
             $memberResolver,
             $typeResolver,
@@ -88,47 +99,48 @@ final class Server
         );
 
         $negotiator = new CapabilityNegotiator($serverInfo);
-        $this->lifecycleHandler = new LifecycleHandler($negotiator);
-        $this->handlers[] = $this->lifecycleHandler;
-        $this->handlers[] = new TextDocumentSyncHandler(
-            $this->documentManager,
-            $this->parser,
-            $classRepository,
-            $classInfoFactory,
-            $indexer,
-        );
-        $this->handlers[] = new DefinitionHandler(
-            $this->documentManager,
-            $symbolResolver,
-        );
-        $this->handlers[] = new HoverHandler(
-            $this->documentManager,
-            $symbolResolver,
-            $negotiator,
-        );
-        $this->handlers[] = new SignatureHelpHandler(
-            $this->documentManager,
-            $symbolResolver,
-        );
-        $this->handlers[] = new CompletionHandler(
-            $this->documentManager,
-            $symbolResolver,
-            new ClassCandidates($symbolIndex, $symbolResolver),
-            new NamespaceCandidates(
-                NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot),
+        $lifecycleHandler = new LifecycleHandler($negotiator);
+
+        $handlers = [
+            $lifecycleHandler,
+            new TextDocumentSyncHandler(
+                $documentManager,
+                $parser,
+                $classRepository,
+                $classInfoFactory,
+                $indexer,
+            ),
+            new DefinitionHandler(
+                $documentManager,
                 $symbolResolver,
             ),
-            new FunctionCandidates($symbolResolver, $negotiator),
-            new KeywordCandidates(),
-            new VariableCandidates($symbolResolver),
-            new MemberCandidates($symbolResolver, $negotiator),
-            new NamedArgumentCandidates(),
-            new BuiltinTypeCandidates(),
-        );
+            new HoverHandler(
+                $documentManager,
+                $symbolResolver,
+                $negotiator,
+            ),
+            new SignatureHelpHandler(
+                $documentManager,
+                $symbolResolver,
+            ),
+            new CompletionHandler(
+                $documentManager,
+                $symbolResolver,
+                new ClassCandidates($symbolIndex, $symbolResolver),
+                new NamespaceCandidates(
+                    NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot),
+                    $symbolResolver,
+                ),
+                new FunctionCandidates($symbolResolver, $negotiator),
+                new KeywordCandidates(),
+                new VariableCandidates($symbolResolver),
+                new MemberCandidates($symbolResolver, $negotiator),
+                new NamedArgumentCandidates(),
+                new BuiltinTypeCandidates(),
+            ),
+        ];
 
-        foreach ($additionalHandlers as $handler) {
-            $this->handlers[] = $handler;
-        }
+        return new self($transport, $handlers, $lifecycleHandler, $parser);
     }
 
     public function run(): int

--- a/src/Server.php
+++ b/src/Server.php
@@ -36,6 +36,8 @@ use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
+use Firehed\PhpLsp\Transport\EndOfStream;
+use Firehed\PhpLsp\Transport\MalformedFrame;
 use Firehed\PhpLsp\Transport\TransportInterface;
 
 final class Server
@@ -131,7 +133,21 @@ final class Server
 
     public function run(): int
     {
-        while (($message = $this->transport->read()) !== null) {
+        while (true) {
+            $message = $this->transport->read();
+
+            if ($message instanceof EndOfStream) {
+                break;
+            }
+
+            if ($message instanceof MalformedFrame) {
+                // The id cannot be recovered from a frame that would not decode,
+                // so it is answered with the JSON-RPC null id (RFC 1 §9). The
+                // loop continues: one bad frame must not end the session.
+                $this->transport->write(ResponseMessage::error(null, $message->error));
+                continue;
+            }
+
             $result = null;
 
             // Lifecycle gate (RFC 1 §4.8): a message not permitted in the current

--- a/src/Server.php
+++ b/src/Server.php
@@ -124,27 +124,33 @@ final class Server
     {
         while (($message = $this->transport->read()) !== null) {
             $result = null;
-            $error = null;
 
-            $handler = $this->findHandler($message->method);
+            // Lifecycle gate (RFC 1 §4.8): a message not permitted in the current
+            // state is answered with the lifecycle error and never dispatched. A
+            // gated notification has no id, so its error is simply dropped.
+            $error = $this->lifecycleHandler->lifecycleErrorFor($message);
 
-            try {
-                if ($handler !== null) {
-                    $result = $handler->handle($message);
-                } elseif ($message instanceof RequestMessage) {
-                    $error = ResponseError::methodNotFound($message->method);
+            if ($error === null) {
+                $handler = $this->findHandler($message->method);
+
+                try {
+                    if ($handler !== null) {
+                        $result = $handler->handle($message);
+                    } elseif ($message instanceof RequestMessage) {
+                        $error = ResponseError::methodNotFound($message->method);
+                    }
+                } finally {
+                    // The parse memo is scoped to one handled message — this loop
+                    // is the only boundary that knows where that ends. Discarding
+                    // it here is what keeps it from becoming the standing cache the
+                    // Step 0 spike declined (0002-execution-plan.md, Section 8.5).
+                    //
+                    // In a finally so the scope closes on every exit from the
+                    // dispatch, not just the ones that return normally: a handler
+                    // that throws is fatal today, but S1.4 makes it survivable, and
+                    // a memo that outlived a message would then be standing.
+                    $this->parser->discardScopedParses();
                 }
-            } finally {
-                // The parse memo is scoped to one handled message — this loop is
-                // the only boundary that knows where that ends. Discarding it
-                // here is what keeps it from becoming the standing cache the
-                // Step 0 spike declined (0002-execution-plan.md, Section 8.5).
-                //
-                // In a finally so the scope closes on every exit from the
-                // dispatch, not just the ones that return normally: a handler
-                // that throws is fatal today, but S1.4 makes it survivable, and
-                // a memo that outlived a message would then be standing.
-                $this->parser->discardScopedParses();
             }
 
             // Send response for requests (not notifications)

--- a/src/Server.php
+++ b/src/Server.php
@@ -46,11 +46,16 @@ final class Server
     /** @var list<HandlerInterface> */
     private array $handlers = [];
 
+    /**
+     * @param list<HandlerInterface> $additionalHandlers Registered after the
+     *        built-in handlers, so they answer only methods none of those claim.
+     */
     public function __construct(
         private TransportInterface $transport,
         ServerInfo $serverInfo,
         ?string $projectRoot = null,
         private readonly ParserService $parser = new ParserService(),
+        array $additionalHandlers = [],
     ) {
         if ($projectRoot === null) {
             $cwd = getcwd();
@@ -118,6 +123,10 @@ final class Server
             new NamedArgumentCandidates(),
             new BuiltinTypeCandidates(),
         );
+
+        foreach ($additionalHandlers as $handler) {
+            $this->handlers[] = $handler;
+        }
     }
 
     public function run(): int
@@ -139,6 +148,12 @@ final class Server
                     } elseif ($message instanceof RequestMessage) {
                         $error = ResponseError::methodNotFound($message->method);
                     }
+                } catch (\Throwable $e) {
+                    // A failing handler must not take the read loop down with it
+                    // (RFC 1 §9): an editor session that dies on one bad request
+                    // loses all unsaved server state. Notifications have no id to
+                    // answer, so their failure is contained and dropped.
+                    $error = ResponseError::internalError($e->getMessage());
                 } finally {
                     // The parse memo is scoped to one handled message — this loop
                     // is the only boundary that knows where that ends. Discarding

--- a/src/Transport/EndOfStream.php
+++ b/src/Transport/EndOfStream.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Transport;
+
+/**
+ * The stream closed cleanly with no frame pending.
+ *
+ * This is a distinct read outcome rather than a null Message because RFC 1 §9
+ * requires a message lacking a required header to be distinguishable from end
+ * of stream: one means stop serving, the other means answer with an error and
+ * keep serving.
+ */
+final readonly class EndOfStream
+{
+}

--- a/src/Transport/MalformedFrame.php
+++ b/src/Transport/MalformedFrame.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Transport;
+
+use Firehed\PhpLsp\Protocol\ResponseError;
+
+/**
+ * A frame was received but could not be turned into a message.
+ *
+ * It carries the JSON-RPC error the sender is to be answered with, decided
+ * where the raw bytes are still in hand. Malformed input must never terminate
+ * the process (RFC 1 §9).
+ */
+final readonly class MalformedFrame
+{
+    public function __construct(
+        public ResponseError $error,
+    ) {
+    }
+}

--- a/src/Transport/MalformedFrame.php
+++ b/src/Transport/MalformedFrame.php
@@ -15,8 +15,15 @@ use Firehed\PhpLsp\Protocol\ResponseError;
  */
 final readonly class MalformedFrame
 {
+    /**
+     * @param int|string|null $id The id to answer at. Null only when none could
+     *        be recovered from the frame, per JSON-RPC 2.0 §5: an id that *was*
+     *        detected must be echoed, or the client's pending request is never
+     *        correlated to this error and never resolves.
+     */
     public function __construct(
         public ResponseError $error,
+        public int|string|null $id = null,
     ) {
     }
 }

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -105,15 +105,25 @@ final class MessageReader
      */
     private static function parseContentLength(string $headerSection): ?int
     {
+        $lengths = [];
+
         foreach (explode("\r\n", $headerSection) as $header) {
             if (str_starts_with(strtolower($header), self::CONTENT_LENGTH)) {
                 $value = trim(substr($header, strlen(self::CONTENT_LENGTH)));
 
-                return ctype_digit($value) ? (int) $value : null;
+                if (!ctype_digit($value)) {
+                    return null;
+                }
+
+                $lengths[] = (int) $value;
             }
         }
 
-        return null;
+        // Conflicting values are unrecoverable framing ([RFC 7230] §3.3.3), and
+        // taking the first silently is the worst option: it is what lets two
+        // readers of the same bytes disagree about where a frame ends. Repeats
+        // of one value say nothing contradictory, so they still frame.
+        return count(array_unique($lengths)) === 1 ? $lengths[0] : null;
     }
 
     private function readBody(int $length): ?string

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -28,19 +28,31 @@ final class MessageReader
      */
     public function read(): Message|MalformedFrame|EndOfStream
     {
-        $contentLength = $this->readContentLength();
-        if (!is_int($contentLength)) {
-            return $contentLength;
-        }
+        while (true) {
+            $contentLength = $this->readContentLength();
+            if (!is_int($contentLength)) {
+                return $contentLength;
+            }
 
-        $body = $this->readBody($contentLength);
-        if ($body === null) {
-            return new MalformedFrame(
-                ResponseError::parseError('stream ended before the declared Content-Length'),
-            );
-        }
+            $body = $this->readBody($contentLength);
+            if ($body === null) {
+                return new MalformedFrame(
+                    ResponseError::parseError('stream ended before the declared Content-Length'),
+                );
+            }
 
-        return $this->decode($body);
+            $outcome = $this->decode($body);
+
+            // A frame that is recognisably a Notification is never answered
+            // (JSON-RPC 2.0 §4.1), so an unusable one leaves nothing to report
+            // and nothing to dispatch. Its bytes are already consumed; read on
+            // to the next frame rather than inventing an outcome for it.
+            if ($outcome === null) {
+                continue;
+            }
+
+            return $outcome;
+        }
     }
 
     private function readContentLength(): int|MalformedFrame|EndOfStream
@@ -125,8 +137,12 @@ final class MessageReader
      * The frame's bytes have already been consumed by the time this runs, so a
      * rejected message costs the sender an error response but does not
      * desynchronize the stream.
+     *
+     * Null means the frame is unusable *and* owes no answer: it is recognisably
+     * a Notification, which JSON-RPC 2.0 §4.1 forbids replying to. Every other
+     * rejection is answered, at the id it could be correlated to.
      */
-    private function decode(string $body): Message|MalformedFrame
+    private function decode(string $body): Message|MalformedFrame|null
     {
         try {
             $data = json_decode($body, associative: true, flags: JSON_THROW_ON_ERROR);
@@ -138,24 +154,46 @@ final class MessageReader
             return new MalformedFrame(ResponseError::invalidRequest('message must be a JSON object'));
         }
 
+        $id = self::recoverId($data);
+
+        // A non-string method is not a usable Notification even without an id,
+        // so it is still answered — JSON-RPC 2.0's own worked example replies
+        // to `{"jsonrpc":"2.0","method":1,"params":"bar"}` with a null id.
         $method = $data['method'] ?? null;
         if (!is_string($method)) {
-            return new MalformedFrame(ResponseError::invalidRequest('message has no string method'));
+            return new MalformedFrame(ResponseError::invalidRequest('message has no string method'), $id);
         }
 
         $params = $data['params'] ?? null;
         if ($params !== null && !is_array($params)) {
-            return new MalformedFrame(ResponseError::invalidRequest('params must be structured'));
+            if (!array_key_exists('id', $data)) {
+                return null;
+            }
+
+            return new MalformedFrame(ResponseError::invalidRequest('params must be structured'), $id);
         }
 
         if (!array_key_exists('id', $data)) {
             return NotificationMessage::fromArray($data);
         }
 
-        if (!is_int($data['id']) && !is_string($data['id'])) {
+        if ($id === null) {
             return new MalformedFrame(ResponseError::invalidRequest('id must be an integer or string'));
         }
 
         return RequestMessage::fromArray($data);
+    }
+
+    /**
+     * The id a rejected frame is answered at, or null when the frame carries
+     * none that could be detected (JSON-RPC 2.0 §5).
+     *
+     * @param array<array-key, mixed> $data
+     */
+    private static function recoverId(array $data): int|string|null
+    {
+        $id = $data['id'] ?? null;
+
+        return is_int($id) || is_string($id) ? $id : null;
     }
 }

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -52,7 +52,9 @@ final class MessageReader
                 $this->buffer = substr($this->buffer, $headerEnd + 4);
 
                 return self::parseContentLength($headerSection)
-                    ?? new MalformedFrame(ResponseError::parseError('missing Content-Length header'));
+                    ?? new MalformedFrame(
+                        ResponseError::parseError('missing or unusable Content-Length header'),
+                    );
             }
 
             $chunk = $this->stream->read();
@@ -72,11 +74,23 @@ final class MessageReader
         }
     }
 
+    /**
+     * Null when no usable Content-Length is present, which per [LSP] "Base
+     * Protocol" is a byte count and so a run of decimal digits.
+     *
+     * A bare (int) cast accepted whatever the sender sent: "abc" framed a
+     * zero-length body and "-5" a negative one, which makes substr() consume
+     * from the wrong end and corrupts every frame that follows. Rejecting the
+     * frame instead leaves the buffer untouched, so a sender that merely
+     * mis-declared one length does not lose the messages behind it.
+     */
     private static function parseContentLength(string $headerSection): ?int
     {
         foreach (explode("\r\n", $headerSection) as $header) {
             if (str_starts_with(strtolower($header), self::CONTENT_LENGTH)) {
-                return (int) trim(substr($header, strlen(self::CONTENT_LENGTH)));
+                $value = trim(substr($header, strlen(self::CONTENT_LENGTH)));
+
+                return ctype_digit($value) ? (int) $value : null;
             }
         }
 

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -88,6 +88,14 @@ final class MessageReader
         while (strlen($this->buffer) < $length) {
             $chunk = $this->stream->read();
             if ($chunk === null) {
+                // Same reasoning as the header path: a body that never reaches
+                // its declared length is a truncated frame, so its bytes are
+                // consumed. Left in place they would be re-read as the next
+                // frame's header block, which both costs a second error
+                // response for one bad frame and lets bytes the sender chose
+                // inside a body declare the Content-Length that follows them.
+                $this->buffer = '';
+
                 return null;
             }
             $this->buffer .= $chunk;

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -63,10 +63,12 @@ final class MessageReader
                 $headerSection = substr($this->buffer, 0, $headerEnd);
                 $this->buffer = substr($this->buffer, $headerEnd + 4);
 
-                return self::parseContentLength($headerSection)
-                    ?? new MalformedFrame(
-                        ResponseError::parseError('missing or unusable Content-Length header'),
-                    );
+                // Without a usable length the frame's extent is unknown, so the
+                // rest of the buffer is offered to the decoder instead. The
+                // content part is JSON, which the decoder can judge on its own:
+                // a client that merely mis-declared the length is served, and
+                // anything else costs one error (see parseContentLength).
+                return self::parseContentLength($headerSection) ?? strlen($this->buffer);
             }
 
             $chunk = $this->stream->read();
@@ -87,14 +89,19 @@ final class MessageReader
     }
 
     /**
-     * Null when no usable Content-Length is present, which per [LSP] "Base
-     * Protocol" is a byte count and so a run of decimal digits.
+     * Null when no usable Content-Length is present. Per [LSP] "Base Protocol"
+     * it is a byte count whose header field structure "conforms to the HTTP
+     * semantic" ([RFC 7230] §3.2), and so is §3.3.2's `Content-Length = 1*DIGIT`.
      *
      * A bare (int) cast accepted whatever the sender sent: "abc" framed a
      * zero-length body and "-5" a negative one, which makes substr() consume
-     * from the wrong end and corrupts every frame that follows. Rejecting the
-     * frame instead leaves the buffer untouched, so a sender that merely
-     * mis-declared one length does not lose the messages behind it.
+     * from the wrong end and corrupts every frame that follows.
+     *
+     * Rejecting the *value* is not the same as rejecting the message. [RFC 7230]
+     * §3.3.3 treats an invalid Content-Length as unrecoverable framing, and it
+     * is — for opaque bytes. An LSP content part is JSON, so the decoder can
+     * still tell a whole message from rubbish, and the caller falls back to it
+     * rather than bouncing a client that got only the header wrong.
      */
     private static function parseContentLength(string $headerSection): ?int
     {

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -8,9 +8,12 @@ use Amp\ByteStream\ReadableStream;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Protocol\ResponseError;
 
 final class MessageReader
 {
+    private const string CONTENT_LENGTH = 'content-length:';
+
     private string $buffer = '';
 
     public function __construct(
@@ -18,53 +21,66 @@ final class MessageReader
     ) {
     }
 
-    public function read(): ?Message
+    /**
+     * Reads one frame, reporting the three outcomes RFC 1 §9 requires be told
+     * apart: a usable message, a frame that could not be decoded (answer with
+     * an error and keep serving), and a clean end of stream (stop serving).
+     */
+    public function read(): Message|MalformedFrame|EndOfStream
     {
-        $contentLength = $this->readHeaders();
-        if ($contentLength === null) {
-            return null;
+        $contentLength = $this->readContentLength();
+        if (!is_int($contentLength)) {
+            return $contentLength;
         }
 
         $body = $this->readBody($contentLength);
         if ($body === null) {
-            return null;
+            return new MalformedFrame(
+                ResponseError::parseError('stream ended before the declared Content-Length'),
+            );
         }
 
-        $data = json_decode($body, associative: true, flags: JSON_THROW_ON_ERROR);
-        assert(is_array($data));
-
-        if (array_key_exists('id', $data)) {
-            return RequestMessage::fromArray($data);
-        }
-
-        return NotificationMessage::fromArray($data);
+        return $this->decode($body);
     }
 
-    private function readHeaders(): ?int
+    private function readContentLength(): int|MalformedFrame|EndOfStream
     {
-        $contentLength = null;
-
         while (true) {
             $headerEnd = strpos($this->buffer, "\r\n\r\n");
             if ($headerEnd !== false) {
                 $headerSection = substr($this->buffer, 0, $headerEnd);
                 $this->buffer = substr($this->buffer, $headerEnd + 4);
 
-                foreach (explode("\r\n", $headerSection) as $header) {
-                    if (str_starts_with(strtolower($header), 'content-length:')) {
-                        $contentLength = (int) trim(substr($header, 15));
-                    }
-                }
-
-                return $contentLength;
+                return self::parseContentLength($headerSection)
+                    ?? new MalformedFrame(ResponseError::parseError('missing Content-Length header'));
             }
 
             $chunk = $this->stream->read();
             if ($chunk === null) {
-                return null;
+                if ($this->buffer === '') {
+                    return new EndOfStream();
+                }
+
+                // Bytes that never terminate a header block are a truncated
+                // frame, not a clean hang-up. Drop them so the next read
+                // reports end of stream instead of looping on the same bytes.
+                $this->buffer = '';
+
+                return new MalformedFrame(ResponseError::parseError('incomplete header at end of stream'));
             }
             $this->buffer .= $chunk;
         }
+    }
+
+    private static function parseContentLength(string $headerSection): ?int
+    {
+        foreach (explode("\r\n", $headerSection) as $header) {
+            if (str_starts_with(strtolower($header), self::CONTENT_LENGTH)) {
+                return (int) trim(substr($header, strlen(self::CONTENT_LENGTH)));
+            }
+        }
+
+        return null;
     }
 
     private function readBody(int $length): ?string
@@ -81,5 +97,43 @@ final class MessageReader
         $this->buffer = substr($this->buffer, $length);
 
         return $body;
+    }
+
+    /**
+     * The frame's bytes have already been consumed by the time this runs, so a
+     * rejected message costs the sender an error response but does not
+     * desynchronize the stream.
+     */
+    private function decode(string $body): Message|MalformedFrame
+    {
+        try {
+            $data = json_decode($body, associative: true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            return new MalformedFrame(ResponseError::parseError($e->getMessage()));
+        }
+
+        if (!is_array($data)) {
+            return new MalformedFrame(ResponseError::invalidRequest('message must be a JSON object'));
+        }
+
+        $method = $data['method'] ?? null;
+        if (!is_string($method)) {
+            return new MalformedFrame(ResponseError::invalidRequest('message has no string method'));
+        }
+
+        $params = $data['params'] ?? null;
+        if ($params !== null && !is_array($params)) {
+            return new MalformedFrame(ResponseError::invalidRequest('params must be structured'));
+        }
+
+        if (!array_key_exists('id', $data)) {
+            return NotificationMessage::fromArray($data);
+        }
+
+        if (!is_int($data['id']) && !is_string($data['id'])) {
+            return new MalformedFrame(ResponseError::invalidRequest('id must be an integer or string'));
+        }
+
+        return RequestMessage::fromArray($data);
     }
 }

--- a/src/Transport/MessageReader.php
+++ b/src/Transport/MessageReader.php
@@ -173,6 +173,15 @@ final class MessageReader
 
         $id = self::recoverId($data);
 
+        // JSON-RPC 2.0 §4: "jsonrpc ... MUST be exactly '2.0'", so a frame
+        // without it is not a Request object and draws §5.1's InvalidRequest.
+        // [LSP] "Abstract Message" adds only that the protocol "always uses
+        // '2.0'" and defers the content part to JSON-RPC, so nothing here is
+        // relaxed for LSP. Answered even with no id, for the reason below.
+        if (($data['jsonrpc'] ?? null) !== '2.0') {
+            return new MalformedFrame(ResponseError::invalidRequest('jsonrpc must be exactly "2.0"'), $id);
+        }
+
         // A non-string method is not a usable Notification even without an id,
         // so it is still answered — JSON-RPC 2.0's own worked example replies
         // to `{"jsonrpc":"2.0","method":1,"params":"bar"}` with a null id.

--- a/src/Transport/StdioTransport.php
+++ b/src/Transport/StdioTransport.php
@@ -27,7 +27,7 @@ final class StdioTransport implements TransportInterface
         $this->writer = new MessageWriter($this->stdout);
     }
 
-    public function read(): ?Message
+    public function read(): Message|MalformedFrame|EndOfStream
     {
         return $this->reader->read();
     }

--- a/src/Transport/StdioTransport.php
+++ b/src/Transport/StdioTransport.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Transport;
 
 use Amp\ByteStream\ReadableResourceStream;
+use Amp\ByteStream\ReadableStream;
 use Amp\ByteStream\WritableResourceStream;
+use Amp\ByteStream\WritableStream;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
 
@@ -16,15 +18,18 @@ final class StdioTransport implements TransportInterface
 {
     private MessageReader $reader;
     private MessageWriter $writer;
-    private ReadableResourceStream $stdin;
-    private WritableResourceStream $stdout;
 
-    public function __construct()
-    {
-        $this->stdin = new ReadableResourceStream(STDIN);
-        $this->stdout = new WritableResourceStream(STDOUT);
-        $this->reader = new MessageReader($this->stdin);
-        $this->writer = new MessageWriter($this->stdout);
+    /**
+     * Defaults to the process's standard streams, which is how the server runs;
+     * both are injectable so the framing round-trip can be exercised without
+     * taking over the test runner's stdio.
+     */
+    public function __construct(
+        private readonly ReadableStream $input = new ReadableResourceStream(STDIN),
+        private readonly WritableStream $output = new WritableResourceStream(STDOUT),
+    ) {
+        $this->reader = new MessageReader($this->input);
+        $this->writer = new MessageWriter($this->output);
     }
 
     public function read(): Message|MalformedFrame|EndOfStream
@@ -39,7 +44,7 @@ final class StdioTransport implements TransportInterface
 
     public function close(): void
     {
-        $this->stdin->close();
-        $this->stdout->close();
+        $this->input->close();
+        $this->output->close();
     }
 }

--- a/src/Transport/StreamTransport.php
+++ b/src/Transport/StreamTransport.php
@@ -4,29 +4,26 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Transport;
 
-use Amp\ByteStream\ReadableResourceStream;
 use Amp\ByteStream\ReadableStream;
-use Amp\ByteStream\WritableResourceStream;
 use Amp\ByteStream\WritableStream;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
 
-use const STDIN;
-use const STDOUT;
-
-final class StdioTransport implements TransportInterface
+/**
+ * Frames LSP messages over a stream pair, per [LSP] "Base Protocol".
+ *
+ * The streams are supplied by the caller: acquiring the process's real stdio
+ * handles cannot be exercised from a test, so it belongs in the entry point that
+ * composes the server (`bin/php-lsp`), not in here.
+ */
+final class StreamTransport implements TransportInterface
 {
     private MessageReader $reader;
     private MessageWriter $writer;
 
-    /**
-     * Defaults to the process's standard streams, which is how the server runs;
-     * both are injectable so the framing round-trip can be exercised without
-     * taking over the test runner's stdio.
-     */
     public function __construct(
-        private readonly ReadableStream $input = new ReadableResourceStream(STDIN),
-        private readonly WritableStream $output = new WritableResourceStream(STDOUT),
+        private readonly ReadableStream $input,
+        private readonly WritableStream $output,
     ) {
         $this->reader = new MessageReader($this->input);
         $this->writer = new MessageWriter($this->output);

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -9,7 +9,7 @@ use Firehed\PhpLsp\Protocol\ResponseMessage;
 
 interface TransportInterface
 {
-    public function read(): ?Message;
+    public function read(): Message|MalformedFrame|EndOfStream;
 
     public function write(ResponseMessage $response): void;
 

--- a/tests/Handler/LifecycleHandlerTest.php
+++ b/tests/Handler/LifecycleHandlerTest.php
@@ -8,8 +8,10 @@ use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Protocol\InitializeResult;
 use Firehed\PhpLsp\Protocol\MarkupKind;
+use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\ServerInfo;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -134,6 +136,97 @@ class LifecycleHandlerTest extends TestCase
         $result = $handler->handle($notification);
 
         self::assertSame(1, $handler->getExitCode());
+    }
+
+    public function testRequestBeforeInitializeIsRejectedAsNotInitialized(): void
+    {
+        $handler = self::handler();
+
+        $error = $handler->lifecycleErrorFor(self::request('textDocument/hover'));
+
+        self::assertInstanceOf(ResponseError::class, $error, 'a request before initialize must be rejected');
+        self::assertSame(
+            ResponseError::serverNotInitialized()->code,
+            $error->code,
+            'requests before initialize get ServerNotInitialized (RFC 1 §4.8)',
+        );
+    }
+
+    public function testInitializeIsAllowedBeforeInitialize(): void
+    {
+        $handler = self::handler();
+
+        self::assertNull(
+            $handler->lifecycleErrorFor(self::request('initialize')),
+            'the initialize request itself must pass the pre-initialize gate',
+        );
+    }
+
+    public function testExitIsAllowedBeforeInitialize(): void
+    {
+        $handler = self::handler();
+
+        self::assertNull(
+            $handler->lifecycleErrorFor(self::notification('exit')),
+            'exit must be honored without an initialize (LSP "Server lifecycle")',
+        );
+    }
+
+    public function testRequestsAreAllowedAfterInitialize(): void
+    {
+        $handler = self::handler();
+        $handler->handle(self::request('initialize'));
+
+        self::assertNull(
+            $handler->lifecycleErrorFor(self::request('textDocument/hover')),
+            'a normal request must pass once the server is initialized',
+        );
+    }
+
+    public function testRequestAfterShutdownIsRejectedAsInvalid(): void
+    {
+        $handler = self::handler();
+        $handler->handle(self::request('initialize'));
+        $handler->handle(self::request('shutdown'));
+
+        $error = $handler->lifecycleErrorFor(self::request('textDocument/hover'));
+
+        self::assertInstanceOf(ResponseError::class, $error, 'a request after shutdown must be rejected');
+        self::assertSame(
+            ResponseError::invalidRequest()->code,
+            $error->code,
+            'requests after shutdown get InvalidRequest (RFC 1 §4.8)',
+        );
+    }
+
+    public function testExitIsAllowedAfterShutdown(): void
+    {
+        $handler = self::handler();
+        $handler->handle(self::request('initialize'));
+        $handler->handle(self::request('shutdown'));
+
+        self::assertNull(
+            $handler->lifecycleErrorFor(self::notification('exit')),
+            'exit is the expected message after shutdown and must pass',
+        );
+    }
+
+    private static function request(string $method): Message
+    {
+        return RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => $method,
+            'params' => ['capabilities' => []],
+        ]);
+    }
+
+    private static function notification(string $method): Message
+    {
+        return NotificationMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => $method,
+        ]);
     }
 
     private static function handler(): LifecycleHandler

--- a/tests/Handler/LifecycleHandlerTest.php
+++ b/tests/Handler/LifecycleHandlerTest.php
@@ -211,6 +211,28 @@ class LifecycleHandlerTest extends TestCase
         );
     }
 
+    /**
+     * [LSP] "Server lifecycle" → initialize: "The `initialize` request may only
+     * be sent once." A client that sends a second one has violated the
+     * lifecycle; re-running negotiation would silently replace the resolved
+     * session capabilities, so the gate rejects it. The spec names no code, and
+     * InvalidRequest matches the other lifecycle-violation answer.
+     */
+    public function testSecondInitializeIsRejectedAsInvalid(): void
+    {
+        $handler = self::handler();
+        $handler->handle(self::request('initialize'));
+
+        $error = $handler->lifecycleErrorFor(self::request('initialize'));
+
+        self::assertInstanceOf(ResponseError::class, $error, 'a second initialize must be rejected');
+        self::assertSame(
+            ResponseError::invalidRequest()->code,
+            $error->code,
+            'a duplicate initialize gets InvalidRequest',
+        );
+    }
+
     private static function request(string $method): Message
     {
         return RequestMessage::fromArray([

--- a/tests/Integration/DefinitionIntegrationTest.php
+++ b/tests/Integration/DefinitionIntegrationTest.php
@@ -10,6 +10,8 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
 use Firehed\PhpLsp\Server;
 use Firehed\PhpLsp\ServerInfo;
+use Firehed\PhpLsp\Transport\EndOfStream;
+use Firehed\PhpLsp\Transport\MalformedFrame;
 use Firehed\PhpLsp\Transport\MessageReader;
 use Firehed\PhpLsp\Transport\MessageWriter;
 use Firehed\PhpLsp\Transport\TransportInterface;
@@ -140,7 +142,7 @@ class DefinitionIntegrationTest extends TestCase
             ) {
             }
 
-            public function read(): ?Message
+            public function read(): Message|MalformedFrame|EndOfStream
             {
                 return $this->reader->read();
             }

--- a/tests/Integration/DefinitionIntegrationTest.php
+++ b/tests/Integration/DefinitionIntegrationTest.php
@@ -72,7 +72,7 @@ class DefinitionIntegrationTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         $exitCode = $server->run();
 

--- a/tests/Protocol/ResponseErrorTest.php
+++ b/tests/Protocol/ResponseErrorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Protocol;
+
+use Firehed\PhpLsp\Protocol\ResponseError;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResponseError::class)]
+class ResponseErrorTest extends TestCase
+{
+    public function testServerNotInitializedUsesTheLspErrorCode(): void
+    {
+        $error = ResponseError::serverNotInitialized();
+
+        self::assertSame(
+            -32002,
+            $error->code,
+            'ServerNotInitialized is -32002 per LSP "Server lifecycle"',
+        );
+    }
+}

--- a/tests/Protocol/ResponseErrorTest.php
+++ b/tests/Protocol/ResponseErrorTest.php
@@ -6,19 +6,67 @@ namespace Firehed\PhpLsp\Tests\Protocol;
 
 use Firehed\PhpLsp\Protocol\ResponseError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ResponseError::class)]
 class ResponseErrorTest extends TestCase
 {
-    public function testServerNotInitializedUsesTheLspErrorCode(): void
+    /**
+     * The codes are fixed by JSON-RPC 2.0 and, for ServerNotInitialized, by
+     * [LSP] "Server lifecycle". They are asserted as literals rather than
+     * against the factories themselves so a typo cannot agree with itself.
+     *
+     * @param callable(): ResponseError $factory
+     */
+    #[DataProvider('errorFactories')]
+    public function testFactoryUsesTheSpecifiedCode(int $expected, callable $factory): void
     {
-        $error = ResponseError::serverNotInitialized();
+        self::assertSame($expected, $factory()->code, 'the factory must emit the specified error code');
+    }
 
+    /**
+     * Factories are passed as first-class callables rather than invoked here:
+     * a data provider runs before coverage tracking starts.
+     *
+     * @return iterable<string, array{int, callable(): ResponseError}>
+     *
+     * @codeCoverageIgnore
+     */
+    public static function errorFactories(): iterable
+    {
+        yield 'parse error' => [-32700, ResponseError::parseError(...)];
+        yield 'invalid request' => [-32600, ResponseError::invalidRequest(...)];
+        yield 'method not found' => [-32601, ResponseError::methodNotFound(...)];
+        yield 'invalid params' => [-32602, ResponseError::invalidParams(...)];
+        yield 'internal error' => [-32603, ResponseError::internalError(...)];
+        yield 'server not initialized' => [-32002, ResponseError::serverNotInitialized(...)];
+    }
+
+    public function testMethodNotFoundNamesTheMissingMethod(): void
+    {
+        self::assertStringContainsString(
+            'textDocument/hover',
+            ResponseError::methodNotFound('textDocument/hover')->message,
+            'the unsupported method is reported back to aid debugging',
+        );
+    }
+
+    public function testSerializationOmitsAbsentData(): void
+    {
         self::assertSame(
-            -32002,
-            $error->code,
-            'ServerNotInitialized is -32002 per LSP "Server lifecycle"',
+            ['code' => -32603, 'message' => 'Internal error'],
+            ResponseError::internalError()->jsonSerialize(),
+            'an error carrying no data omits the key entirely',
+        );
+    }
+
+    public function testSerializationIncludesData(): void
+    {
+        self::assertSame(
+            ['code' => -32603, 'message' => 'Internal error', 'data' => 'boom'],
+            ResponseError::internalError('boom')->jsonSerialize(),
+            'diagnostic detail is carried in the data member',
         );
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -20,6 +20,7 @@ use Firehed\PhpLsp\Transport\MessageReader;
 use Firehed\PhpLsp\Transport\MessageWriter;
 use Firehed\PhpLsp\Transport\TransportInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Server::class)]
@@ -129,6 +130,106 @@ class ServerTest extends TestCase
             $this->errorCode($this->responseWithId($responses, 5)),
             'a request after shutdown gets InvalidRequest (RFC 1 §4.8)',
         );
+    }
+
+    /**
+     * A gated message must be answered with the lifecycle error *and* never
+     * reach a handler (RFC 1 §4.8; LSP "Server lifecycle" requires pre-
+     * `initialize` notifications be dropped). Asserting the response code alone
+     * cannot tell enforcement from theatre: a server that dispatches the
+     * message and then overwrites the result with the gate error emits byte-
+     * identical output, while having mutated DocumentManager and SymbolIndex.
+     *
+     * @param list<string> $preamble
+     */
+    #[DataProvider('gatedMessages')]
+    public function testGatedMessageIsNeverDispatched(
+        array $preamble,
+        string $gated,
+        ?int $expectedErrorCode,
+    ): void {
+        $spy = new class implements HandlerInterface {
+            /** @var list<string> */
+            public array $dispatched = [];
+
+            public function supports(string $method): bool
+            {
+                return $method === 'test/spy';
+            }
+
+            public function handle(Message $message): mixed
+            {
+                $this->dispatched[] = $message->method;
+                return null;
+            }
+        };
+
+        $input = $this->buildMessages(...[...$preamble, $gated, $this->notificationJson('exit')]);
+        $outputBuffer = new WritableBuffer();
+
+        $lifecycle = new LifecycleHandler(new CapabilityNegotiator(new ServerInfo('test', '1.0')));
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, $lifecycle, [$spy], new ParserService());
+
+        $server->run();
+
+        self::assertSame([], $spy->dispatched, 'a gated message must never reach a handler');
+
+        $responses = $this->decodeResponses($outputBuffer->buffer());
+        $answers = array_values(array_filter(
+            $responses,
+            fn (array $response): bool => ($response['id'] ?? null) === 99,
+        ));
+
+        if ($expectedErrorCode === null) {
+            self::assertSame([], $answers, 'a gated notification is dropped, not answered');
+            self::assertCount(
+                $this->countRequests($preamble),
+                $responses,
+                'a gated notification produces no response frame of any id',
+            );
+            return;
+        }
+
+        self::assertCount(1, $answers, 'a gated request is answered exactly once');
+        self::assertSame(
+            $expectedErrorCode,
+            $this->errorCode($answers[0]),
+            'the gated request carries the lifecycle error for the current state',
+        );
+    }
+
+    /**
+     * The preamble carries the requests that produce a response frame, so the
+     * notification cases can assert on the total frame count.
+     *
+     * @return iterable<string, array{list<string>, string, ?int}>
+     *
+     * @codeCoverageIgnore
+     */
+    public static function gatedMessages(): iterable
+    {
+        $request = json_encode(
+            ['jsonrpc' => '2.0', 'id' => 99, 'method' => 'test/spy'],
+            JSON_THROW_ON_ERROR,
+        );
+        $notification = json_encode(
+            ['jsonrpc' => '2.0', 'method' => 'test/spy'],
+            JSON_THROW_ON_ERROR,
+        );
+        $initialize = json_encode(
+            ['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => ['capabilities' => []]],
+            JSON_THROW_ON_ERROR,
+        );
+        $initialized = json_encode(['jsonrpc' => '2.0', 'method' => 'initialized'], JSON_THROW_ON_ERROR);
+        $shutdown = json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'shutdown'], JSON_THROW_ON_ERROR);
+
+        // Only the id-bearing preamble messages produce response frames, so the
+        // expected frame count for the notification cases is the request count.
+        yield 'request before initialize' => [[], $request, -32002];
+        yield 'notification before initialize' => [[], $notification, null];
+        yield 'request after shutdown' => [[$initialize, $initialized, $shutdown], $request, -32600];
+        yield 'notification after shutdown' => [[$initialize, $initialized, $shutdown], $notification, null];
     }
 
     /**
@@ -340,6 +441,25 @@ class ServerTest extends TestCase
         $exitCode = $server->run();
 
         self::assertSame(1, $exitCode);
+    }
+
+    /**
+     * Only id-bearing messages are answered, so this is how many response
+     * frames a preamble accounts for.
+     *
+     * @param list<string> $jsonMessages
+     */
+    private function countRequests(array $jsonMessages): int
+    {
+        $count = 0;
+        foreach ($jsonMessages as $json) {
+            $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+            if (is_array($decoded) && array_key_exists('id', $decoded)) {
+                $count++;
+            }
+        }
+
+        return $count;
     }
 
     private function initializeJson(int $id = 1): string

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -273,6 +273,45 @@ class ServerTest extends TestCase
         );
     }
 
+    /**
+     * The §8.1 mechanism for RFC 1 §9: a malformed frame is answered with an
+     * error response and the read loop keeps going. The id-less ParseError is
+     * JSON-RPC's answer when the id cannot be recovered from the bad frame.
+     */
+    public function testMalformedFrameIsAnsweredAndDoesNotStopTheLoop(): void
+    {
+        $garbage = 'this is not json';
+        $input = $this->buildMessages($this->initializeJson(100), $this->initializedJson())
+            . 'Content-Length: ' . strlen($garbage) . "\r\n\r\n" . $garbage
+            . $this->buildMessages(
+                $this->requestJson(8, 'shutdown'),
+                $this->notificationJson('exit'),
+            );
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        $exitCode = $server->run();
+
+        self::assertSame(0, $exitCode, 'a malformed frame does not terminate the process');
+
+        $responses = $this->decodeResponses($outputBuffer->buffer());
+
+        $parseErrors = array_filter(
+            $responses,
+            fn (array $response): bool => ($response['id'] ?? null) === null
+                && $this->errorCode($response) === ResponseError::parseError()->code,
+        );
+        self::assertCount(1, $parseErrors, 'the malformed frame is answered with a null-id ParseError');
+
+        self::assertArrayHasKey(
+            'result',
+            $this->responseWithId($responses, 8),
+            'the loop survives the malformed frame and still answers later requests',
+        );
+    }
+
     public function testExitWithoutShutdownReturnsOne(): void
     {
         $input = $this->buildMessages($this->notificationJson('exit'));

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -329,10 +329,27 @@ class ServerTest extends TestCase
      * down the read loop (RFC 1 §9): an editor session that dies on one failed
      * request loses all unsaved server state. The later shutdown proves the loop
      * survived, not merely that one response was written.
+     *
+     * The shape of the failure is what the cases vary, because each narrowing
+     * of the catch passes a RuntimeException-on-a-request test: catching
+     * \Exception still lets through the \Error a null member access raises deep
+     * in resolution, and rethrowing for notifications lets a failing
+     * textDocument/didChange — the highest-traffic message in a live session —
+     * take the loop down.
+     *
+     * @param class-string<\Throwable> $throwable
      */
-    public function testHandlerFailureYieldsInternalErrorAndKeepsRunning(): void
+    #[DataProvider('handlerFailures')]
+    public function testHandlerFailureDoesNotStopTheLoop(string $throwable, bool $asNotification): void
     {
-        $throwing = new class implements HandlerInterface {
+        $throwing = new class ($throwable) implements HandlerInterface {
+            /**
+             * @param class-string<\Throwable> $throwable
+             */
+            public function __construct(private string $throwable)
+            {
+            }
+
             public function supports(string $method): bool
             {
                 return $method === 'test/throw';
@@ -340,14 +357,19 @@ class ServerTest extends TestCase
 
             public function handle(Message $message): mixed
             {
-                throw new \RuntimeException('boom');
+                $class = $this->throwable;
+                throw new $class('boom');
             }
         };
+
+        $failing = $asNotification
+            ? $this->notificationJson('test/throw')
+            : $this->requestJson(7, 'test/throw');
 
         $input = $this->buildMessages(
             $this->initializeJson(100),
             $this->initializedJson(),
-            $this->requestJson(7, 'test/throw'),
+            $failing,
             $this->requestJson(8, 'shutdown'),
             $this->notificationJson('exit'),
         );
@@ -363,16 +385,39 @@ class ServerTest extends TestCase
 
         $responses = $this->decodeResponses($outputBuffer->buffer());
 
-        self::assertSame(
-            ResponseError::internalError()->code,
-            $this->errorCode($this->responseWithId($responses, 7)),
-            'a throwing handler yields InternalError (RFC 1 §9)',
-        );
         self::assertArrayHasKey(
             'result',
             $this->responseWithId($responses, 8),
             'the loop survives the failure and still answers later requests',
         );
+
+        if ($asNotification) {
+            self::assertCount(
+                2,
+                $responses,
+                'a failing notification has no id to answer, so its failure is dropped',
+            );
+            return;
+        }
+
+        self::assertSame(
+            ResponseError::internalError()->code,
+            $this->errorCode($this->responseWithId($responses, 7)),
+            'a throwing handler yields InternalError (RFC 1 §9)',
+        );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<\Throwable>, bool}>
+     *
+     * @codeCoverageIgnore
+     */
+    public static function handlerFailures(): iterable
+    {
+        yield 'exception on a request' => [\RuntimeException::class, false];
+        yield 'error on a request' => [\TypeError::class, false];
+        yield 'exception on a notification' => [\RuntimeException::class, true];
+        yield 'error on a notification' => [\TypeError::class, true];
     }
 
     /**

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -6,7 +6,9 @@ namespace Firehed\PhpLsp\Tests;
 
 use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\WritableBuffer;
+use Firehed\PhpLsp\Handler\HandlerInterface;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\Server;
 use Firehed\PhpLsp\ServerInfo;
@@ -214,6 +216,60 @@ class ServerTest extends TestCase
             3,
             $parser->getMetrics()->getParseCount(),
             'one didOpen and two completion requests, one parse each',
+        );
+    }
+
+    /**
+     * A handler failure must be answered with InternalError rather than taking
+     * down the read loop (RFC 1 §9): an editor session that dies on one failed
+     * request loses all unsaved server state. The later shutdown proves the loop
+     * survived, not merely that one response was written.
+     */
+    public function testHandlerFailureYieldsInternalErrorAndKeepsRunning(): void
+    {
+        $throwing = new class implements HandlerInterface {
+            public function supports(string $method): bool
+            {
+                return $method === 'test/throw';
+            }
+
+            public function handle(Message $message): mixed
+            {
+                throw new \RuntimeException('boom');
+            }
+        };
+
+        $input = $this->buildMessages(
+            $this->initializeJson(100),
+            $this->initializedJson(),
+            $this->requestJson(7, 'test/throw'),
+            $this->requestJson(8, 'shutdown'),
+            $this->notificationJson('exit'),
+        );
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server(
+            $transport,
+            new ServerInfo('test', '1.0'),
+            additionalHandlers: [$throwing],
+        );
+
+        $exitCode = $server->run();
+
+        self::assertSame(0, $exitCode, 'a handler failure does not terminate the read loop');
+
+        $responses = $this->decodeResponses($outputBuffer->buffer());
+
+        self::assertSame(
+            ResponseError::internalError()->code,
+            $this->errorCode($this->responseWithId($responses, 7)),
+            'a throwing handler yields InternalError (RFC 1 §9)',
+        );
+        self::assertArrayHasKey(
+            'result',
+            $this->responseWithId($responses, 8),
+            'the loop survives the failure and still answers later requests',
         );
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -254,7 +254,7 @@ class ServerTest extends TestCase
 
         $lifecycle = new LifecycleHandler(new CapabilityNegotiator(new ServerInfo('test', '1.0')));
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, [$lifecycle, $throwing], $lifecycle, new ParserService());
+        $server = new Server($transport, $lifecycle, [$throwing], new ParserService());
 
         $exitCode = $server->run();
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -57,7 +57,13 @@ class ServerTest extends TestCase
         $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
         $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
 
-        $input = $this->buildMessages($unknownJson, $shutdownJson, $exitJson);
+        $input = $this->buildMessages(
+            $this->initializeJson(100),
+            $this->initializedJson(),
+            $unknownJson,
+            $shutdownJson,
+            $exitJson,
+        );
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
@@ -70,6 +76,60 @@ class ServerTest extends TestCase
         // Should contain method not found error
         self::assertStringContainsString('"error"', $output);
         self::assertStringContainsString((string) ResponseError::methodNotFound()->code, $output);
+    }
+
+    public function testRequestBeforeInitializeIsRejected(): void
+    {
+        $hoverJson = '{"jsonrpc":"2.0","id":5,"method":"textDocument/hover","params":{}}';
+        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
+
+        $input = $this->buildMessages($hoverJson, $exitJson);
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        $server->run();
+
+        $output = $outputBuffer->buffer();
+
+        self::assertStringContainsString('"id":5', $output, 'the rejected request must still be answered');
+        self::assertStringContainsString(
+            (string) ResponseError::serverNotInitialized()->code,
+            $output,
+            'a request before initialize gets ServerNotInitialized (RFC 1 §4.8)',
+        );
+    }
+
+    public function testRequestAfterShutdownIsRejected(): void
+    {
+        $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
+        $hoverJson = '{"jsonrpc":"2.0","id":5,"method":"textDocument/hover","params":{}}';
+        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
+
+        $input = $this->buildMessages(
+            $this->initializeJson(100),
+            $this->initializedJson(),
+            $shutdownJson,
+            $hoverJson,
+            $exitJson,
+        );
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        $exitCode = $server->run();
+
+        $output = $outputBuffer->buffer();
+
+        self::assertSame(0, $exitCode, 'a clean shutdown then exit still exits with 0');
+        self::assertStringContainsString('"id":5', $output, 'the rejected request must still be answered');
+        self::assertStringContainsString(
+            (string) ResponseError::invalidRequest()->code,
+            $output,
+            'a request after shutdown gets InvalidRequest (RFC 1 §4.8)',
+        );
     }
 
     /**
@@ -103,7 +163,14 @@ class ServerTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
 
-        $input = $this->buildMessages($didOpenJson, $didChangeJson, $didChangeJson, $exitJson);
+        $input = $this->buildMessages(
+            $this->initializeJson(),
+            $this->initializedJson(),
+            $didOpenJson,
+            $didChangeJson,
+            $didChangeJson,
+            $exitJson,
+        );
         $outputBuffer = new WritableBuffer();
 
         $parser = new ParserService();
@@ -153,7 +220,14 @@ class ServerTest extends TestCase
         ], JSON_THROW_ON_ERROR);
         $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
 
-        $input = $this->buildMessages($didOpenJson, $completionJson, $completionJson, $exitJson);
+        $input = $this->buildMessages(
+            $this->initializeJson(),
+            $this->initializedJson(),
+            $didOpenJson,
+            $completionJson,
+            $completionJson,
+            $exitJson,
+        );
         $outputBuffer = new WritableBuffer();
 
         $parser = new ParserService();
@@ -182,6 +256,21 @@ class ServerTest extends TestCase
         $exitCode = $server->run();
 
         self::assertSame(1, $exitCode);
+    }
+
+    private function initializeJson(int $id = 1): string
+    {
+        return json_encode([
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'method' => 'initialize',
+            'params' => ['processId' => 1234, 'capabilities' => []],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function initializedJson(): string
+    {
+        return '{"jsonrpc":"2.0","method":"initialized"}';
     }
 
     private function buildMessages(string ...$jsonMessages): string

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -408,6 +408,59 @@ class ServerTest extends TestCase
     }
 
     /**
+     * `supports()` is part of the handler contract, so a failure there is a
+     * handler failure too (RFC 1 §9). It runs during handler lookup, which sat
+     * outside the dispatch try/catch.
+     */
+    public function testFailureSelectingAHandlerYieldsInternalError(): void
+    {
+        $throwing = new class implements HandlerInterface {
+            public function supports(string $method): bool
+            {
+                throw new \RuntimeException('boom');
+            }
+
+            public function handle(Message $message): mixed
+            {
+                return null;
+            }
+        };
+
+        $input = $this->buildMessages(
+            $this->initializeJson(100),
+            $this->initializedJson(),
+            $this->requestJson(7, 'test/lookup'),
+            $this->requestJson(8, 'shutdown'),
+            $this->notificationJson('exit'),
+        );
+        $outputBuffer = new WritableBuffer();
+
+        // The lifecycle handler claims initialize/initialized/shutdown/exit
+        // before the lookup reaches this double, so only the id 7 request trips
+        // it and the session can still be driven to a clean exit.
+        $lifecycle = new LifecycleHandler(new CapabilityNegotiator(new ServerInfo('test', '1.0')));
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, $lifecycle, [$throwing], new ParserService());
+
+        $exitCode = $server->run();
+
+        self::assertSame(0, $exitCode, 'a failure during handler lookup does not terminate the read loop');
+
+        $responses = $this->decodeResponses($outputBuffer->buffer());
+
+        self::assertSame(
+            ResponseError::internalError()->code,
+            $this->errorCode($this->responseWithId($responses, 7)),
+            'a throwing supports() yields InternalError (RFC 1 §9)',
+        );
+        self::assertArrayHasKey(
+            'result',
+            $this->responseWithId($responses, 8),
+            'the loop survives the failure and still answers later requests',
+        );
+    }
+
+    /**
      * A result the handler produced but the encoder cannot represent is a
      * handler failure too, and it surfaces in the writer rather than in
      * `handle()` — outside the dispatch try/catch. Any hover or completion

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -6,7 +6,9 @@ namespace Firehed\PhpLsp\Tests;
 
 use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\WritableBuffer;
+use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Handler\HandlerInterface;
+use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\ResponseError;
@@ -36,7 +38,7 @@ class ServerTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         $exitCode = $server->run();
 
@@ -67,7 +69,7 @@ class ServerTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         $server->run();
 
@@ -89,7 +91,7 @@ class ServerTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         $server->run();
 
@@ -114,7 +116,7 @@ class ServerTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         $exitCode = $server->run();
 
@@ -163,7 +165,7 @@ class ServerTest extends TestCase
 
         $parser = new ParserService();
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'), __DIR__ . '/Fixtures', $parser);
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'), __DIR__ . '/Fixtures', $parser);
 
         $server->run();
 
@@ -210,7 +212,7 @@ class ServerTest extends TestCase
 
         $parser = new ParserService();
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'), __DIR__ . '/Fixtures', $parser);
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'), __DIR__ . '/Fixtures', $parser);
 
         $server->run();
 
@@ -250,12 +252,9 @@ class ServerTest extends TestCase
         );
         $outputBuffer = new WritableBuffer();
 
+        $lifecycle = new LifecycleHandler(new CapabilityNegotiator(new ServerInfo('test', '1.0')));
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server(
-            $transport,
-            new ServerInfo('test', '1.0'),
-            additionalHandlers: [$throwing],
-        );
+        $server = new Server($transport, [$lifecycle, $throwing], $lifecycle, new ParserService());
 
         $exitCode = $server->run();
 
@@ -292,7 +291,7 @@ class ServerTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         $exitCode = $server->run();
 
@@ -325,7 +324,7 @@ class ServerTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         self::assertSame(1, $server->run(), 'a disconnect without exit is not a clean shutdown');
     }
@@ -336,7 +335,7 @@ class ServerTest extends TestCase
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
-        $server = new Server($transport, new ServerInfo('test', '1.0'));
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
 
         $exitCode = $server->run();
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -23,13 +23,12 @@ class ServerTest extends TestCase
 
     public function testFullLifecycle(): void
     {
-        $initializeJson = '{"jsonrpc":"2.0","id":1,"method":"initialize",'
-            . '"params":{"processId":1234,"capabilities":{}}}';
-        $initializedJson = '{"jsonrpc":"2.0","method":"initialized"}';
-        $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
-        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
-
-        $input = $this->buildMessages($initializeJson, $initializedJson, $shutdownJson, $exitJson);
+        $input = $this->buildMessages(
+            $this->initializeJson(1),
+            $this->initializedJson(),
+            $this->requestJson(2, 'shutdown'),
+            $this->notificationJson('exit'),
+        );
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
@@ -39,30 +38,27 @@ class ServerTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        $output = $outputBuffer->buffer();
+        $responses = $this->decodeResponses($outputBuffer->buffer());
 
-        // Verify initialize response
-        self::assertStringContainsString('"jsonrpc":"2.0"', $output);
-        self::assertStringContainsString('"id":1', $output);
-        self::assertStringContainsString('"capabilities"', $output);
-        self::assertStringContainsString('"serverInfo"', $output);
+        $initialize = $this->responseWithId($responses, 1);
+        $result = $initialize['result'];
+        assert(is_array($result));
+        self::assertArrayHasKey('capabilities', $result, 'initialize advertises capabilities');
+        self::assertArrayHasKey('serverInfo', $result, 'initialize reports server info');
 
-        // Verify shutdown response
-        self::assertStringContainsString('"id":2', $output);
+        $shutdown = $this->responseWithId($responses, 2);
+        self::assertArrayHasKey('result', $shutdown, 'shutdown is answered with a success result');
+        self::assertNull($shutdown['result'], 'shutdown result is null');
     }
 
     public function testUnknownMethodReturnsError(): void
     {
-        $unknownJson = '{"jsonrpc":"2.0","id":1,"method":"unknown/method"}';
-        $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
-        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
-
         $input = $this->buildMessages(
             $this->initializeJson(100),
             $this->initializedJson(),
-            $unknownJson,
-            $shutdownJson,
-            $exitJson,
+            $this->requestJson(1, 'unknown/method'),
+            $this->requestJson(2, 'shutdown'),
+            $this->notificationJson('exit'),
         );
         $outputBuffer = new WritableBuffer();
 
@@ -71,19 +67,21 @@ class ServerTest extends TestCase
 
         $server->run();
 
-        $output = $outputBuffer->buffer();
+        $responses = $this->decodeResponses($outputBuffer->buffer());
 
-        // Should contain method not found error
-        self::assertStringContainsString('"error"', $output);
-        self::assertStringContainsString((string) ResponseError::methodNotFound()->code, $output);
+        self::assertSame(
+            ResponseError::methodNotFound()->code,
+            $this->errorCode($this->responseWithId($responses, 1)),
+            'an unknown method gets MethodNotFound',
+        );
     }
 
     public function testRequestBeforeInitializeIsRejected(): void
     {
-        $hoverJson = '{"jsonrpc":"2.0","id":5,"method":"textDocument/hover","params":{}}';
-        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
-
-        $input = $this->buildMessages($hoverJson, $exitJson);
+        $input = $this->buildMessages(
+            $this->requestJson(5, 'textDocument/hover'),
+            $this->notificationJson('exit'),
+        );
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
@@ -91,28 +89,23 @@ class ServerTest extends TestCase
 
         $server->run();
 
-        $output = $outputBuffer->buffer();
+        $responses = $this->decodeResponses($outputBuffer->buffer());
 
-        self::assertStringContainsString('"id":5', $output, 'the rejected request must still be answered');
-        self::assertStringContainsString(
-            (string) ResponseError::serverNotInitialized()->code,
-            $output,
+        self::assertSame(
+            ResponseError::serverNotInitialized()->code,
+            $this->errorCode($this->responseWithId($responses, 5)),
             'a request before initialize gets ServerNotInitialized (RFC 1 §4.8)',
         );
     }
 
     public function testRequestAfterShutdownIsRejected(): void
     {
-        $shutdownJson = '{"jsonrpc":"2.0","id":2,"method":"shutdown"}';
-        $hoverJson = '{"jsonrpc":"2.0","id":5,"method":"textDocument/hover","params":{}}';
-        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
-
         $input = $this->buildMessages(
             $this->initializeJson(100),
             $this->initializedJson(),
-            $shutdownJson,
-            $hoverJson,
-            $exitJson,
+            $this->requestJson(2, 'shutdown'),
+            $this->requestJson(5, 'textDocument/hover'),
+            $this->notificationJson('exit'),
         );
         $outputBuffer = new WritableBuffer();
 
@@ -121,13 +114,13 @@ class ServerTest extends TestCase
 
         $exitCode = $server->run();
 
-        $output = $outputBuffer->buffer();
-
         self::assertSame(0, $exitCode, 'a clean shutdown then exit still exits with 0');
-        self::assertStringContainsString('"id":5', $output, 'the rejected request must still be answered');
-        self::assertStringContainsString(
-            (string) ResponseError::invalidRequest()->code,
-            $output,
+
+        $responses = $this->decodeResponses($outputBuffer->buffer());
+
+        self::assertSame(
+            ResponseError::invalidRequest()->code,
+            $this->errorCode($this->responseWithId($responses, 5)),
             'a request after shutdown gets InvalidRequest (RFC 1 §4.8)',
         );
     }
@@ -144,32 +137,23 @@ class ServerTest extends TestCase
         $uri = 'file:///fixtures/src/Domain/User.php';
         $text = $this->loadFixture('src/Domain/User.php');
 
-        $didOpenJson = json_encode([
-            'jsonrpc' => '2.0',
-            'method' => 'textDocument/didOpen',
-            'params' => [
-                'textDocument' => ['uri' => $uri, 'languageId' => 'php', 'version' => 1, 'text' => $text],
-            ],
-        ], JSON_THROW_ON_ERROR);
+        $didOpen = $this->notificationJson('textDocument/didOpen', [
+            'textDocument' => ['uri' => $uri, 'languageId' => 'php', 'version' => 1, 'text' => $text],
+        ]);
         // Re-sending identical text is what separates a message-scoped memo from
         // a standing one: the memo must have been discarded, so this parses again.
-        $didChangeJson = json_encode([
-            'jsonrpc' => '2.0',
-            'method' => 'textDocument/didChange',
-            'params' => [
-                'textDocument' => ['uri' => $uri, 'version' => 2],
-                'contentChanges' => [['text' => $text]],
-            ],
-        ], JSON_THROW_ON_ERROR);
-        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
+        $didChange = $this->notificationJson('textDocument/didChange', [
+            'textDocument' => ['uri' => $uri, 'version' => 2],
+            'contentChanges' => [['text' => $text]],
+        ]);
 
         $input = $this->buildMessages(
             $this->initializeJson(),
             $this->initializedJson(),
-            $didOpenJson,
-            $didChangeJson,
-            $didChangeJson,
-            $exitJson,
+            $didOpen,
+            $didChange,
+            $didChange,
+            $this->notificationJson('exit'),
         );
         $outputBuffer = new WritableBuffer();
 
@@ -202,31 +186,21 @@ class ServerTest extends TestCase
         $text = $this->loadFixture($fixture);
         $cursor = $this->locateCursor($text, 'param_prefix');
 
-        $didOpenJson = json_encode([
-            'jsonrpc' => '2.0',
-            'method' => 'textDocument/didOpen',
-            'params' => [
-                'textDocument' => ['uri' => $uri, 'languageId' => 'php', 'version' => 1, 'text' => $text],
-            ],
-        ], JSON_THROW_ON_ERROR);
-        $completionJson = json_encode([
-            'jsonrpc' => '2.0',
-            'id' => 1,
-            'method' => 'textDocument/completion',
-            'params' => [
-                'textDocument' => ['uri' => $uri],
-                'position' => ['line' => $cursor['line'], 'character' => $cursor['character']],
-            ],
-        ], JSON_THROW_ON_ERROR);
-        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
+        $didOpen = $this->notificationJson('textDocument/didOpen', [
+            'textDocument' => ['uri' => $uri, 'languageId' => 'php', 'version' => 1, 'text' => $text],
+        ]);
+        $completion = $this->requestJson(1, 'textDocument/completion', [
+            'textDocument' => ['uri' => $uri],
+            'position' => ['line' => $cursor['line'], 'character' => $cursor['character']],
+        ]);
 
         $input = $this->buildMessages(
             $this->initializeJson(),
             $this->initializedJson(),
-            $didOpenJson,
-            $completionJson,
-            $completionJson,
-            $exitJson,
+            $didOpen,
+            $completion,
+            $completion,
+            $this->notificationJson('exit'),
         );
         $outputBuffer = new WritableBuffer();
 
@@ -245,9 +219,7 @@ class ServerTest extends TestCase
 
     public function testExitWithoutShutdownReturnsOne(): void
     {
-        $exitJson = '{"jsonrpc":"2.0","method":"exit"}';
-
-        $input = $this->buildMessages($exitJson);
+        $input = $this->buildMessages($this->notificationJson('exit'));
         $outputBuffer = new WritableBuffer();
 
         $transport = $this->createTransport($input, $outputBuffer);
@@ -260,20 +232,36 @@ class ServerTest extends TestCase
 
     private function initializeJson(int $id = 1): string
     {
-        return json_encode([
-            'jsonrpc' => '2.0',
-            'id' => $id,
-            'method' => 'initialize',
-            'params' => ['processId' => 1234, 'capabilities' => []],
-        ], JSON_THROW_ON_ERROR);
+        return $this->requestJson($id, 'initialize', ['processId' => 1234, 'capabilities' => []]);
     }
 
     private function initializedJson(): string
     {
-        return json_encode([
-            'jsonrpc' => '2.0',
-            'method' => 'initialized',
-        ], JSON_THROW_ON_ERROR);
+        return $this->notificationJson('initialized');
+    }
+
+    /**
+     * @param array<string, mixed>|null $params
+     */
+    private function requestJson(int $id, string $method, ?array $params = null): string
+    {
+        $message = ['jsonrpc' => '2.0', 'id' => $id, 'method' => $method];
+        if ($params !== null) {
+            $message['params'] = $params;
+        }
+        return json_encode($message, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed>|null $params
+     */
+    private function notificationJson(string $method, ?array $params = null): string
+    {
+        $message = ['jsonrpc' => '2.0', 'method' => $method];
+        if ($params !== null) {
+            $message['params'] = $params;
+        }
+        return json_encode($message, JSON_THROW_ON_ERROR);
     }
 
     private function buildMessages(string ...$jsonMessages): string
@@ -283,6 +271,62 @@ class ServerTest extends TestCase
             $result .= "Content-Length: " . strlen($json) . "\r\n\r\n" . $json;
         }
         return $result;
+    }
+
+    /**
+     * Read the framed JSON-RPC responses the server wrote back, the way a client
+     * would, so assertions inspect decoded structure rather than raw substrings.
+     *
+     * @return list<array<array-key, mixed>>
+     */
+    private function decodeResponses(string $output): array
+    {
+        $prefix = 'Content-Length: ';
+        $responses = [];
+        $offset = 0;
+
+        while (($headerEnd = strpos($output, "\r\n\r\n", $offset)) !== false) {
+            $header = substr($output, $offset, $headerEnd - $offset);
+            self::assertStringStartsWith($prefix, $header, 'each frame is Content-Length framed');
+            $length = (int) substr($header, strlen($prefix));
+
+            $bodyStart = $headerEnd + 4;
+            $decoded = json_decode(substr($output, $bodyStart, $length), true, flags: JSON_THROW_ON_ERROR);
+            self::assertIsArray($decoded, 'each frame body is a JSON object');
+            $responses[] = $decoded;
+
+            $offset = $bodyStart + $length;
+        }
+
+        return $responses;
+    }
+
+    /**
+     * @param list<array<array-key, mixed>> $responses
+     * @return array<array-key, mixed>
+     */
+    private function responseWithId(array $responses, int $id): array
+    {
+        foreach ($responses as $response) {
+            if (($response['id'] ?? null) === $id) {
+                return $response;
+            }
+        }
+
+        self::fail("no response found with id $id");
+    }
+
+    /**
+     * @param array<array-key, mixed> $response
+     */
+    private function errorCode(array $response): int
+    {
+        $error = $response['error'] ?? null;
+        self::assertIsArray($error, 'the response carries an error object');
+        $code = $error['code'] ?? null;
+        self::assertIsInt($code, 'the error carries an integer code');
+
+        return $code;
     }
 
     private function createTransport(string $input, WritableBuffer $outputBuffer): TransportInterface

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -12,6 +12,8 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\ResponseError;
 use Firehed\PhpLsp\Server;
 use Firehed\PhpLsp\ServerInfo;
+use Firehed\PhpLsp\Transport\EndOfStream;
+use Firehed\PhpLsp\Transport\MalformedFrame;
 use Firehed\PhpLsp\Transport\MessageReader;
 use Firehed\PhpLsp\Transport\MessageWriter;
 use Firehed\PhpLsp\Transport\TransportInterface;
@@ -438,7 +440,7 @@ class ServerTest extends TestCase
             ) {
             }
 
-            public function read(): ?\Firehed\PhpLsp\Protocol\Message
+            public function read(): Message|MalformedFrame|EndOfStream
             {
                 return $this->reader->read();
             }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests;
 use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\WritableBuffer;
 use Firehed\PhpLsp\Capability\CapabilityNegotiator;
+use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Handler\HandlerInterface;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -321,6 +322,62 @@ class ServerTest extends TestCase
             3,
             $parser->getMetrics()->getParseCount(),
             'one didOpen and two completion requests, one parse each',
+        );
+    }
+
+    /**
+     * The parse memo is discarded in a `finally`, so a handler that parses and
+     * then throws still closes its scope. Both parse-scope tests above use
+     * non-throwing handlers, so moving the discard out of the `finally` to the
+     * tail of the `try` leaves them green while the memo silently outlives a
+     * throwing message and becomes standing. Two identical requests whose
+     * handler parses fixed content and throws separate the cases: the second
+     * re-parses only if the first message's memo was discarded despite the throw.
+     */
+    public function testParseMemoIsDiscardedWhenTheHandlerThrows(): void
+    {
+        $parser = new ParserService();
+        $document = new TextDocument('file:///probe.php', 'php', 1, '<?php class ScopedProbe {}');
+
+        $handler = new class ($parser, $document) implements HandlerInterface {
+            public function __construct(
+                private ParserService $parser,
+                private TextDocument $document,
+            ) {
+            }
+
+            public function supports(string $method): bool
+            {
+                return $method === 'test/parseThenThrow';
+            }
+
+            public function handle(Message $message): mixed
+            {
+                $this->parser->parse($this->document);
+                throw new \RuntimeException('after parsing');
+            }
+        };
+
+        $call = $this->requestJson(1, 'test/parseThenThrow');
+        $input = $this->buildMessages(
+            $this->initializeJson(),
+            $this->initializedJson(),
+            $call,
+            $call,
+            $this->notificationJson('exit'),
+        );
+        $outputBuffer = new WritableBuffer();
+
+        $lifecycle = new LifecycleHandler(new CapabilityNegotiator(new ServerInfo('test', '1.0')));
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, $lifecycle, [$handler], $parser);
+
+        $server->run();
+
+        self::assertSame(
+            2,
+            $parser->getMetrics()->getParseCount(),
+            'the memo is discarded on the throwing message, so the second call parses again',
         );
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -566,6 +566,34 @@ class ServerTest extends TestCase
     }
 
     /**
+     * When the reader could correlate the bad frame to an id, the server must
+     * answer at that id, not at the null id (JSON-RPC 2.0 §5): a client whose
+     * request is answered at null never correlates the error and waits forever.
+     * `{"id":6,"method":42}` is a request whose method is unusable — rejected,
+     * but with the id recovered.
+     */
+    public function testMalformedFrameIsAnsweredAtItsRecoveredId(): void
+    {
+        $badFrame = '{"jsonrpc":"2.0","id":6,"method":42}';
+        $input = 'Content-Length: ' . strlen($badFrame) . "\r\n\r\n" . $badFrame
+            . $this->buildMessages($this->notificationJson('exit'));
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = Server::forProject($transport, new ServerInfo('test', '1.0'));
+
+        $server->run();
+
+        $responses = $this->decodeResponses($outputBuffer->buffer());
+
+        self::assertSame(
+            ResponseError::invalidRequest()->code,
+            $this->errorCode($this->responseWithId($responses, 6)),
+            'the malformed frame is answered at the id the reader recovered from it',
+        );
+    }
+
+    /**
      * A client that disconnects without sending `exit` ends the stream. That is
      * end of stream rather than a malformed frame, so the server closes down
      * quietly and reports the same non-clean exit as an exit without shutdown.

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -314,6 +314,22 @@ class ServerTest extends TestCase
         );
     }
 
+    /**
+     * A client that disconnects without sending `exit` ends the stream. That is
+     * end of stream rather than a malformed frame, so the server closes down
+     * quietly and reports the same non-clean exit as an exit without shutdown.
+     */
+    public function testStreamEndingWithoutExitReturnsOne(): void
+    {
+        $input = $this->buildMessages($this->initializeJson(1), $this->initializedJson());
+        $outputBuffer = new WritableBuffer();
+
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, new ServerInfo('test', '1.0'));
+
+        self::assertSame(1, $server->run(), 'a disconnect without exit is not a clean shutdown');
+    }
+
     public function testExitWithoutShutdownReturnsOne(): void
     {
         $input = $this->buildMessages($this->notificationJson('exit'));

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -270,7 +270,10 @@ class ServerTest extends TestCase
 
     private function initializedJson(): string
     {
-        return '{"jsonrpc":"2.0","method":"initialized"}';
+        return json_encode([
+            'jsonrpc' => '2.0',
+            'method' => 'initialized',
+        ], JSON_THROW_ON_ERROR);
     }
 
     private function buildMessages(string ...$jsonMessages): string

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -408,6 +408,59 @@ class ServerTest extends TestCase
     }
 
     /**
+     * A result the handler produced but the encoder cannot represent is a
+     * handler failure too, and it surfaces in the writer rather than in
+     * `handle()` — outside the dispatch try/catch. Any hover or completion
+     * carrying text lifted from a file that is not valid UTF-8 (a Latin-1
+     * docblock, say) reaches the writer this way, so the read loop must
+     * survive it (RFC 1 §9).
+     */
+    public function testUnencodableResultYieldsInternalErrorAndKeepsRunning(): void
+    {
+        $unencodable = new class implements HandlerInterface {
+            public function supports(string $method): bool
+            {
+                return $method === 'test/unencodable';
+            }
+
+            public function handle(Message $message): mixed
+            {
+                return "not valid utf-8: \xB1\x31";
+            }
+        };
+
+        $input = $this->buildMessages(
+            $this->initializeJson(100),
+            $this->initializedJson(),
+            $this->requestJson(7, 'test/unencodable'),
+            $this->requestJson(8, 'shutdown'),
+            $this->notificationJson('exit'),
+        );
+        $outputBuffer = new WritableBuffer();
+
+        $lifecycle = new LifecycleHandler(new CapabilityNegotiator(new ServerInfo('test', '1.0')));
+        $transport = $this->createTransport($input, $outputBuffer);
+        $server = new Server($transport, $lifecycle, [$unencodable], new ParserService());
+
+        $exitCode = $server->run();
+
+        self::assertSame(0, $exitCode, 'an unencodable result does not terminate the read loop');
+
+        $responses = $this->decodeResponses($outputBuffer->buffer());
+
+        self::assertSame(
+            ResponseError::internalError()->code,
+            $this->errorCode($this->responseWithId($responses, 7)),
+            'a result that cannot be encoded yields InternalError (RFC 1 §9)',
+        );
+        self::assertArrayHasKey(
+            'result',
+            $this->responseWithId($responses, 8),
+            'the loop survives the failure and still answers later requests',
+        );
+    }
+
+    /**
      * @return iterable<string, array{class-string<\Throwable>, bool}>
      *
      * @codeCoverageIgnore

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -315,6 +315,12 @@ class MessageReaderTest extends TestCase
     public static function structurallyInvalidBodies(): iterable
     {
         yield 'not an object' => ['"just a string"'];
+        // JSON-RPC 2.0 §4: "jsonrpc ... MUST be exactly '2.0'". [LSP] "Abstract
+        // Message" adds only that the protocol "always uses '2.0'", and defers
+        // the content part to JSON-RPC, so §5.1's InvalidRequest governs.
+        yield 'missing version' => ['{"id":1,"method":"shutdown"}'];
+        yield 'wrong version' => ['{"jsonrpc":"1.0","id":1,"method":"shutdown"}'];
+        yield 'non-string version' => ['{"jsonrpc":2.0,"id":1,"method":"shutdown"}'];
         yield 'no method' => ['{"jsonrpc":"2.0","id":1}'];
         yield 'non-string method' => ['{"jsonrpc":"2.0","method":42}'];
         yield 'non-array params' => ['{"jsonrpc":"2.0","id":3,"method":"x","params":"nope"}'];

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -499,6 +499,7 @@ class MessageReaderTest extends TestCase
         yield 'integer id' => ['{"jsonrpc":"2.0","id":7,"method":"x","params":"nope"}', 7];
         yield 'string id' => ['{"jsonrpc":"2.0","id":"abc","method":"x","params":"nope"}', 'abc'];
         yield 'id present, method unusable' => ['{"jsonrpc":"2.0","id":9,"method":42}', 9];
+        yield 'id present, wrong version' => ['{"jsonrpc":"1.0","id":4,"method":"x"}', 4];
         yield 'id undetectable' => ['{"jsonrpc":"2.0","id":true,"method":"x"}', null];
         yield 'no id at all' => ['{"jsonrpc":"2.0","method":42}', null];
         yield 'unparseable body' => ['not json', null];

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Transport;
 
 use Amp\ByteStream\ReadableBuffer;
+use Amp\ByteStream\ReadableIterableStream;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseError;
@@ -16,8 +17,33 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(MessageReader::class)]
+#[CoversClass(EndOfStream::class)]
+#[CoversClass(MalformedFrame::class)]
 class MessageReaderTest extends TestCase
 {
+    /**
+     * A frame does not necessarily arrive in one read: the transport hands over
+     * whatever bytes are available, so a body can span several chunks and must
+     * be accumulated until Content-Length is satisfied.
+     */
+    public function testReadsABodyDeliveredAcrossSeveralChunks(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1234}}';
+        $chunks = [
+            'Content-Length: ' . strlen($json) . "\r\n\r\n" . substr($json, 0, 10),
+            substr($json, 10, 30),
+            substr($json, 40),
+        ];
+
+        $reader = new MessageReader(new ReadableIterableStream($chunks));
+
+        $request = $reader->read();
+
+        self::assertInstanceOf(RequestMessage::class, $request, 'a split body still yields one message');
+        self::assertSame('initialize', $request->method);
+        self::assertSame(1, $request->id);
+    }
+
     public function testReadRequest(): void
     {
         $json = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1234}}';

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -270,8 +270,69 @@ class MessageReaderTest extends TestCase
         yield 'not an object' => ['"just a string"'];
         yield 'no method' => ['{"jsonrpc":"2.0","id":1}'];
         yield 'non-string method' => ['{"jsonrpc":"2.0","method":42}'];
-        yield 'non-array params' => ['{"jsonrpc":"2.0","method":"x","params":"nope"}'];
+        yield 'non-array params' => ['{"jsonrpc":"2.0","id":3,"method":"x","params":"nope"}'];
         yield 'non-scalar id' => ['{"jsonrpc":"2.0","id":true,"method":"x"}'];
+    }
+
+    /**
+     * JSON-RPC 2.0 §5: the response id "MUST be the same as the value of the id
+     * member in the Request Object. If there was an error in detecting the id
+     * ... it MUST be Null." An id that was detected must therefore be echoed —
+     * answering at null instead leaves the client's pending request unresolved
+     * forever, because nothing correlates the error back to it.
+     *
+     * @param int|string|null $expectedId
+     */
+    #[DataProvider('rejectedFrameIds')]
+    public function testRejectedFrameIsAnsweredAtTheRecoverableId(string $body, int|string|null $expectedId): void
+    {
+        $reader = new MessageReader(new ReadableBuffer($this->frame($body)));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(MalformedFrame::class, $result, "should reject: $body");
+        self::assertSame(
+            $expectedId,
+            $result->id,
+            "the rejected frame is answered at the id it could be correlated to: $body",
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, int|string|null}>
+     *
+     * @codeCoverageIgnore
+     */
+    public static function rejectedFrameIds(): iterable
+    {
+        yield 'integer id' => ['{"jsonrpc":"2.0","id":7,"method":"x","params":"nope"}', 7];
+        yield 'string id' => ['{"jsonrpc":"2.0","id":"abc","method":"x","params":"nope"}', 'abc'];
+        yield 'id present, method unusable' => ['{"jsonrpc":"2.0","id":9,"method":42}', 9];
+        yield 'id undetectable' => ['{"jsonrpc":"2.0","id":true,"method":"x"}', null];
+        yield 'no id at all' => ['{"jsonrpc":"2.0","method":42}', null];
+        yield 'unparseable body' => ['not json', null];
+    }
+
+    /**
+     * JSON-RPC 2.0 §4.1: "The Server MUST NOT reply to a Notification." A frame
+     * that is recognisably one — a JSON object naming a method, carrying no id
+     * — has no sender to answer, so it is consumed and dropped rather than
+     * reported. The frame behind it still reads.
+     */
+    public function testUnusableNotificationIsDroppedRatherThanAnswered(): void
+    {
+        $input = $this->frame('{"jsonrpc":"2.0","method":"$/setTrace","params":"verbose"}')
+            . $this->frame('{"jsonrpc":"2.0","method":"initialized"}');
+        $reader = new MessageReader(new ReadableBuffer($input));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(
+            NotificationMessage::class,
+            $result,
+            'an unusable notification draws no error outcome, so the next frame surfaces instead',
+        );
+        self::assertSame('initialized', $result->method);
     }
 
     /**

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -179,6 +179,53 @@ class MessageReaderTest extends TestCase
         );
     }
 
+    /**
+     * Per [LSP] "Base Protocol" the Content-Length value is a byte count. A
+     * bare (int) cast accepted anything: "abc" became 0, and "-5" became a
+     * negative length, which makes substr() consume from the wrong end of the
+     * buffer and destroys every frame that follows. Rejecting the header
+     * instead leaves the buffer alone, so the next frame still reads.
+     */
+    #[DataProvider('unusableContentLengths')]
+    public function testUnusableContentLengthDoesNotConsumeTheNextFrame(string $value): void
+    {
+        $input = "Content-Length: $value\r\n\r\n"
+            . $this->frame('{"jsonrpc":"2.0","method":"initialized"}');
+        $reader = new MessageReader(new ReadableBuffer($input));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(MalformedFrame::class, $result, "should reject Content-Length: $value");
+        self::assertSame(
+            ResponseError::parseError()->code,
+            $result->error->code,
+            "an unusable Content-Length yields ParseError: $value",
+        );
+
+        $recovered = $reader->read();
+
+        self::assertInstanceOf(
+            NotificationMessage::class,
+            $recovered,
+            'the frame after an unusable Content-Length is still delivered',
+        );
+        self::assertSame('initialized', $recovered->method);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     *
+     * @codeCoverageIgnore
+     */
+    public static function unusableContentLengths(): iterable
+    {
+        yield 'non-numeric' => ['abc'];
+        yield 'negative' => ['-5'];
+        yield 'empty' => [''];
+        yield 'fractional' => ['1.5'];
+        yield 'scientific notation' => ['1e3'];
+    }
+
     public function testUnparseableBodyYieldsParseError(): void
     {
         $reader = new MessageReader(new ReadableBuffer($this->frame('this is not json')));

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -132,6 +132,16 @@ class MessageReaderTest extends TestCase
             $reader->read(),
             'bytes that never terminate the header block are malformed, not EOF',
         );
+
+        // The reader must consume the stranded bytes, not just report on them.
+        // Server::run answers a malformed frame and continues, so a reader that
+        // kept re-reporting the same buffer would spin emitting ParseError
+        // frames without end rather than winding the session down.
+        self::assertInstanceOf(
+            EndOfStream::class,
+            $reader->read(),
+            'the stranded bytes are consumed, so the next read reports end of stream',
+        );
     }
 
     public function testBodyTruncatedByEndOfStreamIsMalformed(): void

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -7,8 +7,12 @@ namespace Firehed\PhpLsp\Tests\Transport;
 use Amp\ByteStream\ReadableBuffer;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Protocol\ResponseError;
+use Firehed\PhpLsp\Transport\EndOfStream;
+use Firehed\PhpLsp\Transport\MalformedFrame;
 use Firehed\PhpLsp\Transport\MessageReader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(MessageReader::class)]
@@ -62,14 +66,132 @@ class MessageReaderTest extends TestCase
         self::assertInstanceOf(NotificationMessage::class, $notification);
     }
 
-    public function testReadReturnsNullOnEof(): void
+    public function testReadReturnsEndOfStreamOnEof(): void
     {
         $buffer = new ReadableBuffer('');
         $reader = new MessageReader($buffer);
 
+        self::assertInstanceOf(
+            EndOfStream::class,
+            $reader->read(),
+            'a cleanly closed stream is end of stream, not a malformed frame',
+        );
+    }
+
+    /**
+     * RFC 1 §9: "A message lacking a required header MUST be distinguishable
+     * from end of stream." Both used to surface as null, so a truncated or
+     * unframed write looked exactly like the client hanging up.
+     */
+    public function testFrameWithoutContentLengthIsNotEndOfStream(): void
+    {
+        $reader = new MessageReader(new ReadableBuffer("Content-Type: application/json\r\n\r\n"));
+
         $result = $reader->read();
 
-        self::assertNull($result);
+        self::assertInstanceOf(
+            MalformedFrame::class,
+            $result,
+            'a header block carrying no Content-Length is a malformed frame',
+        );
+        self::assertSame(ResponseError::parseError()->code, $result->error->code);
+    }
+
+    public function testUnterminatedHeaderIsNotEndOfStream(): void
+    {
+        $reader = new MessageReader(new ReadableBuffer('Content-Length: 5'));
+
+        self::assertInstanceOf(
+            MalformedFrame::class,
+            $reader->read(),
+            'bytes that never terminate the header block are malformed, not EOF',
+        );
+    }
+
+    public function testBodyTruncatedByEndOfStreamIsMalformed(): void
+    {
+        $reader = new MessageReader(new ReadableBuffer("Content-Length: 100\r\n\r\n{\"a\":1}"));
+
+        self::assertInstanceOf(
+            MalformedFrame::class,
+            $reader->read(),
+            'a body shorter than its declared Content-Length is a malformed frame',
+        );
+    }
+
+    public function testUnparseableBodyYieldsParseError(): void
+    {
+        $reader = new MessageReader(new ReadableBuffer($this->frame('this is not json')));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(MalformedFrame::class, $result);
+        self::assertSame(
+            ResponseError::parseError()->code,
+            $result->error->code,
+            'unparseable JSON yields ParseError (RFC 1 §9)',
+        );
+    }
+
+    /**
+     * Valid JSON that is not a usable JSON-RPC message. These used to trip an
+     * assert() inside the message factories, terminating the process on input a
+     * client controls.
+     */
+    #[DataProvider('structurallyInvalidBodies')]
+    public function testStructurallyInvalidMessageYieldsInvalidRequest(string $body): void
+    {
+        $reader = new MessageReader(new ReadableBuffer($this->frame($body)));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(MalformedFrame::class, $result, "should reject: $body");
+        self::assertSame(
+            ResponseError::invalidRequest()->code,
+            $result->error->code,
+            "valid JSON that is not a JSON-RPC message yields InvalidRequest: $body",
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     *
+     * @codeCoverageIgnore
+     */
+    public static function structurallyInvalidBodies(): iterable
+    {
+        yield 'not an object' => ['"just a string"'];
+        yield 'no method' => ['{"jsonrpc":"2.0","id":1}'];
+        yield 'non-string method' => ['{"jsonrpc":"2.0","method":42}'];
+        yield 'non-array params' => ['{"jsonrpc":"2.0","method":"x","params":"nope"}'];
+        yield 'non-scalar id' => ['{"jsonrpc":"2.0","id":true,"method":"x"}'];
+    }
+
+    /**
+     * The frame is consumed even when it cannot be decoded, so one bad message
+     * does not desynchronize the stream: the server answers it with an error and
+     * keeps serving (RFC 1 §9).
+     */
+    public function testReaderRecoversAfterAMalformedFrame(): void
+    {
+        $input = $this->frame('not json') . $this->frame('{"jsonrpc":"2.0","method":"initialized"}');
+        $reader = new MessageReader(new ReadableBuffer($input));
+
+        self::assertInstanceOf(MalformedFrame::class, $reader->read());
+
+        $recovered = $reader->read();
+
+        self::assertInstanceOf(
+            NotificationMessage::class,
+            $recovered,
+            'the reader resumes at the next frame after a malformed one',
+        );
+        self::assertSame('initialized', $recovered->method);
+    }
+
+    private function frame(string $body): string
+    {
+        return 'Content-Length: ' . strlen($body) . "\r\n\r\n" . $body;
     }
 
     public function testReadWithContentTypeHeader(): void

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -271,6 +271,142 @@ class MessageReaderTest extends TestCase
         yield 'empty' => [''];
         yield 'fractional' => ['1.5'];
         yield 'scientific notation' => ['1e3'];
+        yield 'leading plus' => ['+5'];
+        yield 'hexadecimal' => ['0x10'];
+        yield 'digits with trailing junk' => ['40bytes'];
+        yield 'whitespace separated' => ['4 0'];
+    }
+
+    /**
+     * [RFC 7230] §3.3.2 is `1*DIGIT`, which permits leading zeros, and §3.2.4
+     * allows optional whitespace around a field value. Neither makes the length
+     * unusable, so both frame normally.
+     */
+    #[DataProvider('usableContentLengthSpellings')]
+    public function testContentLengthSpellingsThatStillFrame(string $template): void
+    {
+        $json = '{"jsonrpc":"2.0","method":"initialized"}';
+        $value = sprintf($template, strlen($json));
+        $reader = new MessageReader(new ReadableBuffer("Content-Length:$value\r\n\r\n" . $json));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(NotificationMessage::class, $result, "should frame Content-Length:$value");
+        self::assertSame('initialized', $result->method);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     *
+     * @codeCoverageIgnore
+     */
+    public static function usableContentLengthSpellings(): iterable
+    {
+        yield 'conventional' => [' %d'];
+        yield 'no space' => ['%d'];
+        yield 'leading zeros' => [' 00%d'];
+        yield 'padded' => ['  %d  '];
+    }
+
+    /**
+     * ctype_digit accepts any run of digits, and the (int) cast saturates at
+     * PHP_INT_MAX rather than overflowing, so a sender can declare a length no
+     * stream will ever satisfy. That must wind down as one error with its bytes
+     * consumed — not spin re-reporting the same buffer, and not accumulate
+     * without bound while claiming to be mid-frame.
+     */
+    public function testContentLengthNoStreamCanSatisfyCostsOneError(): void
+    {
+        $reader = new MessageReader(new ReadableBuffer(
+            "Content-Length: 99999999999999999999\r\n\r\n" . '{"jsonrpc":"2.0","method":"initialized"}',
+        ));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(MalformedFrame::class, $result, 'a length no stream can satisfy is malformed');
+        self::assertSame(
+            ResponseError::parseError()->code,
+            $result->error->code,
+            'a body that never reaches its declared length yields ParseError',
+        );
+        self::assertInstanceOf(
+            EndOfStream::class,
+            $reader->read(),
+            'the unsatisfiable frame consumed its bytes rather than being re-reported',
+        );
+    }
+
+    /**
+     * [RFC 7230] §3.3.3 treats conflicting Content-Length values as an
+     * unrecoverable framing error, and taking the first silently is the worst
+     * of the options — it is what lets two readers of the same bytes disagree
+     * about where a frame ends. Neither value is trusted; the decoder judges
+     * the content part instead.
+     */
+    public function testConflictingContentLengthHeadersAreNotTrusted(): void
+    {
+        $json = '{"jsonrpc":"2.0","method":"initialized"}';
+        $reader = new MessageReader(new ReadableBuffer(
+            "Content-Length: 5\r\nContent-Length: 9999\r\n\r\n" . $json,
+        ));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(
+            NotificationMessage::class,
+            $result,
+            'neither conflicting length is used to frame the message',
+        );
+        self::assertSame('initialized', $result->method);
+    }
+
+    /**
+     * A length shorter than the body it describes is the sender's own lie, and
+     * the protocol answer is to believe the header: what follows the declared
+     * byte count is by definition the next frame. The remainder must therefore
+     * be consumed as framing rather than silently re-decoded, and the session
+     * must wind down cleanly instead of cascading.
+     */
+    public function testUnderstatedContentLengthWindsDownCleanly(): void
+    {
+        $json = '{"jsonrpc":"2.0","method":"initialized"}';
+        $reader = new MessageReader(new ReadableBuffer("Content-Length: 10\r\n\r\n" . $json));
+
+        self::assertInstanceOf(MalformedFrame::class, $reader->read(), 'a truncated body cannot decode');
+        self::assertInstanceOf(MalformedFrame::class, $reader->read(), 'the remainder is not a frame either');
+        self::assertInstanceOf(
+            EndOfStream::class,
+            $reader->read(),
+            'an understated length costs a bounded number of errors, not an endless cascade',
+        );
+    }
+
+    /**
+     * A length longer than the body reaches into the frames behind it. Nothing
+     * can prevent that — the sender declared it — but it must cost one error
+     * and leave the reader able to keep serving.
+     */
+    public function testOverstatedContentLengthDoesNotCascade(): void
+    {
+        $json = '{"jsonrpc":"2.0","method":"first"}';
+        $reader = new MessageReader(new ReadableBuffer(
+            'Content-Length: ' . (strlen($json) + 20) . "\r\n\r\n" . $json
+            . $this->frame('{"jsonrpc":"2.0","method":"second"}'),
+        ));
+
+        self::assertInstanceOf(
+            MalformedFrame::class,
+            $reader->read(),
+            'a body that swallowed the next frame does not decode',
+        );
+
+        $outcomes = [$reader->read(), $reader->read()];
+
+        self::assertContainsOnlyInstancesOf(
+            EndOfStream::class,
+            array_slice($outcomes, -1),
+            'the reader reaches end of stream rather than cascading',
+        );
     }
 
     public function testUnparseableBodyYieldsParseError(): void

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -399,13 +399,15 @@ class MessageReaderTest extends TestCase
             $reader->read(),
             'a body that swallowed the next frame does not decode',
         );
-
-        $outcomes = [$reader->read(), $reader->read()];
-
-        self::assertContainsOnlyInstancesOf(
+        self::assertInstanceOf(
+            MalformedFrame::class,
+            $reader->read(),
+            'what that body left behind is not a frame either',
+        );
+        self::assertInstanceOf(
             EndOfStream::class,
-            array_slice($outcomes, -1),
-            'the reader reaches end of stream rather than cascading',
+            $reader->read(),
+            'the reader winds down rather than cascading',
         );
     }
 

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -44,6 +44,28 @@ class MessageReaderTest extends TestCase
         self::assertSame(1, $request->id);
     }
 
+    /**
+     * The header block is subject to the same chunking as the body: a pipe can
+     * hand over a partial header, so the reader must accumulate until the
+     * "\r\n\r\n" terminator arrives rather than judging one chunk.
+     */
+    public function testReadsAHeaderDeliveredAcrossSeveralChunks(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"method":"initialize"}';
+        $chunks = [
+            'Content-Len',
+            'gth: ' . strlen($json) . "\r\n",
+            "\r\n" . $json,
+        ];
+
+        $reader = new MessageReader(new ReadableIterableStream($chunks));
+
+        $request = $reader->read();
+
+        self::assertInstanceOf(RequestMessage::class, $request, 'a split header still yields one message');
+        self::assertSame('initialize', $request->method);
+    }
+
     public function testReadRequest(): void
     {
         $json = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1234}}';
@@ -180,36 +202,61 @@ class MessageReaderTest extends TestCase
     }
 
     /**
-     * Per [LSP] "Base Protocol" the Content-Length value is a byte count. A
-     * bare (int) cast accepted anything: "abc" became 0, and "-5" became a
-     * negative length, which makes substr() consume from the wrong end of the
-     * buffer and destroys every frame that follows. Rejecting the header
-     * instead leaves the buffer alone, so the next frame still reads.
+     * Per [LSP] "Base Protocol" the Content-Length value is a byte count, and
+     * "the structure of header fields conforms to the HTTP semantic"
+     * ([RFC 7230] §3.2) — so §3.3.2's `Content-Length = 1*DIGIT`. A bare (int)
+     * cast accepted anything: "abc" became 0, and "-5" became a negative
+     * length, which makes substr() consume from the wrong end of the buffer.
+     *
+     * A client that mis-declares the length is recovered rather than bounced.
+     * The content part is JSON, which the decoder can judge on its own, so the
+     * remaining bytes are handed to it and a body that parses is served
+     * normally.
      */
     #[DataProvider('unusableContentLengths')]
-    public function testUnusableContentLengthDoesNotConsumeTheNextFrame(string $value): void
+    public function testUnusableContentLengthFallsBackToTheBody(string $value): void
     {
-        $input = "Content-Length: $value\r\n\r\n"
+        $input = "Content-Length: $value\r\n\r\n" . '{"jsonrpc":"2.0","method":"initialized"}';
+        $reader = new MessageReader(new ReadableBuffer($input));
+
+        $result = $reader->read();
+
+        self::assertInstanceOf(
+            NotificationMessage::class,
+            $result,
+            "a mis-declared Content-Length still delivers a body that parses: $value",
+        );
+        self::assertSame('initialized', $result->method);
+    }
+
+    /**
+     * When the remainder is not a JSON message there is nothing to recover, so
+     * the frame costs exactly one error and its bytes are consumed. Left in the
+     * buffer they would be re-read as the next frame's header block, letting
+     * bytes the sender chose inside a body declare the Content-Length of the
+     * frame behind them — the framing desync [RFC 7230] §3.3.3 treats as
+     * unrecoverable, and a frame-injection primitive besides.
+     */
+    public function testUnusableContentLengthWithUnrecoverableBodyCostsOneError(): void
+    {
+        $input = "Content-Length: abc\r\n\r\n"
+            . 'not json'
             . $this->frame('{"jsonrpc":"2.0","method":"initialized"}');
         $reader = new MessageReader(new ReadableBuffer($input));
 
         $result = $reader->read();
 
-        self::assertInstanceOf(MalformedFrame::class, $result, "should reject Content-Length: $value");
+        self::assertInstanceOf(MalformedFrame::class, $result, 'an unrecoverable body is a malformed frame');
         self::assertSame(
             ResponseError::parseError()->code,
             $result->error->code,
-            "an unusable Content-Length yields ParseError: $value",
+            'a body that does not parse yields ParseError',
         );
-
-        $recovered = $reader->read();
-
         self::assertInstanceOf(
-            NotificationMessage::class,
-            $recovered,
-            'the frame after an unusable Content-Length is still delivered',
+            EndOfStream::class,
+            $reader->read(),
+            'the frame consumed its own bytes, so no body is re-read as framing',
         );
-        self::assertSame('initialized', $recovered->method);
     }
 
     /**

--- a/tests/Transport/MessageReaderTest.php
+++ b/tests/Transport/MessageReaderTest.php
@@ -153,6 +153,30 @@ class MessageReaderTest extends TestCase
             $reader->read(),
             'a body shorter than its declared Content-Length is a malformed frame',
         );
+        self::assertInstanceOf(
+            EndOfStream::class,
+            $reader->read(),
+            'the partial body is consumed, so one truncated frame is one error',
+        );
+    }
+
+    /**
+     * A partial body left in the buffer would be re-read as the next frame's
+     * header block, so bytes the sender chose inside a body could name the
+     * Content-Length of the frame after it. One truncated frame must cost one
+     * error response, not turn the body into framing.
+     */
+    public function testTruncatedBodyIsNotReparsedAsHeaders(): void
+    {
+        $body = "{\"a\":1}\r\n\r\nContent-Length: 9999\r\n\r\n";
+        $reader = new MessageReader(new ReadableBuffer("Content-Length: 500\r\n\r\n" . $body));
+
+        self::assertInstanceOf(MalformedFrame::class, $reader->read());
+        self::assertInstanceOf(
+            EndOfStream::class,
+            $reader->read(),
+            'header-looking bytes inside a truncated body are not treated as a frame',
+        );
     }
 
     public function testUnparseableBodyYieldsParseError(): void

--- a/tests/Transport/StdioTransportTest.php
+++ b/tests/Transport/StdioTransportTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Transport;
+
+use Amp\ByteStream\ReadableBuffer;
+use Amp\ByteStream\WritableBuffer;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Protocol\ResponseMessage;
+use Firehed\PhpLsp\Transport\EndOfStream;
+use Firehed\PhpLsp\Transport\StdioTransport;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StdioTransport::class)]
+class StdioTransportTest extends TestCase
+{
+    public function testReadsAFramedMessageFromTheInputStream(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"method":"initialize"}';
+        $transport = new StdioTransport(
+            new ReadableBuffer('Content-Length: ' . strlen($json) . "\r\n\r\n" . $json),
+            new WritableBuffer(),
+        );
+
+        $message = $transport->read();
+
+        self::assertInstanceOf(RequestMessage::class, $message, 'a framed request is decoded');
+        self::assertSame('initialize', $message->method);
+    }
+
+    public function testReportsEndOfStreamOnAClosedInput(): void
+    {
+        $transport = new StdioTransport(new ReadableBuffer(''), new WritableBuffer());
+
+        self::assertInstanceOf(
+            EndOfStream::class,
+            $transport->read(),
+            'the read outcome is passed through from the reader',
+        );
+    }
+
+    public function testWritesAFramedResponseToTheOutputStream(): void
+    {
+        $output = new WritableBuffer();
+        $transport = new StdioTransport(new ReadableBuffer(''), $output);
+
+        $transport->write(ResponseMessage::success(1, null));
+        $output->close();
+
+        self::assertSame(
+            "Content-Length: 38\r\n\r\n" . '{"jsonrpc":"2.0","id":1,"result":null}',
+            $output->buffer(),
+            'the response is Content-Length framed on the output stream',
+        );
+    }
+
+    public function testCloseClosesBothStreams(): void
+    {
+        $input = new ReadableBuffer('');
+        $output = new WritableBuffer();
+        $transport = new StdioTransport($input, $output);
+
+        $transport->close();
+
+        self::assertTrue($input->isClosed(), 'the input stream is closed');
+        self::assertTrue($output->isClosed(), 'the output stream is closed');
+    }
+}

--- a/tests/Transport/StreamTransportTest.php
+++ b/tests/Transport/StreamTransportTest.php
@@ -9,6 +9,7 @@ use Amp\ByteStream\WritableBuffer;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
 use Firehed\PhpLsp\Transport\EndOfStream;
+use Firehed\PhpLsp\Transport\MalformedFrame;
 use Firehed\PhpLsp\Transport\StreamTransport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -38,6 +39,26 @@ class StreamTransportTest extends TestCase
             EndOfStream::class,
             $transport->read(),
             'the read outcome is passed through from the reader',
+        );
+    }
+
+    /**
+     * The transport that `bin/php-lsp` actually constructs must pass a
+     * malformed frame through as its own outcome, not collapse it into
+     * EndOfStream — RFC 1 §9 requires the two be distinguishable, and a
+     * collapse would silently end the session on one bad frame.
+     */
+    public function testPassesAMalformedFrameThroughDistinctFromEndOfStream(): void
+    {
+        $transport = new StreamTransport(
+            new ReadableBuffer("Content-Length: 5\r\n\r\n" . 'not json enough'),
+            new WritableBuffer(),
+        );
+
+        self::assertInstanceOf(
+            MalformedFrame::class,
+            $transport->read(),
+            'a malformed frame reaches the caller as a malformed frame',
         );
     }
 

--- a/tests/Transport/StreamTransportTest.php
+++ b/tests/Transport/StreamTransportTest.php
@@ -9,17 +9,17 @@ use Amp\ByteStream\WritableBuffer;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Protocol\ResponseMessage;
 use Firehed\PhpLsp\Transport\EndOfStream;
-use Firehed\PhpLsp\Transport\StdioTransport;
+use Firehed\PhpLsp\Transport\StreamTransport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(StdioTransport::class)]
-class StdioTransportTest extends TestCase
+#[CoversClass(StreamTransport::class)]
+class StreamTransportTest extends TestCase
 {
     public function testReadsAFramedMessageFromTheInputStream(): void
     {
         $json = '{"jsonrpc":"2.0","id":1,"method":"initialize"}';
-        $transport = new StdioTransport(
+        $transport = new StreamTransport(
             new ReadableBuffer('Content-Length: ' . strlen($json) . "\r\n\r\n" . $json),
             new WritableBuffer(),
         );
@@ -32,7 +32,7 @@ class StdioTransportTest extends TestCase
 
     public function testReportsEndOfStreamOnAClosedInput(): void
     {
-        $transport = new StdioTransport(new ReadableBuffer(''), new WritableBuffer());
+        $transport = new StreamTransport(new ReadableBuffer(''), new WritableBuffer());
 
         self::assertInstanceOf(
             EndOfStream::class,
@@ -44,7 +44,7 @@ class StdioTransportTest extends TestCase
     public function testWritesAFramedResponseToTheOutputStream(): void
     {
         $output = new WritableBuffer();
-        $transport = new StdioTransport(new ReadableBuffer(''), $output);
+        $transport = new StreamTransport(new ReadableBuffer(''), $output);
 
         $transport->write(ResponseMessage::success(1, null));
         $output->close();
@@ -60,7 +60,7 @@ class StdioTransportTest extends TestCase
     {
         $input = new ReadableBuffer('');
         $output = new WritableBuffer();
-        $transport = new StdioTransport($input, $output);
+        $transport = new StreamTransport($input, $output);
 
         $transport->close();
 


### PR DESCRIPTION
Slice **S1.4** of the RFC 1 / Plan 0002 execution.

- **Plan step:** `docs/architecture/0002-execution-plan.md` — Step 1 (capability
  negotiation + encoding edge)
- **RFC sections:** `0001-foundational-architecture.md` §4.8 (lifecycle state), §9
  (robustness), §8.1 (enforcement), conformance item 12
- **Depends on:** S1.1 (merged, #364)

## Acceptance criteria

The two Step 1 criteria this slice owns:

- [x] Malformed frame yields an error response, not a crash
- [x] Pre-`initialize` / post-`shutdown` lifecycle state enforced

Broken out to the specific §9 / §4.8 requirements:

- [x] §4.8 — a request before `initialize` is answered `ServerNotInitialized` (-32002)
- [x] §4.8 — a request after `shutdown` is answered `InvalidRequest` (-32600)
- [x] §4.8 — `exit` is always honored, so the server can terminate either way
- [x] §9 — an unparseable message yields `ParseError`, and the loop keeps serving
- [x] §9 — a handler failure yields `InternalError` rather than crashing the read loop
- [x] §9 — a message lacking a required header is distinguishable from end of stream
- [x] §8.1 — the mechanism listed for §9 ("Test: malformed frames yield error
      responses, not process termination") ships in this slice

## What changed

**Lifecycle.** `LifecycleHandler` now tracks whether `initialize` has been handled and
gates every inbound message through `lifecycleErrorFor()`. `Server` consults it before
dispatch, so a gated message is never handled; a gated notification has no id, so its
error is dropped rather than sent.

**Read outcomes.** `TransportInterface::read()` returns `Message|MalformedFrame|EndOfStream`
instead of `?Message`. §9 requires a frame lacking a required header to be
distinguishable from a closed stream, and a single nullable return cannot express three
outcomes — previously both surfaced as `null`, so an unframed write looked exactly like
the client hanging up.

**Malformed input no longer terminates the process.** `MessageReader` classifies an
unparseable body as `ParseError` and a structurally invalid message as `InvalidRequest`.
This replaces reliance on the `assert()`s inside `RequestMessage::fromArray` /
`NotificationMessage::fromArray`, which raised `AssertionError` on client-controlled
input (and are no-ops in production) — a direct conformance-item-12 violation. The
frame's bytes are consumed before decoding, so one bad message does not desynchronize
the stream.

## Points for the reviewer

- **`Server`'s construction moved into a `forProject()` named constructor.** The
  constructor now takes its handlers, lifecycle handler and parser, so the dispatch loop
  can be exercised against a handler set a test chooses — which is how the
  handler-failure path is reached (crafting input that makes a real handler throw proved
  unreliable; a hover with empty params returns null rather than throwing, and
  `ParserService` is `final` and swallows `PhpParser\Error`). `bin/php-lsp` and the
  existing tests call `Server::forProject(...)`. This also gives the construction that
  Plan §5.5 moves into `Server.php` during Step 2 a home outside the constructor.
- **Three existing tests were changed to send `initialize` first.** They previously
  issued requests before initializing, which this slice now (correctly) rejects. Their
  assertions and intent are unchanged; the parse-count expectations still hold because
  `initialize`/`initialized` parse no documents.
- **`ServerTest` was reworked** to build every frame through `requestJson` /
  `notificationJson` and to assert on decoded responses (`decodeResponses`,
  `responseWithId`, `errorCode`) rather than matching JSON substrings.
- **Filed #368** to convert the JSON-RPC/LSP error codes from magic ints to an enum;
  deferred as a refactor of a pre-existing pattern.

## Candidate closes

None — the manifest lists no `Closes` entries for S1.4.
