### PR TITLE
Migrate SymbolResolver class lookups onto the SymbolSource seam

### DIFF
--- a/src/Knowledge/DelegatingSymbolSource.php
+++ b/src/Knowledge/DelegatingSymbolSource.php
@@ -66,6 +66,11 @@ final class DelegatingSymbolSource implements SymbolSource, SymbolSink
         $this->classes->removeDocument($uri);
     }
 
+    public function isSubclassOf(ClassName $class, ClassName $potentialParent): bool
+    {
+        return $this->classes->isSubclassOf($class, $potentialParent);
+    }
+
     public function lookupClassLike(ClassName $name): ?ClassInfo
     {
         return $this->classes->get($name);

--- a/src/Knowledge/SymbolSource.php
+++ b/src/Knowledge/SymbolSource.php
@@ -32,11 +32,13 @@ interface SymbolSource
     public function childrenOf(NamespaceName $namespace): NamespaceContents;
 
     /**
-     * Whether $class is $potentialParent, or is a subtype of it anywhere along the
-     * type graph (extends, implements, and interface-extends-interface alike). A
-     * subtype relationship the caller cannot answer from a single lookup — it needs
-     * the whole graph — so it is a knowledge query in its own right (Plan 0002 §5.2:
-     * the surface a migrated feature actually needs).
+     * Whether $class is a subtype of $potentialParent somewhere along the type graph
+     * (extends, implements, and interface-extends-interface alike). Not reflexive: a
+     * class is not a subclass of itself, mirroring PHP's `is_subclass_of` — a caller
+     * that also wants the identity case tests it separately. A subtype relationship
+     * the caller cannot answer from a single lookup — it needs the whole graph — so it
+     * is a knowledge query in its own right (Plan 0002 §5.2: the surface a migrated
+     * feature actually needs).
      */
     public function isSubclassOf(ClassName $class, ClassName $potentialParent): bool;
 

--- a/src/Knowledge/SymbolSource.php
+++ b/src/Knowledge/SymbolSource.php
@@ -32,6 +32,15 @@ interface SymbolSource
     public function childrenOf(NamespaceName $namespace): NamespaceContents;
 
     /**
+     * Whether $class is $potentialParent, or is a subtype of it anywhere along the
+     * type graph (extends, implements, and interface-extends-interface alike). A
+     * subtype relationship the caller cannot answer from a single lookup — it needs
+     * the whole graph — so it is a knowledge query in its own right (Plan 0002 §5.2:
+     * the surface a migrated feature actually needs).
+     */
+    public function isSubclassOf(ClassName $class, ClassName $potentialParent): bool;
+
+    /**
      * Full metadata for a class-like by its exact name, or null when nothing the
      * source can reach declares it (RFC 1 §5.3: absence is a bare null).
      */

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -8,8 +8,8 @@ use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\NodeAtPosition;
+use Firehed\PhpLsp\Knowledge\SymbolSource;
 use Firehed\PhpLsp\Parser\ParserService;
-use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\FunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\TypeInference\TypeResolverInterface;
@@ -75,7 +75,7 @@ final class SymbolResolver implements CodeResolver
 
     public function __construct(
         private readonly ParserService $parser,
-        private readonly ClassRepository $classRepository,
+        private readonly SymbolSource $symbolSource,
         private readonly MemberResolver $memberResolver,
         private readonly TypeResolverInterface $typeResolver,
         private readonly FunctionRepository $functionRepository,
@@ -194,7 +194,7 @@ final class SymbolResolver implements CodeResolver
      */
     public function isClassLike(ClassName $className): bool
     {
-        return $this->classRepository->get($className) !== null;
+        return $this->symbolSource->lookupClassLike($className) !== null;
     }
 
     /**
@@ -203,7 +203,7 @@ final class SymbolResolver implements CodeResolver
      */
     public function isInstantiable(ClassName $className): bool
     {
-        $classInfo = $this->classRepository->get($className);
+        $classInfo = $this->symbolSource->lookupClassLike($className);
         if ($classInfo === null) {
             return true;
         }
@@ -217,7 +217,7 @@ final class SymbolResolver implements CodeResolver
      */
     public function isValidTypeHint(ClassName $className): bool
     {
-        $classInfo = $this->classRepository->get($className);
+        $classInfo = $this->symbolSource->lookupClassLike($className);
         if ($classInfo === null) {
             return true;
         }
@@ -231,7 +231,7 @@ final class SymbolResolver implements CodeResolver
      */
     public function isInterface(ClassName $className): bool
     {
-        $classInfo = $this->classRepository->get($className);
+        $classInfo = $this->symbolSource->lookupClassLike($className);
         if ($classInfo === null) {
             return false;
         }
@@ -246,7 +246,7 @@ final class SymbolResolver implements CodeResolver
      */
     public function isExtendableClass(ClassName $className): bool
     {
-        $classInfo = $this->classRepository->get($className);
+        $classInfo = $this->symbolSource->lookupClassLike($className);
         if ($classInfo === null) {
             return false;
         }
@@ -261,7 +261,7 @@ final class SymbolResolver implements CodeResolver
      */
     public function isThrowable(ClassName $className): bool
     {
-        $classInfo = $this->classRepository->get($className);
+        $classInfo = $this->symbolSource->lookupClassLike($className);
         if ($classInfo === null) {
             return false;
         }
@@ -270,7 +270,7 @@ final class SymbolResolver implements CodeResolver
         if ($classInfo->name->equals($throwable)) {
             return true;
         }
-        return $this->classRepository->isSubclassOf($className, $throwable);
+        return $this->symbolSource->isSubclassOf($className, $throwable);
     }
 
     /**
@@ -280,7 +280,7 @@ final class SymbolResolver implements CodeResolver
      */
     public function isAttribute(ClassName $className): bool
     {
-        $classInfo = $this->classRepository->get($className);
+        $classInfo = $this->symbolSource->lookupClassLike($className);
         if ($classInfo === null) {
             return false;
         }
@@ -522,7 +522,7 @@ final class SymbolResolver implements CodeResolver
         }
 
         if (
-            $this->classRepository->isSubclassOf(
+            $this->symbolSource->isSubclassOf(
                 new ClassName($enclosingClassName),
                 new ClassName($targetClassName),
             )
@@ -1421,7 +1421,7 @@ final class SymbolResolver implements CodeResolver
         // Class reference (new, instanceof, static call, type hint, etc.)
         $classNameStr = ScopeFinder::resolveClassName($node);
 
-        $classInfo = $this->classRepository->get(new ClassName($classNameStr));
+        $classInfo = $this->symbolSource->lookupClassLike(new ClassName($classNameStr));
         if ($classInfo === null) {
             return null;
         }
@@ -1499,7 +1499,7 @@ final class SymbolResolver implements CodeResolver
                 throw new LogicException('ClassMethod always has enclosing class');
             }
             // @codeCoverageIgnoreEnd
-            $classInfo = $this->classRepository->get(new ClassName($selfContext));
+            $classInfo = $this->symbolSource->lookupClassLike(new ClassName($selfContext));
             $parentContext = $classInfo?->parent?->fqn;
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -97,19 +97,12 @@ final class Server
         $functionRepository = new DefaultFunctionRepository();
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, $functionRepository);
-        $symbolResolver = new SymbolResolver(
-            $parser,
-            $classRepository,
-            $memberResolver,
-            $typeResolver,
-            $functionRepository,
-        );
 
         $catalog = NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot);
 
         // The read/write knowledge seam (RFC 1 §4.2, §4.3). Consumers migrate onto
         // this one facade instance across Step 2's slices (Plan 0002 §5.5); today
-        // ClassCandidates reads class-like prefix search through it.
+        // ClassCandidates, NamespaceCandidates, and SymbolResolver read through it.
         $symbolSource = new DelegatingSymbolSource(
             $classRepository,
             $symbolIndex,
@@ -117,6 +110,14 @@ final class Server
             $indexer,
             $classInfoFactory,
             $parser,
+        );
+
+        $symbolResolver = new SymbolResolver(
+            $parser,
+            $symbolSource,
+            $memberResolver,
+            $typeResolver,
+            $functionRepository,
         );
 
         $negotiator = new CapabilityNegotiator($serverInfo);

--- a/tests/BuildsSymbolSourceTrait.php
+++ b/tests/BuildsSymbolSourceTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests;
+
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\NamespaceCatalog;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Knowledge\DelegatingSymbolSource;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\ClassRepository;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+
+/**
+ * Builds the production {@see DelegatingSymbolSource} facade over a test's existing
+ * class repository, so a consumer that reads through the {@see \Firehed\PhpLsp\Knowledge\SymbolSource}
+ * seam (e.g. {@see \Firehed\PhpLsp\Resolution\SymbolResolver}) can be wired without
+ * every test class re-assembling the six collaborators by hand.
+ *
+ * The enumeration collaborators (index, indexer, catalog) are inert here: a consumer
+ * that only needs class-like lookup or the subtype query never reaches them, so a
+ * throwaway index and a stubbed catalog are sufficient. A test exercising namespace
+ * enumeration or the write path builds its own facade with real ones instead.
+ */
+trait BuildsSymbolSourceTrait
+{
+    protected function symbolSourceFor(
+        ClassRepository $repository,
+        ParserService $parser,
+    ): DelegatingSymbolSource {
+        $index = new SymbolIndex();
+
+        return new DelegatingSymbolSource(
+            $repository,
+            $index,
+            self::createStub(NamespaceCatalog::class),
+            new DocumentIndexer($parser, new SymbolExtractor(), $index),
+            new DefaultClassInfoFactory(),
+            $parser,
+        );
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -39,6 +39,7 @@ use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -58,6 +59,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(VariableCandidates::class)]
 class CompletionHandlerTest extends TestCase
 {
+    use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
     private DocumentManager $documents;
@@ -88,7 +90,7 @@ class CompletionHandlerTest extends TestCase
         $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());
         $this->symbolResolver = new SymbolResolver(
             $this->parser,
-            $this->classRepository,
+            $this->symbolSourceFor($this->classRepository, $this->parser),
             $this->memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -18,6 +18,7 @@ use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -25,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DefinitionHandler::class)]
 class DefinitionHandlerTest extends TestCase
 {
+    use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
     private DocumentManager $documents;
@@ -48,7 +50,7 @@ class DefinitionHandlerTest extends TestCase
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
         $symbolResolver = new SymbolResolver(
             $this->parser,
-            $this->classRepository,
+            $this->symbolSourceFor($this->classRepository, $this->parser),
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -22,6 +22,7 @@ use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -29,6 +30,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(HoverHandler::class)]
 class HoverHandlerTest extends TestCase
 {
+    use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
     private DocumentManager $documents;
@@ -54,7 +56,7 @@ class HoverHandlerTest extends TestCase
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
         $this->symbolResolver = new SymbolResolver(
             $this->parser,
-            $this->classRepository,
+            $this->symbolSourceFor($this->classRepository, $this->parser),
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -17,6 +17,7 @@ use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(SignatureHelpHandler::class)]
 class SignatureHelpHandlerTest extends TestCase
 {
+    use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
     private DocumentManager $documents;
@@ -49,7 +51,7 @@ class SignatureHelpHandlerTest extends TestCase
         $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());
         $symbolResolver = new SymbolResolver(
             $this->parser,
-            $this->classRepository,
+            $this->symbolSourceFor($this->classRepository, $this->parser),
             $this->memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -136,6 +136,26 @@ final class DelegatingSymbolSourceTest extends TestCase
         );
     }
 
+    public function testIsSubclassOfForwardsToTheRepository(): void
+    {
+        // Pure forwarding, both branches: a real subclass relationship and an
+        // unrelated pair. The two directions also prove the arguments reach the
+        // repository in order rather than swapped (the transitive graph walk itself
+        // is frozen by ClassLikeLookupParityTest, not re-proven here).
+        $source = $this->facade($this->unusedCatalog());
+        $descendant = self::className('Fixtures\Inheritance\FinalDescendant');
+        $ancestor = self::className('Fixtures\Inheritance\ParentClass');
+
+        self::assertTrue(
+            $source->isSubclassOf($descendant, $ancestor),
+            'isSubclassOf must return the repository result for a real subclass',
+        );
+        self::assertFalse(
+            $source->isSubclassOf($ancestor, $descendant),
+            'isSubclassOf must forward its arguments in order, not swapped',
+        );
+    }
+
     public function testChildrenOfForwardsTheNamespacePath(): void
     {
         $expected = new NamespaceContents(['Fixtures\Domain\Sub'], []);

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -36,6 +36,7 @@ use Firehed\PhpLsp\Resolution\ResolvedVariable;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\Resolution\TextFallbackHelper;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\Tests\Handler\OpensDocumentsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -49,6 +50,7 @@ use TypeError;
 #[CoversClass(TextFallbackHelper::class)]
 final class SymbolResolverTest extends TestCase
 {
+    use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
     private SymbolResolver $resolver;
@@ -74,7 +76,7 @@ final class SymbolResolverTest extends TestCase
 
         $this->resolver = new SymbolResolver(
             parser: $this->parser,
-            classRepository: $this->classRepository,
+            symbolSource: $this->symbolSourceFor($this->classRepository, $this->parser),
             memberResolver: $memberResolver,
             typeResolver: $typeResolver,
             functionRepository: new DefaultFunctionRepository(),


### PR DESCRIPTION
## Slice S2.4 — Migrate `SymbolResolver` class lookups to `lookupClassLike`

**Slice:** S2.4 (`docs/architecture/build-manifest.md`, Wave 1)
**Plan step:** `docs/architecture/0002-execution-plan.md` Step 2 (§5.5 consumer-migration
table, `SymbolResolver` row; §5.2 interface JIT) — a consumer migration onto the S2.1
seam, no behavior change.
**Depends on:** S2.1 (`SymbolSource` / `SymbolSink` + delegating facade, #374) — merged.
**RFC sections:** 0001 §4.2 (Symbol Discovery Authority), §4.4 (FQN-based knowledge
queries), §4.5 (type-graph traversal), §5.1 (typed identifiers).

Routes `SymbolResolver`'s class knowledge through the `SymbolSource` seam instead of
naming `ClassRepository` directly. The nine `ClassRepository::get()` sites (the position
predicates `isInstantiable` / `isInterface` / `isThrowable` / … and the `self`/named
class resolution) now call `SymbolSource::lookupClassLike`; `SymbolResolver` is
constructed with the one shared `DelegatingSymbolSource` facade (wired in `Server.php`
since S2.2). The facade construction moves above the resolver in `Server.php`, which is
safe — the facade depends only on the repositories/index, never on the resolver.

### The `isSubclassOf` decision

`SymbolResolver` also called `ClassRepository::isSubclassOf` at two sites (`isThrowable`
and protected-visibility resolution) — a **transitive** subtype query that a single
`lookupClassLike` cannot answer. The Step-2 illustrative interface (§5.2) lists only
three methods, but §5.2 scopes the seam to "the surface today's migrated features
actually need," and this migrated feature needs the subtype query. Leaving it on
`ClassRepository` would keep `SymbolResolver` naming the repository directly, defeating
the migration and forcing an extra exemption in S2.6's §4.2 rule (which is scoped to
`FunctionRepository` only).

So the seam gains `isSubclassOf`, implemented in `DelegatingSymbolSource` by pure
delegation to `ClassRepository::isSubclassOf` — the same strangler pattern as
`lookupClassLike`, no behavior change. `SymbolResolver` now names `ClassRepository`
**nowhere**.

### Behavior preservation

Both new seam calls delegate to the exact same backing methods, so no result changes.
The frozen `ClassLikeLookupParityTest` golden — which covers **both** `get()` and
`isSubclassOf` (`testIsSubclassOfTraversesTheGraph`) — is unchanged, and the full
`SymbolResolver`, Hover, Definition, SignatureHelp, and Completion suites stay green.
A new `DelegatingSymbolSourceTest` case pins the facade's `isSubclassOf` forwarding
(both truth branches, and argument order).

Test wiring for the five suites that construct `SymbolResolver` is de-duplicated behind
a shared `BuildsSymbolSourceTrait` rather than re-assembling the facade by hand in each.

### Acceptance criteria

- [x] `SymbolResolver` reads class-like lookup through `SymbolSource::lookupClassLike`,
  no longer naming `ClassRepository` directly.
- [x] The transitive subtype check reads through the seam (`SymbolSource::isSubclassOf`,
  delegating to today's `ClassRepository::isSubclassOf`); `SymbolResolver`'s direct
  `ClassRepository` dependency is removed entirely.
- [x] Behavior identical — the `ClassLikeLookupParityTest` golden (lookup + subtype) is
  unchanged and green.
- [x] Full `composer test` green.

Candidate closes (pending review verification): none (manifest `Closes` is `—`).
