### PR TITLE
Read autoload.files into ComposerAutoloadMap

### DIFF
--- a/src/Index/ComposerAutoloadMap.php
+++ b/src/Index/ComposerAutoloadMap.php
@@ -22,15 +22,20 @@ final class ComposerAutoloadMap
 {
     private readonly ClassLoader $loader;
 
+    /** @var list<string> */
+    private readonly array $files;
+
     /**
      * @param array<string, list<string>> $psr4 Namespace prefix -> directories
      * @param array<string, list<string>> $psr0 Namespace prefix -> directories
      * @param array<string, string> $classMap Fully qualified name -> file
+     * @param list<string> $files Files loaded wholesale, for their side effects
      */
     public function __construct(
         array $psr4 = [],
         array $psr0 = [],
         array $classMap = [],
+        array $files = [],
     ) {
         $loader = new ClassLoader();
 
@@ -43,6 +48,7 @@ final class ComposerAutoloadMap
         $loader->addClassMap($classMap);
 
         $this->loader = $loader;
+        $this->files = $files;
     }
 
     public static function fromProjectRoot(string $projectRoot): self
@@ -53,6 +59,7 @@ final class ComposerAutoloadMap
             self::loadPrefixes($composerDir . '/autoload_psr4.php'),
             self::loadPrefixes($composerDir . '/autoload_namespaces.php'),
             self::loadClassMap($composerDir . '/autoload_classmap.php'),
+            self::loadFiles($composerDir . '/autoload_files.php'),
         );
     }
 
@@ -79,10 +86,28 @@ final class ComposerAutoloadMap
         [$workspacePsr0, $vendorPsr0] = self::splitPrefixes($this->psr0Prefixes(), $isVendor);
         [$workspaceClassMap, $vendorClassMap] = self::splitClassMap($this->classMap(), $isVendor);
 
+        $vendorFiles = array_values(array_filter($this->files, $isVendor));
+        $workspaceFiles = array_values(array_filter($this->files, static fn(string $path): bool => !$isVendor($path)));
+
         return [
-            new self($workspacePsr4, $workspacePsr0, $workspaceClassMap),
-            new self($vendorPsr4, $vendorPsr0, $vendorClassMap),
+            new self($workspacePsr4, $workspacePsr0, $workspaceClassMap, $workspaceFiles),
+            new self($vendorPsr4, $vendorPsr0, $vendorClassMap, $vendorFiles),
         ];
+    }
+
+    /**
+     * The `autoload.files` set: files Composer loads wholesale rather than by name,
+     * which is where a project's functions and constants are declared.
+     *
+     * Unlike PSR-4, this is not a name -> file map — it cannot be, because functions
+     * and constants have no such map (Plan 0002 §3). It is an explicit, usually tiny
+     * list, which is what makes deriving one by parsing it affordable.
+     *
+     * @return list<string>
+     */
+    public function autoloadFiles(): array
+    {
+        return $this->files;
     }
 
     /**
@@ -201,6 +226,25 @@ final class ComposerAutoloadMap
         }
 
         return $prefixes;
+    }
+
+    /**
+     * Composer keys the generated file by a content hash, which identifies nothing a
+     * consumer needs; the paths are taken as a plain list.
+     *
+     * @return list<string>
+     */
+    private static function loadFiles(string $file): array
+    {
+        $files = [];
+
+        foreach (self::load($file) as $path) {
+            if (is_string($path)) {
+                $files[] = $path;
+            }
+        }
+
+        return $files;
     }
 
     /**

--- a/src/Index/ComposerAutoloadMap.php
+++ b/src/Index/ComposerAutoloadMap.php
@@ -86,8 +86,7 @@ final class ComposerAutoloadMap
         [$workspacePsr0, $vendorPsr0] = self::splitPrefixes($this->psr0Prefixes(), $isVendor);
         [$workspaceClassMap, $vendorClassMap] = self::splitClassMap($this->classMap(), $isVendor);
 
-        $vendorFiles = array_values(array_filter($this->files, $isVendor));
-        $workspaceFiles = array_values(array_filter($this->files, static fn(string $path): bool => !$isVendor($path)));
+        [$workspaceFiles, $vendorFiles] = self::splitFiles($this->files, $isVendor);
 
         return [
             new self($workspacePsr4, $workspacePsr0, $workspaceClassMap, $workspaceFiles),
@@ -183,6 +182,27 @@ final class ComposerAutoloadMap
                 $vendor[$fqn] = $file;
             } else {
                 $workspace[$fqn] = $file;
+            }
+        }
+
+        return [$workspace, $vendor];
+    }
+
+    /**
+     * @param list<string> $files
+     * @param callable(string): bool $isVendor
+     * @return array{list<string>, list<string>}
+     */
+    private static function splitFiles(array $files, callable $isVendor): array
+    {
+        $workspace = [];
+        $vendor = [];
+
+        foreach ($files as $file) {
+            if ($isVendor($file)) {
+                $vendor[] = $file;
+            } else {
+                $workspace[] = $file;
             }
         }
 

--- a/tests/Fixtures/AutoloadFiles/globals.php
+++ b/tests/Fixtures/AutoloadFiles/globals.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * A global-namespace `autoload.files` entry, covering the three ways a constant
+ * reaches the global namespace: a `const` declaration, a `define()` with a literal
+ * name, and a `define()` whose name is computed.
+ *
+ * The computed one is deliberately unreachable: its name exists only at runtime, so
+ * a static parse cannot know it (Plan 0002 §3b, §3's locate-only limitation). It is
+ * here so a test can prove the limitation holds rather than leave it asserted only
+ * in prose.
+ */
+
+const FIXTURE_GLOBAL_LIMIT = 100;
+
+define('FIXTURE_DEFINED_LIMIT', 200);
+
+define('FIXTURE_COMPUTED_' . 'LIMIT', 300);
+
+function fixtureGlobalHelper(int $value): int
+{
+    return $value * 2;
+}

--- a/tests/Fixtures/AutoloadFiles/helpers.php
+++ b/tests/Fixtures/AutoloadFiles/helpers.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Helpers;
+
+/**
+ * A namespaced `autoload.files` entry: functions and constants that no PSR-4
+ * name->file map can reach, because they are not class-likes. This file is the
+ * bounded, explicit reach the plan scopes function/constant lookup to (Plan 0002
+ * §3), so it backs the locator's index rather than any class-like query.
+ */
+
+const HELPER_LIMIT = 25;
+
+function helperFormat(string $value): string
+{
+    return trim($value);
+}
+
+function helperNormalize(string $value): string
+{
+    return strtolower(helperFormat($value));
+}

--- a/tests/Fixtures/MalformedProject/vendor/composer/autoload_files.php
+++ b/tests/Fixtures/MalformedProject/vendor/composer/autoload_files.php
@@ -1,0 +1,11 @@
+<?php
+
+// A deliberately malformed stand-in for Composer's generated autoload.files map,
+// used to prove that reading it validates its shape rather than trusting it. Not a
+// real project: it exists only to be read as data.
+
+return [
+    'a1b2c3' => '/tmp/valid-helpers.php',
+    'd4e5f6' => ['not-a-path'],
+    'g7h8i9' => 12345,
+];

--- a/tests/Fixtures/composer.json
+++ b/tests/Fixtures/composer.json
@@ -11,6 +11,10 @@
         "classmap": [
             "Autoload/Classmap/",
             "TypeInference/"
+        ],
+        "files": [
+            "AutoloadFiles/globals.php",
+            "AutoloadFiles/helpers.php"
         ]
     },
     "require-dev": {

--- a/tests/Index/ComposerAutoloadMapTest.php
+++ b/tests/Index/ComposerAutoloadMapTest.php
@@ -21,6 +21,66 @@ class ComposerAutoloadMapTest extends TestCase
         self::assertArrayHasKey('GlobalConfig', $map->classMap(), 'A classmapped class');
     }
 
+    public function testAutoloadFilesAreReadFromTheProject(): void
+    {
+        $map = ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures');
+
+        $files = $map->autoloadFiles();
+
+        self::assertCount(2, $files, 'The fixture project declares two autoload.files entries');
+        foreach (['AutoloadFiles/globals.php', 'AutoloadFiles/helpers.php'] as $expected) {
+            self::assertTrue(
+                self::containsPathEndingIn($files, $expected),
+                "autoload.files must report {$expected}, the bounded function/constant reach (Plan 0002 §3)",
+            );
+        }
+    }
+
+    public function testAutoloadFilesAreKeyedByPositionRatherThanComposersHashes(): void
+    {
+        $map = ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures');
+
+        self::assertSame(
+            [0, 1],
+            array_keys($map->autoloadFiles()),
+            'Composer keys the generated file by a content hash; consumers want a plain list',
+        );
+    }
+
+    public function testAProjectWithoutAutoloadFilesYieldsAnEmptyList(): void
+    {
+        // A project whose composer.json declares no `files` autoload has no
+        // autoload_files.php at all, which is absence rather than an error.
+        $map = ComposerAutoloadMap::fromProjectRoot('/nonexistent');
+
+        self::assertSame([], $map->autoloadFiles(), 'A project with no files autoload is not an error');
+    }
+
+    public function testMalformedAutoloadFileEntriesAreDiscarded(): void
+    {
+        $map = ComposerAutoloadMap::fromProjectRoot(__DIR__ . '/../Fixtures/MalformedProject');
+
+        self::assertSame(
+            ['/tmp/valid-helpers.php'],
+            $map->autoloadFiles(),
+            'These files are generated, but they are still data from a project we do not control',
+        );
+    }
+
+    /**
+     * @param list<string> $paths
+     */
+    private static function containsPathEndingIn(array $paths, string $suffix): bool
+    {
+        foreach ($paths as $path) {
+            if (str_ends_with($path, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function testAProjectWithoutComposerYieldsEmptyMaps(): void
     {
         $map = ComposerAutoloadMap::fromProjectRoot('/nonexistent');
@@ -107,6 +167,29 @@ class ComposerAutoloadMapTest extends TestCase
             ['Dep\\Widget' => '/project/vendor/dep/Widget.php'],
             $vendor->classMap(),
             'the vendor half keeps classmap entries whose file is under vendor/',
+        );
+    }
+
+    public function testPartitionSplitsAutoloadFilesByVendorDirectory(): void
+    {
+        $map = new ComposerAutoloadMap(
+            files: [
+                '/project/src/helpers.php',
+                '/project/vendor/dep/src/functions.php',
+            ],
+        );
+
+        [$workspace, $vendor] = $map->partitionByVendorDirectory('/project/vendor');
+
+        self::assertSame(
+            ['/project/src/helpers.php'],
+            $workspace->autoloadFiles(),
+            'the workspace half keeps only files outside vendor/',
+        );
+        self::assertSame(
+            ['/project/vendor/dep/src/functions.php'],
+            $vendor->autoloadFiles(),
+            'the vendor half keeps only files under vendor/',
         );
     }
 

--- a/tests/Index/ComposerAutoloadMapTest.php
+++ b/tests/Index/ComposerAutoloadMapTest.php
@@ -49,8 +49,9 @@ class ComposerAutoloadMapTest extends TestCase
 
     public function testAProjectWithoutAutoloadFilesYieldsAnEmptyList(): void
     {
-        // A project whose composer.json declares no `files` autoload has no
-        // autoload_files.php at all, which is absence rather than an error.
+        // Composer generates no autoload_files.php when a project declares no `files`
+        // autoload, so the read reaches a missing file — the same path a root with no
+        // vendor/ at all takes. Either way it is absence, not an error.
         $map = ComposerAutoloadMap::fromProjectRoot('/nonexistent');
 
         self::assertSame([], $map->autoloadFiles(), 'A project with no files autoload is not an error');
@@ -65,20 +66,6 @@ class ComposerAutoloadMapTest extends TestCase
             $map->autoloadFiles(),
             'These files are generated, but they are still data from a project we do not control',
         );
-    }
-
-    /**
-     * @param list<string> $paths
-     */
-    private static function containsPathEndingIn(array $paths, string $suffix): bool
-    {
-        foreach ($paths as $path) {
-            if (str_ends_with($path, $suffix)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public function testAProjectWithoutComposerYieldsEmptyMaps(): void
@@ -211,5 +198,19 @@ class ComposerAutoloadMapTest extends TestCase
             $vendor->psr4Prefixes(),
             'a prefix mapping to both halves keeps its vendor directory in the vendor half',
         );
+    }
+
+    /**
+     * @param list<string> $paths
+     */
+    private static function containsPathEndingIn(array $paths, string $suffix): bool
+    {
+        foreach ($paths as $path) {
+            if (str_ends_with($path, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Slice **S3.7a** (#390). `ComposerAutoloadMap` gains the `autoload.files` set — the files
Composer loads wholesale rather than by name, and the only place a project's functions
and constants are locatable, since they have no name→file map (RFC 1 §3, Plan 0002 §3).

- `autoloadFiles(): list<string>`, read from `vendor/composer/autoload_files.php`.
  Composer keys that file by a content hash; the paths are taken as a plain list.
- Partitioned by vendor directory alongside the PSR-4/PSR-0/classmap splits, so each
  `FilesystemBackend` half sees its own files (RFC 1 §5.3).
- Non-string entries are discarded — generated data from a project we do not control.
- The fixture project declares two `files` entries, which also back S3.7b and S3.7d.

The accessor's consumer is `ComposerSymbolLocator` in S3.7d; it is public because that is
a different class, and caller-less until then because of the split.

Note: `tests/Fixtures` gained a `files` autoload section, so `composer install` needs
re-running there before the suite passes.
