### PR TITLE
Freeze the function surface and add the builtin enumeration oracle

### DIFF
--- a/tests/Parity/BuiltinFunctionParityTest.php
+++ b/tests/Parity/BuiltinFunctionParityTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Parity;
+
+use Firehed\PhpLsp\Cache\CacheFactory;
+use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
+use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\ReflectionNamespaceSource;
+use Firehed\PhpLsp\Knowledge\BuiltinBackend;
+use Firehed\PhpLsp\Knowledge\NamespaceName;
+use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
+use Firehed\PhpLsp\Resolution\NameKind;
+use Firehed\PhpLsp\Utility\NamespacePath;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Reflection-oracle parity for the built-in backend's *function* enumeration:
+ * what `BuiltinBackend::childrenOf()` reports as functions must be exactly what
+ * `get_defined_functions()['internal']` reports, name for name.
+ *
+ * This is an oracle, not a golden. The built-in function list differs across the
+ * 8.3/8.4/8.5 CI matrix and with the extensions a machine happens to load, so it
+ * cannot be frozen — but it can be compared against the same runtime truth the
+ * production path reads today (`FunctionCandidates` calls
+ * `get_defined_functions()` directly). That makes the comparison version-agnostic
+ * in the same way `TypeGraphParityTest` uses reflection as the oracle for member
+ * resolution.
+ *
+ * Why it exists now, in the slice *before* the migration: Step 3b moves function
+ * completion off its direct `get_defined_functions()` call and onto the backend.
+ * Freezing the shape of that path's output is the function-surface golden's job
+ * ({@see FunctionSurfaceParityTest}); proving the backend can supply the same
+ * *set* of names is this test's, and it has to be true before the migration is
+ * attempted, not after.
+ *
+ * Note the two sides are not trivially the same call: reflection produces a flat
+ * list of names, while the backend files each name under the namespace it
+ * carries (an extension may declare namespaced functions) and answers one
+ * namespace at a time. A name filed under the wrong namespace, or dropped while
+ * indexing, fails here.
+ *
+ * See docs/architecture/0002-execution-plan.md, Step 3b; RFC 1 §4.2, §4.7, §5.3.
+ */
+final class BuiltinFunctionParityTest extends TestCase
+{
+    private BuiltinBackend $backend;
+
+    protected function setUp(): void
+    {
+        // Assembled exactly as `KnowledgeStack::forProject` assembles the lowest-
+        // precedence backend, so the oracle measures the shipped configuration.
+        $this->backend = new BuiltinBackend(
+            new DefaultClassInfoFactory(),
+            new CachedNamespaceCatalog(new ReflectionNamespaceSource(), CacheFactory::inMemory()),
+            CacheFactory::inMemory(),
+        );
+    }
+
+    public function testEnumeratedFunctionsMatchReflection(): void
+    {
+        $expected = get_defined_functions()['internal'];
+        sort($expected);
+
+        $enumerated = $this->enumerateFunctions(self::namespacesOf($expected));
+        sort($enumerated);
+
+        self::assertSame(
+            $expected,
+            $enumerated,
+            'the built-in backend must enumerate exactly the internal functions reflection reports',
+        );
+    }
+
+    public function testGlobalNamespaceCarriesTheBulkOfTheFunctions(): void
+    {
+        // Guards the assertion above against a degenerate pass: if the backend
+        // returned nothing *and* reflection somehow reported nothing, two empty
+        // lists would still be `assertSame`. PHP's global built-ins are in the
+        // hundreds on any build, so a floor well below the real count fails loudly
+        // on an empty enumeration without pinning a version-fragile number.
+        $global = $this->enumerateFunctions(['']);
+
+        self::assertGreaterThan(
+            500,
+            count($global),
+            'the global namespace must enumerate PHP\'s built-in functions, not an empty set',
+        );
+        self::assertContains(
+            'array_map',
+            $global,
+            'a well-known global built-in must be enumerated under the global namespace',
+        );
+    }
+
+    /**
+     * @param list<string> $namespaces
+     *
+     * @return list<string>
+     */
+    private function enumerateFunctions(array $namespaces): array
+    {
+        $functions = [];
+        foreach ($namespaces as $namespace) {
+            foreach ($this->backend->childrenOf(new NamespaceName($namespace))->symbols as $symbol) {
+                if ($symbol->kind === NameKind::Function_) {
+                    $functions[] = self::qualifiedName($symbol);
+                }
+            }
+        }
+
+        return $functions;
+    }
+
+    /**
+     * The distinct namespaces the reflected names live in — the global namespace
+     * for core, plus any namespace an extension declares functions in.
+     *
+     * @param list<string> $names
+     *
+     * @return list<string>
+     */
+    private static function namespacesOf(array $names): array
+    {
+        $namespaces = [];
+        foreach ($names as $name) {
+            $namespaces[NamespacePath::namespaceOf($name)] = true;
+        }
+
+        return array_keys($namespaces);
+    }
+
+    /**
+     * `get_defined_functions()` reports names lowercased, so the comparison is
+     * made in that casing. Function names are case-insensitive in PHP, so this
+     * normalizes a spelling difference, not a real one.
+     */
+    private static function qualifiedName(CatalogSymbol $symbol): string
+    {
+        return strtolower($symbol->fullyQualifiedName);
+    }
+}

--- a/tests/Parity/FunctionSurfaceParityTest.php
+++ b/tests/Parity/FunctionSurfaceParityTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Parity;
+
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
+use Firehed\PhpLsp\Completion\FunctionCandidates;
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\SymbolIndex;
+use Firehed\PhpLsp\Knowledge\KnowledgeStack;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Golden parity for the function-completion surface — `FunctionCandidates::find()`,
+ * which Step 3b migrates off its direct `get_defined_functions()` call and onto
+ * `SymbolSource::search`.
+ *
+ * Step 3b both changes and preserves behavior here: the project reach it adds is
+ * new, but the built-in and open-document function completion that exists today
+ * must not regress. This golden is therefore captured *before* the migration, from
+ * today's path, and is the preservation half's acceptance: after the migration
+ * these queries must still produce these items, byte for byte.
+ *
+ * ## Determinism
+ *
+ * The built-in function list is version- and extension-fragile, so a broad prefix
+ * cannot be frozen: `arr` alone shifts between 8.3, 8.4 and 8.5. Every prefix
+ * queried below is instead narrow enough that its built-in matches are a single
+ * long-stable core function, in the same way `ChildrenOfParityTest` freezes only
+ * namespaces that hold no reflected symbols. The version-fragile *breadth* is
+ * covered by {@see testBuiltinFunctionsReachTheSurfaceInBulk} and, name for name,
+ * by {@see BuiltinFunctionParityTest}.
+ *
+ * Order is part of the surface too — document functions precede built-ins, which
+ * is what puts a project's own helper above a similarly-named built-in. No golden
+ * query can freeze that (the prefixes narrow enough to be stable match one half or
+ * the other, never both), so it is asserted separately in
+ * {@see testDocumentFunctionsPrecedeBuiltins}.
+ *
+ * See docs/architecture/0002-execution-plan.md, Step P and Step 3b; RFC 1 §4.2.
+ */
+final class FunctionSurfaceParityTest extends TestCase
+{
+    use AssertsGolden;
+
+    /**
+     * The fixture whose top-level functions the surface should report: one with a
+     * docblock and typed parameters (so `detail` and `documentation` are frozen,
+     * not just the label), one without.
+     */
+    private const string DOCUMENT_WITH_FUNCTIONS = 'src/Completion/FunctionCompletion.php';
+
+    /**
+     * A fixture declaring no top-level functions, used to prove the document half
+     * of the surface is scoped to the document asked about rather than to
+     * everything indexed.
+     */
+    private const string DOCUMENT_WITHOUT_FUNCTIONS = 'src/Domain/User.php';
+
+    private string $fixturesRoot;
+    private SymbolResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->fixturesRoot = dirname(__DIR__) . '/Fixtures';
+
+        $parser = new ParserService();
+        $knowledge = KnowledgeStack::forProject(
+            ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot),
+            $this->fixturesRoot . '/vendor',
+            $parser,
+            new SymbolIndex(),
+        );
+        $memberResolver = new MemberResolver($knowledge->source);
+
+        $this->resolver = new SymbolResolver(
+            $parser,
+            $knowledge->source,
+            $memberResolver,
+            new BasicTypeResolver($memberResolver, new DefaultFunctionRepository()),
+            new DefaultFunctionRepository(),
+        );
+    }
+
+    public function testFunctionCompletionMatchesGolden(): void
+    {
+        $queries = [
+            // A document function: label, signature detail, and the description
+            // lifted from its docblock.
+            'document|calc' => [self::DOCUMENT_WITH_FUNCTIONS, 'calc', false],
+            // The same query with snippet support declared, which is the only
+            // capability that reshapes an item on this surface (RFC 1 §4.8).
+            'document|calc+snippet' => [self::DOCUMENT_WITH_FUNCTIONS, 'calc', true],
+            // Prefix matching is case-insensitive; a case-sensitive regression
+            // returns nothing here.
+            'document|CALCULATE' => [self::DOCUMENT_WITH_FUNCTIONS, 'CALCULATE', false],
+            // A document function with no docblock: no `documentation` key, and a
+            // return type the signature detail must still carry.
+            'document|getConfig' => [self::DOCUMENT_WITH_FUNCTIONS, 'getConfig', false],
+            // Built-ins reach the surface, and carry no signature detail today.
+            'builtin|str_contains' => [self::DOCUMENT_WITH_FUNCTIONS, 'str_contains', false],
+            'builtin|str_contains+snippet' => [self::DOCUMENT_WITH_FUNCTIONS, 'str_contains', true],
+            'builtin|array_map' => [self::DOCUMENT_WITH_FUNCTIONS, 'array_map', false],
+            // The document half is scoped to the document asked about: this one
+            // declares no functions, and no built-in matches the prefix.
+            'other-document|calc' => [self::DOCUMENT_WITHOUT_FUNCTIONS, 'calc', false],
+            // A prefix nothing matches, so an over-eager source shows up as a diff.
+            'no-match|zzzz' => [self::DOCUMENT_WITH_FUNCTIONS, 'zzzz', false],
+        ];
+
+        $captured = [];
+        foreach ($queries as $label => [$fixture, $prefix, $snippetSupport]) {
+            $captured[$label] = $this->candidates($snippetSupport)->find($prefix, $this->document($fixture));
+        }
+
+        $this->assertGoldenMatches('function-surface', $captured);
+    }
+
+    public function testBuiltinFunctionsReachTheSurfaceInBulk(): void
+    {
+        // The golden's prefixes are narrow by necessity, so on their own they
+        // could stay green while the built-in half collapsed to a handful of
+        // names. The exact set is version-fragile and is asserted against
+        // reflection in BuiltinFunctionParityTest; here only that the surface
+        // passes through the bulk of it.
+        $items = $this->candidates(false)->find('array_', $this->document(self::DOCUMENT_WITHOUT_FUNCTIONS));
+
+        $labels = array_column($items, 'label');
+
+        self::assertGreaterThan(
+            50,
+            count($labels),
+            'the built-in array_* family must reach the completion surface, not a token few',
+        );
+        self::assertContains(
+            'array_filter',
+            $labels,
+            'a built-in matched only by a broad prefix must still be offered',
+        );
+    }
+
+    public function testDocumentFunctionsPrecedeBuiltins(): void
+    {
+        // An empty prefix matches everything, so the tail is the whole
+        // version-fragile built-in list — but the head is not: the document's own
+        // functions are emitted first, in declaration order. A migration that
+        // merged the two halves into one ranked list would reorder this.
+        $items = $this->candidates(false)->find('', $this->document(self::DOCUMENT_WITH_FUNCTIONS));
+
+        self::assertSame(
+            ['calculateSum', 'getConfig'],
+            array_slice(array_column($items, 'label'), 0, 2),
+            'a document\'s own functions must be offered ahead of the built-ins',
+        );
+    }
+
+    private function candidates(bool $snippetSupport): FunctionCandidates
+    {
+        $capabilities = self::createStub(SessionCapabilitiesProvider::class);
+        $capabilities->method('getSessionCapabilities')
+            ->willReturn(new SessionCapabilities(snippetSupport: $snippetSupport));
+
+        return new FunctionCandidates($this->resolver, $capabilities);
+    }
+
+    private function document(string $relativePath): TextDocument
+    {
+        $path = $this->fixturesRoot . '/' . $relativePath;
+        $content = file_get_contents($path);
+        self::assertNotFalse($content, "fixture document should be readable: {$relativePath}");
+
+        return new TextDocument('file://' . $path, 'php', 0, $content);
+    }
+}

--- a/tests/Parity/README.md
+++ b/tests/Parity/README.md
@@ -2,7 +2,7 @@
 
 This harness gates the behavior-preserving migrations in Steps 2–4 of
 `docs/architecture/0002-execution-plan.md`. `TypeGraphParityTest` covers member
-resolution; this covers the four surfaces those steps move consumers onto:
+resolution; this covers the surfaces those steps move consumers onto:
 
 | Surface | Production entry point | Golden |
 |---|---|---|
@@ -10,6 +10,21 @@ resolution; this covers the four surfaces those steps move consumers onto:
 | namespace enumeration | `SymbolSource::childrenOf()` | `goldens/children-of.json` |
 | prefix search | `SymbolIndex::findByPrefix()` | `goldens/prefix-search.json` |
 | document write path | open/update/close symbol state | `goldens/write-path.json` |
+| function completion | `FunctionCandidates::find()` | `goldens/function-surface.json` |
+
+The function surface is frozen ahead of the step that changes it: Step 3b moves
+function completion off its direct `get_defined_functions()` call and onto
+`SymbolSource::search`, adding project reach it does not have today. The new reach
+is proven by new fixtures in that slice; the golden is the *preservation* half of
+its acceptance — built-in and open-document function completion must survive the
+migration unchanged.
+
+Alongside it, `BuiltinFunctionParityTest` is an **oracle, not a golden**: it asserts
+the built-in backend enumerates exactly the functions `get_defined_functions()`
+reports, the way `TypeGraphParityTest` uses reflection as the oracle for members.
+That is what makes the version-fragile half of the function surface checkable at
+all — the set cannot be frozen, but it can be compared against the runtime truth
+the production path reads today.
 
 Each surface's observable output over a curated fixture corpus is captured once,
 spot-audited, committed, and diffed on every run. A behavior-preserving step must
@@ -60,8 +75,12 @@ is correct. Recapture is deliberate, not a way to make a red run pass.
 Goldens are frozen only over inputs that are identical across the CI PHP matrix
 (8.3 / 8.4 / 8.5): in-repo fixtures and the locked `psr/http-message` dependency.
 Built-in symbols (reflection) are version-fragile, so they are covered by
-stable-subset assertions instead of being frozen. Absolute paths are relativized
-to the repo root so a golden does not embed the machine it was captured on.
+stable-subset assertions instead of being frozen. Each surface picks the queries
+that keep that true: `children-of` enumerates only namespaces holding no reflected
+symbols, and `function-surface` queries only prefixes narrow enough to match a
+single long-stable core function (`arr` shifts between 8.3 and 8.5; `array_map`
+does not). Absolute paths are relativized to the repo root so a golden does not
+embed the machine it was captured on.
 
 ## Surface coverage (the corpus-gap check)
 

--- a/tests/Parity/goldens/function-surface.json
+++ b/tests/Parity/goldens/function-surface.json
@@ -1,0 +1,57 @@
+{
+    "document|calc": [
+        {
+            "label": "calculateSum",
+            "kind": 3,
+            "detail": "function calculateSum(int $a, int $b): int",
+            "documentation": "Adds two numbers."
+        }
+    ],
+    "document|calc+snippet": [
+        {
+            "label": "calculateSum",
+            "kind": 3,
+            "detail": "function calculateSum(int $a, int $b): int",
+            "documentation": "Adds two numbers.",
+            "insertText": "calculateSum($0)",
+            "insertTextFormat": 2
+        }
+    ],
+    "document|CALCULATE": [
+        {
+            "label": "calculateSum",
+            "kind": 3,
+            "detail": "function calculateSum(int $a, int $b): int",
+            "documentation": "Adds two numbers."
+        }
+    ],
+    "document|getConfig": [
+        {
+            "label": "getConfig",
+            "kind": 3,
+            "detail": "function getConfig(): Fixtures\\Completion\\Config"
+        }
+    ],
+    "builtin|str_contains": [
+        {
+            "label": "str_contains",
+            "kind": 3
+        }
+    ],
+    "builtin|str_contains+snippet": [
+        {
+            "label": "str_contains",
+            "kind": 3,
+            "insertText": "str_contains($0)",
+            "insertTextFormat": 2
+        }
+    ],
+    "builtin|array_map": [
+        {
+            "label": "array_map",
+            "kind": 3
+        }
+    ],
+    "other-document|calc": [],
+    "no-match|zzzz": []
+}


### PR DESCRIPTION
Slice **S3.6** (build manifest) — plan step **3b** (`docs/architecture/0002-execution-plan.md`), RFC 1 **§4.2**, **§4.7**, **§5.3**; Step **P** harness.

Step 3b both changes and preserves behavior on the function surface: the project reach it adds is new, but built-in and open-document function completion is existing behavior that must not regress. This slice lands the two artifacts that make the preservation half checkable, ahead of the migration that needs them. No production code changes.

## What's here

**Function-surface golden** (`tests/Parity/FunctionSurfaceParityTest`, `goldens/function-surface.json`) — freezes `FunctionCandidates::find()` as it behaves today (`get_defined_functions()` internals plus open-document functions). The built-in list is version- and extension-fragile, so every frozen prefix is narrow enough to match a single long-stable core function, the same way `ChildrenOfParityTest` freezes only namespaces holding no reflected symbols. The queries cover signature `detail`, docblock `documentation`, the snippet reshaping, case-insensitive matching, document scoping, and the empty result. Two things no golden query can pin are asserted separately: that built-ins reach the surface in bulk, and that a document's own functions are offered ahead of them.

**Builtin enumeration oracle** (`tests/Parity/BuiltinFunctionParityTest`) — asserts `BuiltinBackend::childrenOf()` enumerates exactly the functions `get_defined_functions()` reports, name for name, in the manner `TypeGraphParityTest` uses reflection as the oracle for members. The two sides are not the same call: reflection yields a flat list, while the backend files each name under the namespace it carries and answers one namespace at a time. A guard assertion keeps two empty lists from passing as agreement.

The parity README gains the surface row, the oracle, and the per-surface determinism rule.

## Acceptance criteria

- [x] The function-surface golden is captured from today's path and committed before the 3b migration touches it
- [x] The golden is deterministic across the 8.3 / 8.4 / 8.5 CI matrix
- [x] Item shape is frozen, not just labels — signature detail, docblock documentation, and snippet fields
- [x] A parity oracle asserts the Builtin backend's function enumeration matches `get_defined_functions()`
- [x] The oracle exercises the backend as `KnowledgeStack::forProject` assembles it
- [x] `tests/Parity/README.md` documents the new surface and the oracle
- [x] No production behavior change; existing goldens unchanged

## Notes

- The oracle is reflection-backed, so it stays valid only while the Builtin backend is (the tracked §4.7 gap, deferred to Step 5). Plan 0002 §5 already flags retiring or re-pointing it as part of that step.
- The golden's corpus reuses `src/Completion/FunctionCompletion.php` and `src/Domain/User.php` rather than growing the shared parity corpus. Editing either now shifts this golden — the documented recapture-and-review contract.

Candidate closes (pending review verification): none listed in the manifest for this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
