### PR TITLE
Migrate ClassCandidates onto the SymbolSource seam

### DIFF
--- a/src/Completion/ClassCandidates.php
+++ b/src/Completion/ClassCandidates.php
@@ -7,8 +7,8 @@ namespace Firehed\PhpLsp\Completion;
 use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Knowledge\SymbolSource;
 use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Resolution\NameContext;
@@ -17,9 +17,9 @@ use Firehed\PhpLsp\Resolution\ReferenceResolver;
 
 /**
  * Produces class-name completion items from two sources: classes imported via
- * `use` statements in the current file, and classes in the workspace symbol
- * index. Filtering for each source is driven centrally by
- * {@see ClassCandidateFilter}.
+ * `use` statements in the current file, and class-likes reached through the
+ * {@see SymbolSource} knowledge seam (RFC 1 §4.2). Filtering for each source is
+ * driven centrally by {@see ClassCandidateFilter}.
  *
  * Imports are read through {@see CodeResolver} rather than the raw AST, so this
  * source is agnostic to the parsing strategy (and to whether imports were
@@ -30,7 +30,7 @@ use Firehed\PhpLsp\Resolution\ReferenceResolver;
 final class ClassCandidates
 {
     public function __construct(
-        private readonly SymbolIndex $symbolIndex,
+        private readonly SymbolSource $symbolSource,
         private readonly CodeResolver $codeResolver,
         private readonly SessionCapabilitiesProvider $capabilities,
     ) {
@@ -94,10 +94,20 @@ final class ClassCandidates
         NameContext $context,
         Range $replaceRange,
     ): array {
-        $symbols = $this->symbolIndex->findByPrefix($prefix, $this->indexKinds($filter));
+        // The seam searches the whole class-like namespace (RFC 1 §4.2); which of
+        // those kinds this position admits stays the consumer's decision, applied
+        // here against each result's own kind. That keeps the coarse narrowing the
+        // index query used to do — and does not defer it to `accepts`, whose
+        // repository lookup cannot vouch for a symbol whose declaration it cannot
+        // reach (Plan 0002 §5.5: identical behavior).
+        $kinds = $this->indexKinds($filter);
+        $symbols = $this->symbolSource->searchClassLikes($prefix);
         $items = [];
 
         foreach ($symbols as $symbol) {
+            if (!in_array($symbol->kind, $kinds, true)) {
+                continue;
+            }
             /** @var class-string $fqcn */
             $fqcn = $symbol->fullyQualifiedName;
             if (!$filter->accepts(new ClassName($fqcn), $this->codeResolver)) {
@@ -118,6 +128,10 @@ final class ClassCandidates
     }
 
     /**
+     * The class-like kinds this position admits, applied to the seam's results.
+     * The per-candidate {@see ClassCandidateFilter::accepts()} predicate narrows
+     * further (abstractness, throwability, …); this is the coarse kind gate.
+     *
      * @return list<SymbolKind>
      */
     private function indexKinds(ClassCandidateFilter $filter): array

--- a/src/Server.php
+++ b/src/Server.php
@@ -26,6 +26,7 @@ use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\NamespaceCatalogFactory;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Knowledge\DelegatingSymbolSource;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
@@ -104,6 +105,20 @@ final class Server
             $functionRepository,
         );
 
+        $catalog = NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot);
+
+        // The read/write knowledge seam (RFC 1 §4.2, §4.3). Consumers migrate onto
+        // this one facade instance across Step 2's slices (Plan 0002 §5.5); today
+        // ClassCandidates reads class-like prefix search through it.
+        $symbolSource = new DelegatingSymbolSource(
+            $classRepository,
+            $symbolIndex,
+            $catalog,
+            $indexer,
+            $classInfoFactory,
+            $parser,
+        );
+
         $negotiator = new CapabilityNegotiator($serverInfo);
         $lifecycleHandler = new LifecycleHandler($negotiator);
 
@@ -131,9 +146,9 @@ final class Server
             new CompletionHandler(
                 $documentManager,
                 $symbolResolver,
-                new ClassCandidates($symbolIndex, $symbolResolver, $negotiator),
+                new ClassCandidates($symbolSource, $symbolResolver, $negotiator),
                 new NamespaceCandidates(
-                    NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot),
+                    $catalog,
                     $symbolResolver,
                     $negotiator,
                 ),

--- a/tests/Completion/ClassCandidatesTest.php
+++ b/tests/Completion/ClassCandidatesTest.php
@@ -10,7 +10,7 @@ use Firehed\PhpLsp\Completion\ClassCandidateFilter;
 use Firehed\PhpLsp\Completion\ClassCandidates;
 use Firehed\PhpLsp\Completion\CompletionItemFactory;
 use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Knowledge\SymbolSource;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Resolution\NameContext;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -27,7 +27,12 @@ class ClassCandidatesTest extends TestCase
         // An imported class whose short name carries a multibyte character.
         $resolver->method('getImports')->willReturn(['Café' => 'App\\Café']);
 
-        $candidates = new ClassCandidates(new SymbolIndex(), $resolver, self::utf16Capabilities());
+        // This case exercises the imports path only; the seam reaches no
+        // class-likes, so its prefix search is empty.
+        $symbolSource = self::createStub(SymbolSource::class);
+        $symbolSource->method('searchClassLikes')->willReturn([]);
+
+        $candidates = new ClassCandidates($symbolSource, $resolver, self::utf16Capabilities());
         $document = new TextDocument('file:///test.php', 'php', 1, '<?php Café');
 
         // "Café" is four codepoints — four UTF-16 units — but five UTF-8 bytes; the

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -1216,6 +1216,52 @@ class CompletionHandlerTest extends TestCase
         self::assertNotContains('AbstractBase', $labels);
     }
 
+    public function testTypeHintCompletionExcludesIndexedTraits(): void
+    {
+        // Both symbols are indexed but their declaration file is never opened, so
+        // the class repository cannot reach them. isValidTypeHint is optimistic for
+        // an unreachable name (it returns true), so the ClassCandidateFilter
+        // predicate does not exclude the trait here — only the class-like kind gate
+        // does. A resolvable trait would be rejected by the predicate regardless,
+        // leaving the gate's TypeHint arm untested; this pins it on the seam path.
+        $this->symbolIndex->add(new Symbol(
+            'MyClass',
+            'MyClass',
+            SymbolKind::Class_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+        $this->symbolIndex->add(new Symbol(
+            'MyTrait',
+            'MyTrait',
+            SymbolKind::Trait_,
+            new Location('file:///other.php', 0, 0, 0, 0),
+        ));
+
+        $code = '<?php function foo(): My';
+        $this->openDocument('file:///test.php', $code);
+
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'textDocument/completion',
+            'params' => [
+                'textDocument' => ['uri' => 'file:///test.php'],
+                'position' => ['line' => 0, 'character' => 24],
+            ],
+        ]);
+
+        $result = $this->handler->handle($request);
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains('MyClass', $labels, 'A class is a valid type hint');
+        self::assertNotContains(
+            'MyTrait',
+            $labels,
+            'A trait is not a valid type hint; only the class-like kind gate excludes an unresolvable indexed trait',
+        );
+    }
+
     /**
      * Step 0 acceptance: one parse per handled message. Completion is the fan-out
      * that made this matter — its sources each call a different CodeResolver

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -29,6 +29,7 @@ use Firehed\PhpLsp\Index\Symbol;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
+use Firehed\PhpLsp\Knowledge\DelegatingSymbolSource;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
@@ -62,6 +63,7 @@ class CompletionHandlerTest extends TestCase
     private DocumentManager $documents;
     private ParserService $parser;
     private SymbolIndex $symbolIndex;
+    private DocumentIndexer $indexer;
     private DefaultClassRepository $classRepository;
     private DefaultClassInfoFactory $classInfoFactory;
     private MemberResolver $memberResolver;
@@ -91,7 +93,7 @@ class CompletionHandlerTest extends TestCase
             $typeResolver,
             new DefaultFunctionRepository(),
         );
-        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
+        $this->indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
         $this->catalog = NamespaceCatalogFactory::forProject($this->symbolIndex, __DIR__ . '/../Fixtures');
         $this->handler = $this->makeHandler($this->catalog);
         $this->syncHandler = new TextDocumentSyncHandler(
@@ -99,7 +101,7 @@ class CompletionHandlerTest extends TestCase
             $this->parser,
             $this->classRepository,
             $this->classInfoFactory,
-            $indexer,
+            $this->indexer,
         );
     }
 
@@ -109,10 +111,19 @@ class CompletionHandlerTest extends TestCase
         $capabilities->method('getSessionCapabilities')
             ->willReturn(new SessionCapabilities(snippetSupport: $snippetSupport));
 
+        $symbolSource = new DelegatingSymbolSource(
+            $this->classRepository,
+            $this->symbolIndex,
+            $catalog,
+            $this->indexer,
+            $this->classInfoFactory,
+            $this->parser,
+        );
+
         return new CompletionHandler(
             $this->documents,
             $this->symbolResolver,
-            new ClassCandidates($this->symbolIndex, $this->symbolResolver, $capabilities),
+            new ClassCandidates($symbolSource, $this->symbolResolver, $capabilities),
             new NamespaceCandidates($catalog, $this->symbolResolver, $capabilities),
             new FunctionCandidates($this->symbolResolver, $capabilities),
             new KeywordCandidates(),


### PR DESCRIPTION
## Slice S2.2 — Migrate `ClassCandidates` to `search`

**Slice:** S2.2 (`docs/architecture/build-manifest.md`, Wave 1)
**Plan step:** `docs/architecture/0002-execution-plan.md` Step 2 (§5.5 consumer-migration table; §5.4 lightweight `SymbolDefinition`) — a consumer migration onto the S2.1 seam, no behavior change.
**Depends on:** S2.1 (`SymbolSource` / `SymbolSink` + delegating facade, #374) — merged.
**RFC sections:** 0001 §4.2 (Symbol Discovery Authority), §4.4 (FQN-based knowledge queries).

Routes `ClassCandidates`' workspace prefix search through `SymbolSource::searchClassLikes` instead of naming `SymbolIndex` directly. The one `DelegatingSymbolSource` facade is constructed in `Server.php` and shared; subsequent Step 2 slices route the remaining consumers onto the same instance (Plan §5.5).

### Behavior preservation

The plan requires this migration be **identical (same backing)**. `searchClassLikes` searches the whole class-like namespace and returns each match with its `kind`, so the per-position kind narrowing that the index query used to do stays in the consumer, applied against each result's own `kind` — before the `ClassCandidateFilter::accepts()` predicate. That ordering matters: `accepts` resolves through the `ClassRepository`, which cannot vouch for a symbol whose declaration it cannot reach (e.g. an indexed interface with no resolvable file), so the index's authoritative kind must gate first. `testNewCompletionExcludesIndexedInterfaces` pins exactly this.

Proven by the existing completion suite across every filter (Any / Instantiable / TypeHint / …) and by the frozen `PrefixSearchParityTest` golden, which stays unchanged because this slice does not touch the search surface itself.

### Acceptance criteria

- [x] `ClassCandidates` reads class-like prefix search through `SymbolSource::searchClassLikes`, no longer naming `SymbolIndex` directly.
- [x] Offered candidates are identical across all `ClassCandidateFilter` positions (existing `CompletionHandlerTest` coverage green, including the synthetic-interface and abstract-class exclusion cases).
- [x] The `PrefixSearchParityTest` golden is unchanged (the search surface is untouched).
- [x] The shared facade is wired once in `Server.php`; `NamespaceCandidates` still reads the raw catalog (its migration is S2.3).
- [x] `composer test` green (PHPStan + tests + PHPCS).

### Not in this slice

- The §4.2 enforcement rule that forbids naming `SymbolIndex` / `ClassRepository` / `NamespaceCatalog` outside a backend lands in **S2.6** (scoped-exempt), once the other consumers (S2.3–S2.5) have migrated.

### Candidate closes

None — the manifest lists no `Closes` for S2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
