### PR TITLE
Gate slice implementation on an explain-and-approve step

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -42,11 +42,16 @@ project's **Squash and Merge**: a squash rewrites the branch into one new commit
   review it first.
 - A slice's branch is merged while a dependency is not — surface the state drift.
 
-## 4. Implement X
+## 4. Explain X
+
+Read X's plan step in `docs/architecture/0002-execution-plan.md` for its acceptance
+criteria, and the RFC sections it cites in `0001-foundational-architecture.md`. Then
+describe the work in plain english and **wait** for approval, clarification, or
+modification before writing anything.
+
+## 5. Implement X
 
 - Create `slice/<X>` off `main`.
-- Read X's plan step in `docs/architecture/0002-execution-plan.md` for its acceptance
-  criteria, and the RFC sections it cites in `0001-foundational-architecture.md`.
 - TDD:
   - Behavior-preserving slice → add/extend the Step P parity fixtures **first**.
   - Seam-introducing slice → add its §8.1 enforcement rule in this slice.
@@ -55,7 +60,7 @@ project's **Squash and Merge**: a squash rewrites the branch into one new commit
 - If you hit a fundamental design question the plan does not answer, **STOP and ask**
   — do not invent an interpretation.
 
-## 5. Open the PR and report
+## 6. Open the PR and report
 
 - PR title carries no issue number; the body cites the slice id, plan step, and RFC
   section(s), and lists the acceptance criteria as a checklist.

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -72,11 +72,13 @@ squash-deleted branch is never misread as unstarted.
      first — one slice in flight at a time);
    - the manifest references a merged branch for a slice whose dependencies are not
      merged (state drift — surface it).
-4. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
+4. **Explain X.** Describe in plain english the work to be done, then wait for
+   approval, clarification, or modification.
+5. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
    (for a behavior-preserving step: parity fixtures first; for a step that
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
    `composer test`; open a PR citing X.
-5. Stop. Report the PR and the *next* computed slice, so the human knows what a
+6. Stop. Report the PR and the *next* computed slice, so the human knows what a
    follow-up "do the next step" would pick up.
 
 ## Mode B — "review this step's branch"


### PR DESCRIPTION
Mode A went straight from computing the next slice to implementing it, so the first thing a session produced was a branch. Adding an explain-and-wait step in between makes the interpretation of a slice reviewable before any code exists, which is where a misread plan step is cheapest to catch.

`.claude/skills/do-next/SKILL.md` is the copy that actually executes, so it carries the same step; leaving it stale would mean the gate exists only in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)