### PR TITLE
Move existing caches behind a replaceable PSR-16 seam

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "ext-mbstring": "*",
         "amphp/amp": "^3.0",
         "amphp/byte-stream": "^2.0",
-        "nikic/php-parser": "^5.7"
+        "nikic/php-parser": "^5.7",
+        "psr/simple-cache": "^3.0",
+        "symfony/cache": "^7 || ^8"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+/**
+ * Builds the default in-process PSR-16 cache for symbol data that is stable for
+ * the life of the server.
+ *
+ * This is a composition helper, not a cache implementation: consumers depend on
+ * {@see CacheInterface} and receive the backend from their composition root, so a
+ * different policy (eviction, bounds, TTL) is a one-line swap here rather than a
+ * change to any consumer.
+ */
+final class CacheFactory
+{
+    public static function inMemory(): CacheInterface
+    {
+        // ArrayAdapter's second argument disables its copy-on-read (named
+        // `storeSerialized` in symfony/cache 7, `deepClone` in 8), so a hit
+        // returns the cached instance rather than a clone.
+        return new Psr16Cache(new ArrayAdapter(0, false));
+    }
+}

--- a/src/Cache/CacheKey.php
+++ b/src/Cache/CacheKey.php
@@ -18,6 +18,7 @@ final class CacheKey
 {
     public static function from(string $normalizedIdentifier): string
     {
+        // xxh128 (xxHash): a fast non-cryptographic hash; hex output is PSR-16-safe and within the 64-char key bound.
         return hash('xxh128', $normalizedIdentifier);
     }
 }

--- a/src/Cache/CacheKey.php
+++ b/src/Cache/CacheKey.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Cache;
+
+/**
+ * Derives a PSR-16-safe cache key from an already-normalized identifier.
+ *
+ * PSR-16 reserves the characters `{}()/\@:` and only guarantees support for
+ * keys up to 64 characters. Class FQNs and namespaces carry backslashes and can
+ * exceed that length, so they cannot be handed to a conformant cache verbatim.
+ * Hashing maps any normalized identifier into the safe hexadecimal alphabet at a
+ * fixed length; callers own semantic normalization (e.g. lowercasing for PHP's
+ * case-insensitive names) before deriving the key.
+ */
+final class CacheKey
+{
+    public static function from(string $normalizedIdentifier): string
+    {
+        return hash('xxh128', $normalizedIdentifier);
+    }
+}

--- a/src/Index/CachedNamespaceCatalog.php
+++ b/src/Index/CachedNamespaceCatalog.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
+use Firehed\PhpLsp\Cache\CacheKey;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
 /**
  * Remembers what a namespace contains, for sources whose answers cannot change.
  *
@@ -17,11 +22,12 @@ namespace Firehed\PhpLsp\Index;
  */
 final class CachedNamespaceCatalog implements NamespaceCatalog
 {
-    /** @var array<string, NamespaceContents> Lowercase namespace -> contents */
-    private array $cache = [];
-
     public function __construct(
         private readonly NamespaceCatalog $source,
+        // ArrayAdapter's second argument disables its copy-on-read (named
+        // `storeSerialized` in symfony/cache 7, `deepClone` in 8), so a hit
+        // returns the cached instance rather than a clone.
+        private readonly CacheInterface $cache = new Psr16Cache(new ArrayAdapter(0, false)),
     ) {
     }
 
@@ -29,6 +35,17 @@ final class CachedNamespaceCatalog implements NamespaceCatalog
     {
         // PHP namespaces are case-insensitive, so `Psr\Log` and `psr\log` are one
         // namespace and must not be two cache entries.
-        return $this->cache[strtolower($namespace)] ??= $this->source->childrenOf($namespace);
+        $key = CacheKey::from(strtolower($namespace));
+
+        $cached = $this->cache->get($key);
+        if ($cached !== null) {
+            assert($cached instanceof NamespaceContents);
+            return $cached;
+        }
+
+        $contents = $this->source->childrenOf($namespace);
+        $this->cache->set($key, $contents);
+
+        return $contents;
     }
 }

--- a/src/Index/CachedNamespaceCatalog.php
+++ b/src/Index/CachedNamespaceCatalog.php
@@ -6,8 +6,6 @@ namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Cache\CacheKey;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Psr16Cache;
 
 /**
  * Remembers what a namespace contains, for sources whose answers cannot change.
@@ -24,10 +22,7 @@ final class CachedNamespaceCatalog implements NamespaceCatalog
 {
     public function __construct(
         private readonly NamespaceCatalog $source,
-        // ArrayAdapter's second argument disables its copy-on-read (named
-        // `storeSerialized` in symfony/cache 7, `deepClone` in 8), so a hit
-        // returns the cached instance rather than a clone.
-        private readonly CacheInterface $cache = new Psr16Cache(new ArrayAdapter(0, false)),
+        private readonly CacheInterface $cache,
     ) {
     }
 

--- a/src/Index/NamespaceCatalogFactory.php
+++ b/src/Index/NamespaceCatalogFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
+use Firehed\PhpLsp\Cache\CacheFactory;
+
 /**
  * Composes the {@see NamespaceCatalog} used for completion discovery from its
  * three sources, applying the one caching rule that matters: the workspace
@@ -16,10 +18,13 @@ final class NamespaceCatalogFactory
     {
         return new CompositeNamespaceCatalog([
             new WorkspaceNamespaceSource($index),
-            new CachedNamespaceCatalog(new CompositeNamespaceCatalog([
-                new ComposerNamespaceSource(ComposerAutoloadMap::fromProjectRoot($projectRoot)),
-                new ReflectionNamespaceSource(),
-            ])),
+            new CachedNamespaceCatalog(
+                new CompositeNamespaceCatalog([
+                    new ComposerNamespaceSource(ComposerAutoloadMap::fromProjectRoot($projectRoot)),
+                    new ReflectionNamespaceSource(),
+                ]),
+                CacheFactory::inMemory(),
+            ),
         ]);
     }
 }

--- a/src/Repository/DefaultClassRepository.php
+++ b/src/Repository/DefaultClassRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Repository;
 
+use Firehed\PhpLsp\Cache\CacheKey;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
@@ -12,14 +13,14 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
+use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use ReflectionException;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 
 final class DefaultClassRepository implements ClassRepository
 {
-    /** @var array<string, ClassInfo> Lowercase FQN -> ClassInfo cache */
-    private array $cache = [];
-
     /** @var array<string, list<ClassInfo>> URI -> Classes in document */
     private array $documentClasses = [];
 
@@ -30,16 +31,23 @@ final class DefaultClassRepository implements ClassRepository
         private readonly ClassInfoFactory $factory,
         private readonly ClassLocator $locator,
         private readonly ParserService $parser,
+        // ArrayAdapter's second argument disables its copy-on-read (named
+        // `storeSerialized` in symfony/cache 7, `deepClone` in 8), so a hit
+        // returns the cached instance rather than a clone.
+        private readonly CacheInterface $cache = new Psr16Cache(new ArrayAdapter(0, false)),
     ) {
     }
 
     public function get(ClassName $name): ?ClassInfo
     {
         $key = $this->normalizeKey($name->fqn);
+        $cacheKey = CacheKey::from($key);
 
         // Check cache first for previously resolved classes
-        if (array_key_exists($key, $this->cache)) {
-            return $this->cache[$key];
+        $cached = $this->cache->get($cacheKey);
+        if ($cached !== null) {
+            assert($cached instanceof ClassInfo);
+            return $cached;
         }
 
         // Open documents take priority - updateDocument() clears cache entries
@@ -56,14 +64,14 @@ final class DefaultClassRepository implements ClassRepository
         // Try to locate and parse from filesystem
         $classInfo = $this->locateAndParse($name);
         if ($classInfo !== null) {
-            $this->cache[$key] = $classInfo;
+            $this->cache->set($cacheKey, $classInfo);
             return $classInfo;
         }
 
         // Fall back to reflection for built-in/autoloaded classes
         $classInfo = $this->fromReflection($name);
         if ($classInfo !== null) {
-            $this->cache[$key] = $classInfo;
+            $this->cache->set($cacheKey, $classInfo);
             return $classInfo;
         }
 
@@ -84,7 +92,7 @@ final class DefaultClassRepository implements ClassRepository
             $this->documentIndex[$key] = $uri;
 
             // Invalidate cache so open document version takes precedence
-            unset($this->cache[$key]);
+            $this->cache->delete(CacheKey::from($key));
         }
     }
 

--- a/src/Repository/DefaultClassRepository.php
+++ b/src/Repository/DefaultClassRepository.php
@@ -16,8 +16,6 @@ use PhpParser\NodeVisitorAbstract;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use ReflectionException;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Psr16Cache;
 
 final class DefaultClassRepository implements ClassRepository
 {
@@ -31,10 +29,7 @@ final class DefaultClassRepository implements ClassRepository
         private readonly ClassInfoFactory $factory,
         private readonly ClassLocator $locator,
         private readonly ParserService $parser,
-        // ArrayAdapter's second argument disables its copy-on-read (named
-        // `storeSerialized` in symfony/cache 7, `deepClone` in 8), so a hit
-        // returns the cached instance rather than a clone.
-        private readonly CacheInterface $cache = new Psr16Cache(new ArrayAdapter(0, false)),
+        private readonly CacheInterface $cache,
     ) {
     }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp;
 
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Capability\CapabilityNegotiator;
 use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
 use Firehed\PhpLsp\Completion\ClassCandidates;
@@ -93,7 +94,12 @@ final class Server
         $classLocator = new ComposerClassLocator($projectRoot);
 
         $classInfoFactory = new DefaultClassInfoFactory();
-        $classRepository = new DefaultClassRepository($classInfoFactory, $classLocator, $parser);
+        $classRepository = new DefaultClassRepository(
+            $classInfoFactory,
+            $classLocator,
+            $parser,
+            CacheFactory::inMemory(),
+        );
         $functionRepository = new DefaultFunctionRepository();
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, $functionRepository);

--- a/tests/BuildsClassRepositoryTrait.php
+++ b/tests/BuildsClassRepositoryTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests;
+
+use Firehed\PhpLsp\Cache\CacheFactory;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\ClassInfoFactory;
+use Firehed\PhpLsp\Repository\ClassLocator;
+use Firehed\PhpLsp\Repository\DefaultClassRepository;
+
+/**
+ * Constructs {@see DefaultClassRepository} for tests through one seam.
+ *
+ * Tests pass the collaborators they customise (factory, locator, parser); the
+ * repository's infrastructure dependencies — currently the PSR-16 cache — are
+ * supplied here with a working default. A new infrastructure dependency on the
+ * repository is then a change to this one helper, not to every test that builds
+ * one. Production wiring lives in the composition roots (Server), not here.
+ */
+trait BuildsClassRepositoryTrait
+{
+    private function buildClassRepository(
+        ClassInfoFactory $factory,
+        ClassLocator $locator,
+        ParserService $parser,
+    ): DefaultClassRepository {
+        return new DefaultClassRepository(
+            $factory,
+            $locator,
+            $parser,
+            CacheFactory::inMemory(),
+        );
+    }
+}

--- a/tests/Cache/CacheFactoryTest.php
+++ b/tests/Cache/CacheFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Cache;
+
+use Firehed\PhpLsp\Cache\CacheFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+#[CoversClass(CacheFactory::class)]
+final class CacheFactoryTest extends TestCase
+{
+    public function testAHitReturnsTheStoredInstanceRatherThanACopy(): void
+    {
+        $cache = CacheFactory::inMemory();
+        $value = new stdClass();
+
+        $cache->set('key', $value);
+
+        self::assertSame(
+            $value,
+            $cache->get('key'),
+            'The cache must return the stored instance, not a clone, so callers keep object identity',
+        );
+    }
+}

--- a/tests/Cache/CacheKeyTest.php
+++ b/tests/Cache/CacheKeyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Cache;
+
+use Firehed\PhpLsp\Cache\CacheKey;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CacheKey::class)]
+final class CacheKeyTest extends TestCase
+{
+    public function testDerivedKeyContainsNoPsr16ReservedCharacters(): void
+    {
+        // A backslash-laden identifier is exactly what a raw FQN or namespace is.
+        $key = CacheKey::from('psr\\http\\message\\requestinterface');
+
+        self::assertFalse(
+            strpbrk($key, '{}()/\\@:'),
+            'PSR-16 forbids these characters in a key, so the derived key must avoid them',
+        );
+    }
+
+    public function testDerivationIsDeterministic(): void
+    {
+        self::assertSame(
+            CacheKey::from('app\\service'),
+            CacheKey::from('app\\service'),
+            'The same identifier must resolve to the same cache entry',
+        );
+    }
+
+    public function testDistinctIdentifiersDeriveDistinctKeys(): void
+    {
+        self::assertNotSame(
+            CacheKey::from('app\\service'),
+            CacheKey::from('app\\other'),
+            'Different identifiers must not collide onto one cache entry',
+        );
+    }
+
+    public function testKeyStaysWithinThePsr16LengthGuarantee(): void
+    {
+        $longIdentifier = str_repeat('firehed\\phplsp\\', 20);
+
+        self::assertLessThanOrEqual(
+            64,
+            strlen(CacheKey::from($longIdentifier)),
+            'PSR-16 only guarantees support for keys up to 64 characters',
+        );
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -35,6 +35,7 @@ use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -85,6 +86,7 @@ class CompletionHandlerTest extends TestCase
             $this->classInfoFactory,
             $locator,
             $this->parser,
+            CacheFactory::inMemory(),
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -35,11 +35,11 @@ use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -60,6 +60,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(VariableCandidates::class)]
 class CompletionHandlerTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
@@ -82,11 +83,10 @@ class CompletionHandlerTest extends TestCase
         $this->symbolIndex = new SymbolIndex();
         $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = new ComposerClassLocator(__DIR__ . '/../Fixtures');
-        $this->classRepository = new DefaultClassRepository(
+        $this->classRepository = $this->buildClassRepository(
             $this->classInfoFactory,
             $locator,
             $this->parser,
-            CacheFactory::inMemory(),
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -11,6 +11,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -42,6 +43,7 @@ class DefinitionHandlerTest extends TestCase
             $classInfoFactory,
             $locator,
             $this->parser,
+            CacheFactory::inMemory(),
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -11,11 +11,11 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DefinitionHandler::class)]
 class DefinitionHandlerTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
@@ -39,11 +40,10 @@ class DefinitionHandlerTest extends TestCase
         $this->parser = new ParserService();
         $classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
-        $this->classRepository = new DefaultClassRepository(
+        $this->classRepository = $this->buildClassRepository(
             $classInfoFactory,
             $locator,
             $this->parser,
-            CacheFactory::inMemory(),
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -15,6 +15,7 @@ use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -48,6 +49,7 @@ class HoverHandlerTest extends TestCase
             $this->classInfoFactory,
             $locator,
             $this->parser,
+            CacheFactory::inMemory(),
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -15,11 +15,11 @@ use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -28,6 +28,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(HoverHandler::class)]
 class HoverHandlerTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
@@ -45,11 +46,10 @@ class HoverHandlerTest extends TestCase
         $this->parser = new ParserService();
         $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
-        $this->classRepository = new DefaultClassRepository(
+        $this->classRepository = $this->buildClassRepository(
             $this->classInfoFactory,
             $locator,
             $this->parser,
-            CacheFactory::inMemory(),
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -10,11 +10,11 @@ use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(SignatureHelpHandler::class)]
 class SignatureHelpHandlerTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
@@ -40,11 +41,10 @@ class SignatureHelpHandlerTest extends TestCase
         $this->parser = new ParserService();
         $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = new ComposerClassLocator(__DIR__ . '/../Fixtures');
-        $this->classRepository = new DefaultClassRepository(
+        $this->classRepository = $this->buildClassRepository(
             $this->classInfoFactory,
             $locator,
             $this->parser,
-            CacheFactory::inMemory(),
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -43,6 +44,7 @@ class SignatureHelpHandlerTest extends TestCase
             $this->classInfoFactory,
             $locator,
             $this->parser,
+            CacheFactory::inMemory(),
         );
         $this->memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($this->memberResolver, new DefaultFunctionRepository());

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -11,6 +11,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
@@ -35,7 +36,12 @@ class TextDocumentSyncHandlerTest extends TestCase
         $this->parser = new ParserService();
         $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
-        $this->classRepository = new DefaultClassRepository($this->classInfoFactory, $locator, $this->parser);
+        $this->classRepository = new DefaultClassRepository(
+            $this->classInfoFactory,
+            $locator,
+            $this->parser,
+            CacheFactory::inMemory(),
+        );
         $this->handler = new TextDocumentSyncHandler(
             $this->manager,
             $this->symbolSourceFor($this->classRepository, $this->parser),

--- a/tests/Handler/TextDocumentSyncHandlerTest.php
+++ b/tests/Handler/TextDocumentSyncHandlerTest.php
@@ -11,8 +11,8 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TextDocumentSyncHandler::class)]
 class TextDocumentSyncHandlerTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use BuildsSymbolSourceTrait;
     use LoadsFixturesTrait;
 
@@ -36,11 +37,10 @@ class TextDocumentSyncHandlerTest extends TestCase
         $this->parser = new ParserService();
         $this->classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
-        $this->classRepository = new DefaultClassRepository(
+        $this->classRepository = $this->buildClassRepository(
             $this->classInfoFactory,
             $locator,
             $this->parser,
-            CacheFactory::inMemory(),
         );
         $this->handler = new TextDocumentSyncHandler(
             $this->manager,

--- a/tests/Index/CachedNamespaceCatalogTest.php
+++ b/tests/Index/CachedNamespaceCatalogTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Index;
 
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +18,7 @@ class CachedNamespaceCatalogTest extends TestCase
     protected function setUp(): void
     {
         $this->source = new CountingNamespaceCatalog();
-        $this->catalog = new CachedNamespaceCatalog($this->source);
+        $this->catalog = new CachedNamespaceCatalog($this->source, CacheFactory::inMemory());
     }
 
     public function testARepeatedLookupIsServedFromTheCache(): void

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -19,8 +19,7 @@ use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
-use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +32,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class DelegatingSymbolSourceTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
+
     private DefaultClassInfoFactory $factory;
     private SymbolIndex $index;
     private DocumentIndexer $indexer;
@@ -47,11 +48,10 @@ final class DelegatingSymbolSourceTest extends TestCase
         $this->factory = new DefaultClassInfoFactory();
         $this->index = new SymbolIndex();
         $this->indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->index);
-        $this->repository = new DefaultClassRepository(
+        $this->repository = $this->buildClassRepository(
             $this->factory,
             new ComposerClassLocator($this->projectRoot . '/tests/Fixtures'),
             $this->parser,
-            CacheFactory::inMemory(),
         );
     }
 

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -19,6 +19,7 @@ use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -50,6 +51,7 @@ final class DelegatingSymbolSourceTest extends TestCase
             $this->factory,
             new ComposerClassLocator($this->projectRoot . '/tests/Fixtures'),
             $this->parser,
+            CacheFactory::inMemory(),
         );
     }
 

--- a/tests/Parity/ClassLikeLookupParityTest.php
+++ b/tests/Parity/ClassLikeLookupParityTest.php
@@ -10,8 +10,8 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,6 +27,7 @@ use PHPUnit\Framework\TestCase;
 final class ClassLikeLookupParityTest extends TestCase
 {
     use AssertsGolden;
+    use BuildsClassRepositoryTrait;
 
     /**
      * Corpus of class-like names whose full `ClassInfo` is deterministic and
@@ -78,11 +79,10 @@ final class ClassLikeLookupParityTest extends TestCase
     protected function setUp(): void
     {
         $this->projectRoot = dirname(__DIR__, 2);
-        $this->repository = new DefaultClassRepository(
+        $this->repository = $this->buildClassRepository(
             new DefaultClassInfoFactory(),
             new ComposerClassLocator($this->projectRoot . '/tests/Fixtures'),
             new ParserService(),
-            CacheFactory::inMemory(),
         );
     }
 

--- a/tests/Parity/ClassLikeLookupParityTest.php
+++ b/tests/Parity/ClassLikeLookupParityTest.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -81,6 +82,7 @@ final class ClassLikeLookupParityTest extends TestCase
             new DefaultClassInfoFactory(),
             new ComposerClassLocator($this->projectRoot . '/tests/Fixtures'),
             new ParserService(),
+            CacheFactory::inMemory(),
         );
     }
 

--- a/tests/Repository/DefaultClassRepositoryTest.php
+++ b/tests/Repository/DefaultClassRepositoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Repository;
 
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
@@ -12,12 +11,15 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(DefaultClassRepository::class)]
 final class DefaultClassRepositoryTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
+
     public function testGetReturnsNullForUnknownClass(): void
     {
         $factory = self::createStub(ClassInfoFactory::class);
@@ -25,7 +27,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         self::assertNull($repo->get(new ClassName($this->nonExistentClass())));
     }
@@ -38,7 +40,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $classInfo = $this->createClassInfo(DocumentClass::class);
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
         $repo->updateDocument('file:///test.php', [$classInfo]);
 
         $result = $repo->get(new ClassName(DocumentClass::class));
@@ -61,7 +63,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         $result = $repo->get(new ClassName(TestFixture::class));
 
@@ -82,7 +84,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         $result = $repo->get(new ClassName(\stdClass::class));
 
@@ -103,7 +105,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         $repo->get(new ClassName(\stdClass::class));
         $result = $repo->get(new ClassName(\stdClass::class));
@@ -123,7 +125,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         $repo->get(new ClassName(TestFixture::class));
         $parsesAfterFirst = $parser->getMetrics()->getParseCount();
@@ -152,7 +154,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
         $repo->updateDocument('file:///test.php', [$oldInfo]);
 
         $repo->get(new ClassName(DocumentClass::class));
@@ -190,7 +192,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
         $repo->updateDocument('file:///test.php', [$classInfo]);
 
         $repo->removeDocument('file:///test.php');
@@ -206,7 +208,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
         $repo->updateDocument('file:///test.php', [$classInfo]);
 
         /** @var class-string $withBackslash */
@@ -222,7 +224,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         $repo->removeDocument('file:///nonexistent.php');
 
@@ -243,7 +245,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         $repo->get(new ClassName(\stdClass::class));
 
@@ -343,7 +345,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
 
         self::assertFalse($repo->isSubclassOf(
             new ClassName('App\\Unknown'), // @phpstan-ignore argument.type
@@ -360,7 +362,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
+        $repo = $this->buildClassRepository($factory, $locator, $parser);
         $repo->updateDocument('file:///test.php', $classes);
 
         return $repo;

--- a/tests/Repository/DefaultClassRepositoryTest.php
+++ b/tests/Repository/DefaultClassRepositoryTest.php
@@ -110,6 +110,38 @@ final class DefaultClassRepositoryTest extends TestCase
         self::assertSame($classInfo, $result);
     }
 
+    public function testCacheHitIsServedWithoutReparsingTheFile(): void
+    {
+        $classInfo = $this->createClassInfo(TestFixture::class);
+
+        $factory = self::createStub(ClassInfoFactory::class);
+        $factory->method('fromAstNode')->willReturn($classInfo);
+
+        $locator = self::createStub(ClassLocator::class);
+        $locator->method('locate')->willReturn(__DIR__ . '/TestFixture.php');
+
+        $parser = new ParserService();
+
+        $repo = new DefaultClassRepository($factory, $locator, $parser);
+
+        $repo->get(new ClassName(TestFixture::class));
+        $parsesAfterFirst = $parser->getMetrics()->getParseCount();
+
+        $repo->get(new ClassName(TestFixture::class));
+        $parsesAfterSecond = $parser->getMetrics()->getParseCount();
+
+        self::assertGreaterThan(
+            0,
+            $parsesAfterFirst,
+            'Resolving a class off disk must parse its file at least once',
+        );
+        self::assertSame(
+            $parsesAfterFirst,
+            $parsesAfterSecond,
+            'A cached class must be returned without re-parsing its file',
+        );
+    }
+
     public function testUpdateDocumentInvalidatesCache(): void
     {
         $oldInfo = $this->createClassInfo(DocumentClass::class);

--- a/tests/Repository/DefaultClassRepositoryTest.php
+++ b/tests/Repository/DefaultClassRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Repository;
 
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
@@ -24,7 +25,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         self::assertNull($repo->get(new ClassName($this->nonExistentClass())));
     }
@@ -37,7 +38,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $classInfo = $this->createClassInfo(DocumentClass::class);
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
         $repo->updateDocument('file:///test.php', [$classInfo]);
 
         $result = $repo->get(new ClassName(DocumentClass::class));
@@ -60,7 +61,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         $result = $repo->get(new ClassName(TestFixture::class));
 
@@ -81,7 +82,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         $result = $repo->get(new ClassName(\stdClass::class));
 
@@ -102,7 +103,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         $repo->get(new ClassName(\stdClass::class));
         $result = $repo->get(new ClassName(\stdClass::class));
@@ -122,7 +123,7 @@ final class DefaultClassRepositoryTest extends TestCase
 
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         $repo->get(new ClassName(TestFixture::class));
         $parsesAfterFirst = $parser->getMetrics()->getParseCount();
@@ -151,7 +152,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
         $repo->updateDocument('file:///test.php', [$oldInfo]);
 
         $repo->get(new ClassName(DocumentClass::class));
@@ -189,7 +190,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
         $repo->updateDocument('file:///test.php', [$classInfo]);
 
         $repo->removeDocument('file:///test.php');
@@ -205,7 +206,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
         $repo->updateDocument('file:///test.php', [$classInfo]);
 
         /** @var class-string $withBackslash */
@@ -221,7 +222,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         $repo->removeDocument('file:///nonexistent.php');
 
@@ -242,7 +243,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         $repo->get(new ClassName(\stdClass::class));
 
@@ -342,7 +343,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator->method('locate')->willReturn(null);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
 
         self::assertFalse($repo->isSubclassOf(
             new ClassName('App\\Unknown'), // @phpstan-ignore argument.type
@@ -359,7 +360,7 @@ final class DefaultClassRepositoryTest extends TestCase
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
 
-        $repo = new DefaultClassRepository($factory, $locator, $parser);
+        $repo = new DefaultClassRepository($factory, $locator, $parser, CacheFactory::inMemory());
         $repo->updateDocument('file:///test.php', $classes);
 
         return $repo;

--- a/tests/Repository/TypeGraphParityTest.php
+++ b/tests/Repository/TypeGraphParityTest.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -66,6 +67,7 @@ final class TypeGraphParityTest extends TestCase
             new DefaultClassInfoFactory(),
             new ComposerClassLocator(dirname(__DIR__) . '/Fixtures'),
             $parser,
+            CacheFactory::inMemory(),
         );
         $this->resolver = new MemberResolver($repository);
     }

--- a/tests/Repository/TypeGraphParityTest.php
+++ b/tests/Repository/TypeGraphParityTest.php
@@ -9,8 +9,7 @@ use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
-use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -29,6 +28,8 @@ use ReflectionProperty;
 #[CoversClass(MemberResolver::class)]
 final class TypeGraphParityTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
+
     private MemberResolver $resolver;
 
     public static function setUpBeforeClass(): void
@@ -63,11 +64,10 @@ final class TypeGraphParityTest extends TestCase
     protected function setUp(): void
     {
         $parser = new ParserService();
-        $repository = new DefaultClassRepository(
+        $repository = $this->buildClassRepository(
             new DefaultClassInfoFactory(),
             new ComposerClassLocator(dirname(__DIR__) . '/Fixtures'),
             $parser,
-            CacheFactory::inMemory(),
         );
         $this->resolver = new MemberResolver($repository);
     }

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -9,7 +9,6 @@ use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -34,6 +33,7 @@ use Firehed\PhpLsp\Resolution\ResolvedVariable;
 use Firehed\PhpLsp\Resolution\SymbolResolver;
 use Firehed\PhpLsp\Resolution\TextFallbackHelper;
 use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Tests\BuildsSymbolSourceTrait;
 use Firehed\PhpLsp\Tests\Handler\OpensDocumentsTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -48,6 +48,7 @@ use TypeError;
 #[CoversClass(TextFallbackHelper::class)]
 final class SymbolResolverTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use BuildsSymbolSourceTrait;
     use OpensDocumentsTrait;
 
@@ -63,11 +64,10 @@ final class SymbolResolverTest extends TestCase
         $this->documents = new DocumentManager();
         $classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
-        $this->classRepository = new DefaultClassRepository(
+        $this->classRepository = $this->buildClassRepository(
             $classInfoFactory,
             $locator,
             $this->parser,
-            CacheFactory::inMemory(),
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -66,6 +67,7 @@ final class SymbolResolverTest extends TestCase
             $classInfoFactory,
             $locator,
             $this->parser,
+            CacheFactory::inMemory(),
         );
         $memberResolver = new MemberResolver($this->classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());

--- a/tests/Resolution/TextFallbackHelperTest.php
+++ b/tests/Resolution/TextFallbackHelperTest.php
@@ -13,6 +13,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Resolution\MemberFilter;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
@@ -41,7 +42,7 @@ class TextFallbackHelperTest extends TestCase
         $factory = new DefaultClassInfoFactory();
         $locator = new ComposerClassLocator(__DIR__ . '/../Fixtures');
         $this->parser = new ParserService();
-        $fixtureRepo = new DefaultClassRepository($factory, $locator, $this->parser);
+        $fixtureRepo = new DefaultClassRepository($factory, $locator, $this->parser, CacheFactory::inMemory());
         $this->helperWithReflection = new TextFallbackHelper(new MemberResolver($fixtureRepo));
     }
 

--- a/tests/Resolution/TextFallbackHelperTest.php
+++ b/tests/Resolution/TextFallbackHelperTest.php
@@ -13,8 +13,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Resolution\MemberFilter;
 use Firehed\PhpLsp\Repository\ClassRepository;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
-use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\TextFallbackHelper;
@@ -25,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TextFallbackHelper::class)]
 class TextFallbackHelperTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use LoadsFixturesTrait;
 
     private TextFallbackHelper $helper;
@@ -42,7 +42,7 @@ class TextFallbackHelperTest extends TestCase
         $factory = new DefaultClassInfoFactory();
         $locator = new ComposerClassLocator(__DIR__ . '/../Fixtures');
         $this->parser = new ParserService();
-        $fixtureRepo = new DefaultClassRepository($factory, $locator, $this->parser, CacheFactory::inMemory());
+        $fixtureRepo = $this->buildClassRepository($factory, $locator, $this->parser);
         $this->helperWithReflection = new TextFallbackHelper(new MemberResolver($fixtureRepo));
     }
 

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -16,6 +16,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Throwable;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -40,7 +41,7 @@ class BasicTypeResolverTest extends TestCase
         $classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser, CacheFactory::inMemory());
         $memberResolver = new MemberResolver($classRepository);
 
         $this->resolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
@@ -934,7 +935,7 @@ class BasicTypeResolverTest extends TestCase
         $classInfoFactory = new DefaultClassInfoFactory();
         $locator = new \Firehed\PhpLsp\Index\ComposerClassLocator(__DIR__ . '/../Fixtures');
         $parser = new ParserService();
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser);
+        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser, CacheFactory::inMemory());
         $memberResolver = new MemberResolver($classRepository);
 
         return new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -16,8 +16,7 @@ use Firehed\PhpLsp\Parser\ParserService;
 use Throwable;
 use Firehed\PhpLsp\Repository\ClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Cache\CacheFactory;
-use Firehed\PhpLsp\Repository\DefaultClassRepository;
+use Firehed\PhpLsp\Tests\BuildsClassRepositoryTrait;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
@@ -32,6 +31,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(BasicTypeResolver::class)]
 class BasicTypeResolverTest extends TestCase
 {
+    use BuildsClassRepositoryTrait;
     use LoadsFixturesTrait;
 
     private BasicTypeResolver $resolver;
@@ -41,7 +41,7 @@ class BasicTypeResolverTest extends TestCase
         $classInfoFactory = new DefaultClassInfoFactory();
         $locator = self::createStub(ClassLocator::class);
         $parser = new ParserService();
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser, CacheFactory::inMemory());
+        $classRepository = $this->buildClassRepository($classInfoFactory, $locator, $parser);
         $memberResolver = new MemberResolver($classRepository);
 
         $this->resolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
@@ -935,7 +935,7 @@ class BasicTypeResolverTest extends TestCase
         $classInfoFactory = new DefaultClassInfoFactory();
         $locator = new \Firehed\PhpLsp\Index\ComposerClassLocator(__DIR__ . '/../Fixtures');
         $parser = new ParserService();
-        $classRepository = new DefaultClassRepository($classInfoFactory, $locator, $parser, CacheFactory::inMemory());
+        $classRepository = $this->buildClassRepository($classInfoFactory, $locator, $parser);
         $memberResolver = new MemberResolver($classRepository);
 
         return new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());


### PR DESCRIPTION
## Slice S3.1 — Existing caches → replaceable §5.3 seam (verify)

**Plan step:** 0002 Step 3a(i) — "the replaceable cache abstraction (PSR-6/16 seam, §5.3)".
**RFC:** 0001 §5.3 (Backend Substitutability and Caching Policy).
**Manifest:** `build-manifest.md` Wave 2, S3.1.

This is the verify-then-seam slice. It moves the two existing hand-rolled
memoizations behind a replaceable PSR-16 cache abstraction. Per the manifest note,
each kept cache must **demonstrably drop a parse / source call on a hit**; a cache
that cannot is removed, not wrapped. Both demonstrably drop work, so both are kept
and wrapped:

- `DefaultClassRepository::$cache` (ClassInfo by FQN) — a hit skips
  `locateAndParse()`, so it drops a parse (asserted via `ParseMetrics`).
- `CachedNamespaceCatalog::$cache` (stable-source `childrenOf`) — a hit skips the
  underlying source call (already asserted via the counting-source test).

### Design notes

- The seam is `Psr\SimpleCache\CacheInterface`. Consumers take it as a **required
  constructor dependency** — no implicit wiring — and the concrete backend
  (`Psr16Cache(new ArrayAdapter(...))`, built by `Cache\CacheFactory::inMemory()`)
  is injected from the composition roots (`Server`, `NamespaceCatalogFactory`). A
  different policy (eviction, bounds, TTL) is then a one-line swap at a root, not a
  change to any consumer (§5.3).
- `symfony/cache` is constrained `^7 || ^8`: v8 requires PHP 8.4.1 while the project
  supports PHP 8.3 (CI matrix 8.3/8.4/8.5), so each runtime resolves its newest
  compatible line.
- `ArrayAdapter`'s copy-on-read is disabled via its positional second argument
  (renamed `storeSerialized`→`deepClone` between v7 and v8), preserving cached-object
  identity and avoiding per-hit clone cost.
- FQNs and namespaces contain `\`, a PSR-16 reserved character, and can exceed the
  64-char key bound, so keys are derived through `Cache\CacheKey` (hash into the safe
  alphabet). Callers still own semantic normalization (lowercasing).
- Test construction of `DefaultClassRepository` goes through a `BuildsClassRepositoryTrait`
  builder (mirroring the existing `BuildsSymbolSourceTrait`), so a future
  infrastructure dependency on the repository touches one helper rather than every
  test that builds one.

### Acceptance criteria

- [x] Both memoizations route through the replaceable §5.3 cache seam rather than a
      private memo array.
- [x] ClassInfo cache: a hit is served without re-parsing the file (`ParseMetrics`
      assertion).
- [x] Namespace cache: a hit is served without a source call (counting-source
      assertion, retained green).
- [x] Neither cache is removed (both demonstrably drop work).
- [x] Cache backends are injected at the composition roots, not wired implicitly in
      consumer constructors.
- [x] `composer test` green; new code fully covered.

### Scaffolding / teardown ledger

None discharged by this slice (S3.1 introduces the abstraction; the double-write
facade, ComposerAutoloadMap dup, and §4.2 exemption are later slices).

_No `Closes` candidates in the manifest for S3.1._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
