### PR TITLE
One parse / one write path + write-path consistency check

### DIFF
--- a/src/Index/DocumentIndexer.php
+++ b/src/Index/DocumentIndexer.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Parser\ParserService;
+use PhpParser\Node\Stmt;
 
 final class DocumentIndexer
 {
@@ -18,18 +19,21 @@ final class DocumentIndexer
 
     public function index(TextDocument $document): void
     {
-        // Clear old symbols from this file
+        $this->indexParsed($document, $this->parser->parse($document) ?? []);
+    }
+
+    /**
+     * Index a document from an already-parsed AST rather than reparsing it. The
+     * single write path (RFC 1 §4.3) parses once and feeds that AST here, so the
+     * index and the class-lookup store share one parse (Plan 0002 §5.5, Step 3a(iv)).
+     *
+     * @param array<Stmt> $ast
+     */
+    public function indexParsed(TextDocument $document, array $ast): void
+    {
         $this->index->clearByUri($document->uri);
 
-        // Parse
-        $ast = $this->parser->parse($document);
-        if ($ast === null) {
-            return; // Parse error, skip indexing
-        }
-
-        // Extract and index symbols
-        $symbols = $this->extractor->extract($document, $ast);
-        foreach ($symbols as $symbol) {
+        foreach ($this->extractor->extract($document, $ast) as $symbol) {
             $this->index->add($symbol);
         }
     }

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -13,14 +14,14 @@ use PhpParser\Node\Stmt;
 
 /**
  * The single write path for open-document symbol state (RFC 1 §4.3, §5.2): document
- * lifecycle events register class metadata with the {@see OpenDocumentBackend} and
- * index the document's symbols in one place.
+ * lifecycle events register class metadata with the {@see OpenDocumentBackend} for
+ * lookup and index the document's symbols for enumeration and search, in one place.
  *
- * It still performs today's *double* write — full {@see \Firehed\PhpLsp\Domain\ClassInfo}
- * for lookup, lightweight symbols for enumeration and search, fed from one document.
- * Collapsing the two into one parse with a consistency check is Step 3a(iv) (Plan
- * 0002 §5.5, Teardown ledger); here both are driven from the same document so a
- * parse failure clears both rather than leaving one stale.
+ * The two stores are distinct structures serving different consumers (Plan 0002
+ * §5.5, Step 3a(iv)), but a document event drives both from **one parse**: the sink
+ * parses once and feeds that AST to the class registration and to the index alike,
+ * so neither reparses. A parse failure yields no statements, clearing both stores
+ * together rather than leaving one stale (RFC 1 §5.2).
  */
 final class DocumentSymbolSink implements SymbolSink
 {
@@ -50,24 +51,28 @@ final class DocumentSymbolSink implements SymbolSink
 
     private function write(TextDocument $document): void
     {
-        $this->registerClasses($document);
-        $this->indexer->index($document);
-    }
-
-    private function registerClasses(TextDocument $document): void
-    {
-        // A parse failure yields no classes rather than skipping registration, so the
-        // backend is cleared for this document exactly as the index is (RFC 1 §5.2):
-        // both stores move together instead of one keeping a stale answer.
+        // One parse feeds both stores (RFC 1 §4.3): the class-lookup registration and
+        // the symbol index are written transactionally from this single AST. A parse
+        // failure yields no statements, so both are cleared together.
         $ast = $this->parser->parse($document) ?? [];
 
+        $this->backend->updateDocument($document->uri, $this->classesIn($ast, $document->uri));
+        $this->indexer->indexParsed($document, $ast);
+    }
+
+    /**
+     * @param array<Stmt> $ast
+     * @return list<ClassInfo>
+     */
+    private function classesIn(array $ast, string $uri): array
+    {
         $classes = [];
         foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
             if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
-                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $document->uri);
+                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
             }
         }
 
-        $this->backend->updateDocument($document->uri, $classes);
+        return $classes;
     }
 }

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -81,9 +81,10 @@ final class DocumentSymbolSink implements SymbolSink
     {
         foreach ($classes as $classInfo) {
             if ($this->index->findByFqn($classInfo->name->fqn) === null) {
-                // @codeCoverageIgnoreStart — unreachable: both stores derive their
-                // class-likes from the one AST parsed above, so a class registered for
-                // lookup is always indexed. The guard fails loudly if that ceases to hold.
+                // Unreachable: both stores derive their class-likes from the one AST
+                // parsed above, so a class registered for lookup is always indexed. The
+                // guard fails loudly if that ever ceases to hold.
+                // @codeCoverageIgnoreStart
                 throw new \LogicException(sprintf(
                     'Write-path divergence: class-like %s is registered for lookup but absent '
                     . 'from the symbol index; the two stores are written from one parse and '

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Knowledge;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Utility\ScopeFinder;
@@ -28,6 +29,7 @@ final class DocumentSymbolSink implements SymbolSink
     public function __construct(
         private readonly OpenDocumentBackend $backend,
         private readonly DocumentIndexer $indexer,
+        private readonly SymbolIndex $index,
         private readonly ClassInfoFactory $classInfoFactory,
         private readonly ParserService $parser,
     ) {
@@ -56,8 +58,41 @@ final class DocumentSymbolSink implements SymbolSink
         // failure yields no statements, so both are cleared together.
         $ast = $this->parser->parse($document) ?? [];
 
-        $this->backend->updateDocument($document->uri, $this->classesIn($ast, $document->uri));
+        $classes = $this->classesIn($ast, $document->uri);
+        $this->backend->updateDocument($document->uri, $classes);
         $this->indexer->indexParsed($document, $ast);
+
+        $this->assertStoresAgree($classes);
+    }
+
+    /**
+     * The lookup store and the symbol index are separate structures, so the Step P
+     * parity harness — which compares only observable outputs — could stay green
+     * while they diverged internally (Plan 0002 §5.5, Step 3a(iv)). This guards the
+     * invariant directly: every class-like registered for lookup MUST also be
+     * indexed, so a name is never resolvable through one surface yet invisible to the
+     * other (RFC 1 §4.3). The check is one-directional because the index is a
+     * superset — it also records class-likes declared inside conditional or nested
+     * statements, which the top-level lookup registration does not.
+     *
+     * @param list<ClassInfo> $classes
+     */
+    private function assertStoresAgree(array $classes): void
+    {
+        foreach ($classes as $classInfo) {
+            if ($this->index->findByFqn($classInfo->name->fqn) === null) {
+                // @codeCoverageIgnoreStart — unreachable: both stores derive their
+                // class-likes from the one AST parsed above, so a class registered for
+                // lookup is always indexed. The guard fails loudly if that ceases to hold.
+                throw new \LogicException(sprintf(
+                    'Write-path divergence: class-like %s is registered for lookup but absent '
+                    . 'from the symbol index; the two stores are written from one parse and '
+                    . 'must agree (RFC 1 §4.3).',
+                    $classInfo->name->fqn,
+                ));
+                // @codeCoverageIgnoreEnd
+            }
+        }
     }
 
     /**

--- a/src/Knowledge/KnowledgeStack.php
+++ b/src/Knowledge/KnowledgeStack.php
@@ -69,6 +69,7 @@ final readonly class KnowledgeStack
         $sink = new DocumentSymbolSink(
             $openDocuments,
             new DocumentIndexer($parser, new SymbolExtractor(), $index),
+            $index,
             $classInfoFactory,
             $parser,
         );

--- a/src/Knowledge/OpenDocumentBackend.php
+++ b/src/Knowledge/OpenDocumentBackend.php
@@ -21,8 +21,8 @@ use Firehed\PhpLsp\Index\WorkspaceNamespaceSource;
  * backend reads the live symbol index and its own registered class metadata
  * directly. Class-like lookup is served from the {@see ClassInfo} registered per
  * document by the write path; namespace enumeration and prefix search are served
- * from the {@see SymbolIndex} the write path also populates. That both stores are
- * fed from one document is the double write Step 3a(iv) collapses (Plan 0002 §5.5);
+ * from the {@see SymbolIndex} the write path also populates. The write path feeds
+ * both stores from one parse ({@see DocumentSymbolSink}, Plan 0002 §5.5 Step 3a(iv));
  * here they are read as they stand.
  */
 final class OpenDocumentBackend implements SymbolBackend

--- a/tests/Index/DocumentIndexerTest.php
+++ b/tests/Index/DocumentIndexerTest.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,43 +20,37 @@ use PHPUnit\Framework\TestCase;
  */
 final class DocumentIndexerTest extends TestCase
 {
+    use LoadsFixturesTrait;
+
+    private ParserService $parser;
     private SymbolIndex $index;
     private DocumentIndexer $indexer;
 
     protected function setUp(): void
     {
+        $this->parser = new ParserService();
         $this->index = new SymbolIndex();
-        $this->indexer = new DocumentIndexer(new ParserService(), new SymbolExtractor(), $this->index);
+        $this->indexer = new DocumentIndexer($this->parser, new SymbolExtractor(), $this->index);
     }
 
     public function testIndexParsedIndexesTheGivenAstRatherThanReparsingTheDocument(): void
     {
-        // The document content declares a class, but the supplied AST is empty. If the
-        // indexer reparsed the content it would index the class; indexing the given AST
-        // means it must not — that is what lets the sink feed one parse to both stores.
-        $document = new TextDocument('file:///Reparse.php', 'php', 1, "<?php\nnamespace V;\nclass Reparsed {}\n");
+        // A document whose content declares a class, indexed against an empty AST: were
+        // the indexer to reparse the content it would index the class; indexing the AST
+        // it is given means it must not. That is what lets the sink feed one parse to
+        // both stores instead of each reparsing.
+        $document = new TextDocument('file:///User.php', 'php', 1, $this->loadFixture('src/Domain/User.php'));
 
         $this->indexer->indexParsed($document, []);
-
         self::assertNull(
-            $this->index->findByFqn('V\Reparsed'),
+            $this->index->findByFqn('Fixtures\Domain\User'),
             'indexParsed must index the supplied AST, not a reparse of the document content',
         );
-    }
 
-    public function testIndexParsedReplacesThePriorSymbolsForTheDocument(): void
-    {
-        $uri = 'file:///Doc.php';
-        $parser = new ParserService();
-
-        $first = new TextDocument($uri, 'php', 1, "<?php\nnamespace V;\nclass Alpha {}\n");
-        $this->indexer->indexParsed($first, $parser->parse($first) ?? []);
-        self::assertNotNull($this->index->findByFqn('V\Alpha'), 'the first AST must be indexed');
-
-        $second = new TextDocument($uri, 'php', 2, "<?php\nnamespace V;\nclass Beta {}\n");
-        $this->indexer->indexParsed($second, $parser->parse($second) ?? []);
-
-        self::assertNull($this->index->findByFqn('V\Alpha'), 'reindexing must clear the prior symbols');
-        self::assertNotNull($this->index->findByFqn('V\Beta'), 'reindexing must add the new symbols');
+        $this->indexer->indexParsed($document, $this->parser->parse($document) ?? []);
+        self::assertNotNull(
+            $this->index->findByFqn('Fixtures\Domain\User'),
+            'indexParsed must index the symbols in the AST it is given',
+        );
     }
 }

--- a/tests/Index/DocumentIndexerTest.php
+++ b/tests/Index/DocumentIndexerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\SymbolExtractor;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Parser\ParserService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * {@see DocumentIndexer::indexParsed} is the seam that lets the single write path
+ * (RFC 1 §4.3) hand one parse to the index rather than reparsing: the indexer
+ * indexes the AST it is given, so the sink and the indexer share a parse
+ * (Plan 0002 §5.5, Step 3a(iv)).
+ */
+final class DocumentIndexerTest extends TestCase
+{
+    private SymbolIndex $index;
+    private DocumentIndexer $indexer;
+
+    protected function setUp(): void
+    {
+        $this->index = new SymbolIndex();
+        $this->indexer = new DocumentIndexer(new ParserService(), new SymbolExtractor(), $this->index);
+    }
+
+    public function testIndexParsedIndexesTheGivenAstRatherThanReparsingTheDocument(): void
+    {
+        // The document content declares a class, but the supplied AST is empty. If the
+        // indexer reparsed the content it would index the class; indexing the given AST
+        // means it must not — that is what lets the sink feed one parse to both stores.
+        $document = new TextDocument('file:///Reparse.php', 'php', 1, "<?php\nnamespace V;\nclass Reparsed {}\n");
+
+        $this->indexer->indexParsed($document, []);
+
+        self::assertNull(
+            $this->index->findByFqn('V\Reparsed'),
+            'indexParsed must index the supplied AST, not a reparse of the document content',
+        );
+    }
+
+    public function testIndexParsedReplacesThePriorSymbolsForTheDocument(): void
+    {
+        $uri = 'file:///Doc.php';
+        $parser = new ParserService();
+
+        $first = new TextDocument($uri, 'php', 1, "<?php\nnamespace V;\nclass Alpha {}\n");
+        $this->indexer->indexParsed($first, $parser->parse($first) ?? []);
+        self::assertNotNull($this->index->findByFqn('V\Alpha'), 'the first AST must be indexed');
+
+        $second = new TextDocument($uri, 'php', 2, "<?php\nnamespace V;\nclass Beta {}\n");
+        $this->indexer->indexParsed($second, $parser->parse($second) ?? []);
+
+        self::assertNull($this->index->findByFqn('V\Alpha'), 'reindexing must clear the prior symbols');
+        self::assertNotNull($this->index->findByFqn('V\Beta'), 'reindexing must add the new symbols');
+    }
+}

--- a/tests/Knowledge/DocumentSymbolSinkTest.php
+++ b/tests/Knowledge/DocumentSymbolSinkTest.php
@@ -13,6 +13,8 @@ use Firehed\PhpLsp\Knowledge\DocumentSymbolSink;
 use Firehed\PhpLsp\Knowledge\OpenDocumentBackend;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,6 +26,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class DocumentSymbolSinkTest extends TestCase
 {
+    use LoadsFixturesTrait;
+
     private SymbolIndex $index;
     private OpenDocumentBackend $backend;
     private DocumentSymbolSink $sink;
@@ -118,31 +122,40 @@ final class DocumentSymbolSinkTest extends TestCase
         );
     }
 
-    public function testEveryRegisteredClassLikeIsAlsoIndexed(): void
+    #[DataProvider('classLikeFixtures')]
+    public function testEveryRegisteredClassLikeIsAlsoIndexed(string $fixture, string $fqn): void
     {
         // The lookup store and the symbol index are separate structures fed from one
-        // parse; the write path keeps them consistent (RFC 1 §4.3). Across every
-        // class-like kind, a name registered for lookup must also be indexed, so it is
-        // never resolvable through one surface yet invisible to the other.
-        $content = "<?php\nnamespace V;\n"
-            . "class TheClass {}\n"
-            . "interface TheInterface {}\n"
-            . "trait TheTrait {}\n"
-            . "enum TheEnum {}\n";
+        // parse; the write path keeps them consistent (RFC 1 §4.3). A name registered
+        // for lookup must also be indexed — never resolvable through one surface yet
+        // invisible to the other — across every class-like kind.
+        $uri = 'file:///' . $fixture;
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $this->loadFixture($fixture)));
 
-        $uri = 'file:///AllKinds.php';
-        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $content));
+        self::assertNotNull(
+            $this->backend->lookupClassLike(self::className($fqn)),
+            "{$fqn} must be registered for lookup",
+        );
+        self::assertNotNull(
+            $this->index->findByFqn($fqn),
+            "{$fqn} is registered for lookup so it must also be indexed (RFC 1 §4.3)",
+        );
+    }
 
-        foreach (['V\TheClass', 'V\TheInterface', 'V\TheTrait', 'V\TheEnum'] as $fqn) {
-            self::assertNotNull(
-                $this->backend->lookupClassLike(self::className($fqn)),
-                "{$fqn} must be registered for lookup",
-            );
-            self::assertNotNull(
-                $this->index->findByFqn($fqn),
-                "{$fqn} is registered for lookup so it must also be indexed (RFC 1 §4.3)",
-            );
-        }
+    /**
+     * A fixture per class-like kind, each with the FQN it declares.
+     *
+     * @codeCoverageIgnore
+     * @return array<string, array{string, string}>
+     */
+    public static function classLikeFixtures(): array
+    {
+        return [
+            'class' => ['src/Domain/User.php', 'Fixtures\Domain\User'],
+            'interface' => ['src/Domain/Entity.php', 'Fixtures\Domain\Entity'],
+            'trait' => ['src/Traits/HasTimestamps.php', 'Fixtures\Traits\HasTimestamps'],
+            'enum' => ['src/Enum/Status.php', 'Fixtures\Enum\Status'],
+        ];
     }
 
     public function testWriteSurvivesAMalformedDocument(): void

--- a/tests/Knowledge/DocumentSymbolSinkTest.php
+++ b/tests/Knowledge/DocumentSymbolSinkTest.php
@@ -36,6 +36,7 @@ final class DocumentSymbolSinkTest extends TestCase
         $this->sink = new DocumentSymbolSink(
             $this->backend,
             new DocumentIndexer($parser, new SymbolExtractor(), $this->index),
+            $this->index,
             new DefaultClassInfoFactory(),
             $parser,
         );
@@ -115,6 +116,33 @@ final class DocumentSymbolSinkTest extends TestCase
             $this->indexedFqnsFor($uri),
             'the index must clear too — both stores move together (RFC 1 §4.3)',
         );
+    }
+
+    public function testEveryRegisteredClassLikeIsAlsoIndexed(): void
+    {
+        // The lookup store and the symbol index are separate structures fed from one
+        // parse; the write path keeps them consistent (RFC 1 §4.3). Across every
+        // class-like kind, a name registered for lookup must also be indexed, so it is
+        // never resolvable through one surface yet invisible to the other.
+        $content = "<?php\nnamespace V;\n"
+            . "class TheClass {}\n"
+            . "interface TheInterface {}\n"
+            . "trait TheTrait {}\n"
+            . "enum TheEnum {}\n";
+
+        $uri = 'file:///AllKinds.php';
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $content));
+
+        foreach (['V\TheClass', 'V\TheInterface', 'V\TheTrait', 'V\TheEnum'] as $fqn) {
+            self::assertNotNull(
+                $this->backend->lookupClassLike(self::className($fqn)),
+                "{$fqn} must be registered for lookup",
+            );
+            self::assertNotNull(
+                $this->index->findByFqn($fqn),
+                "{$fqn} is registered for lookup so it must also be indexed (RFC 1 §4.3)",
+            );
+        }
     }
 
     public function testWriteSurvivesAMalformedDocument(): void


### PR DESCRIPTION
## Slice

- **Slice:** S3.4 — *One parse / one write path + consistency check*
- **Plan step:** Plan 0002 Step 3a(iv) (`docs/architecture/0002-execution-plan.md`)
- **RFC:** `0001-foundational-architecture.md` §4.3 (Read/Write Segregation — exactly one write path), §5.2 (SymbolSink write contract)

## What this does

Collapses the sink's double write into **one parse feeding both stores**, and adds a
consistency guard so the two structures cannot silently diverge.

Before, `DocumentSymbolSink::write()` registered class metadata and indexed symbols
via two independent code paths, each of which parsed the document (the content-keyed
parse memo made this one *actual* parse, but two parse calls / two extraction
entries). Now the sink parses once and feeds that single AST to both the class-lookup
registration and the symbol index:

- `DocumentIndexer::indexParsed(TextDocument, array $ast)` indexes a supplied AST
  instead of reparsing; `index()` is now `parse()` → `indexParsed()`. The sink drives
  the index through `indexParsed`, so the indexer no longer reparses.
- The two stores stay distinct structures (Plan 0002 §5.5 permits this — `ClassInfo`
  for lookup, lightweight `Symbol`s for enumeration/search), but are written
  transactionally from the one AST.

Because the Step P parity harness compares only observable outputs, an internal
divergence between the two structures could pass parity. `assertStoresAgree()` guards
the invariant directly: every class-like registered for lookup must also be present in
the symbol index, so a name is never resolvable through one surface yet invisible to
the other. The check is one-directional — the index is a legitimate superset (it also
records class-likes declared inside conditional/nested statements, which the top-level
lookup registration does not), so the reverse would false-positive on valid PHP. The
divergence branch is an unreachable `LogicException`.

This discharges the Teardown-ledger row *"Step 2 facade hides today's double write
(§5.5) → Step 3a(iv)"*: the scaffolding was the double write inside the sink (S3.3
already replaced the illustrative `DelegatingSymbolSource` with `DocumentSymbolSink`),
now collapsed.

**Behavior-preserving (Step 3a):** the Step P parity goldens (class-like lookup,
`childrenOf`, prefix-search, write-path symbol state) are unchanged and the full suite
is green. The consistency guard is a new *internal* invariant, so it carries its own
unit coverage rather than a parity golden.

## Acceptance criteria

- [x] One parse per `didOpen`/`didChange` write, feeding both stores (the sink parses; the indexer no longer reparses — `indexParsed`)
- [x] The two structures may stay distinct, written transactionally from the same parse (§4.3, Plan 0002 §5.5)
- [x] Consistency check that both stores are written from the same parse and agree (`assertStoresAgree`)
- [x] Teardown-ledger row (Step 2 double write, §5.5) discharged
- [x] Behavior-preserving: Step P parity goldens unchanged; full suite green

## Candidate closes

None — the manifest lists no `Closes` for S3.4.
