### PR TITLE
Scan a file for its function and constant declarations

### DIFF
--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -73,29 +73,28 @@ needed only for the deferred workspace scope.
 |---|---|---|
 | `lookupClassLike(FQN)` | No | PSR-4 `findFile` → parse that one file (today's `ClassRepository`) |
 | `childrenOf(namespace)` | No | `scandir` that one directory (today's `NamespaceCatalog`) |
-| Function / constant reach (Step 3) | Bounded, small | parse the `autoload.files` set (explicit, tiny; #181) + open docs |
+| `autoload.files` reach — all kinds (Step 3) | Bounded, small | parse the `autoload.files` set eagerly at startup (explicit, tiny; #181) + open docs |
 | Project-wide `search(prefix)` / `workspace/symbol` | Yes | deferred workspace scope |
 | Reverse queries (find-references, implementations) | Yes (reverse index) | deferred workspace scope |
 
 Notes:
 
-- Functions and constants have **no name→file map** (unlike PSR-4 classes);
-  `autoload.files` is an explicit, usually tiny list. So their project reach is a
-  small, bounded index of that set — not a project walk.
-- **That index is derived lazily, and an eager warm-up was measured and declined.**
-  A `Warmable` seam plus an `initialized` listener that pre-derived it was built
-  during S3.7 and is not being kept. It was never a correctness requirement — an
-  unwarmed locator answers identically, deriving on the first lookup — so the whole
-  question is which message pays a one-off cost. Sized against §8.1's measured
-  ~4 MB/s parse rate: this repository's own `autoload.files` is 12 entries totalling
-  139,006 bytes ≈ **35 ms** (≈70 ms with pcov on), of which 111,322 bytes are
-  PHPUnit's `Assert/Functions.php`; the remaining 11 files total 27,684 bytes ≈
-  **7 ms**. Moving 7–35 ms, once per session, does not justify ~105 lines, a second
-  `InitializedListener`, and a non-obvious "warm at `initialized`, not at
-  construction" rule. **Reopen condition:** a measured first function or constant
-  lookup that exceeds §8.4's 50 ms per-request budget on a real project. The seam
-  can be re-added verbatim if so — `warm()` changes no interface, which is precisely
-  why deferring it is free.
+- An `autoload.files` entry has **no name→file map at all** — not for functions and
+  constants, and not for the class-likes it may also declare. PHP `require`s every
+  entry at bootstrap; nothing indexes them by name. So this set is the one place the
+  model cannot resolve a name lazily, and its reach is a small, bounded index of the
+  whole set — still not a project walk, because the list is explicit and usually tiny.
+- **That index is built eagerly, at startup.** Deferring it to the first lookup was
+  considered and does not hold up once class-likes are in scope: a lazy build has to
+  fire on any name the autoload maps fail to resolve, so every unresolvable
+  class-like — every half-typed name mid-completion — would risk paying for the scan,
+  and the trigger point stops being predictable. Building once, up front, is both
+  simpler and closer to what PHP itself does. The cost is bounded and measurable:
+  sized against §8.1's ~4 MB/s parse rate, this repository's own set is a dozen
+  entries totalling ~140 KB ≈ **35 ms**, most of it one large PHPUnit file; the rest
+  total ~30 KB ≈ **7 ms**. **Revisit if** a real project's set is large enough that
+  startup becomes perceptible (§8.4), in which case the work moves to the deferred
+  scheduler tier (Step 6) rather than back to a lazy trigger.
 - Background/eager indexing is optional and bounded (§5.3). `WorkspaceIndexer` is
   revived only if/when the workspace scope is taken up; otherwise it is deleted — which
   is slice **SC.1**, since it is dead today (zero references) and the workspace scope is
@@ -103,18 +102,18 @@ Notes:
 - On-disk backends cache **derived info** (`ClassInfo`, symbols — small), never raw
   ASTs. `ClassRepository` already does this; preserve it.
 - Reach is scoped to declarations the model can *locate*: PSR-4 / classmap classes,
-  the `autoload.files` set (its functions and constants), and open documents. A
-  function or constant defined as a **load side-effect** of a PSR-4 / classmap file
-  (declared alongside a class in a file loaded for that class) is reachable at PHP
-  runtime but invisible to this model. Scoping it out is deliberate — a known
-  limitation, not complete reach.
-  - The **mirror case is a gap, not a boundary**: a class-like reached only through
-    an `autoload.files` entry. That section is never itself a classmap source, so
-    such a class has no name→file map and `lookupClassLike` misses it — though an
-    entry that also sits under a scanned `classmap`/PSR-4 path is mapped as usual.
-    Closing it needs no project walk, since the derived index already parses that
-    set, and it is **#181's "classes are discoverable" criterion** — so the slice
-    claiming #181 either carries class-likes or narrows the issue first.
+  everything the `autoload.files` set declares, and open documents. A function or
+  constant defined as a **load side-effect** of a PSR-4 / classmap file (declared
+  alongside a class in a file loaded for that class) is reachable at PHP runtime but
+  invisible to this model. Scoping it out is deliberate — a known limitation, not
+  complete reach.
+  - **The `files` set is scanned whole, for all three symbol namespaces.** Composer
+    addresses those files by no name at all — the `files` section is not a classmap
+    source, and PHP loads every entry unconditionally at bootstrap — so there is no
+    key on which to resolve one name lazily. The only choice is *when* to scan, not
+    what: once an entry is parsed, every kind costs the same walk, and indexing
+    only functions and constants would leave a class-like declared there reachable
+    at runtime but invisible here, for no saving. This is #181's reach.
 - The **Builtin backend is reflection-backed today** (zero-index, instant lookup via
   `get_defined_functions()` / reflection), so it introduces **no** lazy-first
   exception. An exception would arise only if a future static, version-aware source
@@ -263,12 +262,14 @@ Step 4 (Section 6).
   harness compares only observable outputs, an internal divergence between the two
   structures could pass parity, so add a consistency check that both are written from
   the same parse and agree. Proven by the Step P harness.
-- **3b — `SymbolLocator` + function/constant reach (behavior-changing).** Generalize
+- **3b — `SymbolLocator` + `autoload.files` reach (behavior-changing).** Generalize
   `ClassLocator` to a kind-agnostic `SymbolLocator`; fold in `autoload.files`; give
-  `lookupFunction` / `lookupConstant` real project reach (constant reach covers
-  `const` declarations and literal-name `define()`; a **computed-name `define()`** is
-  a runtime call invisible to static parse and is out of scope, per §3's locate-only
-  limitation); migrate `FunctionCandidates`
+  `lookupFunction` / `lookupConstant` real project reach, and extend
+  `lookupClassLike` to the class-likes those files declare, which the autoload maps
+  cannot address (constant reach covers `const` declarations and literal-name
+  `define()`; a **computed-name `define()`** is a runtime call invisible to static
+  parse and is out of scope, per §3's locate-only limitation; an anonymous class has
+  no name to index); migrate `FunctionCandidates`
   to `search` (which subsumes `getFileFunctions` — the open-document backend knows a
   document's functions, so that query disappears with its last caller); remove the
   Step 2 rule exemption. This step **both changes and preserves** behavior on the

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -73,7 +73,7 @@ needed only for the deferred workspace scope.
 |---|---|---|
 | `lookupClassLike(FQN)` | No | PSR-4 `findFile` → parse that one file (today's `ClassRepository`) |
 | `childrenOf(namespace)` | No | `scandir` that one directory (today's `NamespaceCatalog`) |
-| `autoload.files` reach — all kinds (Step 3) | Bounded, small | parse the `autoload.files` set eagerly at startup (explicit, tiny; #181) + open docs |
+| `autoload.files` reach — all kinds (Step 3) | Bounded, small | parse the `autoload.files` set (explicit, tiny; #181) + open docs |
 | Project-wide `search(prefix)` / `workspace/symbol` | Yes | deferred workspace scope |
 | Reverse queries (find-references, implementations) | Yes (reverse index) | deferred workspace scope |
 
@@ -84,17 +84,15 @@ Notes:
   entry at bootstrap; nothing indexes them by name. So this set is the one place the
   model cannot resolve a name lazily, and its reach is a small, bounded index of the
   whole set — still not a project walk, because the list is explicit and usually tiny.
-- **That index is built eagerly, at startup.** Deferring it to the first lookup was
-  considered and does not hold up once class-likes are in scope: a lazy build has to
-  fire on any name the autoload maps fail to resolve, so every unresolvable
-  class-like — every half-typed name mid-completion — would risk paying for the scan,
-  and the trigger point stops being predictable. Building once, up front, is both
-  simpler and closer to what PHP itself does. The cost is bounded and measurable:
-  sized against §8.1's ~4 MB/s parse rate, this repository's own set is a dozen
-  entries totalling ~140 KB ≈ **35 ms**, most of it one large PHPUnit file; the rest
-  total ~30 KB ≈ **7 ms**. **Revisit if** a real project's set is large enough that
-  startup becomes perceptible (§8.4), in which case the work moves to the deferred
-  scheduler tier (Step 6) rather than back to a lazy trigger.
+- **Whether that index is built eagerly or on first use is S3.7d's call**, the slice
+  that builds it. Widening the set's reach to class-likes reopens the question rather
+  than settling it: a lazy build's trigger stops being a function or constant lookup
+  and becomes any name the autoload maps fail to resolve — commoner and far less
+  predictable, though still paid once, by whichever name arrives first. The cost is
+  bounded either way: sized against §8.1's ~4 MB/s parse rate, this repository's own
+  set is a dozen entries totalling ~140 KB ≈ **35 ms**, most of it one large PHPUnit
+  file; the rest total ~30 KB ≈ **7 ms**. If a real project's set ever makes that
+  perceptible (§8.4), the work moves to the deferred scheduler tier (Step 6).
 - Background/eager indexing is optional and bounded (§5.3). `WorkspaceIndexer` is
   revived only if/when the workspace scope is taken up; otherwise it is deleted — which
   is slice **SC.1**, since it is dead today (zero references) and the workspace scope is

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -103,10 +103,18 @@ Notes:
 - On-disk backends cache **derived info** (`ClassInfo`, symbols — small), never raw
   ASTs. `ClassRepository` already does this; preserve it.
 - Reach is scoped to declarations the model can *locate*: PSR-4 / classmap classes,
-  the `autoload.files` set, and open documents. A function or constant defined as a
-  **load side-effect** of a PSR-4 / classmap file (declared alongside a class in a
-  file loaded for that class) is reachable at PHP runtime but invisible to this
-  model. Scoping it out is deliberate — a known limitation, not complete reach.
+  the `autoload.files` set (its functions and constants), and open documents. A
+  function or constant defined as a **load side-effect** of a PSR-4 / classmap file
+  (declared alongside a class in a file loaded for that class) is reachable at PHP
+  runtime but invisible to this model. Scoping it out is deliberate — a known
+  limitation, not complete reach.
+  - The **mirror case is also out**: a class-like declared in an `autoload.files`
+    entry. Composer builds the classmap from `classmap` paths and, only when
+    optimizing, from PSR-0/PSR-4 paths — never from `files` — so such a class has no
+    name→file map in any dump mode, and `lookupClassLike` misses it. Convention puts
+    non-PSR-4 classes under `classmap`, where they are found, so the cost is small;
+    the fix, if one is ever wanted, is to let the derived `autoload.files` index
+    carry class-likes too.
 - The **Builtin backend is reflection-backed today** (zero-index, instant lookup via
   `get_defined_functions()` / reflection), so it introduces **no** lazy-first
   exception. An exception would arise only if a future static, version-aware source

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -108,15 +108,13 @@ Notes:
   (declared alongside a class in a file loaded for that class) is reachable at PHP
   runtime but invisible to this model. Scoping it out is deliberate — a known
   limitation, not complete reach.
-  - The **mirror case is also out**: a class-like reached *only* through an
-    `autoload.files` entry. Composer builds the classmap from `classmap` paths and,
-    only when optimizing, from PSR-0/PSR-4 paths — the `files` section is never
-    itself a classmap source — so a class whose file sits outside all of those paths
-    has no name→file map in any dump mode, and `lookupClassLike` misses it. The
-    classmap scans *paths*, not sections, so a `files` entry that also falls under a
-    scanned path is mapped as usual. Convention puts non-PSR-4 classes under
-    `classmap`, where they are found, so the cost is small; the fix, if one is ever
-    wanted, is to let the derived `autoload.files` index carry class-likes too.
+  - The **mirror case is a gap, not a boundary**: a class-like reached only through
+    an `autoload.files` entry. That section is never itself a classmap source, so
+    such a class has no name→file map and `lookupClassLike` misses it — though an
+    entry that also sits under a scanned `classmap`/PSR-4 path is mapped as usual.
+    Closing it needs no project walk, since the derived index already parses that
+    set, and it is **#181's "classes are discoverable" criterion** — so the slice
+    claiming #181 either carries class-likes or narrows the issue first.
 - The **Builtin backend is reflection-backed today** (zero-index, instant lookup via
   `get_defined_functions()` / reflection), so it introduces **no** lazy-first
   exception. An exception would arise only if a future static, version-aware source

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -268,7 +268,8 @@ Step 4 (Section 6).
   `lookupClassLike` to the class-likes those files declare, which the autoload maps
   cannot address (constant reach covers `const` declarations and literal-name
   `define()`; a **computed-name `define()`** is a runtime call invisible to static
-  parse and is out of scope, per §3's locate-only limitation; an anonymous class has
+  parse and is out of scope, per §3's locate-only limitation, as is a name introduced
+  by **`class_alias()`** rather than by a declaration; an anonymous class has
   no name to index); migrate `FunctionCandidates`
   to `search` (which subsumes `getFileFunctions` — the open-document backend knows a
   document's functions, so that query disappears with its last caller); remove the

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -108,13 +108,15 @@ Notes:
   (declared alongside a class in a file loaded for that class) is reachable at PHP
   runtime but invisible to this model. Scoping it out is deliberate — a known
   limitation, not complete reach.
-  - The **mirror case is also out**: a class-like declared in an `autoload.files`
-    entry. Composer builds the classmap from `classmap` paths and, only when
-    optimizing, from PSR-0/PSR-4 paths — never from `files` — so such a class has no
-    name→file map in any dump mode, and `lookupClassLike` misses it. Convention puts
-    non-PSR-4 classes under `classmap`, where they are found, so the cost is small;
-    the fix, if one is ever wanted, is to let the derived `autoload.files` index
-    carry class-likes too.
+  - The **mirror case is also out**: a class-like reached *only* through an
+    `autoload.files` entry. Composer builds the classmap from `classmap` paths and,
+    only when optimizing, from PSR-0/PSR-4 paths — the `files` section is never
+    itself a classmap source — so a class whose file sits outside all of those paths
+    has no name→file map in any dump mode, and `lookupClassLike` misses it. The
+    classmap scans *paths*, not sections, so a `files` entry that also falls under a
+    scanned path is mapped as usual. Convention puts non-PSR-4 classes under
+    `classmap`, where they are found, so the cost is small; the fix, if one is ever
+    wanted, is to let the derived `autoload.files` index carry class-likes too.
 - The **Builtin backend is reflection-backed today** (zero-index, instant lookup via
   `get_defined_functions()` / reflection), so it introduces **no** lazy-first
   exception. An exception would arise only if a future static, version-aware source

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -165,6 +165,9 @@ Notes:
 - **`Closes` is assigned at slice-issue creation, after a reviewer reads the issue —
   never inferred.** Candidates from Wave 1's note: #239 / #181 / #317 land somewhere in
   S3.7a–S3.10; #295 (Visibility enum) wants a small cleanup slice not yet placed.
+  - **#181 is wider than S3.7's reach.** It scopes class-likes alongside functions
+    and constants, which 0002 §3 leaves an open gap. The slice claiming #181 either
+    carries class-likes in the derived index or narrows the issue first.
 
 ### Deferred (not scheduled; excluded from `/do-next` until reached)
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -65,7 +65,7 @@ Definition-of-Done gate.
     S3.7a  3b    Read autoload.files into ComposerAutoloadMap       S3.3              —
     S3.7b  3b    Scan a file for the declarations it makes          S3.3              —
     S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator        S3.3,SC.4         —
-    S3.7d  3b    Derived autoload.files index, built at startup     S3.7a,S3.7b,S3.7c —
+    S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
     S3.8b  3b    lookupConstant project reach                       S3.7d             —
     S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -63,9 +63,9 @@ Definition-of-Done gate.
     S3.5   3a    External-file-change invalidation                  S3.3,S3.4         —
     S3.6   3b    Function-surface golden + Builtin enum oracle      S3.3              —
     S3.7a  3b    Read autoload.files into ComposerAutoloadMap       S3.3              —
-    S3.7b  3b    Scan a file for its function/constant declarations S3.3              —
+    S3.7b  3b    Scan a file for the declarations it makes          S3.3              —
     S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator        S3.3,SC.4         —
-    S3.7d  3b    Derived autoload.files function/constant index     S3.7a,S3.7b,S3.7c —
+    S3.7d  3b    Derived autoload.files index, built at startup     S3.7a,S3.7b,S3.7c —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
     S3.8b  3b    lookupConstant project reach                       S3.7d             —
     S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —
@@ -94,10 +94,12 @@ Notes:
   a hit (asserted via `ParseMetrics`); one that cannot is removed, not wrapped.
 - **S3.7 is four slices, cut where Composer's own data divides.** A single slice was
   built first (PR #388, 622 src lines over 17 files) and was too large to review as
-  one unit. The seam it missed is already in the code: a class-like lookup is
-  arithmetic on the name (`findFile`, five lines — the old `ComposerClassLocator`
-  verbatim), while a function or constant lookup has no name→file map and must derive
-  one by parsing the `autoload.files` set. So **S3.7c generalizes the shape** — the
+  one unit. The seam it missed is already in the code: a lookup against the autoload
+  maps is arithmetic on the name (`findFile`, five lines — the old
+  `ComposerClassLocator` verbatim), while anything an `autoload.files` entry declares
+  has no name→file map of any kind and must derive one by parsing that set. The cut
+  is therefore by *route*, not by symbol kind — class-likes use both routes. So
+  **S3.7c generalizes the shape** — the
   kind-agnostic `SymbolLocator` interface, `QualifiedName`, and the class-like branch
   — which is behavior-preserving and proven by the existing class-like-lookup golden;
   **S3.7d adds the reach**, which is new behavior proven by new fixtures. S3.7a and
@@ -165,9 +167,9 @@ Notes:
 - **`Closes` is assigned at slice-issue creation, after a reviewer reads the issue —
   never inferred.** Candidates from Wave 1's note: #239 / #181 / #317 land somewhere in
   S3.7a–S3.10; #295 (Visibility enum) wants a small cleanup slice not yet placed.
-  - **#181 is wider than S3.7's reach.** It scopes class-likes alongside functions
-    and constants, which 0002 §3 leaves an open gap. The slice claiming #181 either
-    carries class-likes in the derived index or narrows the issue first.
+  - **#181 covers all three kinds**, which is now what S3.7b–S3.7d build: the
+    `files` set has no name→file map of any kind, so it is scanned whole. A slice
+    claiming #181 must show class-like reach, not just functions and constants.
 
 ### Deferred (not scheduled; excluded from `/do-next` until reached)
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -119,8 +119,8 @@ Notes:
   golden is what catches it.
 - **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
-  Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7c**,
-  whose `SymbolLocator::locate` is its first caller; `FunctionName` in **S3.8a** and
+  Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
+  whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
   `ConstantName` in **S3.8b**, with their lookups.
   - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
     name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before

--- a/src/Domain/QualifiedName.php
+++ b/src/Domain/QualifiedName.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
+use Firehed\PhpLsp\Utility\NamespacePath;
+
 /**
  * A fully-qualified name split into namespace path and short name, carrying no
  * notion of what it names (Plan 0002 §5.3: the kind-neutral base FQN value type).
@@ -27,20 +29,11 @@ final readonly class QualifiedName
     {
         $fqn = ltrim($fullyQualifiedName, '\\');
 
-        $lastSeparator = strrpos($fqn, '\\');
-        if ($lastSeparator === false) {
-            return new self('', $fqn);
-        }
-
-        return new self(substr($fqn, 0, $lastSeparator), substr($fqn, $lastSeparator + 1));
+        return new self(NamespacePath::namespaceOf($fqn), NamespacePath::shortNameOf($fqn));
     }
 
     public function fullyQualifiedName(): string
     {
-        if ($this->namespace === '') {
-            return $this->shortName;
-        }
-
-        return $this->namespace . '\\' . $this->shortName;
+        return NamespacePath::join($this->namespace, $this->shortName);
     }
 }

--- a/src/Domain/QualifiedName.php
+++ b/src/Domain/QualifiedName.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * A fully-qualified name split into namespace path and short name, carrying no
+ * notion of what it names (Plan 0002 §5.3: the kind-neutral base FQN value type).
+ * A name alone does not identify a symbol — PHP has three symbol namespaces — so a
+ * {@see \Firehed\PhpLsp\Resolution\NameKind} travels alongside it.
+ *
+ * The global namespace is the empty path.
+ */
+final readonly class QualifiedName
+{
+    public function __construct(
+        public string $namespace,
+        public string $shortName,
+    ) {
+    }
+
+    /**
+     * A leading `\` is spelling rather than identity, so it is dropped.
+     */
+    public static function fromFullyQualified(string $fullyQualifiedName): self
+    {
+        $fqn = ltrim($fullyQualifiedName, '\\');
+
+        $lastSeparator = strrpos($fqn, '\\');
+        if ($lastSeparator === false) {
+            return new self('', $fqn);
+        }
+
+        return new self(substr($fqn, 0, $lastSeparator), substr($fqn, $lastSeparator + 1));
+    }
+
+    public function fullyQualifiedName(): string
+    {
+        if ($this->namespace === '') {
+            return $this->shortName;
+        }
+
+        return $this->namespace . '\\' . $this->shortName;
+    }
+}

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -66,12 +66,33 @@ final class DeclarationScanner
                     return;
                 }
 
-                $first = $node->args[0] ?? null;
-                if (!$first instanceof Node\Arg || !$first->value instanceof Scalar\String_) {
+                $name = $this->constantNameArgument($node);
+                if (!$name instanceof Scalar\String_) {
                     return;
                 }
 
-                $this->constants[] = QualifiedName::fromFullyQualified($first->value->value);
+                $this->constants[] = QualifiedName::fromFullyQualified($name->value);
+            }
+
+            /**
+             * A named argument may only follow the positional ones, so the first
+             * unnamed argument is the name. A named one is the name only if it says
+             * so — read positionally, `define(value: 'x', constant_name: 'Y')` would
+             * declare a constant called `x`.
+             */
+            private function constantNameArgument(Expr\FuncCall $node): ?Node\Expr
+            {
+                foreach ($node->args as $argument) {
+                    if (!$argument instanceof Node\Arg) {
+                        continue;
+                    }
+
+                    if ($argument->name === null || $argument->name->toString() === 'constant_name') {
+                        return $argument->value;
+                    }
+                }
+
+                return null;
             }
 
             /**

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -19,9 +19,9 @@ use PhpParser\NodeVisitorAbstract;
  *
  * What counts as a declaration is decided lexically, not by what a `require` of the
  * file would execute: a conditional polyfill (`if (!function_exists(...))`) and a
- * declaration inside a function body are both reported, because whether either runs
- * is a runtime question. That over-reports a never-called function's body rather
- * than dropping the polyfill, which is the shape most `autoload.files` entries take.
+ * declaration nested in a function body are both reported. Whether either runs is a
+ * runtime question, and a name the file validly declares is a name the editor should
+ * be able to resolve.
  *
  * The blind spots are Plan 0002 §3's locate-only limitation rather than oversights:
  * a `define()` whose name — or whose call — resolves only at runtime, a name

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Domain\QualifiedName;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Reads the functions and constants a parsed file declares, so a name -> file map
+ * can be derived for the two symbol namespaces Composer cannot address by name
+ * (Plan 0002 §3).
+ *
+ * Qualified names come from the `namespacedName` attribute {@see \PhpParser\NodeVisitor\NameResolver}
+ * already sets during {@see \Firehed\PhpLsp\Parser\ParserService::parse()}, rather
+ * than from tracking namespace statements by hand.
+ *
+ * `define()` is recognised only when its name is a literal string. A computed name
+ * is produced by a runtime call and cannot be known from a static parse, so it is
+ * skipped — the locate-only limitation Plan 0002 §3 scopes out, not an oversight.
+ *
+ * Only the given AST is read; `require`/`include` are not followed. An entry that
+ * merely pulls in a sibling — the common polyfill layout — therefore contributes
+ * nothing. That is the same scoped-out limitation, recorded here because it is the
+ * one a reader is most likely to mistake for a bug.
+ */
+final class DeclarationScanner
+{
+    /**
+     * @param array<Stmt> $ast
+     */
+    public function scan(array $ast): FileDeclarations
+    {
+        $visitor = new class () extends NodeVisitorAbstract {
+            /** @var list<QualifiedName> */
+            public array $functions = [];
+
+            /** @var list<QualifiedName> */
+            public array $constants = [];
+
+            public function enterNode(Node $node): null
+            {
+                if ($node instanceof Stmt\Function_) {
+                    $this->addFrom($node->namespacedName, $this->functions);
+                    return null;
+                }
+
+                if ($node instanceof Stmt\Const_) {
+                    foreach ($node->consts as $const) {
+                        $this->addFrom($const->namespacedName, $this->constants);
+                    }
+                    return null;
+                }
+
+                if ($node instanceof Expr\FuncCall) {
+                    $this->addDefinedConstant($node);
+                }
+
+                return null;
+            }
+
+            /**
+             * `define()` writes into the global namespace whatever namespace it is
+             * called from, so its literal argument is already the qualified name.
+             */
+            private function addDefinedConstant(Expr\FuncCall $node): void
+            {
+                if (!$node->name instanceof Node\Name || $node->name->toLowerString() !== 'define') {
+                    return;
+                }
+
+                $first = $node->args[0] ?? null;
+                if (!$first instanceof Node\Arg || !$first->value instanceof Scalar\String_) {
+                    return;
+                }
+
+                $this->constants[] = QualifiedName::fromFullyQualified($first->value->value);
+            }
+
+            /**
+             * @param list<QualifiedName> $into
+             */
+            private function addFrom(?Node\Name $name, array &$into): void
+            {
+                if ($name === null) {
+                    // @codeCoverageIgnoreStart
+                    // NameResolver populates namespacedName for every declaration it
+                    // visits, and ParserService always runs it; a declaration without
+                    // one cannot be reached through the parser this server uses.
+                    return;
+                    // @codeCoverageIgnoreEnd
+                }
+
+                $into[] = QualifiedName::fromFullyQualified($name->toString());
+            }
+        };
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return new FileDeclarations($visitor->functions, $visitor->constants);
+    }
+}

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -17,9 +17,16 @@ use PhpParser\NodeVisitorAbstract;
  * name -> file map can be derived for an `autoload.files` entry, which Composer
  * addresses by no name at all (Plan 0002 §3).
  *
+ * What counts as a declaration is decided lexically, not by what a `require` of the
+ * file would execute: a conditional polyfill (`if (!function_exists(...))`) and a
+ * declaration inside a function body are both reported, because whether either runs
+ * is a runtime question. That over-reports a never-called function's body rather
+ * than dropping the polyfill, which is the shape most `autoload.files` entries take.
+ *
  * The blind spots are Plan 0002 §3's locate-only limitation rather than oversights:
- * a `define()` whose name — or whose call — resolves only at runtime, and anything
- * reached only through a `require`/`include`, which is not followed.
+ * a `define()` whose name — or whose call — resolves only at runtime, a name
+ * introduced by `class_alias()` rather than by a declaration, and anything reached
+ * only through a `require`/`include`, which is not followed.
  */
 final class DeclarationScanner
 {

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -17,9 +17,9 @@ use PhpParser\NodeVisitorAbstract;
  * can be derived for the two symbol namespaces Composer cannot address by name
  * (Plan 0002 §3).
  *
- * Two deliberate blind spots, both the locate-only limitation of Plan 0002 §3
- * rather than oversights: a `define()` whose name is computed at runtime, and
- * anything reached only through a `require`/`include`, which is not followed.
+ * The blind spots are Plan 0002 §3's locate-only limitation rather than oversights:
+ * a `define()` whose name — or whose call — resolves only at runtime, and anything
+ * reached only through a `require`/`include`, which is not followed.
  */
 final class DeclarationScanner
 {

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -13,9 +13,9 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * Reads the functions and constants a parsed file declares, so a name -> file map
- * can be derived for the two symbol namespaces Composer cannot address by name
- * (Plan 0002 §3).
+ * Reads the class-likes, functions and constants a parsed file declares, so a
+ * name -> file map can be derived for an `autoload.files` entry, which Composer
+ * addresses by no name at all (Plan 0002 §3).
  *
  * The blind spots are Plan 0002 §3's locate-only limitation rather than oversights:
  * a `define()` whose name — or whose call — resolves only at runtime, and anything
@@ -30,6 +30,9 @@ final class DeclarationScanner
     {
         $visitor = new class () extends NodeVisitorAbstract {
             /** @var list<QualifiedName> */
+            public array $classLikes = [];
+
+            /** @var list<QualifiedName> */
             public array $functions = [];
 
             /** @var list<QualifiedName> */
@@ -37,6 +40,12 @@ final class DeclarationScanner
 
             public function enterNode(Node $node): null
             {
+                // An anonymous class has no name, so there is nothing to index.
+                if ($node instanceof Stmt\ClassLike && $node->name !== null) {
+                    $this->classLikes[] = self::qualify($node->namespacedName ?? $node->name);
+                    return null;
+                }
+
                 if ($node instanceof Stmt\Function_) {
                     $this->functions[] = self::qualify($node->namespacedName ?? $node->name);
                     return null;
@@ -110,6 +119,6 @@ final class DeclarationScanner
         $traverser->addVisitor($visitor);
         $traverser->traverse($ast);
 
-        return new FileDeclarations($visitor->functions, $visitor->constants);
+        return new FileDeclarations($visitor->classLikes, $visitor->functions, $visitor->constants);
     }
 }

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -17,18 +17,9 @@ use PhpParser\NodeVisitorAbstract;
  * can be derived for the two symbol namespaces Composer cannot address by name
  * (Plan 0002 §3).
  *
- * Qualified names come from the `namespacedName` attribute {@see \PhpParser\NodeVisitor\NameResolver}
- * already sets during {@see \Firehed\PhpLsp\Parser\ParserService::parse()}, rather
- * than from tracking namespace statements by hand.
- *
- * `define()` is recognised only when its name is a literal string. A computed name
- * is produced by a runtime call and cannot be known from a static parse, so it is
- * skipped — the locate-only limitation Plan 0002 §3 scopes out, not an oversight.
- *
- * Only the given AST is read; `require`/`include` are not followed. An entry that
- * merely pulls in a sibling — the common polyfill layout — therefore contributes
- * nothing. That is the same scoped-out limitation, recorded here because it is the
- * one a reader is most likely to mistake for a bug.
+ * Two deliberate blind spots, both the locate-only limitation of Plan 0002 §3
+ * rather than oversights: a `define()` whose name is computed at runtime, and
+ * anything reached only through a `require`/`include`, which is not followed.
  */
 final class DeclarationScanner
 {
@@ -90,9 +81,8 @@ final class DeclarationScanner
             {
                 if ($name === null) {
                     // @codeCoverageIgnoreStart
-                    // NameResolver populates namespacedName for every declaration it
-                    // visits, and ParserService always runs it; a declaration without
-                    // one cannot be reached through the parser this server uses.
+                    // ParserService always runs NameResolver, which populates
+                    // namespacedName for every declaration it visits.
                     return;
                     // @codeCoverageIgnoreEnd
                 }

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -38,13 +38,13 @@ final class DeclarationScanner
             public function enterNode(Node $node): null
             {
                 if ($node instanceof Stmt\Function_) {
-                    $this->functions[] = self::qualify($node->namespacedName);
+                    $this->functions[] = self::qualify($node->namespacedName ?? $node->name);
                     return null;
                 }
 
                 if ($node instanceof Stmt\Const_) {
                     foreach ($node->consts as $const) {
-                        $this->constants[] = self::qualify($const->namespacedName);
+                        $this->constants[] = self::qualify($const->namespacedName ?? $const->name);
                     }
                     return null;
                 }
@@ -96,13 +96,12 @@ final class DeclarationScanner
             }
 
             /**
-             * ParserService always runs NameResolver, which sets namespacedName on
-             * every declaration it visits.
+             * ParserService always runs NameResolver, so `namespacedName` is set.
+             * Falling back to the declared name keeps this total for an AST parsed
+             * without it, where the two differ only under a namespace.
              */
-            private static function qualify(?Node\Name $name): QualifiedName
+            private static function qualify(Node\Name|Node\Identifier $name): QualifiedName
             {
-                assert($name !== null);
-
                 return QualifiedName::fromFullyQualified($name->toString());
             }
         };

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -38,13 +38,13 @@ final class DeclarationScanner
             public function enterNode(Node $node): null
             {
                 if ($node instanceof Stmt\Function_) {
-                    $this->addFrom($node->namespacedName, $this->functions);
+                    $this->functions[] = self::qualify($node->namespacedName);
                     return null;
                 }
 
                 if ($node instanceof Stmt\Const_) {
                     foreach ($node->consts as $const) {
-                        $this->addFrom($const->namespacedName, $this->constants);
+                        $this->constants[] = self::qualify($const->namespacedName);
                     }
                     return null;
                 }
@@ -96,19 +96,14 @@ final class DeclarationScanner
             }
 
             /**
-             * @param list<QualifiedName> $into
+             * ParserService always runs NameResolver, which sets namespacedName on
+             * every declaration it visits.
              */
-            private function addFrom(?Node\Name $name, array &$into): void
+            private static function qualify(?Node\Name $name): QualifiedName
             {
-                if ($name === null) {
-                    // @codeCoverageIgnoreStart
-                    // ParserService always runs NameResolver, which populates
-                    // namespacedName for every declaration it visits.
-                    return;
-                    // @codeCoverageIgnoreEnd
-                }
+                assert($name !== null);
 
-                $into[] = QualifiedName::fromFullyQualified($name->toString());
+                return QualifiedName::fromFullyQualified($name->toString());
             }
         };
 

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -11,8 +11,9 @@ use Firehed\PhpLsp\Domain\QualifiedName;
  * Composer's autoload maps cannot address by name (Plan 0002 §3).
  *
  * Class-likes are absent because PSR-4, PSR-0 and the classmap address them by name.
- * A class declared in an `autoload.files` entry escapes all three — Composer never
- * scans those into the classmap — and is the known gap Plan 0002 §3 records.
+ * A class reached only through an `autoload.files` entry escapes all three — the
+ * `files` section is never itself a classmap source — and is the known gap Plan 0002
+ * §3 records.
  */
 final readonly class FileDeclarations
 {

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -20,8 +20,8 @@ final readonly class FileDeclarations
      * @param list<QualifiedName> $constants
      */
     public function __construct(
-        public array $functions = [],
-        public array $constants = [],
+        public array $functions,
+        public array $constants,
     ) {
     }
 }

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -10,8 +10,9 @@ use Firehed\PhpLsp\Domain\QualifiedName;
  * The function and constant names one file declares — the two symbol namespaces
  * Composer's autoload maps cannot address by name (Plan 0002 §3).
  *
- * Class-likes are absent by design: they already have a name -> file map, so nothing
- * has to scan a file to discover them.
+ * Class-likes are absent because PSR-4, PSR-0 and the classmap address them by name.
+ * A class declared in an `autoload.files` entry escapes all three — Composer never
+ * scans those into the classmap — and is the known gap Plan 0002 §3 records.
  */
 final readonly class FileDeclarations
 {

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -7,21 +7,22 @@ namespace Firehed\PhpLsp\Index;
 use Firehed\PhpLsp\Domain\QualifiedName;
 
 /**
- * The function and constant names one file declares. Composer publishes no name ->
- * file map for either symbol namespace, so one is derived by parsing the
- * `autoload.files` set (Plan 0002 §3).
+ * The names one file declares, across all three of PHP's symbol namespaces.
  *
- * Class-likes usually need no such index: PSR-4, PSR-0 and the classmap resolve them
- * by arithmetic. The exception — a class reachable only through a `files` entry — is
- * #181.
+ * An `autoload.files` entry has no name -> file map of any kind, so the only way to
+ * learn what it declares is to parse it — and once parsed, every kind costs the same
+ * walk. Narrowing this to functions and constants would leave a class-like declared
+ * there reachable at runtime but invisible here, for no saving (Plan 0002 §3).
  */
 final readonly class FileDeclarations
 {
     /**
+     * @param list<QualifiedName> $classLikes
      * @param list<QualifiedName> $functions
      * @param list<QualifiedName> $constants
      */
     public function __construct(
+        public array $classLikes,
         public array $functions,
         public array $constants,
     ) {

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -11,10 +11,9 @@ use Firehed\PhpLsp\Domain\QualifiedName;
  * file map for either symbol namespace, so one is derived by parsing the
  * `autoload.files` set (Plan 0002 §3).
  *
- * Class-likes are out because the common case already has a cheaper route: PSR-4,
- * PSR-0 and the classmap turn a class name into a path by arithmetic, with no parse.
- * A class reachable only through a `files` entry has no such route and is missed —
- * the known gap Plan 0002 §3 records, tracked by #181.
+ * Class-likes usually need no such index: PSR-4, PSR-0 and the classmap resolve them
+ * by arithmetic. The exception — a class reachable only through a `files` entry — is
+ * #181.
  */
 final readonly class FileDeclarations
 {

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Domain\QualifiedName;
+
+/**
+ * The function and constant names one file declares — the two symbol namespaces
+ * Composer's autoload maps cannot address by name (Plan 0002 §3).
+ *
+ * Class-likes are absent by design: they already have a name -> file map, so nothing
+ * has to scan a file to discover them.
+ */
+final readonly class FileDeclarations
+{
+    /**
+     * @param list<QualifiedName> $functions
+     * @param list<QualifiedName> $constants
+     */
+    public function __construct(
+        public array $functions = [],
+        public array $constants = [],
+    ) {
+    }
+}

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -7,13 +7,14 @@ namespace Firehed\PhpLsp\Index;
 use Firehed\PhpLsp\Domain\QualifiedName;
 
 /**
- * The function and constant names one file declares — the two symbol namespaces
- * Composer's autoload maps cannot address by name (Plan 0002 §3).
+ * The function and constant names one file declares. Composer publishes no name ->
+ * file map for either symbol namespace, so one is derived by parsing the
+ * `autoload.files` set (Plan 0002 §3).
  *
- * Class-likes are absent because PSR-4, PSR-0 and the classmap address them by name.
- * A class reached only through an `autoload.files` entry escapes all three — the
- * `files` section is never itself a classmap source — and is the known gap Plan 0002
- * §3 records.
+ * Class-likes are out because the common case already has a cheaper route: PSR-4,
+ * PSR-0 and the classmap turn a class name into a path by arithmetic, with no parse.
+ * A class reachable only through a `files` entry has no such route and is missed —
+ * the known gap Plan 0002 §3 records, tracked by #181.
  */
 final readonly class FileDeclarations
 {

--- a/tests/Domain/QualifiedNameTest.php
+++ b/tests/Domain/QualifiedNameTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Domain;
+
+use Firehed\PhpLsp\Domain\QualifiedName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(QualifiedName::class)]
+final class QualifiedNameTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string, string}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function fullyQualifiedNames(): iterable
+    {
+        yield 'namespaced' => ['Psr\Log\LoggerInterface', 'Psr\Log', 'LoggerInterface'];
+        yield 'single segment namespace' => ['Psr\Log', 'Psr', 'Log'];
+        yield 'global' => ['strlen', '', 'strlen'];
+        yield 'leading separator' => ['\Psr\Log\LoggerInterface', 'Psr\Log', 'LoggerInterface'];
+        yield 'leading separator, global' => ['\strlen', '', 'strlen'];
+    }
+
+    #[DataProvider('fullyQualifiedNames')]
+    public function testFromFullyQualifiedSplitsOnTheFinalSeparator(
+        string $fqn,
+        string $expectedNamespace,
+        string $expectedShortName,
+    ): void {
+        $name = QualifiedName::fromFullyQualified($fqn);
+
+        self::assertSame($expectedNamespace, $name->namespace);
+        self::assertSame($expectedShortName, $name->shortName);
+        // A leading separator is spelling, not identity: the round-trip drops it.
+        self::assertSame(ltrim($fqn, '\\'), $name->fullyQualifiedName());
+    }
+
+    public function testGlobalNameHasAnEmptyNamespace(): void
+    {
+        $name = new QualifiedName('', 'strlen');
+
+        self::assertSame('strlen', $name->fullyQualifiedName());
+    }
+}

--- a/tests/Fixtures/AutoloadFiles/globals.php
+++ b/tests/Fixtures/AutoloadFiles/globals.php
@@ -61,9 +61,9 @@ if (!function_exists('fixtureConditionalHelper')) {
     }
 }
 
-// Declarations inside a function body. Whether they happen is a runtime question —
-// an immediately-invoked bootstrap closure declares them, this never-called
-// function does not — so the scan reports them either way, on the lexical rule.
+// Declarations inside a function body: legal PHP, declaring real global symbols
+// once the body runs. Whether it runs is a runtime question, so they are scanned
+// like any other declaration.
 function fixtureBootstrap(): void
 {
     define('FIXTURE_BODY_LIMIT', 500);

--- a/tests/Fixtures/AutoloadFiles/globals.php
+++ b/tests/Fixtures/AutoloadFiles/globals.php
@@ -38,6 +38,14 @@ define(value: 'FIXTURE_NOT_A_CONSTANT_NAME', constant_name: 'FIXTURE_REORDERED_L
 // Not a declaration: a first-class callable makes a Closure and defines nothing.
 define(...);
 
+class FixtureGlobalRegistry
+{
+}
+
+// An anonymous class has no name to index, so it is not a declaration.
+$fixtureAnonymous = new class () {
+};
+
 function fixtureGlobalHelper(int $value): int
 {
     return $value * 2;

--- a/tests/Fixtures/AutoloadFiles/globals.php
+++ b/tests/Fixtures/AutoloadFiles/globals.php
@@ -28,6 +28,16 @@ DEFINE('FIXTURE_UPPERCASE_DEFINED_LIMIT', 250);
 
 define('FIXTURE_COMPUTED_' . 'LIMIT', 300);
 
+// `define` takes named arguments like any other function, and a named argument may
+// be written in any order — so position alone does not say which one is the name.
+define(constant_name: 'FIXTURE_NAMED_LIMIT', value: 400);
+// A string value in first position is the case that misleads: read positionally it
+// looks exactly like a name.
+define(value: 'FIXTURE_NOT_A_CONSTANT_NAME', constant_name: 'FIXTURE_REORDERED_LIMIT');
+
+// Not a declaration: a first-class callable makes a Closure and defines nothing.
+define(...);
+
 function fixtureGlobalHelper(int $value): int
 {
     return $value * 2;

--- a/tests/Fixtures/AutoloadFiles/globals.php
+++ b/tests/Fixtures/AutoloadFiles/globals.php
@@ -60,3 +60,16 @@ if (!function_exists('fixtureConditionalHelper')) {
         return $value + 1;
     }
 }
+
+// Declarations inside a function body. Whether they happen is a runtime question —
+// an immediately-invoked bootstrap closure declares them, this never-called
+// function does not — so the scan reports them either way, on the lexical rule.
+function fixtureBootstrap(): void
+{
+    define('FIXTURE_BODY_LIMIT', 500);
+
+    function fixtureNestedHelper(int $value): int
+    {
+        return $value - 1;
+    }
+}

--- a/tests/Fixtures/AutoloadFiles/globals.php
+++ b/tests/Fixtures/AutoloadFiles/globals.php
@@ -3,9 +3,10 @@
 declare(strict_types=1);
 
 /**
- * A global-namespace `autoload.files` entry, covering the three ways a constant
- * reaches the global namespace: a `const` declaration, a `define()` with a literal
- * name, and a `define()` whose name is computed.
+ * A global-namespace `autoload.files` entry, covering the ways a constant reaches
+ * the global namespace: a `const` declaration, several names in one `const`
+ * statement, a `define()` with a literal name, a `define()` spelled in another case,
+ * and a `define()` whose name is computed.
  *
  * The computed one is deliberately unreachable: its name exists only at runtime, so
  * a static parse cannot know it (Plan 0002 §3b, §3's locate-only limitation). It is
@@ -15,11 +16,29 @@ declare(strict_types=1);
 
 const FIXTURE_GLOBAL_LIMIT = 100;
 
+// One statement, several constants: a scanner reading only the first declarator
+// would silently drop the rest.
+const FIXTURE_GLOBAL_ALPHA = 1, FIXTURE_GLOBAL_BETA = 2;
+
 define('FIXTURE_DEFINED_LIMIT', 200);
+
+// `define` is a function, and function names are case-insensitive, so this declares
+// a constant exactly as the lowercase spelling above does.
+DEFINE('FIXTURE_UPPERCASE_DEFINED_LIMIT', 250);
 
 define('FIXTURE_COMPUTED_' . 'LIMIT', 300);
 
 function fixtureGlobalHelper(int $value): int
 {
     return $value * 2;
+}
+
+// The shape most real `autoload.files` entries take: a polyfill declares itself only
+// where the runtime lacks it. The declaration is therefore nested rather than
+// top-level, which a scanner that walked only top-level statements would miss.
+if (!function_exists('fixtureConditionalHelper')) {
+    function fixtureConditionalHelper(int $value): int
+    {
+        return $value + 1;
+    }
 }

--- a/tests/Fixtures/AutoloadFiles/helpers.php
+++ b/tests/Fixtures/AutoloadFiles/helpers.php
@@ -19,6 +19,16 @@ const HELPER_LIMIT = 25;
 define('FIXTURE_HELPER_DEFINED', 30);
 define('Fixtures\Helpers\HELPER_DEFINED_QUALIFIED', 35);
 
+// Class-likes declared in a `files` entry. Composer's autoload maps never address
+// these by name, so the derived index is the only route to them.
+interface HelperContract
+{
+}
+
+class HelperRegistry implements HelperContract
+{
+}
+
 function helperFormat(string $value): string
 {
     return trim($value);

--- a/tests/Fixtures/AutoloadFiles/helpers.php
+++ b/tests/Fixtures/AutoloadFiles/helpers.php
@@ -19,14 +19,25 @@ const HELPER_LIMIT = 25;
 define('FIXTURE_HELPER_DEFINED', 30);
 define('Fixtures\Helpers\HELPER_DEFINED_QUALIFIED', 35);
 
-// Class-likes declared in a `files` entry. Composer's autoload maps never address
-// these by name, so the derived index is the only route to them.
+// Every class-like flavour, declared in a `files` entry. Composer's autoload maps
+// never address these by name, so the derived index is the only route to them —
+// and a scan narrowed to `class`/`interface` would lose the other two silently.
 interface HelperContract
 {
 }
 
+trait HelperFallback
+{
+}
+
+enum HelperMode
+{
+    case Strict;
+}
+
 class HelperRegistry implements HelperContract
 {
+    use HelperFallback;
 }
 
 function helperFormat(string $value): string

--- a/tests/Fixtures/AutoloadFiles/helpers.php
+++ b/tests/Fixtures/AutoloadFiles/helpers.php
@@ -13,6 +13,12 @@ namespace Fixtures\Helpers;
 
 const HELPER_LIMIT = 25;
 
+// `define()` is a function call, so the namespace it is written in does not reach
+// its argument: the literal is the whole name. Both spellings below declare exactly
+// what they say, one global and one qualified.
+define('FIXTURE_HELPER_DEFINED', 30);
+define('Fixtures\Helpers\HELPER_DEFINED_QUALIFIED', 35);
+
 function helperFormat(string $value): string
 {
     return trim($value);

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\FileDeclarations;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
@@ -18,6 +19,8 @@ use ReflectionFunction;
 #[CoversClass(FileDeclarations::class)]
 final class DeclarationScannerTest extends TestCase
 {
+    use LoadsFixturesTrait;
+
     private DeclarationScanner $scanner;
     private ParserService $parser;
 
@@ -214,11 +217,10 @@ final class DeclarationScannerTest extends TestCase
 
     private function scanFixture(string $relativePath): FileDeclarations
     {
-        $path = __DIR__ . '/../Fixtures/' . $relativePath;
-        $content = file_get_contents($path);
-        self::assertNotFalse($content, "fixture should be readable: {$relativePath}");
+        $uri = FileUri::fromPath($this->fixturePath($relativePath));
+        $content = $this->loadFixture($relativePath);
 
-        $ast = $this->parser->parse(new TextDocument(FileUri::fromPath($path), 'php', 0, $content));
+        $ast = $this->parser->parse(new TextDocument($uri, 'php', 0, $content));
         self::assertNotNull($ast, "fixture should parse: {$relativePath}");
 
         return $this->scanner->scan($ast);

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Index\DeclarationScanner;
+use Firehed\PhpLsp\Index\FileDeclarations;
+use Firehed\PhpLsp\Parser\ParserService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DeclarationScanner::class)]
+#[CoversClass(FileDeclarations::class)]
+final class DeclarationScannerTest extends TestCase
+{
+    private DeclarationScanner $scanner;
+    private ParserService $parser;
+
+    protected function setUp(): void
+    {
+        $this->scanner = new DeclarationScanner();
+        $this->parser = new ParserService();
+    }
+
+    public function testNamespacedFunctionsAreReportedByFullyQualifiedName(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/helpers.php');
+
+        self::assertSame(
+            ['Fixtures\Helpers\helperFormat', 'Fixtures\Helpers\helperNormalize'],
+            self::fqns($declarations->functions),
+            'a function declared under a namespace is reachable only by its qualified name',
+        );
+    }
+
+    public function testNamespacedConstantsAreReportedByFullyQualifiedName(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/helpers.php');
+
+        self::assertSame(
+            ['Fixtures\Helpers\HELPER_LIMIT'],
+            self::fqns($declarations->constants),
+            'a const declaration under a namespace is namespaced like a function',
+        );
+    }
+
+    public function testGlobalFunctionsAreReportedWithoutANamespace(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        self::assertSame(
+            ['fixtureGlobalHelper', 'fixtureConditionalHelper'],
+            self::fqns($declarations->functions),
+            'a function declared outside any namespace has an empty namespace path',
+        );
+    }
+
+    public function testAConditionallyDeclaredFunctionIsReported(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // A guarded polyfill declaration is nested inside an `if`, not top-level.
+        // Walking only top-level statements — a plausible simplification of the
+        // traversal — would drop the shape most real autoload.files entries take.
+        self::assertContains(
+            'fixtureConditionalHelper',
+            self::fqns($declarations->functions),
+            'a declaration nested inside a conditional is still a declaration',
+        );
+    }
+
+    public function testConstDeclarationAndLiteralDefineAreBothReported(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        self::assertSame(
+            [
+                'FIXTURE_GLOBAL_LIMIT',
+                'FIXTURE_GLOBAL_ALPHA',
+                'FIXTURE_GLOBAL_BETA',
+                'FIXTURE_DEFINED_LIMIT',
+                'FIXTURE_UPPERCASE_DEFINED_LIMIT',
+            ],
+            self::fqns($declarations->constants),
+            'constant reach covers const declarations and literal-name define() alike (Plan 0002 §3b)',
+        );
+    }
+
+    public function testEveryDeclaratorOfAConstStatementIsReported(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // `const A = 1, B = 2;` is one statement holding two declarations. Reading
+        // only the statement's first declarator loses the rest silently.
+        self::assertContains(
+            'FIXTURE_GLOBAL_BETA',
+            self::fqns($declarations->constants),
+            'the second declarator of a const statement is a declaration too',
+        );
+    }
+
+    public function testDefineIsRecognisedRegardlessOfItsSpelling(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // PHP function names are case-insensitive, so `DEFINE(...)` declares a
+        // constant; matching the callee case-sensitively would skip it.
+        self::assertContains(
+            'FIXTURE_UPPERCASE_DEFINED_LIMIT',
+            self::fqns($declarations->constants),
+            'define() is a function call, and function names are case-insensitive',
+        );
+    }
+
+    public function testComputedDefineNameIsNotReported(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // globals.php introduces six constants, the last of which is a `define()`
+        // whose name is concatenated at runtime. Asserting the absence of the
+        // computed *name* cannot fail — no static parse could ever produce it — so
+        // the count is what carries the limitation: whatever a scanner chose to
+        // record for that site would show up as an extra entry.
+        self::assertCount(
+            5,
+            $declarations->constants,
+            'a computed define() name exists only at runtime and contributes nothing (Plan 0002 §3b)',
+        );
+    }
+
+    public function testAFileDeclaringNeitherYieldsNothing(): void
+    {
+        // A class-like file is the common case in an autoload.files set that also
+        // pulls in a bootstrap; it contributes no function or constant names.
+        $declarations = $this->scanFixture('src/Domain/User.php');
+
+        self::assertSame([], $declarations->functions, 'a class declares no free functions');
+        self::assertSame([], $declarations->constants, 'a class constant is not a namespaced constant');
+    }
+
+    public function testAnUnparseableFileYieldsNothing(): void
+    {
+        $declarations = $this->scanner->scan([]);
+
+        self::assertSame([], $declarations->functions, 'no AST means nothing declared, not an error');
+        self::assertSame([], $declarations->constants, 'no AST means nothing declared, not an error');
+    }
+
+    private function scanFixture(string $relativePath): FileDeclarations
+    {
+        $path = __DIR__ . '/../Fixtures/' . $relativePath;
+        $content = file_get_contents($path);
+        self::assertNotFalse($content, "fixture should be readable: {$relativePath}");
+
+        $ast = $this->parser->parse(new TextDocument('file://' . $path, 'php', 0, $content));
+        self::assertNotNull($ast, "fixture should parse: {$relativePath}");
+
+        return $this->scanner->scan($ast);
+    }
+
+    /**
+     * @param list<QualifiedName> $names
+     * @return list<string>
+     */
+    private static function fqns(array $names): array
+    {
+        return array_map(static fn(QualifiedName $name): string => $name->fullyQualifiedName(), $names);
+    }
+}

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -116,11 +116,9 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
-        // The rule is lexical, not executional: the scan reports what the file
-        // declares, because whether the enclosing body runs at require time is a
-        // runtime question (an immediately-invoked bootstrap closure runs; a
-        // never-called function does not) that a static parse cannot settle. So
-        // this over-reports rather than dropping a real bootstrap declaration.
+        // The rule is lexical, not executional. Nesting is legal PHP that declares
+        // a real symbol once the body runs, and whether it runs is a runtime
+        // question a static parse cannot settle — so the name resolves.
         self::assertContains(
             'fixtureNestedHelper',
             self::fqns($declarations->functions),

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Index;
 
+use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Index\DeclarationScanner;
@@ -62,9 +63,7 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
-        // A guarded polyfill declaration is nested inside an `if`, not top-level.
-        // Walking only top-level statements — a plausible simplification of the
-        // traversal — would drop the shape most real autoload.files entries take.
+        // Nested inside an `if`, so a top-level-only walk would drop it.
         self::assertContains(
             'fixtureConditionalHelper',
             self::fqns($declarations->functions),
@@ -93,8 +92,7 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
-        // `const A = 1, B = 2;` is one statement holding two declarations. Reading
-        // only the statement's first declarator loses the rest silently.
+        // `const A = 1, B = 2;` is one statement holding two declarations.
         self::assertContains(
             'FIXTURE_GLOBAL_BETA',
             self::fqns($declarations->constants),
@@ -106,8 +104,6 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
-        // PHP function names are case-insensitive, so `DEFINE(...)` declares a
-        // constant; matching the callee case-sensitively would skip it.
         self::assertContains(
             'FIXTURE_UPPERCASE_DEFINED_LIMIT',
             self::fqns($declarations->constants),
@@ -119,11 +115,8 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
-        // globals.php introduces six constants, the last of which is a `define()`
-        // whose name is concatenated at runtime. Asserting the absence of the
-        // computed *name* cannot fail — no static parse could ever produce it — so
-        // the count is what carries the limitation: whatever a scanner chose to
-        // record for that site would show up as an extra entry.
+        // The fixture declares six; asserting the computed name's absence could
+        // never fail, so the count is what carries the limitation.
         self::assertCount(
             5,
             $declarations->constants,
@@ -133,8 +126,6 @@ final class DeclarationScannerTest extends TestCase
 
     public function testAFileDeclaringNeitherYieldsNothing(): void
     {
-        // A class-like file is the common case in an autoload.files set that also
-        // pulls in a bootstrap; it contributes no function or constant names.
         $declarations = $this->scanFixture('src/Domain/User.php');
 
         self::assertSame([], $declarations->functions, 'a class declares no free functions');
@@ -155,7 +146,7 @@ final class DeclarationScannerTest extends TestCase
         $content = file_get_contents($path);
         self::assertNotFalse($content, "fixture should be readable: {$relativePath}");
 
-        $ast = $this->parser->parse(new TextDocument('file://' . $path, 'php', 0, $content));
+        $ast = $this->parser->parse(new TextDocument(FileUri::fromPath($path), 'php', 0, $content));
         self::assertNotNull($ast, "fixture should parse: {$relativePath}");
 
         return $this->scanner->scan($ast);

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -42,9 +42,42 @@ final class DeclarationScannerTest extends TestCase
         $declarations = $this->scanFixture('AutoloadFiles/helpers.php');
 
         self::assertSame(
-            ['Fixtures\Helpers\HELPER_LIMIT'],
+            [
+                'Fixtures\Helpers\HELPER_LIMIT',
+                'FIXTURE_HELPER_DEFINED',
+                'Fixtures\Helpers\HELPER_DEFINED_QUALIFIED',
+            ],
             self::fqns($declarations->constants),
             'a const declaration under a namespace is namespaced like a function',
+        );
+    }
+
+    public function testDefineIgnoresTheNamespaceItIsWrittenIn(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/helpers.php');
+
+        // The one non-obvious rule on this path: `const` under `namespace Foo` is
+        // `Foo\X`, but `define('X')` in the same file is the global `X`.
+        self::assertContains(
+            'FIXTURE_HELPER_DEFINED',
+            self::fqns($declarations->constants),
+            'define() takes its whole name from the literal, not from the enclosing namespace',
+        );
+    }
+
+    public function testAQualifiedDefineLiteralIsSplitIntoNamespaceAndShortName(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/helpers.php');
+
+        $qualified = array_values(array_filter(
+            $declarations->constants,
+            static fn(QualifiedName $name): bool => $name->namespace !== '',
+        ));
+
+        self::assertSame(
+            ['Fixtures\Helpers', 'Fixtures\Helpers'],
+            array_map(static fn(QualifiedName $name): string => $name->namespace, $qualified),
+            'a define() literal carrying a namespace is split like any other qualified name',
         );
     }
 

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -12,6 +12,7 @@ use Firehed\PhpLsp\Index\FileDeclarations;
 use Firehed\PhpLsp\Parser\ParserService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
 
 #[CoversClass(DeclarationScanner::class)]
 #[CoversClass(FileDeclarations::class)]
@@ -115,9 +116,47 @@ final class DeclarationScannerTest extends TestCase
                 'FIXTURE_GLOBAL_BETA',
                 'FIXTURE_DEFINED_LIMIT',
                 'FIXTURE_UPPERCASE_DEFINED_LIMIT',
+                'FIXTURE_NAMED_LIMIT',
+                'FIXTURE_REORDERED_LIMIT',
             ],
             self::fqns($declarations->constants),
             'constant reach covers const declarations and literal-name define() alike (Plan 0002 §3b)',
+        );
+    }
+
+    public function testDefineNamesItsConstantByNamedArgumentToo(): void
+    {
+        // Reading the first argument positionally would index the *value* of the
+        // reordered call as if it were a constant name.
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        self::assertSame(
+            'constant_name',
+            (new ReflectionFunction('define'))->getParameters()[0]->getName(),
+            'the parameter the scanner matches by name is the one PHP declares',
+        );
+        self::assertContains(
+            'FIXTURE_REORDERED_LIMIT',
+            self::fqns($declarations->constants),
+            'a named argument declares the constant it names regardless of its position',
+        );
+        self::assertNotContains(
+            'FIXTURE_NOT_A_CONSTANT_NAME',
+            self::fqns($declarations->constants),
+            'the value of a define() call is not a constant name',
+        );
+    }
+
+    public function testAFirstClassCallableDefineDeclaresNothing(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // `define(...)` parses to a placeholder rather than an argument: it makes a
+        // Closure and declares nothing.
+        self::assertNotContains(
+            '',
+            self::fqns($declarations->constants),
+            'a call carrying no arguments contributes no constant',
         );
     }
 
@@ -148,11 +187,11 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
-        // The fixture declares six; asserting the computed name's absence could
-        // never fail, so the count is what carries the limitation.
-        self::assertCount(
-            5,
-            $declarations->constants,
+        // Named rather than counted: this stays red for the right reason if the
+        // scanner ever learns to fold `'A' . 'B'` into a name.
+        self::assertNotContains(
+            'FIXTURE_COMPUTED_LIMIT',
+            self::fqns($declarations->constants),
             'a computed define() name exists only at runtime and contributes nothing (Plan 0002 §3b)',
         );
     }

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -34,6 +34,7 @@ final class DeclarationScannerTest extends TestCase
         'FIXTURE_UPPERCASE_DEFINED_LIMIT',
         'FIXTURE_NAMED_LIMIT',
         'FIXTURE_REORDERED_LIMIT',
+        'FIXTURE_BODY_LIMIT',
     ];
 
     private DeclarationScanner $scanner;
@@ -105,9 +106,30 @@ final class DeclarationScannerTest extends TestCase
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
         self::assertSame(
-            ['fixtureGlobalHelper', 'fixtureConditionalHelper'],
+            ['fixtureGlobalHelper', 'fixtureConditionalHelper', 'fixtureBootstrap', 'fixtureNestedHelper'],
             self::fqns($declarations->functions),
             'a function declared outside any namespace has an empty namespace path',
+        );
+    }
+
+    public function testDeclarationsInsideAFunctionBodyAreReported(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // The rule is lexical, not executional: the scan reports what the file
+        // declares, because whether the enclosing body runs at require time is a
+        // runtime question (an immediately-invoked bootstrap closure runs; a
+        // never-called function does not) that a static parse cannot settle. So
+        // this over-reports rather than dropping a real bootstrap declaration.
+        self::assertContains(
+            'fixtureNestedHelper',
+            self::fqns($declarations->functions),
+            'a function declared inside a function body is still lexically declared',
+        );
+        self::assertContains(
+            'FIXTURE_BODY_LIMIT',
+            self::fqns($declarations->constants),
+            'a define() inside a function body is reported on the same lexical rule',
         );
     }
 

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -204,12 +204,12 @@ final class DeclarationScannerTest extends TestCase
         self::assertSame([], $declarations->constants, 'a class constant is not a namespaced constant');
     }
 
-    public function testAnUnparseableFileYieldsNothing(): void
+    public function testAnEmptyAstYieldsNothing(): void
     {
         $declarations = $this->scanner->scan([]);
 
-        self::assertSame([], $declarations->functions, 'no AST means nothing declared, not an error');
-        self::assertSame([], $declarations->constants, 'no AST means nothing declared, not an error');
+        self::assertSame([], $declarations->functions, 'an empty AST declares nothing, and is not an error');
+        self::assertSame([], $declarations->constants, 'an empty AST declares nothing, and is not an error');
     }
 
     private function scanFixture(string $relativePath): FileDeclarations

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -21,6 +21,21 @@ final class DeclarationScannerTest extends TestCase
 {
     use LoadsFixturesTrait;
 
+    /**
+     * Every constant AutoloadFiles/globals.php declares, in declaration order.
+     * A first-class-callable `define(...)` yields no name to probe for, so the test
+     * for it asserts against this whole list instead.
+     */
+    private const GLOBAL_CONSTANTS = [
+        'FIXTURE_GLOBAL_LIMIT',
+        'FIXTURE_GLOBAL_ALPHA',
+        'FIXTURE_GLOBAL_BETA',
+        'FIXTURE_DEFINED_LIMIT',
+        'FIXTURE_UPPERCASE_DEFINED_LIMIT',
+        'FIXTURE_NAMED_LIMIT',
+        'FIXTURE_REORDERED_LIMIT',
+    ];
+
     private DeclarationScanner $scanner;
     private ParserService $parser;
 
@@ -113,15 +128,7 @@ final class DeclarationScannerTest extends TestCase
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
         self::assertSame(
-            [
-                'FIXTURE_GLOBAL_LIMIT',
-                'FIXTURE_GLOBAL_ALPHA',
-                'FIXTURE_GLOBAL_BETA',
-                'FIXTURE_DEFINED_LIMIT',
-                'FIXTURE_UPPERCASE_DEFINED_LIMIT',
-                'FIXTURE_NAMED_LIMIT',
-                'FIXTURE_REORDERED_LIMIT',
-            ],
+            self::GLOBAL_CONSTANTS,
             self::fqns($declarations->constants),
             'constant reach covers const declarations and literal-name define() alike (Plan 0002 §3b)',
         );
@@ -155,11 +162,12 @@ final class DeclarationScannerTest extends TestCase
         $declarations = $this->scanFixture('AutoloadFiles/globals.php');
 
         // `define(...)` parses to a placeholder rather than an argument: it makes a
-        // Closure and declares nothing.
-        self::assertNotContains(
-            '',
+        // Closure and declares nothing. Asserted against the whole list, so a
+        // placeholder that contributed any name at all would show up.
+        self::assertSame(
+            self::GLOBAL_CONSTANTS,
             self::fqns($declarations->constants),
-            'a call carrying no arguments contributes no constant',
+            'a call whose arguments are a placeholder contributes no constant',
         );
     }
 

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -207,10 +207,52 @@ final class DeclarationScannerTest extends TestCase
         );
     }
 
-    public function testAFileDeclaringNeitherYieldsNothing(): void
+    public function testNamespacedClassLikesAreReportedByFullyQualifiedName(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/helpers.php');
+
+        // An interface is a class-like too: Composer addresses none of them by name
+        // when the file is reached only through `autoload.files`.
+        self::assertSame(
+            ['Fixtures\Helpers\HelperContract', 'Fixtures\Helpers\HelperRegistry'],
+            self::fqns($declarations->classLikes),
+            'every class-like flavour in a files entry is indexed, not just classes',
+        );
+    }
+
+    public function testGlobalClassLikesAreReportedWithoutANamespace(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        self::assertSame(
+            ['FixtureGlobalRegistry'],
+            self::fqns($declarations->classLikes),
+            'a class declared outside any namespace has an empty namespace path',
+        );
+    }
+
+    public function testAnAnonymousClassIsNotADeclaration(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // Asserted through the whole list: an anonymous class has no name to probe
+        // for, and reporting one would mean indexing an unnameable symbol.
+        self::assertSame(
+            ['FixtureGlobalRegistry'],
+            self::fqns($declarations->classLikes),
+            'an anonymous class cannot be looked up by name, so it is not indexed',
+        );
+    }
+
+    public function testAClassFileDeclaresOnlyItsClassLike(): void
     {
         $declarations = $this->scanFixture('src/Domain/User.php');
 
+        self::assertSame(
+            ['Fixtures\Domain\User'],
+            self::fqns($declarations->classLikes),
+            'a PSR-4 class file declares exactly the class it is named for',
+        );
         self::assertSame([], $declarations->functions, 'a class declares no free functions');
         self::assertSame([], $declarations->constants, 'a class constant is not a namespaced constant');
     }
@@ -219,6 +261,7 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanner->scan([]);
 
+        self::assertSame([], $declarations->classLikes, 'an empty AST declares nothing, and is not an error');
         self::assertSame([], $declarations->functions, 'an empty AST declares nothing, and is not an error');
         self::assertSame([], $declarations->constants, 'an empty AST declares nothing, and is not an error');
     }

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -211,10 +211,16 @@ final class DeclarationScannerTest extends TestCase
     {
         $declarations = $this->scanFixture('AutoloadFiles/helpers.php');
 
-        // An interface is a class-like too: Composer addresses none of them by name
-        // when the file is reached only through `autoload.files`.
+        // Interfaces, traits and enums are class-likes too: Composer addresses none
+        // of them by name when the file is reached only through `autoload.files`, so
+        // narrowing the scan to `class` and `interface` would lose two of the four.
         self::assertSame(
-            ['Fixtures\Helpers\HelperContract', 'Fixtures\Helpers\HelperRegistry'],
+            [
+                'Fixtures\Helpers\HelperContract',
+                'Fixtures\Helpers\HelperFallback',
+                'Fixtures\Helpers\HelperMode',
+                'Fixtures\Helpers\HelperRegistry',
+            ],
             self::fqns($declarations->classLikes),
             'every class-like flavour in a files entry is indexed, not just classes',
         );

--- a/tests/LoadsFixturesTrait.php
+++ b/tests/LoadsFixturesTrait.php
@@ -17,14 +17,24 @@ use Firehed\PhpLsp\Protocol\PositionEncoding;
 trait LoadsFixturesTrait
 {
     /**
+     * The absolute path of a fixture, for tests that need to address the file
+     * itself (a URI, a locator input) rather than only its contents.
+     *
+     * @param string $fixturePath Path relative to tests/Fixtures/
+     */
+    private function fixturePath(string $fixturePath): string
+    {
+        return __DIR__ . '/Fixtures/' . $fixturePath;
+    }
+
+    /**
      * Load fixture file contents.
      *
      * @param string $fixturePath Path relative to tests/Fixtures/
      */
     private function loadFixture(string $fixturePath): string
     {
-        $fullPath = __DIR__ . '/Fixtures/' . $fixturePath;
-        $content = file_get_contents($fullPath);
+        $content = file_get_contents($this->fixturePath($fixturePath));
         assert($content !== false, "Fixture not found: $fixturePath");
         return $content;
     }


### PR DESCRIPTION
Slice **S3.7b** (#390). `DeclarationScanner` reads the functions and constants a parsed
file declares, so S3.7d can derive a name→file index for the two symbol namespaces
Composer cannot address by name.

- Qualified names come from `namespacedName` (set by `NameResolver` during
  `ParserService::parse()`), not hand-tracked `Stmt\Namespace_` — the shape SC.3 is
  removing elsewhere.
- Covered: namespaced and global declarations, every declarator of a multi-name `const`,
  literal `define()` in any casing, and declarations nested in a conditional (the polyfill
  shape, which a top-level-only walk would drop).
- Out of scope, per Plan 0002 §3's locate-only limitation: a computed `define()` name, and
  anything reached only through a `require`/`include`.

`QualifiedName` lands here rather than in S3.7c as the manifest said — the scanner is its
first caller. Manifest corrected in this branch; `fromClassName()` is left for S3.7c,
where `FilesystemBackend` needs it.
