### PR TITLE
Convert interior positions at the byte column under the negotiated encoding

### DIFF
--- a/src/Completion/ClassCandidates.php
+++ b/src/Completion/ClassCandidates.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Completion;
 
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\SymbolIndex;
@@ -31,6 +32,7 @@ final class ClassCandidates
     public function __construct(
         private readonly SymbolIndex $symbolIndex,
         private readonly CodeResolver $codeResolver,
+        private readonly SessionCapabilitiesProvider $capabilities,
     ) {
     }
 
@@ -45,8 +47,15 @@ final class ClassCandidates
         ClassCandidateFilter $filter,
     ): array {
         $context = $this->codeResolver->getNameContext($document, $line);
-        // What a selected item replaces: the token the cursor sits at the end of.
-        $replaceRange = Range::onLine($line, $character - strlen($prefix), $character);
+        // What a selected item replaces: the token the cursor sits at the end of,
+        // sized in the negotiated encoding so a multibyte prefix is not mis-measured
+        // against the wire column (RFC 1 §4.9).
+        $replaceRange = Range::forPrefix(
+            $line,
+            $character,
+            $prefix,
+            $this->capabilities->getSessionCapabilities()->positionEncoding,
+        );
 
         $items = $this->fromImports($prefix, $document, $filter, $replaceRange);
         return array_merge($items, $this->fromIndex($prefix, $filter, $context, $replaceRange));

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Completion;
 
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
@@ -36,6 +37,7 @@ final class NamespaceCandidates
     public function __construct(
         private readonly NamespaceCatalog $catalog,
         private readonly CodeResolver $codeResolver,
+        private readonly SessionCapabilitiesProvider $capabilities,
     ) {
     }
 
@@ -119,7 +121,7 @@ final class NamespaceCandidates
     ): array {
         $contents = $this->catalog->childrenOf($namespace);
         // The partial segment the user is typing; a selection replaces just it.
-        $replaceRange = Range::onLine($line, $character - strlen($prefix), $character);
+        $replaceRange = $this->replaceRange($line, $character, $prefix);
 
         $items = [];
         foreach ($contents->childNamespaces as $child) {
@@ -162,7 +164,7 @@ final class NamespaceCandidates
         int $character,
         ClassCandidateFilter $filter,
     ): array {
-        $range = Range::onLine($line, $character - strlen($prefix), $character);
+        $range = $this->replaceRange($line, $character, $prefix);
 
         $targets = [];
         foreach ($this->catalog->childrenOf($context->namespace)->childNamespaces as $child) {
@@ -203,6 +205,21 @@ final class NamespaceCandidates
             $line,
             $character,
             $filter,
+        );
+    }
+
+    /**
+     * The span a selected candidate replaces: the partial segment the user has
+     * typed, measured in the negotiated encoding so a multibyte segment is not
+     * mis-sized against the wire column (RFC 1 §4.9).
+     */
+    private function replaceRange(int $line, int $character, string $prefix): Range
+    {
+        return Range::forPrefix(
+            $line,
+            $character,
+            $prefix,
+            $this->capabilities->getSessionCapabilities()->positionEncoding,
         );
     }
 

--- a/src/Document/TextDocument.php
+++ b/src/Document/TextDocument.php
@@ -45,6 +45,20 @@ final class TextDocument
         return substr($this->content, $start, $end - $start);
     }
 
+    /**
+     * The text on `$line` up to `$character`, sliced at the byte column the wire
+     * column maps to under the negotiated encoding. Interior components that scan
+     * the text before the cursor use this rather than slicing the raw wire column
+     * as a byte length, which drops or keeps bytes past a multibyte character
+     * (RFC 1 §4.9).
+     */
+    public function textBeforeCursor(int $line, int $character): string
+    {
+        $lineText = $this->getLine($line);
+
+        return substr($lineText, 0, $this->encoding->characterToByteOffset($lineText, $character));
+    }
+
     public function offsetAt(int $line, int $character): int
     {
         if ($line < 0 || $line >= count($this->lineOffsets)) {

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -87,8 +87,7 @@ final class CompletionHandler implements HandlerInterface
         }
 
         // Get text before cursor to determine completion context
-        $lineText = $document->getLine($line);
-        $textBeforeCursor = substr($lineText, 0, $character);
+        $textBeforeCursor = $document->textBeforeCursor($line, $character);
 
         $items = $this->getCompletionItems($textBeforeCursor, $document, $line, $character);
 

--- a/src/Protocol/PositionEncoding.php
+++ b/src/Protocol/PositionEncoding.php
@@ -47,6 +47,17 @@ enum PositionEncoding: string
     }
 
     /**
+     * The length of `$text` in this encoding's code units — the wire column span
+     * a byte string occupies. Used to size an outbound completion `Range` from a
+     * byte-measured prefix, since the client reads the range in the negotiated
+     * encoding, not in bytes (RFC 1 §4.9).
+     */
+    public function codeUnitLength(string $text): int
+    {
+        return $this->byteToCharacterOffset($text, strlen($text));
+    }
+
+    /**
      * A UTF-8 codepoint occupies two UTF-16 code units (a surrogate pair) iff
      * its UTF-8 encoding is four bytes long; every shorter codepoint is a single
      * BMP code unit.

--- a/src/Protocol/PositionEncoding.php
+++ b/src/Protocol/PositionEncoding.php
@@ -17,6 +17,16 @@ namespace Firehed\PhpLsp\Protocol;
  * UTF-16 is the only encoding the server currently negotiates; it is also the
  * [LSP] mandatory default. A further encoding is a new case plus the match arm
  * PHPStan then requires, not a rewrite of the boundary.
+ *
+ * Do NOT "simplify" the conversions below with the native `mb_` functions. A
+ * `character` is a UTF-16 *code unit* count, but `mb_strlen` / `mb_substr` count
+ * *codepoints*: an astral codepoint (e.g. "😀", U+1F389, four UTF-8 bytes) is one
+ * `mb_` character but *two* UTF-16 code units (a surrogate pair). So `mb_strlen`
+ * over-shortens a length and `mb_substr` mis-slices whenever an astral codepoint
+ * is in play — the exact §4.9 defect this class exists to prevent. The surrogate
+ * accounting in {@see utf16Units()} is precisely what `mb_` does not give you;
+ * `mb_str_split` (splitting into codepoints) is the only `mb_` primitive that
+ * fits, and it is already used. (`grapheme_*` is grapheme-based, also wrong.)
  */
 enum PositionEncoding: string
 {

--- a/src/Protocol/Range.php
+++ b/src/Protocol/Range.php
@@ -35,6 +35,17 @@ final readonly class Range
     }
 
     /**
+     * The span a completion selection replaces: the typed $prefix ending at the
+     * cursor's $character column. Both columns are in the negotiated encoding, so
+     * the prefix is measured in that encoding's code units — never in bytes, which
+     * would misplace the start past any multibyte character (RFC 1 §4.9).
+     */
+    public static function forPrefix(int $line, int $character, string $prefix, PositionEncoding $encoding): self
+    {
+        return self::onLine($line, $character - $encoding->codeUnitLength($prefix), $character);
+    }
+
+    /**
      * @return LspRange
      */
     public function toArray(): array

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -406,8 +406,7 @@ final class SymbolResolver implements CodeResolver
         int $character,
         array $ast,
     ): ?MemberAccessContext {
-        $lineText = $document->getLine($line);
-        $textBeforeCursor = substr($lineText, 0, $character);
+        $textBeforeCursor = $document->textBeforeCursor($line, $character);
 
         // Match $var-> but not $this->
         if (preg_match('/\$(\w+)\??->([\w]*)$/', $textBeforeCursor, $m) !== 1) {

--- a/src/Resolution/TextFallbackHelper.php
+++ b/src/Resolution/TextFallbackHelper.php
@@ -46,8 +46,7 @@ final class TextFallbackHelper
         int $character,
         array $ast,
     ): ?MemberAccessContext {
-        $lineText = $document->getLine($line);
-        $textBeforeCursor = substr($lineText, 0, $character);
+        $textBeforeCursor = $document->textBeforeCursor($line, $character);
 
         // Chained instance access: $this->member->prefix or $this?->member->prefix
         if (preg_match('/(\$this(?:\??->[\w]+(?:\([^)]*\))?)+)\??->([\w]*)$/', $textBeforeCursor, $m) === 1) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -135,6 +135,7 @@ final class Server
                 new NamespaceCandidates(
                     NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot),
                     $symbolResolver,
+                    $negotiator,
                 ),
                 new FunctionCandidates($symbolResolver, $negotiator),
                 new KeywordCandidates(),

--- a/src/Server.php
+++ b/src/Server.php
@@ -131,7 +131,7 @@ final class Server
             new CompletionHandler(
                 $documentManager,
                 $symbolResolver,
-                new ClassCandidates($symbolIndex, $symbolResolver),
+                new ClassCandidates($symbolIndex, $symbolResolver, $negotiator),
                 new NamespaceCandidates(
                     NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot),
                     $symbolResolver,

--- a/tests/Completion/ClassCandidatesTest.php
+++ b/tests/Completion/ClassCandidatesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Completion;
+
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
+use Firehed\PhpLsp\Completion\ClassCandidateFilter;
+use Firehed\PhpLsp\Completion\ClassCandidates;
+use Firehed\PhpLsp\Completion\CompletionItemFactory;
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Resolution\CodeResolver;
+use Firehed\PhpLsp\Resolution\NameContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClassCandidates::class)]
+#[CoversClass(CompletionItemFactory::class)]
+class ClassCandidatesTest extends TestCase
+{
+    public function testReplaceRangeMeasuresAMultibytePrefixInCodeUnits(): void
+    {
+        $resolver = self::createStub(CodeResolver::class);
+        $resolver->method('getNameContext')->willReturn(new NameContext(''));
+        // An imported class whose short name carries a multibyte character.
+        $resolver->method('getImports')->willReturn(['Café' => 'App\\Café']);
+
+        $candidates = new ClassCandidates(new SymbolIndex(), $resolver, self::utf16Capabilities());
+        $document = new TextDocument('file:///test.php', 'php', 1, '<?php Café');
+
+        // "Café" is four codepoints — four UTF-16 units — but five UTF-8 bytes; the
+        // cursor sits at wire column 4 after typing it.
+        $items = $candidates->find('Café', $document, 0, 4, ClassCandidateFilter::Any);
+
+        self::assertCount(1, $items);
+        self::assertSame(
+            ['start' => ['line' => 0, 'character' => 0], 'end' => ['line' => 0, 'character' => 4]],
+            $items[0]['textEdit']['range'] ?? null,
+            'The replace range sizes the typed prefix in code units, not bytes (RFC 1 §4.9)',
+        );
+    }
+
+    private static function utf16Capabilities(): SessionCapabilitiesProvider
+    {
+        $capabilities = self::createStub(SessionCapabilitiesProvider::class);
+        $capabilities->method('getSessionCapabilities')->willReturn(new SessionCapabilities());
+        return $capabilities;
+    }
+}

--- a/tests/Completion/NamespaceCandidatesTest.php
+++ b/tests/Completion/NamespaceCandidatesTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Completion;
 
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Completion\ClassCandidateFilter;
 use Firehed\PhpLsp\Completion\CompletionItemFactory;
 use Firehed\PhpLsp\Completion\CompletionItemKind;
@@ -70,11 +72,23 @@ class NamespaceCandidatesTest extends TestCase
         return $resolver;
     }
 
+    /**
+     * A capabilities provider resolved to the default UTF-16 encoding, so the
+     * replace-range columns these tests assert are wire columns.
+     */
+    private static function utf16Capabilities(): SessionCapabilitiesProvider
+    {
+        $capabilities = self::createStub(SessionCapabilitiesProvider::class);
+        $capabilities->method('getSessionCapabilities')->willReturn(new SessionCapabilities());
+        return $capabilities;
+    }
+
     public function testOffersChildNamespacesAsModuleNodes(): void
     {
         $candidates = new NamespaceCandidates(
             self::catalog(['Psr' => new NamespaceContents(['Psr\Http', 'Psr\Log'], [])]),
             self::createStub(CodeResolver::class),
+            self::utf16Capabilities(),
         );
 
         $items = $candidates->find('Psr', '', 0, 0, ClassCandidateFilter::Any);
@@ -100,6 +114,7 @@ class NamespaceCandidatesTest extends TestCase
         $candidates = new NamespaceCandidates(
             self::catalog(['Psr' => new NamespaceContents(['Psr\Http', 'Psr\Log'], [])]),
             self::createStub(CodeResolver::class),
+            self::utf16Capabilities(),
         );
 
         $items = $candidates->find('Psr', 'Ht', 0, 2, ClassCandidateFilter::Any);
@@ -119,6 +134,7 @@ class NamespaceCandidatesTest extends TestCase
         $candidates = new NamespaceCandidates(
             self::catalog(['Psr' => new NamespaceContents(['Psr\Http'], [])]),
             self::createStub(CodeResolver::class),
+            self::utf16Capabilities(),
         );
 
         $items = $candidates->find('Psr', 'Ht', 0, 2, ClassCandidateFilter::Any);
@@ -134,6 +150,25 @@ class NamespaceCandidatesTest extends TestCase
         );
     }
 
+    public function testReplaceRangeMeasuresAMultibyteSegmentInCodeUnits(): void
+    {
+        $catalog = self::catalog(['App' => new NamespaceContents([], [
+            new CatalogSymbol('App\Café', NameKind::ClassLike),
+        ])]);
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
+
+        // "Café" is four codepoints — four UTF-16 units — but five UTF-8 bytes; the
+        // cursor sits at wire column 4 after typing it at the start of the line.
+        $items = $candidates->find('App', 'Café', 0, 4, ClassCandidateFilter::Any);
+
+        self::assertCount(1, $items);
+        self::assertSame(
+            ['start' => ['line' => 0, 'character' => 0], 'end' => ['line' => 0, 'character' => 4]],
+            $items[0]['textEdit']['range'] ?? null,
+            'The replace range sizes the typed segment in code units, not bytes (RFC 1 §4.9)',
+        );
+    }
+
     public function testOffersClassLikesButNotOtherKinds(): void
     {
         $catalog = self::catalog(['App' => new NamespaceContents([], [
@@ -141,7 +176,7 @@ class NamespaceCandidatesTest extends TestCase
             new CatalogSymbol('App\helper', NameKind::Function_),
         ])]);
         // Any accepts every class-like, so only the kind gate is exercised here.
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $labels = array_column($candidates->find('App', '', 0, 0, ClassCandidateFilter::Any), 'label');
 
@@ -155,7 +190,7 @@ class NamespaceCandidatesTest extends TestCase
             new CatalogSymbol('App\Widget', NameKind::ClassLike),
             new CatalogSymbol('App\Gadget', NameKind::ClassLike),
         ])]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $labels = array_column($candidates->find('App', 'Wi', 0, 2, ClassCandidateFilter::Any), 'label');
 
@@ -170,7 +205,7 @@ class NamespaceCandidatesTest extends TestCase
         // isClassLike is true (a real class-like) but isInstantiable is false,
         // standing in for an interface after `new`: the position filter rejects
         // it, via the same predicate the index and imports use.
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         self::assertSame(
             [],
@@ -189,7 +224,7 @@ class NamespaceCandidatesTest extends TestCase
         ])]);
         $resolver = self::createStub(CodeResolver::class);
         $resolver->method('isClassLike')->willReturn(false);
-        $candidates = new NamespaceCandidates($catalog, $resolver);
+        $candidates = new NamespaceCandidates($catalog, $resolver, self::utf16Capabilities());
 
         self::assertSame(
             [],
@@ -207,7 +242,7 @@ class NamespaceCandidatesTest extends TestCase
             'App' => new NamespaceContents(['App\Env'], [new CatalogSymbol('App\Env', NameKind::ClassLike)]),
             'App\Env' => new NamespaceContents([], [new CatalogSymbol('App\Env\Repository', NameKind::ClassLike)]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $labels = array_column($candidates->find('App', '', 0, 0, ClassCandidateFilter::Any), 'label');
 
@@ -225,7 +260,7 @@ class NamespaceCandidatesTest extends TestCase
             'App' => new NamespaceContents(['App\Env'], []),
             'App\Env' => new NamespaceContents([], [new CatalogSymbol('App\Env\Repository', NameKind::ClassLike)]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $byLabel = array_column($candidates->find('App', '', 0, 0, ClassCandidateFilter::Any), 'filterText', 'label');
 
@@ -251,7 +286,7 @@ class NamespaceCandidatesTest extends TestCase
         $resolver->method('isClassLike')->willReturnCallback(
             static fn(ClassName $name): bool => str_ends_with($name->fqn, 'Repository'),
         );
-        $candidates = new NamespaceCandidates($catalog, $resolver);
+        $candidates = new NamespaceCandidates($catalog, $resolver, self::utf16Capabilities());
 
         $labels = array_column($candidates->find('App', '', 0, 0, ClassCandidateFilter::Any), 'label');
 
@@ -270,7 +305,7 @@ class NamespaceCandidatesTest extends TestCase
             'App' => new NamespaceContents(['App\Five'], []),
             'App\Five' => new NamespaceContents([], $five),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $labels = array_column($candidates->find('App', '', 0, 0, ClassCandidateFilter::Any), 'label');
 
@@ -286,7 +321,7 @@ class NamespaceCandidatesTest extends TestCase
             'App' => new NamespaceContents(['App\Small'], []),
             'App\Small' => new NamespaceContents(['App\Small\Deep'], []),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $labels = array_column($candidates->find('App', '', 0, 0, ClassCandidateFilter::Any), 'label');
 
@@ -304,7 +339,7 @@ class NamespaceCandidatesTest extends TestCase
             'Vendor\Big' => new NamespaceContents([], self::manyClassLikes('Vendor\Big')),
             'Vendor\Plain' => new NamespaceContents([], []),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
         $context = new NameContext('App', ['Big' => 'Vendor\Big', 'Plain' => 'Vendor\Plain']);
 
         $labels = array_column($candidates->descend($context, '', 0, 0, ClassCandidateFilter::Any), 'label');
@@ -325,7 +360,7 @@ class NamespaceCandidatesTest extends TestCase
             'Vendor\Mapping' => new NamespaceContents([], self::manyClassLikes('Vendor\Mapping')),
             'Vendor\Other' => new NamespaceContents([], self::manyClassLikes('Vendor\Other')),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
         $context = new NameContext('App', ['Mapping' => 'Vendor\Mapping', 'Other' => 'Vendor\Other']);
 
         $labels = array_column($candidates->descend($context, 'Map', 0, 3, ClassCandidateFilter::Any), 'label');
@@ -340,7 +375,7 @@ class NamespaceCandidatesTest extends TestCase
                 new CatalogSymbol('Psr\Http\Message', NameKind::ClassLike),
             ]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $items = $candidates->navigate('\Psr\Http\M', new NameContext(''), 0, 12, ClassCandidateFilter::Any);
 
@@ -357,7 +392,7 @@ class NamespaceCandidatesTest extends TestCase
             'App' => new NamespaceContents([], []),
             'Vendor\Pkg' => new NamespaceContents([], self::manyClassLikes('Vendor\Pkg')),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
         $context = new NameContext('App', ['Pkg' => 'Vendor\Pkg']);
 
         $items = $candidates->navigate('Pk', $context, 0, 2, ClassCandidateFilter::Any);
@@ -372,7 +407,7 @@ class NamespaceCandidatesTest extends TestCase
                 new CatalogSymbol('Vendor\Pkg\Thing', NameKind::ClassLike),
             ]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
         $context = new NameContext('App', ['Pkg' => 'Vendor\Pkg']);
 
         $items = $candidates->navigate('Pkg\T', $context, 0, 5, ClassCandidateFilter::Any);
@@ -387,7 +422,7 @@ class NamespaceCandidatesTest extends TestCase
                 new CatalogSymbol('App\Sub\Thing', NameKind::ClassLike),
             ]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $items = $candidates->navigate('Sub\T', new NameContext('App'), 0, 5, ClassCandidateFilter::Any);
 
@@ -405,7 +440,7 @@ class NamespaceCandidatesTest extends TestCase
                 new CatalogSymbol('Psr\Http\Message', NameKind::ClassLike),
             ]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $items = $candidates->useStatement('Psr\Http\M', 0, 10, ClassCandidateFilter::Any);
 
@@ -423,7 +458,7 @@ class NamespaceCandidatesTest extends TestCase
                 new CatalogSymbol('Psr\Http\Message', NameKind::ClassLike),
             ]),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $items = $candidates->useStatement('\Psr\Http\M', 0, 11, ClassCandidateFilter::Any);
 
@@ -442,7 +477,7 @@ class NamespaceCandidatesTest extends TestCase
             '' => new NamespaceContents(['Psr'], []),
             'Psr' => new NamespaceContents([], self::manyClassLikes('Psr')),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $labels = array_column($candidates->useStatement('Ps', 0, 2, ClassCandidateFilter::Any), 'label');
 
@@ -459,7 +494,7 @@ class NamespaceCandidatesTest extends TestCase
             'App' => new NamespaceContents(['App\Big'], [new CatalogSymbol('App\Widget', NameKind::ClassLike)]),
             'App\Big' => new NamespaceContents([], self::manyClassLikes('App\Big')),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $byLabel = array_column($candidates->find('App', '', 0, 0, ClassCandidateFilter::Any), 'sortText', 'label');
 
@@ -483,7 +518,7 @@ class NamespaceCandidatesTest extends TestCase
             ),
             'App\Entities\Env' => new NamespaceContents([], self::manyClassLikes('App\Entities\Env')),
         ]);
-        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver());
+        $candidates = new NamespaceCandidates($catalog, self::classLikeResolver(), self::utf16Capabilities());
 
         $labels = array_column($candidates->find('App\Entities', '', 0, 0, ClassCandidateFilter::Any), 'label');
 

--- a/tests/Document/PositionRoundTripCorpusTest.php
+++ b/tests/Document/PositionRoundTripCorpusTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Document;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The position round-trip corpus (RFC 1 §4.9, Step 1 acceptance): positions must
+ * survive a round trip through the document boundary under the negotiated
+ * encoding. {@see TextDocumentTest} pins specific multibyte conversions; this
+ * corpus proves the boundary is a bijection across a whole file of mixed-width
+ * codepoints, and that the existing cursor-marker fixtures address the same byte
+ * the interior resolves once their wire column is converted.
+ */
+#[CoversClass(TextDocument::class)]
+class PositionRoundTripCorpusTest extends TestCase
+{
+    use LoadsFixturesTrait;
+
+    public function testBoundaryIsABijectionAcrossTheMultibyteCorpus(): void
+    {
+        $content = $this->loadFixture('src/Encoding/Multibyte.php');
+        $document = new TextDocument('file:///test.php', 'php', 1, $content);
+
+        // Every codepoint boundary in the file, byte offsets included. A byte offset
+        // that lands on a boundary must convert to a wire position and back to the
+        // same byte offset; anything else would misplace the cursor past a
+        // multibyte character.
+        $offset = 0;
+        foreach (mb_str_split($content, 1, 'UTF-8') as $codepoint) {
+            $this->assertRoundTrips($document, $offset);
+            $offset += strlen($codepoint);
+        }
+        // The end-of-file boundary is a valid cursor position too.
+        $this->assertRoundTrips($document, $offset);
+    }
+
+    #[DataProvider('existingCursorMarkerCases')]
+    public function testExistingCursorMarkerRoundTripsUnderNegotiatedEncoding(
+        string $fixture,
+        string $marker,
+    ): void {
+        $content = $this->loadFixture($fixture);
+        $document = new TextDocument('file:///test.php', 'php', 1, $content);
+        $wire = $this->locateCursorUtf16($content, $marker);
+
+        $offset = $document->offsetAt($wire['line'], $wire['character']);
+
+        self::assertSame(
+            $wire,
+            $document->positionAt($offset),
+            "cursor marker '$marker' must round-trip through the document boundary",
+        );
+    }
+
+    /**
+     * A spread of existing cursor-marker fixtures, re-run under the negotiated
+     * encoding to prove the corpus that predates it still addresses the boundary
+     * correctly.
+     *
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function existingCursorMarkerCases(): iterable
+    {
+        yield 'this member access' => ['src/Completion/MethodAccess.php', 'this_prefix'];
+        yield 'variable member access' => ['src/Completion/MethodAccess.php', 'var_prefix'];
+        yield 'new keyword' => ['src/Completion/NewCompletion.php', 'new_abstract'];
+        yield 'variable prefix' => ['src/Completion/Variables.php', 'param_prefix'];
+    }
+
+    private function assertRoundTrips(TextDocument $document, int $offset): void
+    {
+        $position = $document->positionAt($offset);
+
+        self::assertSame(
+            $offset,
+            $document->offsetAt($position['line'], $position['character']),
+            "byte offset $offset must survive a conversion to a wire position and back",
+        );
+    }
+}

--- a/tests/Document/TextDocumentTest.php
+++ b/tests/Document/TextDocumentTest.php
@@ -111,6 +111,34 @@ class TextDocumentTest extends TestCase
         );
     }
 
+    public function testTextBeforeCursorReadsAsciiToTheColumn(): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, "<?php\n\$user->getName();");
+
+        self::assertSame(
+            '$user->',
+            $doc->textBeforeCursor(line: 1, character: 7),
+            'the interior reads text up to the cursor, sliced at the byte column',
+        );
+    }
+
+    /**
+     * A multibyte character before the cursor makes the wire column smaller than
+     * the byte column: `é` is one UTF-16 unit but two bytes, so column 7 in
+     * `$café->` lands at byte 8. Slicing the raw wire column as a byte length
+     * would drop the `>` (RFC 1 §4.9).
+     */
+    public function testTextBeforeCursorConvertsMultibyteColumnToBytes(): void
+    {
+        $doc = new TextDocument('file:///test.php', 'php', 1, "<?php\n\$café->x");
+
+        self::assertSame(
+            '$café->',
+            $doc->textBeforeCursor(line: 1, character: 7),
+            'a wire column past a multibyte char must slice at the byte column, not the raw column',
+        );
+    }
+
     /**
      * @codeCoverageIgnore
      *

--- a/tests/Fixtures/TopLevel/multibyte_static.php
+++ b/tests/Fixtures/TopLevel/multibyte_static.php
@@ -1,0 +1,4 @@
+<?php
+use Fixtures\Domain\User;
+
+$flag = '🎉'; User::fromArray/*|multibyte_static*/

--- a/tests/Fixtures/src/Completion/MultibyteCompletion.php
+++ b/tests/Fixtures/src/Completion/MultibyteCompletion.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Completion;
+
+/**
+ * Completion triggered on lines carrying a multibyte character before the cursor,
+ * so the UTF-16 wire column diverges from the byte column. The interior must slice
+ * the text before the cursor at the byte column, not the raw wire column, or the
+ * typed prefix is silently truncated (RFC 1 §4.9). "🎉" is one astral codepoint:
+ * two UTF-16 code units, four bytes.
+ *
+ * Each incomplete statement lives in its own method (parser error recovery).
+ */
+class MultibyteCompletion
+{
+    public function getName(): string
+    {
+        return '';
+    }
+
+    public function variableAfterEmoji(): void
+    {
+        $total = 0;
+        $taxRate = '🎉'; $tax/*|var_after_emoji*/
+    }
+}

--- a/tests/Fixtures/src/Encoding/Multibyte.php
+++ b/tests/Fixtures/src/Encoding/Multibyte.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Encoding;
+
+/**
+ * Content mixing ASCII with multibyte codepoints of every UTF-8 width, for the
+ * position round-trip corpus (RFC 1 §4.9): "é" is two bytes and one UTF-16 unit,
+ * "€" and "中" are three bytes and one unit, and "😀" is four bytes and a UTF-16
+ * surrogate pair (two units). The variety across several lines makes the boundary
+ * conversion a bijection worth sweeping in full.
+ */
+class Multibyte
+{
+    /**
+     * @return array<string, string>
+     */
+    public function greetings(): array
+    {
+        // café, naïve — accented Latin sits in the two-byte range
+        return [
+            'euro' => '€ 中 £',
+            'party' => '😀🎉',
+            'mixed' => 'aéb€c😀d',
+        ];
+    }
+}

--- a/tests/Fixtures/src/IncompleteCode/MultibyteVarAccess.php
+++ b/tests/Fixtures/src/IncompleteCode/MultibyteVarAccess.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\IncompleteCode;
+
+/**
+ * A local variable's member access on a line that also carries a multibyte
+ * character, so the UTF-16 wire column trails the byte column (RFC 1 §4.9).
+ * "🎉" is one astral codepoint: two UTF-16 code units, four bytes. The trailing
+ * "$obj->" with no member drives resolution through the text/AST variable
+ * fallback rather than a clean member-access node.
+ */
+class MultibyteVarAccess
+{
+    public function getValue(): string
+    {
+        return '';
+    }
+
+    public function assignedVarAfterEmoji(): void
+    {
+        $obj = new self();
+        $flag = '🎉'; $obj->/*|var_member_multibyte*/
+    }
+}

--- a/tests/Fixtures/src/IncompleteCode/MultibyteVarAccess.php
+++ b/tests/Fixtures/src/IncompleteCode/MultibyteVarAccess.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fixtures\IncompleteCode;
 
+use Fixtures\Domain\User;
+
 /**
  * A local variable's member access on a line that also carries a multibyte
  * character, so the UTF-16 wire column trails the byte column (RFC 1 §4.9).
@@ -22,5 +24,20 @@ class MultibyteVarAccess
     {
         $obj = new self();
         $flag = '🎉'; $obj->/*|var_member_multibyte*/
+    }
+}
+
+/**
+ * A typed parameter accessed inside an incomplete `while (` on a line carrying a
+ * multibyte character (RFC 1 §4.9). The incomplete control structure denies the
+ * parser a clean member-access node, so resolution reaches the variable-access
+ * text fallback, which slices the text before the cursor at the byte column. A
+ * raw wire-column slice would truncate "$user->" past the "🎉" and fail the match.
+ */
+class MultibyteParamAccessInWhile
+{
+    public function test(User $user): void
+    {
+        $flag = '🎉'; while ($user->/*|var_while_multibyte*/
     }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -113,7 +113,7 @@ class CompletionHandlerTest extends TestCase
             $this->documents,
             $this->symbolResolver,
             new ClassCandidates($this->symbolIndex, $this->symbolResolver),
-            new NamespaceCandidates($catalog, $this->symbolResolver),
+            new NamespaceCandidates($catalog, $this->symbolResolver, $capabilities),
             new FunctionCandidates($this->symbolResolver, $capabilities),
             new KeywordCandidates(),
             new VariableCandidates($this->symbolResolver),

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1911,6 +1911,26 @@ class CompletionHandlerTest extends TestCase
         self::assertContains('$logger', $labels);
     }
 
+    public function testCompletionSlicesPrefixAtByteColumnPastMultibyte(): void
+    {
+        $cursor = $this->openFixtureAtUtf16Cursor('src/Completion/MultibyteCompletion.php', 'var_after_emoji');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains(
+            '$taxRate',
+            $labels,
+            'the typed prefix "tax" on a line with a multibyte char must still match $taxRate',
+        );
+        self::assertNotContains(
+            '$total',
+            $labels,
+            'slicing the raw wire column truncates "tax" to "t" and over-matches $total (RFC 1 §4.9)',
+        );
+    }
+
     public function testVariableCompletionWorksInGlobalScope(): void
     {
         $cursor = $this->openFixtureAtCursor('TopLevel/global_scope_variable.php', 'global_var_prefix');

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -112,7 +112,7 @@ class CompletionHandlerTest extends TestCase
         return new CompletionHandler(
             $this->documents,
             $this->symbolResolver,
-            new ClassCandidates($this->symbolIndex, $this->symbolResolver),
+            new ClassCandidates($this->symbolIndex, $this->symbolResolver, $capabilities),
             new NamespaceCandidates($catalog, $this->symbolResolver, $capabilities),
             new FunctionCandidates($this->symbolResolver, $capabilities),
             new KeywordCandidates(),

--- a/tests/Handler/OpensDocumentsTrait.php
+++ b/tests/Handler/OpensDocumentsTrait.php
@@ -102,6 +102,25 @@ trait OpensDocumentsTrait
     }
 
     /**
+     * Opens a fixture and returns the cursor position for the named marker with
+     * `character` as the UTF-16 wire column a conformant client sends, rather than
+     * the byte column {@see openFixtureAtCursor()} returns. Use for fixtures with
+     * multibyte content before the cursor, where the two columns diverge and the
+     * interior must convert the wire column at the boundary (RFC 1 §4.9).
+     *
+     * @param string $fixturePath Path relative to tests/Fixtures/
+     * @param string $cursorName The marker name (without delimiters)
+     * @return CursorPosition
+     * @phpstan-ignore missingType.iterableValue
+     */
+    private function openFixtureAtUtf16Cursor(string $fixturePath, string $cursorName): array
+    {
+        [$uri, $content] = $this->loadAndOpenFixture($fixturePath);
+
+        return ['uri' => $uri, ...$this->locateCursorUtf16($content, $cursorName)];
+    }
+
+    /**
      * Builds a textDocument/completion request for the given cursor position.
      *
      * Typically used with the return value of openFixtureAtCursor():

--- a/tests/LoadsFixturesTrait.php
+++ b/tests/LoadsFixturesTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests;
 
+use Firehed\PhpLsp\Protocol\PositionEncoding;
+
 /**
  * Provides fixture file loading for unit tests.
  *
@@ -39,6 +41,44 @@ trait LoadsFixturesTrait
      */
     private function locateCursor(string $content, string $cursorName): array
     {
+        ['line' => $line, 'before' => $before] = $this->splitAtCursor($content, $cursorName);
+
+        return [
+            'line' => $line,
+            'character' => strlen($before),
+        ];
+    }
+
+    /**
+     * Resolves a fixture cursor marker to its position with `character` as the
+     * negotiated-encoding (UTF-16) wire column — what a conformant client sends.
+     * {@see locateCursor()} returns a byte column, which coincides with the wire
+     * column only for ASCII; a fixture with multibyte content before the cursor
+     * needs the true wire column to exercise the boundary conversion the interior
+     * relies on (RFC 1 §4.9).
+     *
+     * @param string $cursorName The marker name (without delimiters)
+     * @return array{line: int, character: int}
+     */
+    private function locateCursorUtf16(string $content, string $cursorName): array
+    {
+        ['line' => $line, 'before' => $before] = $this->splitAtCursor($content, $cursorName);
+
+        return [
+            'line' => $line,
+            'character' => PositionEncoding::Utf16->codeUnitLength($before),
+        ];
+    }
+
+    /**
+     * The line the cursor marker sits on and the text preceding it on that line,
+     * shared by the byte- and wire-column marker resolvers.
+     *
+     * @param string $cursorName The marker name (without delimiters)
+     * @return array{line: int, before: string}
+     */
+    private function splitAtCursor(string $content, string $cursorName): array
+    {
         $marker = "/*|{$cursorName}*/";
         $pos = strpos($content, $marker);
         assert($pos !== false, "Cursor marker not found: $cursorName");
@@ -49,7 +89,7 @@ trait LoadsFixturesTrait
 
         return [
             'line' => $line,
-            'character' => strlen($lines[$line]),
+            'before' => $lines[$line],
         ];
     }
 }

--- a/tests/Protocol/PositionEncodingTest.php
+++ b/tests/Protocol/PositionEncodingTest.php
@@ -41,6 +41,30 @@ class PositionEncodingTest extends TestCase
         );
     }
 
+    #[DataProvider('codeUnitLengthCases')]
+    public function testCodeUnitLength(string $text, int $expected): void
+    {
+        self::assertSame(
+            $expected,
+            PositionEncoding::Utf16->codeUnitLength($text),
+            'a completion Range start column is a wire column, so a byte prefix must be measured in code units',
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return iterable<string, array{string, int}>
+     */
+    public static function codeUnitLengthCases(): iterable
+    {
+        yield 'empty string is zero' => ['', 0];
+        yield 'ascii length is byte length' => ['Log', 3];
+        yield 'bmp multibyte counts one unit per char' => ['café', 4];
+        yield 'astral char counts two units' => ['😀', 2];
+        yield 'mixed ascii and astral' => ['a😀b', 4];
+    }
+
     /**
      * @codeCoverageIgnore
      *

--- a/tests/Protocol/PositionEncodingTest.php
+++ b/tests/Protocol/PositionEncodingTest.php
@@ -60,7 +60,8 @@ class PositionEncodingTest extends TestCase
     {
         yield 'empty string is zero' => ['', 0];
         yield 'ascii length is byte length' => ['Log', 3];
-        yield 'bmp multibyte counts one unit per char' => ['café', 4];
+        yield 'two-byte bmp char counts one unit' => ['café', 4];
+        yield 'three-byte bmp char counts one unit' => ['€', 1];
         yield 'astral char counts two units' => ['😀', 2];
         yield 'mixed ascii and astral' => ['a😀b', 4];
     }
@@ -75,10 +76,12 @@ class PositionEncodingTest extends TestCase
         yield 'ascii is identity' => ['abc', 2, 2];
         yield 'ascii start' => ['abc', 0, 0];
         yield 'column past end clamps to byte length' => ['abc', 5, 3];
-        yield 'bmp multibyte counts one unit, two bytes' => ['é', 1, 2];
+        yield 'two-byte bmp char is one unit, two bytes' => ['é', 1, 2];
         yield 'column before a multibyte char' => ['aéb', 1, 1];
         yield 'column after a multibyte char' => ['aéb', 2, 3];
         yield 'column at end after multibyte' => ['aéb', 3, 4];
+        yield 'three-byte bmp char is one unit, three bytes' => ['€', 1, 3];
+        yield 'column after a three-byte char' => ['a€b', 2, 4];
         yield 'astral char is two units, four bytes' => ['😀', 2, 4];
         yield 'column inside a surrogate pair rounds up' => ['😀', 1, 4];
         yield 'column after an astral char' => ['a😀b', 3, 5];
@@ -95,9 +98,10 @@ class PositionEncodingTest extends TestCase
         yield 'ascii is identity' => ['abc', 2, 2];
         yield 'ascii start' => ['abc', 0, 0];
         yield 'byte before a multibyte char' => ['aéb', 1, 1];
-        yield 'byte after a multibyte char' => ['aéb', 3, 2];
+        yield 'byte after a two-byte char' => ['aéb', 3, 2];
         yield 'byte inside a multibyte char rounds up' => ['aéb', 2, 2];
         yield 'byte at end after multibyte' => ['aéb', 4, 3];
+        yield 'byte after a three-byte char' => ['a€b', 4, 2];
         yield 'astral char is two units' => ['😀', 4, 2];
         yield 'byte after an astral char' => ['a😀b', 5, 3];
         yield 'byte at end after astral' => ['a😀b', 6, 4];

--- a/tests/Protocol/RangeTest.php
+++ b/tests/Protocol/RangeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Protocol;
 
+use Firehed\PhpLsp\Protocol\PositionEncoding;
 use Firehed\PhpLsp\Protocol\Range;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -11,6 +12,34 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Range::class)]
 class RangeTest extends TestCase
 {
+    public function testForPrefixSpansTheTypedPrefixEndingAtTheWireColumn(): void
+    {
+        $range = Range::forPrefix(0, 5, 'Log', PositionEncoding::Utf16);
+
+        self::assertSame(
+            [
+                'start' => ['line' => 0, 'character' => 2],
+                'end' => ['line' => 0, 'character' => 5],
+            ],
+            $range->toArray(),
+            'The span starts a prefix-width back from the wire column and ends at it',
+        );
+    }
+
+    public function testForPrefixMeasuresThePrefixInCodeUnitsNotBytes(): void
+    {
+        // "café" is four codepoints but five UTF-8 bytes; the range is measured in
+        // the negotiated encoding's code units, so it starts four columns back, not
+        // five (RFC 1 §4.9).
+        $range = Range::forPrefix(0, 4, 'café', PositionEncoding::Utf16);
+
+        self::assertSame(
+            ['line' => 0, 'character' => 0],
+            $range->toArray()['start'],
+            'A multibyte prefix must not push the range start past the line by counting bytes',
+        );
+    }
+
     public function testOnLineIsASingleLineSpan(): void
     {
         $range = Range::onLine(4, 8, 10);

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -896,6 +896,28 @@ final class SymbolResolverTest extends TestCase
         self::assertSame('get', $context->prefix);
     }
 
+    /**
+     * Variable member access resolves correctly on a line carrying a multibyte
+     * character before the cursor, where the wire column trails the byte column
+     * (RFC 1 §4.9). A regression net over the variable-access surface the wire
+     * column feeds.
+     */
+    public function testGetMemberAccessContextForVariablePastMultibyte(): void
+    {
+        $cursor = $this->openFixtureAtUtf16Cursor(
+            'src/IncompleteCode/MultibyteVarAccess.php',
+            'var_member_multibyte',
+        );
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame('Fixtures\\IncompleteCode\\MultibyteVarAccess', $context->type->format());
+        self::assertSame('', $context->prefix);
+    }
+
     public function testGetMemberAccessContextForNullsafeAccess(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'nullsafe_this_empty');

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -918,6 +918,29 @@ final class SymbolResolverTest extends TestCase
         self::assertSame('', $context->prefix);
     }
 
+    /**
+     * The same wire-column-past-multibyte scenario, but through the variable
+     * access text fallback: an incomplete `while ($user->` denies a clean AST
+     * node, so resolution slices the text before the cursor itself. A raw
+     * wire-column slice would truncate past the "🎉" and resolve nothing
+     * (RFC 1 §4.9).
+     */
+    public function testGetMemberAccessContextForVariableViaFallbackPastMultibyte(): void
+    {
+        $cursor = $this->openFixtureAtUtf16Cursor(
+            'src/IncompleteCode/MultibyteVarAccess.php',
+            'var_while_multibyte',
+        );
+        $document = $this->documents->get($cursor['uri']);
+        assert($document !== null);
+
+        $context = $this->resolver->getMemberAccessContext($document, $cursor['line'], $cursor['character']);
+
+        self::assertInstanceOf(MemberAccessContext::class, $context);
+        self::assertSame('Fixtures\\Domain\\User', $context->type->format());
+        self::assertSame('', $context->prefix);
+    }
+
     public function testGetMemberAccessContextForNullsafeAccess(): void
     {
         $cursor = $this->openFixtureAtCursor('src/Completion/MethodAccess.php', 'nullsafe_this_empty');

--- a/tests/Resolution/TextFallbackHelperTest.php
+++ b/tests/Resolution/TextFallbackHelperTest.php
@@ -17,12 +17,15 @@ use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\TextFallbackHelper;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(TextFallbackHelper::class)]
 class TextFallbackHelperTest extends TestCase
 {
+    use LoadsFixturesTrait;
+
     private TextFallbackHelper $helper;
     private TextFallbackHelper $helperWithReflection;
     private ParserService $parser;
@@ -248,6 +251,25 @@ class TextFallbackHelperTest extends TestCase
         self::assertNotNull($result, 'Should resolve class in global namespace');
         // No namespace, no use - class name stays as-is
         self::assertSame('SomeClass', $result->type->format());
+    }
+
+    public function testGetMemberAccessContextSlicesPrefixAtByteColumnPastMultibyte(): void
+    {
+        $content = $this->loadFixture('TopLevel/multibyte_static.php');
+        $document = new TextDocument('file:///test.php', 'php', 1, $content);
+        // The line carries a "🎉" (one astral codepoint: 2 UTF-16 units, 4 bytes)
+        // before "User::fromArray", so the wire column trails the byte column.
+        ['line' => $line, 'character' => $character] = $this->locateCursorUtf16($content, 'multibyte_static');
+
+        $result = $this->helperWithReflection->getMemberAccessContext($document, $line, $character, []);
+
+        self::assertNotNull($result, 'a static access past a multibyte char must still resolve');
+        self::assertSame('Fixtures\\Domain\\User', $result->type->format());
+        self::assertSame(
+            'fromArray',
+            $result->prefix,
+            'slicing the raw wire column would truncate the member prefix (RFC 1 §4.9)',
+        );
     }
 
     public function testFindParameterTypeWithMultilineSignature(): void


### PR DESCRIPTION
## Slice

- **Slice:** S1.5 — Position round-trip corpus (regression net)
- **Plan step:** Execution Plan 0002, Step 1 (capability negotiation + encoding edge)
- **RFC:** `0001-foundational-architecture.md` §4.9 (Position Encoding); §8.1 invariant 9

## Related

- **Builds on #366** (S1.2) — that slice negotiated `positionEncoding` and converted
  positions at the document boundary, but deferred the *interior* sites; this slice
  is that deferred interior half.
- **Advances #192** (Multibyte/Unicode character handling) — the §4.9 divergence
  being driven out. The boundary half landed in #366; this completes the interior
  reads/writes. (Left for the reviewer to decide whether #192 is fully closed.)
- **Consumes #364** (S1.1) — the completion sources now reach the negotiated encoding
  through the immutable `SessionCapabilities` resolved there.
- **Follow-up #371** — a latent gap this slice surfaced: the negotiated encoding is
  not yet threaded into `TextDocument` (documents use the default). Correct while
  UTF-16 is the only encoding; tracked for when a second one is added.

## What and why

S1.2 (#366) fixed the conversion at the document boundary (`TextDocument::offsetAt` /
`positionAt`) but deferred the *interior* sites that still treated the wire
`character` as a byte length — a §4.9 violation ("interior components MUST operate
only on [the negotiated] representation"). This slice drives those out and adds the
regression net Step P deliberately excludes for the positional surface.

**Inbound reads** (text before the cursor) now slice at the byte column via a shared
`TextDocument::textBeforeCursor()` helper instead of `substr($lineText, 0, $character)`:

- `CompletionHandler` (classification / call-context text)
- `TextFallbackHelper::getMemberAccessContext`
- `SymbolResolver::resolveVariableAccessWithAst`

**Outbound completion `Range` columns** now size the typed prefix in the negotiated
encoding via a new `Range::forPrefix(line, character, prefix, encoding)` factory —
the one place the conversion lives — instead of `$character - strlen($prefix)`:

- `ClassCandidates` and `NamespaceCandidates`, which now receive the negotiated
  encoding through `SessionCapabilitiesProvider` (S1.2 kept it confined to the
  document boundary).

## Why not native `mb_` functions

Flagging this so it is not "simplified" later (and it is documented in
`PositionEncoding`): an LSP `character` is a **UTF-16 code unit** count, but the
native `mb_` functions count **codepoints**. An astral codepoint (e.g. `😀`,
U+1F389, four UTF-8 bytes) is one `mb_` character but **two** UTF-16 code units (a
surrogate pair). So `mb_strlen` over-shortens a length and `mb_substr` mis-slices
whenever an astral codepoint is present — the exact defect this slice fixes. The
surrogate accounting in `PositionEncoding::utf16Units()` is what `mb_` does not
provide; `mb_str_split` (codepoint split) is the one `mb_` primitive that fits and
is already used. `mb_convert_encoding(..., 'UTF-16LE', ...)` could shorten the
length-only case but not the `character → byte` direction, so it would fork the
single shared mechanism for no net gain.

## Acceptance criteria

- [x] Interior inbound reads no longer treat the wire column as a byte length; the
      repeated pattern is a shared `TextDocument` helper (byte column from the
      document's own encoding, no encoding threading).
- [x] Outbound completion `Range` start columns are measured in the negotiated
      encoding's code units, with `PositionEncoding` reachable at the completion
      sources.
- [x] A position round-trip corpus proves the boundary is a bijection across a file
      of mixed-width codepoints, and re-runs existing cursor-marker fixtures under
      the negotiated encoding.
- [x] Each corrected site is covered by a dedicated multibyte fixture/test.
- [x] `composer test` green (PHPStan + suite + PHPCS).

## §4.9 enforcement

Per §8.1, invariant 9's mechanism is a test (multibyte round-trip at the boundary)
plus review of interior offset use — no new static rule. This slice supplies the
tests: `PositionRoundTripCorpusTest`, plus per-site multibyte cases across
`TextDocumentTest`, `PositionEncodingTest`, `RangeTest`, `CompletionHandlerTest`,
`TextFallbackHelperTest`, `SymbolResolverTest`, `ClassCandidatesTest`, and
`NamespaceCandidatesTest`.

## Candidate closes

None attributed to S1.5 in the build manifest. See **Related** above for #192, which
this slice advances (its `Closes` sits with S1.2 in the manifest); the reviewer
decides whether it is now fully resolved.

## Notes for review

`SymbolResolver::resolveVariableAccessWithAst` is a deep fallback: for the multibyte
scenarios tried, the AST path (which already uses the correct `offsetAt`) serves the
query, so its `substr` is corrected for consistency and kept covered by the existing
tests (16×) rather than by a contrived red case. The shared text-fallback prefix
behavior is proven red→green in `TextFallbackHelperTest`.
