### PR TITLE
Migrate TextDocumentSyncHandler onto SymbolSink

### DIFF
--- a/src/Handler/TextDocumentSyncHandler.php
+++ b/src/Handler/TextDocumentSyncHandler.php
@@ -5,13 +5,9 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Handler;
 
 use Firehed\PhpLsp\Document\DocumentManager;
-use Firehed\PhpLsp\Index\DocumentIndexer;
-use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Knowledge\SymbolSink;
 use Firehed\PhpLsp\Protocol\Message;
-use Firehed\PhpLsp\Repository\ClassInfoFactory;
-use Firehed\PhpLsp\Repository\ClassRepository;
-use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node\Stmt;
 
 final class TextDocumentSyncHandler implements HandlerInterface
 {
@@ -23,10 +19,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
 
     public function __construct(
         private readonly DocumentManager $documentManager,
-        private readonly ParserService $parser,
-        private readonly ClassRepository $classRepository,
-        private readonly ClassInfoFactory $classInfoFactory,
-        private readonly DocumentIndexer $indexer,
+        private readonly SymbolSink $symbols,
     ) {
     }
 
@@ -66,7 +59,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         assert(is_string($text));
 
         $this->documentManager->open($uri, $languageId, $version, $text);
-        $this->indexDocument($uri);
+        $this->symbols->openDocument($this->documentFor($uri));
 
         return null;
     }
@@ -93,7 +86,7 @@ final class TextDocumentSyncHandler implements HandlerInterface
         if (is_array($lastChange) && isset($lastChange['text'])) {
             assert(is_string($lastChange['text']));
             $this->documentManager->update($uri, $lastChange['text'], $version);
-            $this->indexDocument($uri);
+            $this->symbols->updateDocument($this->documentFor($uri));
         }
 
         return null;
@@ -110,37 +103,17 @@ final class TextDocumentSyncHandler implements HandlerInterface
         $uri = $textDocument['uri'] ?? '';
         assert(is_string($uri));
 
-        $this->indexer->remove($uri);
-        $this->classRepository->removeDocument($uri);
+        $this->symbols->closeDocument($uri);
         $this->documentManager->close($uri);
 
         return null;
     }
 
-    private function indexDocument(string $uri): void
+    private function documentFor(string $uri): TextDocument
     {
         $document = $this->documentManager->get($uri);
         assert($document !== null);
 
-        $ast = $this->parser->parse($document);
-        if ($ast !== null) {
-            $this->registerDocumentClasses($uri, $ast);
-        }
-
-        $this->indexer->index($document);
-    }
-
-    /**
-     * @param array<Stmt> $ast
-     */
-    private function registerDocumentClasses(string $uri, array $ast): void
-    {
-        $classes = [];
-        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
-            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
-                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
-            }
-        }
-        $this->classRepository->updateDocument($uri, $classes);
+        return $document;
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -126,10 +126,7 @@ final class Server
         $handlers = [
             new TextDocumentSyncHandler(
                 $documentManager,
-                $parser,
-                $classRepository,
-                $classInfoFactory,
-                $indexer,
+                $symbolSource,
             ),
             new DefinitionHandler(
                 $documentManager,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -100,10 +100,14 @@ class CompletionHandlerTest extends TestCase
         $this->handler = $this->makeHandler($this->catalog);
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
-            $this->parser,
-            $this->classRepository,
-            $this->classInfoFactory,
-            $this->indexer,
+            new DelegatingSymbolSource(
+                $this->classRepository,
+                $this->symbolIndex,
+                $this->catalog,
+                $this->indexer,
+                $this->classInfoFactory,
+                $this->parser,
+            ),
         );
     }
 

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -7,9 +7,6 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\DefinitionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
-use Firehed\PhpLsp\Index\DocumentIndexer;
-use Firehed\PhpLsp\Index\SymbolExtractor;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
@@ -48,9 +45,10 @@ class DefinitionHandlerTest extends TestCase
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $symbolSource = $this->symbolSourceFor($this->classRepository, $this->parser);
         $symbolResolver = new SymbolResolver(
             $this->parser,
-            $this->symbolSourceFor($this->classRepository, $this->parser),
+            $symbolSource,
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
@@ -59,13 +57,9 @@ class DefinitionHandlerTest extends TestCase
             $this->documents,
             $symbolResolver,
         );
-        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
-            $this->parser,
-            $this->classRepository,
-            $classInfoFactory,
-            $indexer,
+            $symbolSource,
         );
     }
 

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -9,9 +9,6 @@ use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\HoverHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
-use Firehed\PhpLsp\Index\DocumentIndexer;
-use Firehed\PhpLsp\Index\SymbolExtractor;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
@@ -54,9 +51,10 @@ class HoverHandlerTest extends TestCase
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $symbolSource = $this->symbolSourceFor($this->classRepository, $this->parser);
         $this->symbolResolver = new SymbolResolver(
             $this->parser,
-            $this->symbolSourceFor($this->classRepository, $this->parser),
+            $symbolSource,
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
@@ -65,13 +63,9 @@ class HoverHandlerTest extends TestCase
         // minimal client is served); the fenced-markdown path is exercised
         // explicitly below.
         $this->handler = $this->handlerFor(MarkupKind::PlainText);
-        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
-            $this->parser,
-            $this->classRepository,
-            $this->classInfoFactory,
-            $indexer,
+            $symbolSource,
         );
     }
 

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -8,9 +8,6 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
-use Firehed\PhpLsp\Index\DocumentIndexer;
-use Firehed\PhpLsp\Index\SymbolExtractor;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
@@ -49,9 +46,10 @@ class SignatureHelpHandlerTest extends TestCase
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());
+        $symbolSource = $this->symbolSourceFor($this->classRepository, $this->parser);
         $symbolResolver = new SymbolResolver(
             $this->parser,
-            $this->symbolSourceFor($this->classRepository, $this->parser),
+            $symbolSource,
             $this->memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
@@ -60,13 +58,9 @@ class SignatureHelpHandlerTest extends TestCase
             $this->documents,
             $symbolResolver,
         );
-        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
-            $this->parser,
-            $this->classRepository,
-            $this->classInfoFactory,
-            $indexer,
+            $symbolSource,
         );
     }
 

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -7,14 +7,12 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
-use Firehed\PhpLsp\Index\DocumentIndexer;
-use Firehed\PhpLsp\Index\SymbolExtractor;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TextDocumentSyncHandler::class)]
 class TextDocumentSyncHandlerTest extends TestCase
 {
+    use BuildsSymbolSourceTrait;
     use LoadsFixturesTrait;
 
     private DocumentManager $manager;
@@ -37,13 +36,9 @@ class TextDocumentSyncHandlerTest extends TestCase
         $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
         $this->classRepository = new DefaultClassRepository($this->classInfoFactory, $locator, $this->parser);
-        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
         $this->handler = new TextDocumentSyncHandler(
             $this->manager,
-            $this->parser,
-            $this->classRepository,
-            $this->classInfoFactory,
-            $indexer,
+            $this->symbolSourceFor($this->classRepository, $this->parser),
         );
     }
 

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -6,9 +6,6 @@ namespace Firehed\PhpLsp\Tests\Resolution;
 
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
-use Firehed\PhpLsp\Index\DocumentIndexer;
-use Firehed\PhpLsp\Index\SymbolExtractor;
-use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
@@ -72,11 +69,11 @@ final class SymbolResolverTest extends TestCase
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
-        $indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), new SymbolIndex());
+        $symbolSource = $this->symbolSourceFor($this->classRepository, $this->parser);
 
         $this->resolver = new SymbolResolver(
             parser: $this->parser,
-            symbolSource: $this->symbolSourceFor($this->classRepository, $this->parser),
+            symbolSource: $symbolSource,
             memberResolver: $memberResolver,
             typeResolver: $typeResolver,
             functionRepository: new DefaultFunctionRepository(),
@@ -84,10 +81,7 @@ final class SymbolResolverTest extends TestCase
 
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,
-            $this->parser,
-            $this->classRepository,
-            $classInfoFactory,
-            $indexer,
+            $symbolSource,
         );
     }
 


### PR DESCRIPTION
## Slice S2.5 — Migrate `TextDocumentSyncHandler` onto `SymbolSink`

**Slice:** S2.5 (`docs/architecture/build-manifest.md`, Wave 1)
**Plan step:** `docs/architecture/0002-execution-plan.md` Step 2 (§5.5 consumer-migration
table, `TextDocumentSyncHandler` row; §5.2 `SymbolSink` write interface) — a consumer
migration onto the S2.1 seam, no behavior change.
**Depends on:** S2.1 (`SymbolSource` / `SymbolSink` + delegating facade, #374) — merged.
**RFC sections:** 0001 §4.2 (Symbol Discovery Authority), §4.3 (one write path for
symbol state), §5.2.

Routes the document write path through the `SymbolSink` seam instead of naming the
write-side collaborators directly. `TextDocumentSyncHandler` previously assembled the
double write itself — parsing the document, registering its class-likes on
`ClassRepository`, and calling `DocumentIndexer` — plus removing from both on close.
It now depends on a single `SymbolSink` and calls `openDocument` / `updateDocument` /
`closeDocument`; the parse, the class registration, and the index write live behind the
`DelegatingSymbolSource` facade (which has reproduced this exact double write since
S2.1). `Server.php` wires the one shared facade instance as the sink.

The handler no longer names `DocumentIndexer`, `ClassInfoFactory`, `ClassRepository`,
`ParserService`, or `ScopeFinder`; `ParserService` and the class-registration traversal
leave the handler entirely (they already exist inside the facade).

### Behavior preservation

The facade's write path is byte-for-byte the handler's old one (same parse, same
`ClassRepository::updateDocument`, same `DocumentIndexer::index`, same close order), so
no observable output changes. The frozen `WritePathParityTest` golden is unchanged and
green, and the full sync-handler suite — which pins class registration on open/change,
class replacement on change, class removal on close, and the Step-0 single-parse
invariant — stays green against the migrated handler.

Test wiring for the five downstream suites that also construct the sync handler now
feeds it a `DelegatingSymbolSource` (via the shared `BuildsSymbolSourceTrait`, matching
production's one-facade wiring) rather than re-assembling the write collaborators by
hand; `CompletionHandlerTest` feeds a facade over its real shared `SymbolIndex` so
opened documents still surface in completion.

### Acceptance criteria

- [x] The document write path (open / change / close) flows through `SymbolSink`.
- [x] `TextDocumentSyncHandler` no longer names `DocumentIndexer`, `ClassInfoFactory`,
  or `ClassRepository` directly (nor `ParserService` / `ScopeFinder`).
- [x] Behavior identical — the `WritePathParityTest` golden is unchanged and green.
- [x] Full `composer test` green.

Candidate closes (pending review verification): none (manifest `Closes` is `—`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
