### PR TITLE
Schedule three unowned removals as SC.1-SC.3

### DIFF
--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -83,7 +83,9 @@ Notes:
   `autoload.files` is an explicit, usually tiny list. So their project reach is a
   small, bounded index of that set — not a project walk.
 - Background/eager indexing is optional and bounded (§5.3). `WorkspaceIndexer` is
-  revived only if/when the workspace scope is taken up; otherwise it is deleted.
+  revived only if/when the workspace scope is taken up; otherwise it is deleted — which
+  is slice **SC.1**, since it is dead today (zero references) and the workspace scope is
+  not scheduled. Reviving it later is cheaper than carrying dead code until then.
 - On-disk backends cache **derived info** (`ClassInfo`, symbols — small), never raw
   ASTs. `ClassRepository` already does this; preserve it.
 - Reach is scoped to declarations the model can *locate*: PSR-4 / classmap classes,
@@ -373,11 +375,21 @@ row must be discharged at the Definition of Done (Step Z).
     TextFallbackHelper breadth (narrow to FQN recovery)       Step 4
     CodeResolver knowledge-facing methods                     Step 4
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
-    WorkspaceIndexer (dead today)                             §3 note (delete unless workspace scope taken)
+    WorkspaceIndexer (dead today)                             SC.1
+    ScopeFinder::extractImports/resolveFromUseStatements       SC.2
+    Hand-rolled namespace tracking (SymbolExtractor,           SC.3
+      FilesystemBackend::findClassInAst)
 
 A scaffold with no discharged remover by Step Z is a defect, not an acceptable end
 state. Conversely, the Step P parity harness is deliberately **not** on this ledger:
 it is a permanent regression net kept past Step Z, not scaffolding to remove.
+
+The `SC.*` rows are **pre-existing** duplication and dead code, not scaffolding this
+plan introduced — so no step's acceptance covers them, which is how they stayed
+unowned. They are listed anyway: the series exists to remove duplication, so a
+known-removable thing without an owning slice is the same defect as an undischarged
+scaffold. A remover must be a slice id; a prose note is not an owner, because
+`/do-next` cannot select one.
 
 ### Step Z — Definition of Done (final verification gate)
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -72,7 +72,10 @@ Definition-of-Done gate.
     S4.4   4     Extract name-context resolver                      S4.2              —
     S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
     S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
-    SZ.1   Z     Definition of Done gate                            S3.10,S4.6        —
+    SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
+    SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
+    SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
+    SZ.1   Z     Definition of Done gate                            S3.10,S4.6,SC.1,SC.2,SC.3  —
 
 Notes:
 
@@ -95,6 +98,23 @@ Notes:
   AST-in signature; S4.5/S4.6 the `SymbolResolver` god class, `TextFallbackHelper`
   breadth, and the `CodeResolver` knowledge-facing methods. SZ.1 verifies the ledger is
   fully discharged.
+- **The SC.* slices carry no step, on purpose.** They are duplication and dead code that
+  predate the plan rather than scaffolding it introduced, so no step's acceptance covers
+  them — which is exactly how they went unowned until an audit found them. They are in
+  the table so `/do-next` can select them and SZ.1 can require them, not because a step
+  produced them. A removal with no owning slice is a defect; put it here.
+  - **SC.1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`. It was
+    previously a ledger row whose remover was a *§3 note*, which no slice could discharge.
+  - **SC.2** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were superseded
+    by `NameContextFactory` and their own docblock says they go away once #331 moves the
+    callers. #331 landed (#337); three callers did not move (`SymbolResolver` ×2,
+    `TextFallbackHelper` ×1). Gated on S4.4/S4.5, which rewrite exactly those sites.
+  - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
+    `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
+    `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
+    `ScopeFinder`, and `DeclarationScanner` all read). Behavior-preserving, so the Step P
+    write-path and class-like-lookup goldens prove it. `SymbolExtractor`'s `Class::method`
+    FQNs are its own and stay.
 - **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
   §4.7** (0002 §5 known gap) — file the tracked §4.7 issue when S3.3 lands; its fix is
   the deferred Step 5.


### PR DESCRIPTION
An audit of `src/` against the teardown ledger found three removable things that **no slice owns**, so no `/do-next` iteration can select them and Step Z would meet them as undischarged. This gives each one a slice id and a ledger row. Docs only — no code changes.

The series' explicit goal is removing duplication, so a known-removable thing without an owning slice is the same defect as an undischarged scaffold. The ledger already said that about scaffolding; it now says it about these too.

## What was unowned

**SC.1 — `Index/WorkspaceIndexer`.** Zero references in `src/` or `tests/`. It *had* a ledger row, but its remover column read *"§3 note (delete unless workspace scope taken)"* — a prose note, which `/do-next` cannot select. The workspace scope is not scheduled, so reviving it later is cheaper than carrying dead code until then.

**SC.2 — `ScopeFinder::extractImports` / `resolveFromUseStatements`.** Superseded by `NameContextFactory`; the method's own docblock says *"its callers are moved over in #331, after which it goes away."* #331 landed as #337, but three callers did not move — `SymbolResolver:652`, `SymbolResolver:914`, `TextFallbackHelper:418`. Absent from the ledger entirely. Gated on S4.4/S4.5, which rewrite exactly those sites.

**SC.3 — hand-rolled namespace tracking.** `ParserService` runs `NameResolver`, which populates `namespacedName`; `DefaultClassInfoFactory`, `DefaultFunctionRepository`, `ScopeFinder`, and `DeclarationScanner` all read it. But `SymbolExtractor` and `FilesystemBackend::findClassInAst` each keep a `private string $namespace` and rebuild FQNs by hand from `Stmt\Namespace_` — two hand-rolled copies of data the parser already computed. Behavior-preserving, so the Step P write-path and class-like-lookup goldens prove it. `SymbolExtractor`'s `Class::method` FQNs are genuinely its own and stay.

## Changes

- `build-manifest.md` — adds SC.1–SC.3 rows with dependencies, and a note explaining why they carry no `Step` (they are pre-existing, not scaffolding any step introduced — which is how they went unowned).
- `0002-execution-plan.md` — three teardown-ledger rows; the `WorkspaceIndexer` row now names SC.1 instead of a note; §3's `WorkspaceIndexer` bullet points at SC.1; a paragraph stating that a remover must be a slice id, because a prose note is not an owner.
- `SZ.1` now depends on SC.1–SC.3, so the Definition of Done gate cannot pass while any remain.

## Verified as already scheduled

Not part of this PR, confirmed as having owners: `FunctionRepository` / `DefaultFunctionRepository`, `getFileFunctions`, and the §4.2 function-path exemption (S3.10); `FunctionCandidates` on the old path (S3.9); the `SymbolResolver` god class, `TextFallbackHelper` breadth, and `CodeResolver` knowledge-facing methods (Step 4). The Step 2 facade and duplicate `ComposerAutoloadMap` rows are already discharged (S3.4, S3.2).

Candidate closes (pending review verification): none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
