### PR TITLE
Dedupe the hand-rolled file:// conversion behind FileUri

### DIFF
--- a/src/Document/FileUri.php
+++ b/src/Document/FileUri.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Document;
+
+/**
+ * Converts between the `file://` URIs LSP identifies documents by and the
+ * filesystem paths the autoload maps and the parser work in.
+ *
+ * A URI percent-encodes reserved characters and a path does not, so the two
+ * directions are not string concatenation: skipping the decode makes a path
+ * containing a space or `#` silently wrong, and only shows up on the machines whose
+ * checkout happens to sit under such a directory.
+ */
+final class FileUri
+{
+    private const string SCHEME = 'file://';
+
+    /**
+     * A path that is not a `file://` URI is returned unchanged: callers hold
+     * identifiers from several sources and a bare path must not be mangled.
+     */
+    public static function toPath(string $uri): string
+    {
+        if (!str_starts_with($uri, self::SCHEME)) {
+            return $uri;
+        }
+
+        return rawurldecode(substr($uri, strlen(self::SCHEME)));
+    }
+
+    public static function fromPath(string $path): string
+    {
+        // Directory separators are structure rather than data, so they are restored
+        // after encoding rather than escaped into %2F.
+        return self::SCHEME . str_replace('%2F', '/', rawurlencode($path));
+    }
+}

--- a/src/Index/Location.php
+++ b/src/Index/Location.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
+use Firehed\PhpLsp\Document\FileUri;
+
 final readonly class Location
 {
     public function __construct(
@@ -24,7 +26,10 @@ final readonly class Location
         if ($file === null || $line === null) {
             return null;
         }
-        $uri = str_starts_with($file, 'file://') ? $file : 'file://' . $file;
+        // Callers pass either a path or an already-formed URI, so normalize through
+        // the one conversion seam rather than concatenating: this URI goes to the
+        // client, and an unencoded space or `#` in it is not a valid URI.
+        $uri = FileUri::fromPath(FileUri::toPath($file));
         return new self($uri, $line - 1, 0, $line - 1, 0);
     }
 

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Cache\CacheKey;
 use Firehed\PhpLsp\Cache\Invalidatable;
+use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
@@ -97,7 +98,7 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
      */
     public function invalidate(string $uri): void
     {
-        $path = self::pathFromUri($uri);
+        $path = FileUri::toPath($uri);
         foreach ($this->cacheKeysByPath[$path] ?? [] as $cacheKey) {
             $this->cache->delete($cacheKey);
         }
@@ -119,22 +120,6 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
         return [];
     }
 
-    /**
-     * The filesystem path a `file://` document URI addresses, matching the paths
-     * the locator produces (which are what {@see $cacheKeysByPath} is keyed by). A
-     * URI percent-encodes reserved characters; the locator's path does not, so the
-     * scheme is stripped and the remainder decoded. A path that is not a `file://`
-     * URI is returned unchanged.
-     */
-    private static function pathFromUri(string $uri): string
-    {
-        if (!str_starts_with($uri, 'file://')) {
-            return $uri;
-        }
-
-        return rawurldecode(substr($uri, strlen('file://')));
-    }
-
     private function parseClassFrom(ClassName $name, string $filePath): ?ClassInfo
     {
         $content = file_get_contents($filePath);
@@ -146,7 +131,7 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
             // @codeCoverageIgnoreEnd
         }
 
-        $uri = 'file://' . $filePath;
+        $uri = FileUri::fromPath($filePath);
         $document = new TextDocument($uri, 'php', 0, $content);
         $ast = $this->parser->parse($document);
         if ($ast === null) {

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -701,5 +701,4 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
         }
         return Visibility::Public;
     }
-
 }

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Repository;
 
+use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
@@ -34,7 +35,7 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
     public function fromAstNode(Stmt\ClassLike $node, string $uri): ClassInfo
     {
         $className = $this->resolveClassName($node);
-        $filePath = $this->uriToPath($uri);
+        $filePath = FileUri::toPath($uri);
 
         return new ClassInfo(
             name: $className,
@@ -701,11 +702,4 @@ final class DefaultClassInfoFactory implements ClassInfoFactory
         return Visibility::Public;
     }
 
-    private function uriToPath(string $uri): string
-    {
-        if (str_starts_with($uri, 'file://')) {
-            return substr($uri, 7);
-        }
-        return $uri;
-    }
 }

--- a/tests/Document/FileUriTest.php
+++ b/tests/Document/FileUriTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Document;
+
+use Firehed\PhpLsp\Document\FileUri;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FileUri::class)]
+final class FileUriTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function uriAndPath(): iterable
+    {
+        yield 'plain' => ['file:///app/src/User.php', '/app/src/User.php'];
+        yield 'encoded space' => ['file:///app/my%20project/User.php', '/app/my project/User.php'];
+        yield 'encoded hash' => ['file:///app/a%23b/User.php', '/app/a#b/User.php'];
+    }
+
+    #[DataProvider('uriAndPath')]
+    public function testToPathStripsTheSchemeAndDecodes(string $uri, string $path): void
+    {
+        self::assertSame(
+            $path,
+            FileUri::toPath($uri),
+            'a URI percent-encodes reserved characters; a filesystem path does not',
+        );
+    }
+
+    #[DataProvider('uriAndPath')]
+    public function testFromPathAddsTheSchemeAndEncodes(string $uri, string $path): void
+    {
+        self::assertSame($uri, FileUri::fromPath($path), 'the conversion must round-trip');
+    }
+
+    public function testToPathLeavesANonFileUriUnchanged(): void
+    {
+        // Callers hold paths and URIs from several sources; a bare path passed here
+        // is returned as-is rather than mangled.
+        self::assertSame('/already/a/path.php', FileUri::toPath('/already/a/path.php'));
+    }
+
+    public function testFromPathDoesNotEncodeDirectorySeparators(): void
+    {
+        self::assertSame(
+            'file:///a/b/c.php',
+            FileUri::fromPath('/a/b/c.php'),
+            'separators are structure, not data, and must survive encoding',
+        );
+    }
+}

--- a/tests/Index/LocationTest.php
+++ b/tests/Index/LocationTest.php
@@ -67,6 +67,27 @@ class LocationTest extends TestCase
         self::assertSame(4, $location->startLine);
     }
 
+    public function testFromFileLineEncodesReservedCharactersInThePath(): void
+    {
+        // This URI is what a definition or hover response carries to the client, so
+        // it has to be a valid URI: a workspace under a directory with a space is
+        // common on macOS, and `#` would otherwise start a fragment.
+        $location = Location::fromFileLine('/My Projects/a#b/file.php', 3);
+
+        self::assertNotNull($location);
+        self::assertSame('file:///My%20Projects/a%23b/file.php', $location->uri);
+    }
+
+    public function testFromFileLineLeavesAnEncodedUriUnchanged(): void
+    {
+        // Callers pass either form, so normalizing must be idempotent rather than
+        // double-encoding the `%` of an already-encoded URI.
+        $location = Location::fromFileLine('file:///My%20Projects/file.php', 3);
+
+        self::assertNotNull($location);
+        self::assertSame('file:///My%20Projects/file.php', $location->uri);
+    }
+
     public function testFromFileLineWithNullFile(): void
     {
         $location = Location::fromFileLine(null, 10);


### PR DESCRIPTION
Slice **SC.4**: `file://` URI and path conversion was hand-rolled in three live places,
each handling the scheme slightly differently and none of them consistently handling
percent-encoding. One `FileUri` replaces them.

Pre-existing duplication owned by no plan step, which is what the SC.* block is for. It
surfaced while splitting S3.7, whose locator wanted a fourth copy; S3.7c is gated on this
landing rather than adding one.

## The three sites

| Site | Before | After |
|---|---|---|
| `FilesystemBackend` | private `pathFromUri` (decoded) + `'file://' . $path` | `FileUri::toPath` / `FileUri::fromPath` |
| `DefaultClassInfoFactory` | private `uriToPath` — stripped the scheme, **did not decode** | `FileUri::toPath` |
| `Location::fromFileLine` | `str_starts_with(...) ? $file : 'file://' . $file` — **never encoded** | normalized through the seam |

## Two behavior fixes fall out

Both were latent: they only appear when the workspace sits under a path containing a
reserved character, which is ordinary on macOS (`~/My Projects/...`).

- `DefaultClassInfoFactory` did not decode, so a class in a directory with a space
  produced a path that does not exist on disk.
- `Location::fromFileLine` did not encode, and its output is what a definition or hover
  response carries **to the client** — an unencoded space or `#` makes that an invalid
  URI. Covered by a test committed red before the fix.

## Not in scope

`WorkspaceIndexer:61` holds a fourth copy and is deliberately untouched: it is dead code
with zero references, and slice SC.1 deletes the file outright.
