### PR TITLE
Dedupe the duplicate ComposerAutoloadMap

### DIFF
--- a/src/Index/ComposerClassLocator.php
+++ b/src/Index/ComposerClassLocator.php
@@ -4,23 +4,14 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
-use Composer\Autoload\ClassLoader;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Repository\ClassLocator;
 
 final class ComposerClassLocator implements ClassLocator
 {
-    private ?ClassLoader $loader = null;
-
-    public function __construct(string $projectRoot)
-    {
-        $composerDir = rtrim($projectRoot, '/') . '/vendor/composer';
-
-        if (!is_dir($composerDir)) {
-            return;
-        }
-
-        $this->loader = ComposerAutoloadMap::fromProjectRoot($projectRoot)->classLoader();
+    public function __construct(
+        private readonly ComposerAutoloadMap $map,
+    ) {
     }
 
     public function locate(ClassName $name): ?string
@@ -30,11 +21,7 @@ final class ComposerClassLocator implements ClassLocator
 
     public function locateClass(string $fullyQualifiedName): ?string
     {
-        if ($this->loader === null) {
-            return null;
-        }
-
-        $file = $this->loader->findFile($fullyQualifiedName);
+        $file = $this->map->classLoader()->findFile($fullyQualifiedName);
         return $file !== false ? $file : null;
     }
 }

--- a/src/Index/NamespaceCatalogFactory.php
+++ b/src/Index/NamespaceCatalogFactory.php
@@ -14,13 +14,13 @@ use Firehed\PhpLsp\Cache\CacheFactory;
  */
 final class NamespaceCatalogFactory
 {
-    public static function forProject(SymbolIndex $index, string $projectRoot): NamespaceCatalog
+    public static function forProject(SymbolIndex $index, ComposerAutoloadMap $map): NamespaceCatalog
     {
         return new CompositeNamespaceCatalog([
             new WorkspaceNamespaceSource($index),
             new CachedNamespaceCatalog(
                 new CompositeNamespaceCatalog([
-                    new ComposerNamespaceSource(ComposerAutoloadMap::fromProjectRoot($projectRoot)),
+                    new ComposerNamespaceSource($map),
                     new ReflectionNamespaceSource(),
                 ]),
                 CacheFactory::inMemory(),

--- a/src/Server.php
+++ b/src/Server.php
@@ -22,6 +22,7 @@ use Firehed\PhpLsp\Handler\HoverHandler;
 use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\NamespaceCatalogFactory;
@@ -91,7 +92,7 @@ final class Server
         $documentManager = new DocumentManager();
         $symbolIndex = new SymbolIndex();
         $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
-        $classLocator = new ComposerClassLocator($projectRoot);
+        $classLocator = new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot($projectRoot));
 
         $classInfoFactory = new DefaultClassInfoFactory();
         $classRepository = new DefaultClassRepository(

--- a/src/Server.php
+++ b/src/Server.php
@@ -92,7 +92,11 @@ final class Server
         $documentManager = new DocumentManager();
         $symbolIndex = new SymbolIndex();
         $indexer = new DocumentIndexer($parser, new SymbolExtractor(), $symbolIndex);
-        $classLocator = new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot($projectRoot));
+        // One autoload map, shared by every consumer of Composer's maps: reading
+        // the generated autoload files and building the ClassLoader happens once,
+        // not once per consumer (Plan 0002 §3a(ii)).
+        $autoloadMap = ComposerAutoloadMap::fromProjectRoot($projectRoot);
+        $classLocator = new ComposerClassLocator($autoloadMap);
 
         $classInfoFactory = new DefaultClassInfoFactory();
         $classRepository = new DefaultClassRepository(
@@ -105,10 +109,7 @@ final class Server
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, $functionRepository);
 
-        $catalog = NamespaceCatalogFactory::forProject(
-            $symbolIndex,
-            ComposerAutoloadMap::fromProjectRoot($projectRoot),
-        );
+        $catalog = NamespaceCatalogFactory::forProject($symbolIndex, $autoloadMap);
 
         // The read/write knowledge seam (RFC 1 §4.2, §4.3). Consumers migrate onto
         // this one facade instance across Step 2's slices (Plan 0002 §5.5); today

--- a/src/Server.php
+++ b/src/Server.php
@@ -105,7 +105,10 @@ final class Server
         $memberResolver = new MemberResolver($classRepository);
         $typeResolver = new BasicTypeResolver($memberResolver, $functionRepository);
 
-        $catalog = NamespaceCatalogFactory::forProject($symbolIndex, $projectRoot);
+        $catalog = NamespaceCatalogFactory::forProject(
+            $symbolIndex,
+            ComposerAutoloadMap::fromProjectRoot($projectRoot),
+        );
 
         // The read/write knowledge seam (RFC 1 §4.2, §4.3). Consumers migrate onto
         // this one facade instance across Step 2's slices (Plan 0002 §5.5); today

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -33,6 +33,7 @@ use Firehed\PhpLsp\Knowledge\DelegatingSymbolSource;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
 use Firehed\PhpLsp\Repository\DefaultClassRepository;
@@ -82,7 +83,8 @@ class CompletionHandlerTest extends TestCase
         $this->parser = new ParserService();
         $this->symbolIndex = new SymbolIndex();
         $this->classInfoFactory = new DefaultClassInfoFactory();
-        $locator = new ComposerClassLocator(__DIR__ . '/../Fixtures');
+        $autoloadMap = ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures');
+        $locator = new ComposerClassLocator($autoloadMap);
         $this->classRepository = $this->buildClassRepository(
             $this->classInfoFactory,
             $locator,

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -100,7 +100,7 @@ class CompletionHandlerTest extends TestCase
             new DefaultFunctionRepository(),
         );
         $this->indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->symbolIndex);
-        $this->catalog = NamespaceCatalogFactory::forProject($this->symbolIndex, __DIR__ . '/../Fixtures');
+        $this->catalog = NamespaceCatalogFactory::forProject($this->symbolIndex, $autoloadMap);
         $this->handler = $this->makeHandler($this->catalog);
         $this->syncHandler = new TextDocumentSyncHandler(
             $this->documents,

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Handler;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
@@ -40,7 +41,7 @@ class SignatureHelpHandlerTest extends TestCase
         $this->documents = new DocumentManager();
         $this->parser = new ParserService();
         $this->classInfoFactory = new DefaultClassInfoFactory();
-        $locator = new ComposerClassLocator(__DIR__ . '/../Fixtures');
+        $locator = new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures'));
         $this->classRepository = $this->buildClassRepository(
             $this->classInfoFactory,
             $locator,

--- a/tests/Index/ComposerClassLocatorTest.php
+++ b/tests/Index/ComposerClassLocatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Index;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Tests\Fixtures\Autoload\ClassmapFixture;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -18,7 +19,7 @@ final class ComposerClassLocatorTest extends TestCase
 
     public function testLocateClassFromClassmap(): void
     {
-        $locator = new ComposerClassLocator(self::FIXTURES_ROOT);
+        $locator = self::locatorForRoot(self::FIXTURES_ROOT);
 
         // @phpstan-ignore class.notFound
         $path = $locator->locateClass(ClassmapFixture::class);
@@ -29,7 +30,7 @@ final class ComposerClassLocatorTest extends TestCase
 
     public function testLocateResolvesAClassName(): void
     {
-        $locator = new ComposerClassLocator(self::FIXTURES_ROOT);
+        $locator = self::locatorForRoot(self::FIXTURES_ROOT);
 
         // @phpstan-ignore class.notFound
         $path = $locator->locate(new ClassName(ClassmapFixture::class));
@@ -40,7 +41,7 @@ final class ComposerClassLocatorTest extends TestCase
 
     public function testLocateClassReturnsNullForNonexistentClass(): void
     {
-        $locator = new ComposerClassLocator(self::PROJECT_ROOT);
+        $locator = self::locatorForRoot(self::PROJECT_ROOT);
 
         $path = $locator->locateClass('NonExistent\\Class');
 
@@ -49,7 +50,7 @@ final class ComposerClassLocatorTest extends TestCase
 
     public function testLocateClassFromPsr4(): void
     {
-        $locator = new ComposerClassLocator(self::PROJECT_ROOT);
+        $locator = self::locatorForRoot(self::PROJECT_ROOT);
 
         $path = $locator->locateClass(ComposerClassLocator::class);
 
@@ -59,7 +60,7 @@ final class ComposerClassLocatorTest extends TestCase
 
     public function testLocateClassFromVendorClassmap(): void
     {
-        $locator = new ComposerClassLocator(self::PROJECT_ROOT);
+        $locator = self::locatorForRoot(self::PROJECT_ROOT);
 
         $path = $locator->locateClass(TestCase::class);
 
@@ -69,7 +70,7 @@ final class ComposerClassLocatorTest extends TestCase
 
     public function testLocateClassFromPsr0(): void
     {
-        $locator = new ComposerClassLocator(self::FIXTURES_ROOT);
+        $locator = self::locatorForRoot(self::FIXTURES_ROOT);
 
         // @phpstan-ignore class.notFound
         $path = $locator->locateClass(\Psr0\Psr0Fixture::class);
@@ -82,7 +83,7 @@ final class ComposerClassLocatorTest extends TestCase
     {
         $autoloadersBefore = spl_autoload_functions();
 
-        new ComposerClassLocator(self::PROJECT_ROOT);
+        self::locatorForRoot(self::PROJECT_ROOT);
 
         $autoloadersAfter = spl_autoload_functions();
 
@@ -95,10 +96,15 @@ final class ComposerClassLocatorTest extends TestCase
 
     public function testMissingComposerDirectoryReturnsNull(): void
     {
-        $locator = new ComposerClassLocator('/nonexistent/path');
+        $locator = self::locatorForRoot('/nonexistent/path');
 
         $path = $locator->locateClass(TestCase::class);
 
         self::assertNull($path);
+    }
+
+    private static function locatorForRoot(string $projectRoot): ComposerClassLocator
+    {
+        return new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot($projectRoot));
     }
 }

--- a/tests/Index/NamespaceCatalogFactoryTest.php
+++ b/tests/Index/NamespaceCatalogFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Index;
 
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\NamespaceCatalogFactory;
 use Firehed\PhpLsp\Index\Symbol;
@@ -25,7 +26,10 @@ class NamespaceCatalogFactoryTest extends TestCase
             new Location('file:///Widget.php', 0, 0, 0, 1),
         ));
 
-        $catalog = NamespaceCatalogFactory::forProject($index, __DIR__ . '/../Fixtures');
+        $catalog = NamespaceCatalogFactory::forProject(
+            $index,
+            ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures'),
+        );
         $globalChildren = $catalog->childrenOf('')->childNamespaces;
 
         self::assertContains('Workspace', $globalChildren, 'The workspace index source contributes');
@@ -36,7 +40,10 @@ class NamespaceCatalogFactoryTest extends TestCase
     public function testTheWorkspaceSourceIsNotCached(): void
     {
         $index = new SymbolIndex();
-        $catalog = NamespaceCatalogFactory::forProject($index, __DIR__ . '/../Fixtures');
+        $catalog = NamespaceCatalogFactory::forProject(
+            $index,
+            ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures'),
+        );
 
         self::assertNotContains('Late', $catalog->childrenOf('')->childNamespaces, 'Not declared yet');
 

--- a/tests/Knowledge/DelegatingSymbolSourceTest.php
+++ b/tests/Knowledge/DelegatingSymbolSourceTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
@@ -50,7 +51,7 @@ final class DelegatingSymbolSourceTest extends TestCase
         $this->indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->index);
         $this->repository = $this->buildClassRepository(
             $this->factory,
-            new ComposerClassLocator($this->projectRoot . '/tests/Fixtures'),
+            new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot($this->projectRoot . '/tests/Fixtures')),
             $this->parser,
         );
     }

--- a/tests/Parity/ChildrenOfParityTest.php
+++ b/tests/Parity/ChildrenOfParityTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Parity;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceCatalogFactory;
@@ -101,7 +102,10 @@ final class ChildrenOfParityTest extends TestCase
             "<?php\nnamespace Fixtures\\Model\\OpenOnly;\nclass Unsaved {}\n",
         ));
 
-        $this->catalog = NamespaceCatalogFactory::forProject($index, $this->fixturesRoot);
+        $this->catalog = NamespaceCatalogFactory::forProject(
+            $index,
+            ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot),
+        );
     }
 
     public function testChildrenOfMatchesGolden(): void

--- a/tests/Parity/ClassLikeLookupParityTest.php
+++ b/tests/Parity/ClassLikeLookupParityTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Parity;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
@@ -81,7 +82,7 @@ final class ClassLikeLookupParityTest extends TestCase
         $this->projectRoot = dirname(__DIR__, 2);
         $this->repository = $this->buildClassRepository(
             new DefaultClassInfoFactory(),
-            new ComposerClassLocator($this->projectRoot . '/tests/Fixtures'),
+            new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot($this->projectRoot . '/tests/Fixtures')),
             new ParserService(),
         );
     }

--- a/tests/Repository/TypeGraphParityTest.php
+++ b/tests/Repository/TypeGraphParityTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Repository;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
@@ -66,7 +67,7 @@ final class TypeGraphParityTest extends TestCase
         $parser = new ParserService();
         $repository = $this->buildClassRepository(
             new DefaultClassInfoFactory(),
-            new ComposerClassLocator(dirname(__DIR__) . '/Fixtures'),
+            new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot(dirname(__DIR__) . '/Fixtures')),
             $parser,
         );
         $this->resolver = new MemberResolver($repository);

--- a/tests/Resolution/TextFallbackHelperTest.php
+++ b/tests/Resolution/TextFallbackHelperTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Resolution\MemberFilter;
@@ -40,7 +41,7 @@ class TextFallbackHelperTest extends TestCase
 
         // Create helper with fixture-based class resolution for chain tests
         $factory = new DefaultClassInfoFactory();
-        $locator = new ComposerClassLocator(__DIR__ . '/../Fixtures');
+        $locator = new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures'));
         $this->parser = new ParserService();
         $fixtureRepo = $this->buildClassRepository($factory, $locator, $this->parser);
         $this->helperWithReflection = new TextFallbackHelper(new MemberResolver($fixtureRepo));

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -12,6 +12,8 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\IntersectionType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\UnionType;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\ComposerClassLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Throwable;
 use Firehed\PhpLsp\Repository\ClassLocator;
@@ -933,7 +935,7 @@ class BasicTypeResolverTest extends TestCase
     private function createResolverWithFixtures(): BasicTypeResolver
     {
         $classInfoFactory = new DefaultClassInfoFactory();
-        $locator = new \Firehed\PhpLsp\Index\ComposerClassLocator(__DIR__ . '/../Fixtures');
+        $locator = new ComposerClassLocator(ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures'));
         $parser = new ParserService();
         $classRepository = $this->buildClassRepository($classInfoFactory, $locator, $parser);
         $memberResolver = new MemberResolver($classRepository);


### PR DESCRIPTION
## Slice S3.2 — Dedupe the duplicate `ComposerAutoloadMap`

- **Slice:** S3.2 (`build-manifest.md`, Wave 2)
- **Plan step:** `0002-execution-plan.md` Step 3a(ii) — "dedupe the double `ComposerAutoloadMap`" (behavior-preserving)
- **RFC:** `0001-foundational-architecture.md` §4.2 (Symbol Discovery Authority), §5.3 (backends)

### What changed

`Server::forProject` previously built two `ComposerAutoloadMap` instances from the
same project root: one inside `ComposerClassLocator` and a second inside
`NamespaceCatalogFactory::forProject`. Each re-`require`d the three generated Composer
autoload files and built its own `ClassLoader`.

Both consumers now receive an injected `ComposerAutoloadMap`, and the composition root
builds exactly one and shares it. `ComposerClassLocator` no longer knows about project
roots or map construction — it holds the shared map and reads through it (the old
nullable `ClassLoader` and `is_dir` guard fall out; an empty map's loader already
returns `false` for every name).

### Acceptance criteria

- [x] The two production `ComposerAutoloadMap` instances collapse to a single shared
      instance (one construction site remains in `src/`, in `Server::forProject`).
- [x] Behavior preserved — full suite green, and the Step P parity goldens
      (`class-like-lookup`, `childrenOf`) are unchanged.

### Candidate closes

None (manifest `Closes` column is `—` for this slice).
