### PR TITLE
Define SymbolSource / SymbolSink seam and delegating facade

### DIFF
--- a/src/Knowledge/DelegatingSymbolSource.php
+++ b/src/Knowledge/DelegatingSymbolSource.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Knowledge;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\NamespaceCatalog;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Index\Symbol;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\ClassInfoFactory;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Utility\ScopeFinder;
+use PhpParser\Node\Stmt;
+
+/**
+ * The Step-2 {@see SymbolSource} / {@see SymbolSink} implementation: pure delegation
+ * to today's collaborators, introducing the read/write seam (RFC 1 §4.2, §4.3) with
+ * no behavior change (Plan 0002 §5.5).
+ *
+ * The write path deliberately reproduces today's *double* write — the class
+ * repository and the symbol index are two stores fed from one document — behind a
+ * single method. Collapsing them to one parse and one write is Step 3a; here the two
+ * writes are preserved exactly so the Step P parity harness is identical before and
+ * after (Plan 0002 §5.5, Teardown ledger).
+ */
+final class DelegatingSymbolSource implements SymbolSource, SymbolSink
+{
+    /**
+     * The symbol kinds that are class-likes. searchClassLikes searches this namespace
+     * alone; the function and constant namespaces are Step 3b (Plan 0002 §5.3).
+     *
+     * @var list<SymbolKind>
+     */
+    private const array CLASS_LIKE_KINDS = [
+        SymbolKind::Class_,
+        SymbolKind::Enum_,
+        SymbolKind::Interface_,
+        SymbolKind::Trait_,
+    ];
+
+    public function __construct(
+        private readonly ClassRepository $classes,
+        private readonly SymbolIndex $index,
+        private readonly NamespaceCatalog $catalog,
+        private readonly DocumentIndexer $indexer,
+        private readonly ClassInfoFactory $classInfoFactory,
+        private readonly ParserService $parser,
+    ) {
+    }
+
+    public function childrenOf(NamespaceName $namespace): NamespaceContents
+    {
+        return $this->catalog->childrenOf($namespace->path);
+    }
+
+    public function closeDocument(string $uri): void
+    {
+        $this->indexer->remove($uri);
+        $this->classes->removeDocument($uri);
+    }
+
+    public function lookupClassLike(ClassName $name): ?ClassInfo
+    {
+        return $this->classes->get($name);
+    }
+
+    public function openDocument(TextDocument $document): void
+    {
+        $this->writeDocument($document);
+    }
+
+    /**
+     * @return list<Symbol>
+     */
+    public function searchClassLikes(string $prefix): array
+    {
+        return $this->index->findByPrefix($prefix, self::CLASS_LIKE_KINDS);
+    }
+
+    public function updateDocument(TextDocument $document): void
+    {
+        $this->writeDocument($document);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     */
+    private function registerClasses(string $uri, array $ast): void
+    {
+        $classes = [];
+        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
+            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
+                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
+            }
+        }
+        $this->classes->updateDocument($uri, $classes);
+    }
+
+    private function writeDocument(TextDocument $document): void
+    {
+        $ast = $this->parser->parse($document);
+        if ($ast !== null) {
+            $this->registerClasses($document->uri, $ast);
+        }
+
+        $this->indexer->index($document);
+    }
+}

--- a/src/Knowledge/NamespaceName.php
+++ b/src/Knowledge/NamespaceName.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Knowledge;
+
+/**
+ * The fully-qualified namespace path that {@see SymbolSource::childrenOf} enumerates,
+ * as a typed identifier rather than a bare string (RFC 1 §5.1). The global namespace
+ * is the empty path.
+ *
+ * A namespace is not a symbol: it has no declaration site and no {@see \Firehed\PhpLsp\Resolution\NameKind},
+ * existing only because something is declared beneath it (RFC 1 §5.1; Plan 0002 §5.6).
+ * So this carries the path alone.
+ */
+final readonly class NamespaceName
+{
+    public function __construct(
+        public string $path,
+    ) {
+    }
+}

--- a/src/Knowledge/SymbolSink.php
+++ b/src/Knowledge/SymbolSink.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Knowledge;
+
+use Firehed\PhpLsp\Document\TextDocument;
+
+/**
+ * The write contract for symbol state (RFC 1 §4.3, §5.2): the sole means of mutating
+ * what {@see SymbolSource} reports, keyed by document lifecycle. Kept a separate
+ * interface from the read side so a read-only consumer depends only on SymbolSource;
+ * a single class may implement both (RFC 1 §4.3).
+ *
+ * There MUST be exactly one write path for symbol state (RFC 1 §4.3): any other
+ * producer — background indexing, external on-disk change — writes through this
+ * interface rather than a second store.
+ */
+interface SymbolSink
+{
+    public function closeDocument(string $uri): void;
+
+    public function openDocument(TextDocument $document): void;
+
+    public function updateDocument(TextDocument $document): void;
+}

--- a/src/Knowledge/SymbolSource.php
+++ b/src/Knowledge/SymbolSource.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Knowledge;
+
+use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Index\Symbol;
+
+/**
+ * The read contract for symbol knowledge (RFC 1 §4.2, §5.1): every query for symbol
+ * existence, metadata, and namespace enumeration is answered here, so that *where* a
+ * symbol comes from is a backend concern (Section 5.3) with no change to consumers.
+ *
+ * Queries are FQN-based (RFC 1 §4.4): this takes an already-qualified name and never
+ * a cursor position or a syntax tree. Turning "`Foo` in this namespace with these
+ * imports" into a candidate FQN is the positional layer's job, not this interface's.
+ *
+ * The method set is the Step-2 subset the migrated features need — exact class-like
+ * lookup, class-like prefix search, and namespace enumeration. Per-kind function and
+ * constant lookup, and a kind-parameterized search, arrive with the features that
+ * first need them (Plan 0002 §5.2); a method with no caller is not carried ahead.
+ */
+interface SymbolSource
+{
+    /**
+     * Enumerate a namespace's immediate children — its child namespaces and the
+     * symbols declared directly in it.
+     */
+    public function childrenOf(NamespaceName $namespace): NamespaceContents;
+
+    /**
+     * Full metadata for a class-like by its exact name, or null when nothing the
+     * source can reach declares it (RFC 1 §5.3: absence is a bare null).
+     */
+    public function lookupClassLike(ClassName $name): ?ClassInfo;
+
+    /**
+     * The class-likes whose short name begins with $prefix. The prefix is the partial
+     * fragment the user is typing, not a complete identifier, so a bare string is
+     * correct here (Plan 0002 §5.3).
+     *
+     * @return list<Symbol>
+     */
+    public function searchClassLikes(string $prefix): array;
+}

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -222,9 +222,10 @@ final class DelegatingSymbolSourceTest extends TestCase
 
     public function testWriteSurvivesAMalformedDocument(): void
     {
-        // A mid-edit broken file the parser cannot recover to an AST must leave both
-        // stores untouched rather than crash (RFC 1 §9): the null-AST guard skips class
-        // registration, so no bogus class reaches the repository, and the indexer no-ops.
+        // A mid-edit broken file the parser reduces to an empty statement list ([],
+        // not null) must not crash and must contribute no symbols (RFC 1 §9): class
+        // registration and indexing both run over the empty AST and find nothing to
+        // add, so no symbol reaches the index.
         $source = $this->facade($this->unusedCatalog());
         $uri = 'file:///virtual/Broken.php';
         $broken = file_get_contents($this->projectRoot . '/tests/Fixtures/src/IncompleteCode/VeryBroken.php');

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Knowledge;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\NamespaceCatalog;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Index\Symbol;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Knowledge\DelegatingSymbolSource;
+use Firehed\PhpLsp\Knowledge\NamespaceName;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The Step-2 facade is pure delegation, so these tests prove it forwards to today's
+ * collaborators unchanged: the read side against real fixture-backed repositories and
+ * indexes, the namespace enumeration against a forwarding assertion, and the write
+ * side against the double write it must reproduce (Plan 0002 §5.5; RFC 1 §4.2–§4.3,
+ * §5.1–§5.2). Behavior parity with the surfaces themselves is frozen separately by the
+ * Step P golden harness (tests/Parity), which the facade rides unchanged.
+ */
+final class DelegatingSymbolSourceTest extends TestCase
+{
+    private DefaultClassInfoFactory $factory;
+    private SymbolIndex $index;
+    private DocumentIndexer $indexer;
+    private ParserService $parser;
+    private string $projectRoot;
+    private ClassRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = dirname(__DIR__, 2);
+        $this->parser = new ParserService();
+        $this->factory = new DefaultClassInfoFactory();
+        $this->index = new SymbolIndex();
+        $this->indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->index);
+        $this->repository = new DefaultClassRepository(
+            $this->factory,
+            new ComposerClassLocator($this->projectRoot . '/tests/Fixtures'),
+            $this->parser,
+        );
+    }
+
+    public function testLookupClassLikeReturnsTheRepositoryResult(): void
+    {
+        $source = $this->facade($this->unusedCatalog());
+
+        $info = $source->lookupClassLike(self::className('Fixtures\Domain\User'));
+
+        self::assertNotNull($info, 'a fixture class must resolve through the repository');
+        self::assertSame(
+            'Fixtures\Domain\User',
+            $info->name->fqn,
+            'lookupClassLike must return the repository result unchanged',
+        );
+    }
+
+    public function testLookupClassLikeReturnsNullForAnAbsentClass(): void
+    {
+        $source = $this->facade($this->unusedCatalog());
+
+        self::assertNull(
+            $source->lookupClassLike(self::className('Fixtures\Does\Not\Exist')),
+            'a name nothing declares must resolve to null, not an error (RFC 1 §5.3)',
+        );
+    }
+
+    public function testSearchClassLikesReturnsOnlyClassLikeKinds(): void
+    {
+        // The index also holds methods and functions; searchClassLikes searches the
+        // class-like namespace only (function/constant search is Step 3b).
+        $this->indexFixture('src/Domain/User.php');
+        $this->indexFixture('src/Catalog/functions.php');
+        $source = $this->facade($this->unusedCatalog());
+
+        $results = $source->searchClassLikes('');
+
+        self::assertNotEmpty(
+            $this->index->findByPrefix('', [SymbolKind::Function_]),
+            'the corpus must index at least one function so its exclusion is meaningful',
+        );
+        foreach ($results as $symbol) {
+            self::assertContains(
+                $symbol->kind,
+                [SymbolKind::Class_, SymbolKind::Enum_, SymbolKind::Interface_, SymbolKind::Trait_],
+                'searchClassLikes must return class-likes only, never methods or functions',
+            );
+        }
+        self::assertContains(
+            'Fixtures\Domain\User',
+            self::fqns($results),
+            'the indexed class must be found',
+        );
+    }
+
+    public function testSearchClassLikesFiltersByPrefix(): void
+    {
+        $this->indexFixture('src/Domain/User.php');
+        $this->indexFixture('src/Domain/Entity.php');
+        $source = $this->facade($this->unusedCatalog());
+
+        $fqns = self::fqns($source->searchClassLikes('User'));
+
+        self::assertContains('Fixtures\Domain\User', $fqns, 'a matching prefix must be included');
+        self::assertNotContains(
+            'Fixtures\Domain\Entity',
+            $fqns,
+            'a symbol whose name does not begin with the prefix must be excluded',
+        );
+    }
+
+    public function testChildrenOfForwardsTheNamespacePath(): void
+    {
+        $expected = new NamespaceContents(['Fixtures\Domain\Sub'], []);
+        $catalog = $this->createMock(NamespaceCatalog::class);
+        $catalog->expects($this->once())
+            ->method('childrenOf')
+            ->with('Fixtures\Domain')
+            ->willReturn($expected);
+
+        self::assertSame(
+            $expected,
+            $this->facade($catalog)->childrenOf(new NamespaceName('Fixtures\Domain')),
+            'childrenOf must forward the namespace path and return the catalog result unchanged',
+        );
+    }
+
+    public function testChildrenOfForwardsTheGlobalNamespaceAsAnEmptyPath(): void
+    {
+        $expected = new NamespaceContents(['Fixtures'], []);
+        $catalog = $this->createMock(NamespaceCatalog::class);
+        $catalog->expects($this->once())
+            ->method('childrenOf')
+            ->with('')
+            ->willReturn($expected);
+
+        self::assertSame(
+            $expected,
+            $this->facade($catalog)->childrenOf(new NamespaceName('')),
+            'the global namespace must forward as the empty path',
+        );
+    }
+
+    public function testOpenDocumentWritesToBothTheRepositoryAndTheIndex(): void
+    {
+        $source = $this->facade($this->unusedCatalog());
+        $uri = 'file:///virtual/Widget.php';
+        $content = "<?php\nnamespace Virtual;\nfinal class Widget { public function tick(): void {} }\n";
+
+        $source->openDocument(new TextDocument($uri, 'php', 1, $content));
+
+        $info = $this->repository->get(self::className('Virtual\Widget'));
+        self::assertNotNull($info, 'openDocument must register the class with the repository');
+        self::assertSame('Virtual\Widget', $info->name->fqn, 'the registered class must be the opened one');
+        self::assertNotNull(
+            $this->index->findByFqn('Virtual\Widget'),
+            'openDocument must also index the document — the second of the double write',
+        );
+    }
+
+    public function testUpdateDocumentReplacesThePriorSymbolsInBothStores(): void
+    {
+        $source = $this->facade($this->unusedCatalog());
+        $uri = 'file:///virtual/Doc.php';
+
+        $source->openDocument(new TextDocument($uri, 'php', 1, "<?php\nnamespace V;\nclass Alpha {}\n"));
+        $source->updateDocument(new TextDocument($uri, 'php', 2, "<?php\nnamespace V;\nclass Beta {}\n"));
+
+        self::assertNull($this->index->findByFqn('V\Alpha'), 'update must clear the prior symbols from the index');
+        self::assertNotNull($this->index->findByFqn('V\Beta'), 'update must index the new symbols');
+        self::assertNotNull(
+            $this->repository->get(self::className('V\Beta')),
+            'update must register the new class with the repository',
+        );
+        self::assertNull(
+            $this->repository->get(self::className('V\Alpha')),
+            'update must drop the prior class from the repository',
+        );
+    }
+
+    public function testCloseDocumentClearsBothStores(): void
+    {
+        $source = $this->facade($this->unusedCatalog());
+        $uri = 'file:///virtual/Ephemeral.php';
+        $source->openDocument(new TextDocument($uri, 'php', 1, "<?php\nnamespace V;\nclass Ephemeral {}\n"));
+
+        $source->closeDocument($uri);
+
+        self::assertNull($this->index->findByFqn('V\Ephemeral'), 'close must clear the indexed symbols');
+        self::assertNull(
+            $this->repository->get(self::className('V\Ephemeral')),
+            'close must drop the registered class from the repository',
+        );
+    }
+
+    public function testWriteSurvivesAMalformedDocument(): void
+    {
+        // A mid-edit broken file must leave the stores consistent rather than crash
+        // (RFC 1 §9): the write path indexes what it can and registers no bogus class.
+        $source = $this->facade($this->unusedCatalog());
+        $uri = 'file:///virtual/Broken.php';
+        $broken = file_get_contents($this->projectRoot . '/tests/Fixtures/src/IncompleteCode/VeryBroken.php');
+        self::assertNotFalse($broken, 'the broken fixture should be readable');
+
+        $source->openDocument(new TextDocument($uri, 'php', 1, $broken));
+
+        self::assertSame(
+            [],
+            $this->indexedFqnsFor($uri),
+            'a malformed document must contribute no indexed symbols and must not crash',
+        );
+    }
+
+    private function facade(NamespaceCatalog $catalog): DelegatingSymbolSource
+    {
+        return new DelegatingSymbolSource(
+            $this->repository,
+            $this->index,
+            $catalog,
+            $this->indexer,
+            $this->factory,
+            $this->parser,
+        );
+    }
+
+    private function indexFixture(string $relative): void
+    {
+        $path = $this->projectRoot . '/tests/Fixtures/' . $relative;
+        $content = file_get_contents($path);
+        self::assertNotFalse($content, "fixture document should be readable: {$relative}");
+        $this->indexer->index(new TextDocument('file://' . $path, 'php', 0, $content));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function indexedFqnsFor(string $uri): array
+    {
+        $fqns = [];
+        foreach ($this->index->findByPrefix('') as $symbol) {
+            if ($symbol->location->uri === $uri) {
+                $fqns[] = $symbol->fullyQualifiedName;
+            }
+        }
+        sort($fqns);
+
+        return $fqns;
+    }
+
+    private function unusedCatalog(): NamespaceCatalog
+    {
+        return self::createStub(NamespaceCatalog::class);
+    }
+
+    /**
+     * Fixture and virtual names are outside PHPStan's autoload path, so they are not
+     * seen as class-strings; the repository reads only the FQN, so the concession is
+     * harmless and confined here.
+     */
+    private static function className(string $fqn): ClassName
+    {
+        /** @phpstan-ignore argument.type (fixture and virtual names are not analyzed) */
+        return new ClassName($fqn);
+    }
+
+    /**
+     * @param list<Symbol> $symbols
+     * @return list<string>
+     */
+    private static function fqns(array $symbols): array
+    {
+        return array_map(static fn(Symbol $symbol): string => $symbol->fullyQualifiedName, $symbols);
+    }
+}

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -80,9 +80,14 @@ final class DelegatingSymbolSourceTest extends TestCase
     public function testSearchClassLikesReturnsOnlyClassLikeKinds(): void
     {
         // The index also holds methods and functions; searchClassLikes searches the
-        // class-like namespace only (function/constant search is Step 3b).
-        $this->indexFixture('src/Domain/User.php');
-        $this->indexFixture('src/Catalog/functions.php');
+        // class-like namespace only (function/constant search is Step 3b). Index one
+        // fixture of every class-like kind so a kind dropped from the search set is
+        // caught by its missing FQN, not only by the allowlist below.
+        $this->indexFixture('src/Domain/User.php'); // class
+        $this->indexFixture('src/Enum/Status.php'); // enum
+        $this->indexFixture('src/Hierarchy/BaseInterface.php'); // interface
+        $this->indexFixture('src/Traits/HasTimestamps.php'); // trait
+        $this->indexFixture('src/Catalog/functions.php'); // function (must be excluded)
         $source = $this->facade($this->unusedCatalog());
 
         $results = $source->searchClassLikes('');
@@ -98,11 +103,21 @@ final class DelegatingSymbolSourceTest extends TestCase
                 'searchClassLikes must return class-likes only, never methods or functions',
             );
         }
-        self::assertContains(
-            'Fixtures\Domain\User',
-            self::fqns($results),
-            'the indexed class must be found',
-        );
+        $fqns = self::fqns($results);
+        foreach (
+            [
+                'Fixtures\Domain\User',
+                'Fixtures\Enum\Status',
+                'Fixtures\Hierarchy\BaseInterface',
+                'Fixtures\Traits\HasTimestamps',
+            ] as $expected
+        ) {
+            self::assertContains(
+                $expected,
+                $fqns,
+                "every class-like kind must be searchable; {$expected} was dropped",
+            );
+        }
     }
 
     public function testSearchClassLikesFiltersByPrefix(): void

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -222,8 +222,9 @@ final class DelegatingSymbolSourceTest extends TestCase
 
     public function testWriteSurvivesAMalformedDocument(): void
     {
-        // A mid-edit broken file must leave the stores consistent rather than crash
-        // (RFC 1 §9): the write path indexes what it can and registers no bogus class.
+        // A mid-edit broken file the parser cannot recover to an AST must leave both
+        // stores untouched rather than crash (RFC 1 §9): the null-AST guard skips class
+        // registration, so no bogus class reaches the repository, and the indexer no-ops.
         $source = $this->facade($this->unusedCatalog());
         $uri = 'file:///virtual/Broken.php';
         $broken = file_get_contents($this->projectRoot . '/tests/Fixtures/src/IncompleteCode/VeryBroken.php');


### PR DESCRIPTION
## Slice S2.1 — Define `SymbolSource` / `SymbolSink` + delegating facade

**Slice:** S2.1 (build-manifest.md, Wave 1)
**Plan step:** 0002-execution-plan.md Step 2 (§5.1–§5.6) — the seam-introducing slice of Step 2
**RFC sections:** 0001 §4.2 (Symbol Discovery Authority), §4.3 (Read/Write Segregation), §4.4 (Positional/Knowledge separation), §5.1 (read contract), §5.2 (write contract), §5.3 (absence is a bare `null`)

Introduces the read/write knowledge seam over today's collaborators, with **no behavior change**. No consumer is migrated onto it here — this slice only defines the interfaces and the delegating facade.

### What's here

- `Firehed\PhpLsp\Knowledge\NamespaceName` — typed identifier for a namespace path (RFC §5.1 "names MUST be typed identifiers"); the global namespace is the empty path.
- `SymbolSource` (read) and `SymbolSink` (write) — separate interfaces per RFC §4.3; FQN-based, no cursor/AST per §4.4.
- `DelegatingSymbolSource` — implements both by pure delegation to `ClassRepository` (`lookupClassLike`), `SymbolIndex` (`searchClassLikes`), `NamespaceCatalog` (`childrenOf`), and the existing write paths (`DocumentIndexer` + `ClassInfoFactory` + `ClassRepository`). The write path reproduces today's **double write** behind one method (Plan §5.5); collapsing it is Step 3a.

### Acceptance criteria (this slice)

- [x] Read interface (`SymbolSource`) and write interface (`SymbolSink`) exist as separate interfaces (RFC §4.3).
- [x] A facade implements both by delegating to `ClassRepository` / `SymbolIndex` / `NamespaceCatalog` and the existing write paths (Plan §5.5).
- [x] Class-like lookup, class-like prefix search, and namespace enumeration are expressible through `SymbolSource`; document open/update/close through `SymbolSink`.
- [x] Behavior-preserving: the Step P parity harness is untouched and green — per `tests/Parity/README.md`, the facade rides the goldens unchanged (goldens assert surface output; the surfaces are the concrete classes, which this slice does not modify).
- [x] Facade delegation proven by unit tests (`tests/Knowledge/`); 100% line/method coverage of the new classes.
- [x] `composer test` green (PHPStan + tests + PHPCS).

### Resolved open decisions (Plan §7)

- **`ClassLikeName` = today's `ClassName`, reused as-is** (Plan §5.3 lean; §7 open decision). No new class-name type; `lookupClassLike(ClassName)` keeps the diff minimal and `ClassName`'s dual role (identity + `Type`) intact.
- **`SymbolDefinition` = today's `Symbol`, reused** (Plan §5.4). `searchClassLikes(): list<Symbol>`.
- **No kind parameter on `searchClassLikes`** — searches the class-like namespace only; a kind-parameterized `search` and per-kind function/constant lookup arrive in Step 3b (Plan §5.3).
- **Package namespace `Firehed\PhpLsp\Knowledge`** — grounded in the RFC's own vocabulary (§3.2 "Knowledge layer (SymbolSource)", §5.1 "Symbol Knowledge").

### Deferred (later slices, per the manifest)

- **§4.2 enforcement rule** (scoped-exempt `FunctionRepository`) → **S2.6**, after the consumer migrations.
- **Consumer migrations** (`ClassCandidates`, `NamespaceCandidates`, `SymbolResolver` class lookups, `TextDocumentSyncHandler`) → **S2.2–S2.5**.
- **Wiring into `Server.php`** rides the migration slices, so no unused service is constructed here.
- The write path's transitional duplication with `TextDocumentSyncHandler::registerDocumentClasses` is the ledger's "Step 2 facade hides today's double write" scaffold; the handler's copy is removed when it migrates onto `SymbolSink` (S2.5).

_This PR body was written by AI and reviewed by a human._
