### PR TITLE
Derive a symbol index from the autoload.files set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,16 @@ over a fixed-precedence list of **`SymbolBackend`s** (RFC 1 §5.3):
 A lookup takes the first backend that answers; enumeration and search merge every
 backend, the earlier (more authoritative) one winning a name clash. Caching is a
 per-backend PSR-16 policy (`src/Cache/`); on-disk and built-in results are cached, open
-documents never. The write path is **`SymbolSink`** (`DocumentSymbolSink`), which
+documents never.
+
+Each `FilesystemBackend` finds its file through a **`CompositeSymbolLocator`** chaining
+two routes, cheapest first: `ComposerSymbolLocator` (PSR-4/PSR-0/classmap — arithmetic
+on the name) and `AutoloadFilesLocator`. The latter exists because `autoload.files`
+entries are addressed by *no* name at all, so the only route is to parse the set and
+derive the map; it is built eagerly, covers all three symbol namespaces (a name-keyed
+route cannot know which kind a file declares), and applies PHP's per-kind case rules via
+`NameKind::isCaseSensitive()`. Its startup cost is pinned by a test — the set is
+explicit and usually tiny, and the bound is what keeps it from drifting. The write path is **`SymbolSink`** (`DocumentSymbolSink`), which
 registers class metadata and indexes symbols from one document.
 **`KnowledgeStack::forProject`** assembles the read composite and the write sink,
 sharing one open-document backend and symbol index.
@@ -120,7 +129,9 @@ producer alongside the editor lifecycle. `SymbolSink extends Cache\Invalidatable
 `invalidate($uri)` drops the on-disk cache for a file changed outside the editor and
 the next query re-reads disk. It fans out to the cached on-disk backends (also
 `Invalidatable`): `FilesystemBackend` evicts that file's class-likes (a path→key
-reverse map) and `CachedNamespaceCatalog` drops its listings. Two triggers reach it:
+reverse map), `CachedNamespaceCatalog` drops its listings, and the locator chain
+re-derives the `autoload.files` index if the changed file is in that set — evicting
+only the `ClassInfo` cache would leave the name→file map itself stale. Two triggers reach it:
 the `workspace/didChangeWatchedFiles` notification (`DidChangeWatchedFilesHandler`)
 and `didClose` (so a closed-after-edit file re-reads disk). Watched files are
 registered dynamically after `initialized` (`WatchedFilesRegistrar` via the outbound

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,10 @@ on the name) and `AutoloadFilesLocator`. The latter exists because `autoload.fil
 entries are addressed by *no* name at all, so the only route is to parse the set and
 derive the map; it is built eagerly, covers all three symbol namespaces (a name-keyed
 route cannot know which kind a file declares), and applies PHP's per-kind case rules via
-`NameKind::isCaseSensitive()`. Its startup cost is pinned by a test — the set is
-explicit and usually tiny, and the bound is what keeps it from drifting. The write path is **`SymbolSink`** (`DocumentSymbolSink`), which
+`NameKind::isCaseSensitive()`. A test pins the parse *count* at construction, which is
+not a cost measurement; the set is explicit and usually tiny.
+
+The write path is **`SymbolSink`** (`DocumentSymbolSink`), which
 registers class metadata and indexes symbols from one document.
 **`KnowledgeStack::forProject`** assembles the read composite and the write sink,
 sharing one open-document backend and symbol index.
@@ -131,7 +133,8 @@ the next query re-reads disk. It fans out to the cached on-disk backends (also
 `Invalidatable`): `FilesystemBackend` evicts that file's class-likes (a path→key
 reverse map), `CachedNamespaceCatalog` drops its listings, and the locator chain
 re-derives the `autoload.files` index if the changed file is in that set — evicting
-only the `ClassInfo` cache would leave the name→file map itself stale. Two triggers reach it:
+only the `ClassInfo` cache would leave the name→file map itself stale.
+Two triggers reach it:
 the `workspace/didChangeWatchedFiles` notification (`DidChangeWatchedFilesHandler`)
 and `didClose` (so a closed-after-edit file re-reads disk). Watched files are
 registered dynamically after `initialized` (`WatchedFilesRegistrar` via the outbound

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -91,14 +91,8 @@ final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
     }
 
     /**
-     * PHP matches class-like and function names case-insensitively and constant
-     * names exactly, so the key a kind is stored and looked up under follows the
-     * rule for that kind rather than one rule for all three.
-     *
-     * The rule governs the *short name* only: a namespace path is case-insensitive
-     * for every kind ({@see NamespacePath}), so `FIXTURES\HELPERS\HELPER_LIMIT`
-     * names the same constant as `Fixtures\Helpers\HELPER_LIMIT` while
-     * `Fixtures\Helpers\helper_limit` names a different one.
+     * Only constant short names are matched exactly. A namespace path is
+     * case-insensitive for every kind, so the rule applies to the short name alone.
      */
     private static function key(QualifiedName $name, NameKind $kind): string
     {

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Resolution\NameKind;
+use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * Locates a declaration in Composer's `autoload.files` set, by deriving the
@@ -93,12 +94,17 @@ final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
      * PHP matches class-like and function names case-insensitively and constant
      * names exactly, so the key a kind is stored and looked up under follows the
      * rule for that kind rather than one rule for all three.
+     *
+     * The rule governs the *short name* only: a namespace path is case-insensitive
+     * for every kind ({@see NamespacePath}), so `FIXTURES\HELPERS\HELPER_LIMIT`
+     * names the same constant as `Fixtures\Helpers\HELPER_LIMIT` while
+     * `Fixtures\Helpers\helper_limit` names a different one.
      */
     private static function key(QualifiedName $name, NameKind $kind): string
     {
-        $fqn = $name->fullyQualifiedName();
+        $shortName = $kind->isCaseSensitive() ? $name->shortName : strtolower($name->shortName);
 
-        return $kind->isCaseSensitive() ? $fqn : strtolower($fqn);
+        return NamespacePath::join(strtolower($name->namespace), $shortName);
     }
 
     /**

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Cache\Invalidatable;
+use Firehed\PhpLsp\Document\FileUri;
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Knowledge\SymbolLocator;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Resolution\NameKind;
+
+/**
+ * Locates a declaration in Composer's `autoload.files` set, by deriving the
+ * name -> file map that set does not have.
+ *
+ * Every other autoload route is arithmetic on the name: PSR-4, PSR-0 and the
+ * classmap all address a class-like by name, so {@see ComposerSymbolLocator} answers
+ * without reading anything. The `files` set cannot — PHP `require`s each entry
+ * wholesale at bootstrap and nothing keys them by name — so this is the one place
+ * the model must scan rather than resolve (Plan 0002 §3).
+ *
+ * The index is built eagerly, and covers all three symbol namespaces: once an entry
+ * is parsed every kind costs the same walk, so indexing only functions and constants
+ * would leave a class-like declared there reachable at runtime but invisible here,
+ * for no saving. The cost is bounded because the set is explicit and usually tiny.
+ */
+final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
+{
+    /**
+     * Kind => normalized name => declaring file.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private array $index;
+
+    public function __construct(
+        private readonly ComposerAutoloadMap $map,
+        private readonly ParserService $parser,
+        private readonly DeclarationScanner $scanner,
+    ) {
+        $this->index = $this->buildIndex();
+    }
+
+    /**
+     * Re-derives the index when a file in the set changed on disk. A change
+     * outside the set cannot affect it, so it costs nothing (RFC 1 §5.2, §5.3).
+     */
+    public function invalidate(string $uri): void
+    {
+        if (!in_array(FileUri::toPath($uri), $this->map->autoloadFiles(), true)) {
+            return;
+        }
+
+        $this->index = $this->buildIndex();
+    }
+
+    public function locate(QualifiedName $name, NameKind $kind): ?string
+    {
+        $declarations = $this->index[$kind->name];
+        $key = self::key($name, $kind);
+
+        return array_key_exists($key, $declarations) ? $declarations[$key] : null;
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function buildIndex(): array
+    {
+        $index = [];
+        foreach (NameKind::cases() as $kind) {
+            $index[$kind->name] = [];
+        }
+
+        foreach ($this->map->autoloadFiles() as $path) {
+            $ast = $this->parser->parseFile($path);
+            if ($ast === null) {
+                continue;
+            }
+
+            $declarations = $this->scanner->scan($ast);
+            self::record($index, NameKind::ClassLike, $declarations->classLikes, $path);
+            self::record($index, NameKind::Function_, $declarations->functions, $path);
+            self::record($index, NameKind::Constant, $declarations->constants, $path);
+        }
+
+        return $index;
+    }
+
+    /**
+     * PHP matches class-like and function names case-insensitively and constant
+     * names exactly, so the key a kind is stored and looked up under follows the
+     * rule for that kind rather than one rule for all three.
+     */
+    private static function key(QualifiedName $name, NameKind $kind): string
+    {
+        $fqn = $name->fullyQualifiedName();
+
+        return $kind->isCaseSensitive() ? $fqn : strtolower($fqn);
+    }
+
+    /**
+     * @param array<string, array<string, string>> $index
+     * @param list<QualifiedName> $names
+     */
+    private static function record(array &$index, NameKind $kind, array $names, string $path): void
+    {
+        foreach ($names as $name) {
+            $key = self::key($name, $kind);
+
+            // Composer requires the entries in order, so the first declaration of a
+            // name is the one that takes effect; a later guarded redeclaration of
+            // the same name never runs.
+            if (!array_key_exists($key, $index[$kind->name])) {
+                $index[$kind->name][$key] = $path;
+            }
+        }
+    }
+}

--- a/src/Index/ComposerSymbolLocator.php
+++ b/src/Index/ComposerSymbolLocator.php
@@ -12,7 +12,9 @@ use Firehed\PhpLsp\Resolution\NameKind;
  * Locates a declaration through Composer's autoload maps, which address class-likes
  * and nothing else: PSR-4, PSR-0 and the classmap all map a class name to a file, so
  * a lookup is arithmetic on the name. Functions and constants are reachable only by
- * parsing the `autoload.files` set, which S3.7d derives an index from.
+ * parsing the `autoload.files` set, which {@see AutoloadFilesLocator} derives an
+ * index from; the two are chained by
+ * {@see \Firehed\PhpLsp\Knowledge\CompositeSymbolLocator}.
  */
 final class ComposerSymbolLocator implements SymbolLocator
 {

--- a/src/Knowledge/CompositeSymbolLocator.php
+++ b/src/Knowledge/CompositeSymbolLocator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Knowledge;
+
+use Firehed\PhpLsp\Cache\Invalidatable;
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Resolution\NameKind;
+
+/**
+ * Chains the routes to a declaration, in order of cost and authority.
+ *
+ * Composer addresses class-likes by arithmetic on the name and everything in the
+ * `autoload.files` set by no name at all, so the two are separate locators rather
+ * than one: the map lookup is cheap and answers most names, and the derived index
+ * covers what the maps structurally cannot (Plan 0002 §3). Chaining keeps the
+ * cheaper route first and leaves each locator responsible for one mechanism.
+ */
+final class CompositeSymbolLocator implements SymbolLocator, Invalidatable
+{
+    /**
+     * @param list<SymbolLocator> $locators In precedence order
+     */
+    public function __construct(
+        private readonly array $locators,
+    ) {
+    }
+
+    /**
+     * Fans out to the members that hold derived state. A locator that resolves by
+     * arithmetic alone holds none and does not implement {@see Invalidatable}.
+     */
+    public function invalidate(string $uri): void
+    {
+        foreach ($this->locators as $locator) {
+            if ($locator instanceof Invalidatable) {
+                $locator->invalidate($uri);
+            }
+        }
+    }
+
+    public function locate(QualifiedName $name, NameKind $kind): ?string
+    {
+        foreach ($this->locators as $locator) {
+            $path = $locator->locate($name, $kind);
+            if ($path !== null) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -107,6 +107,12 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
         if ($this->namespaces instanceof Invalidatable) {
             $this->namespaces->invalidate($uri);
         }
+
+        // The autoload.files index is derived from disk too, so a change must reach
+        // the locator or the name -> file map stays stale behind an evicted cache.
+        if ($this->locator instanceof Invalidatable) {
+            $this->locator->invalidate($uri);
+        }
     }
 
     /**

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -7,7 +7,6 @@ namespace Firehed\PhpLsp\Knowledge;
 use Firehed\PhpLsp\Cache\CacheKey;
 use Firehed\PhpLsp\Cache\Invalidatable;
 use Firehed\PhpLsp\Document\FileUri;
-use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\QualifiedName;
@@ -79,7 +78,7 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
         }
 
         $filePath = $this->locator->locate(QualifiedName::fromClassName($name), NameKind::ClassLike);
-        if ($filePath === null || !is_readable($filePath)) {
+        if ($filePath === null) {
             return null;
         }
 
@@ -123,24 +122,9 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
 
     private function parseClassFrom(ClassName $name, string $filePath): ?ClassInfo
     {
-        $content = file_get_contents($filePath);
-        if ($content === false) {
-            // @codeCoverageIgnoreStart
-            // A readable file that then fails to read is an IO race, not a code path
-            // the corpus can drive; it degrades to "not found" rather than crashing.
-            return null;
-            // @codeCoverageIgnoreEnd
-        }
-
-        $uri = FileUri::fromPath($filePath);
-        $document = new TextDocument($uri, 'php', 0, $content);
-        $ast = $this->parser->parse($document);
+        $ast = $this->parser->parseFile($filePath);
         if ($ast === null) {
-            // @codeCoverageIgnoreStart
-            // ParserService yields null only when a parse throws despite error
-            // recovery — unreachable for a located, well-formed file (RFC 1 §9).
             return null;
-            // @codeCoverageIgnoreEnd
         }
 
         $node = $this->findClassInAst($name->fqn, $ast);
@@ -148,7 +132,7 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
             return null;
         }
 
-        return $this->factory->fromAstNode($node, $uri);
+        return $this->factory->fromAstNode($node, FileUri::fromPath($filePath));
     }
 
     /**

--- a/src/Knowledge/KnowledgeStack.php
+++ b/src/Knowledge/KnowledgeStack.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Cache\CacheFactory;
+use Firehed\PhpLsp\Index\AutoloadFilesLocator;
 use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerNamespaceSource;
 use Firehed\PhpLsp\Index\ComposerSymbolLocator;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\ReflectionNamespaceSource;
 use Firehed\PhpLsp\Index\SymbolExtractor;
@@ -54,9 +56,11 @@ final readonly class KnowledgeStack
 
         [$workspaceMap, $vendorMap] = $autoloadMap->partitionByVendorDirectory($vendorDirectory);
 
+        $scanner = new DeclarationScanner();
+
         $openDocuments = new OpenDocumentBackend($index);
-        $workspace = self::filesystemBackend($workspaceMap, $parser, $classInfoFactory);
-        $vendor = self::filesystemBackend($vendorMap, $parser, $classInfoFactory);
+        $workspace = self::filesystemBackend($workspaceMap, $parser, $classInfoFactory, $scanner);
+        $vendor = self::filesystemBackend($vendorMap, $parser, $classInfoFactory, $scanner);
         $source = new CompositeSymbolSource([
             $openDocuments,
             $workspace,
@@ -84,13 +88,22 @@ final readonly class KnowledgeStack
         return new self($source, $sink);
     }
 
+    /**
+     * The two routes to a declaration, cheapest first: Composer's autoload maps
+     * address class-likes by arithmetic on the name, and the derived index covers
+     * the `autoload.files` set, which they address by no name at all (Plan 0002 §3).
+     */
     private static function filesystemBackend(
         ComposerAutoloadMap $map,
         ParserService $parser,
         ClassInfoFactory $classInfoFactory,
+        DeclarationScanner $scanner,
     ): FilesystemBackend {
         return new FilesystemBackend(
-            new ComposerSymbolLocator($map),
+            new CompositeSymbolLocator([
+                new ComposerSymbolLocator($map),
+                new AutoloadFilesLocator($map, $parser, $scanner),
+            ]),
             new CachedNamespaceCatalog(new ComposerNamespaceSource($map), CacheFactory::inMemory()),
             $parser,
             $classInfoFactory,

--- a/src/Parser/ParserService.php
+++ b/src/Parser/ParserService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Parser;
 
+use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Document\TextDocument;
 use PhpParser\ErrorHandler;
 use PhpParser\Node\Stmt;
@@ -82,6 +83,31 @@ final class ParserService
         }
 
         return $this->scopedParses[$content];
+    }
+
+    /**
+     * Parses a file identified by path rather than by open document, so a caller
+     * holding a path does not re-implement the read-and-wrap. Shares the
+     * content-keyed memo, so a file two callers read costs one parse.
+     *
+     * @return array<Stmt>|null Null when the path cannot be read as a file
+     */
+    public function parseFile(string $path): ?array
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            return null;
+        }
+
+        $content = file_get_contents($path);
+        if ($content === false) {
+            // @codeCoverageIgnoreStart
+            // Guarded against above, so reaching this means the file changed
+            // under us between the check and the read.
+            throw new \LogicException("Readable file could not be read: $path");
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $this->parse(new TextDocument(FileUri::fromPath($path), 'php', 0, $content));
     }
 
     /**

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -115,6 +115,19 @@ final class AutoloadFilesLocatorTest extends TestCase
         // The one kind PHP matches exactly: a differently-cased constant is a
         // different constant, so resolving it would be a false positive.
         yield 'constant' => ['fixture_global_limit', NameKind::Constant, false];
+        // The exact match a constant requires is of its *short name* only. A
+        // namespace path is case-insensitive for every kind, so applying the
+        // constant rule to the whole name would miss a name PHP resolves.
+        yield 'constant under a recased namespace' => [
+            'FIXTURES\HELPERS\HELPER_LIMIT',
+            NameKind::Constant,
+            true,
+        ];
+        yield 'constant with a recased short name' => [
+            'Fixtures\Helpers\helper_limit',
+            NameKind::Constant,
+            false,
+        ];
     }
 
     #[DataProvider('caseVariants')]
@@ -127,11 +140,11 @@ final class AutoloadFilesLocatorTest extends TestCase
             ->locate(QualifiedName::fromFullyQualified($fullyQualifiedName), $kind);
 
         if ($shouldResolve) {
-            self::assertNotNull($path, 'class-like and function names are matched case-insensitively');
+            self::assertNotNull($path, 'only a constant short name is matched case-sensitively');
             return;
         }
 
-        self::assertNull($path, 'constant names are matched case-sensitively');
+        self::assertNull($path, 'a constant short name in another case is another constant');
     }
 
     /**

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -185,7 +185,8 @@ final class AutoloadFilesLocatorTest extends TestCase
     {
         // PHP requires the files in order, so the first declaration is the one that
         // takes effect; a later guarded redeclaration never runs.
-        [$first, $second] = [self::tempFile('<?php const DUPE_TARGET = 1;'), self::tempFile('<?php const DUPE_TARGET = 2;')];
+        $first = self::tempFile('<?php const DUPE_TARGET = 1;');
+        $second = self::tempFile('<?php const DUPE_TARGET = 2;');
 
         try {
             $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$first, $second]));

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -253,10 +253,12 @@ final class AutoloadFilesLocatorTest extends TestCase
         try {
             $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$path]));
 
-            // Deleting the indexed file proves the index was not rebuilt: a rebuild
-            // would drop the name, since the file can no longer be read.
-            $locator->invalidate('file:///some/other/file.php');
+            // Deleting the indexed file first is what makes the assertion load
+            // bearing: from here a rebuild can only drop the name, because the file
+            // can no longer be read. Invalidating before the delete would prove
+            // nothing, since the rebuild would find the file still there.
             unlink($path);
+            $locator->invalidate('file:///some/other/file.php');
 
             self::assertNotNull(
                 $locator->locate(QualifiedName::fromFullyQualified('UNTOUCHED'), NameKind::Constant),

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Document\FileUri;
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Index\AutoloadFilesLocator;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `autoload.files` set is the one place Composer addresses a declaration by no
+ * name at all, so the only route to it is to parse the set and derive a name -> file
+ * map. These prove the derived index reaches all three symbol namespaces, applies
+ * PHP's per-kind case rules, and does not overreach into names it never saw
+ * (Plan 0002 §3, Step 3b).
+ */
+#[CoversClass(AutoloadFilesLocator::class)]
+final class AutoloadFilesLocatorTest extends TestCase
+{
+    private const string FIXTURES_ROOT = __DIR__ . '/../Fixtures';
+
+    /**
+     * @return iterable<string, array{string, NameKind, ?non-empty-string}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function declaredNames(): iterable
+    {
+        // Every class-like flavour: Composer's maps address none of these, because
+        // the file is reached only through `files`.
+        yield 'interface' => ['Fixtures\Helpers\HelperContract', NameKind::ClassLike, 'AutoloadFiles/helpers.php'];
+        yield 'trait' => ['Fixtures\Helpers\HelperFallback', NameKind::ClassLike, 'AutoloadFiles/helpers.php'];
+        yield 'enum' => ['Fixtures\Helpers\HelperMode', NameKind::ClassLike, 'AutoloadFiles/helpers.php'];
+        yield 'class' => ['Fixtures\Helpers\HelperRegistry', NameKind::ClassLike, 'AutoloadFiles/helpers.php'];
+        yield 'global class' => ['FixtureGlobalRegistry', NameKind::ClassLike, 'AutoloadFiles/globals.php'];
+
+        yield 'namespaced function' => [
+            'Fixtures\Helpers\helperFormat',
+            NameKind::Function_,
+            'AutoloadFiles/helpers.php',
+        ];
+        yield 'global function' => ['fixtureGlobalHelper', NameKind::Function_, 'AutoloadFiles/globals.php'];
+        yield 'conditional function' => ['fixtureConditionalHelper', NameKind::Function_, 'AutoloadFiles/globals.php'];
+        yield 'nested function' => ['fixtureNestedHelper', NameKind::Function_, 'AutoloadFiles/globals.php'];
+
+        yield 'namespaced const' => ['Fixtures\Helpers\HELPER_LIMIT', NameKind::Constant, 'AutoloadFiles/helpers.php'];
+        yield 'global const' => ['FIXTURE_GLOBAL_LIMIT', NameKind::Constant, 'AutoloadFiles/globals.php'];
+        yield 'second declarator' => ['FIXTURE_GLOBAL_BETA', NameKind::Constant, 'AutoloadFiles/globals.php'];
+        yield 'literal define' => ['FIXTURE_DEFINED_LIMIT', NameKind::Constant, 'AutoloadFiles/globals.php'];
+        yield 'define inside a body' => ['FIXTURE_BODY_LIMIT', NameKind::Constant, 'AutoloadFiles/globals.php'];
+        yield 'qualified define' => [
+            'Fixtures\Helpers\HELPER_DEFINED_QUALIFIED',
+            NameKind::Constant,
+            'AutoloadFiles/helpers.php',
+        ];
+        // `define()` takes its whole name from the literal, so this one is global
+        // despite being written under a namespace — and must be found as such.
+        yield 'define ignores its namespace' => [
+            'FIXTURE_HELPER_DEFINED',
+            NameKind::Constant,
+            'AutoloadFiles/helpers.php',
+        ];
+
+        yield 'leading separator' => [
+            '\Fixtures\Helpers\HelperRegistry',
+            NameKind::ClassLike,
+            'AutoloadFiles/helpers.php',
+        ];
+
+        // Out of reach, each for its own reason.
+        yield 'computed define name' => ['FIXTURE_COMPUTED_LIMIT', NameKind::Constant, null];
+        yield 'a define value is not a name' => ['FIXTURE_NOT_A_CONSTANT_NAME', NameKind::Constant, null];
+        yield 'undeclared name' => ['Fixtures\Helpers\absentHelper', NameKind::Function_, null];
+        // A PSR-4 class is reachable, but not by *this* locator: it addresses only
+        // what the `files` set declares, and the autoload maps cover the rest.
+        yield 'psr-4 class' => ['Fixtures\Domain\User', NameKind::ClassLike, null];
+    }
+
+    /**
+     * @param ?non-empty-string $expectedPathSuffix
+     */
+    #[DataProvider('declaredNames')]
+    public function testLocateResolvesWhatTheAutoloadFilesSetDeclares(
+        string $fullyQualifiedName,
+        NameKind $kind,
+        ?string $expectedPathSuffix,
+    ): void {
+        $path = self::locatorForRoot(self::FIXTURES_ROOT)
+            ->locate(QualifiedName::fromFullyQualified($fullyQualifiedName), $kind);
+
+        if ($expectedPathSuffix === null) {
+            self::assertNull($path, 'a name the files set does not declare has no declaring file');
+            return;
+        }
+
+        self::assertNotNull($path, "a name declared in the files set must resolve: {$fullyQualifiedName}");
+        self::assertStringEndsWith($expectedPathSuffix, $path);
+    }
+
+    /**
+     * @return iterable<string, array{string, NameKind, bool}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function caseVariants(): iterable
+    {
+        yield 'class-like' => ['fixtures\helpers\helperregistry', NameKind::ClassLike, true];
+        yield 'function' => ['Fixtures\Helpers\HELPERFORMAT', NameKind::Function_, true];
+        // The one kind PHP matches exactly: a differently-cased constant is a
+        // different constant, so resolving it would be a false positive.
+        yield 'constant' => ['fixture_global_limit', NameKind::Constant, false];
+    }
+
+    #[DataProvider('caseVariants')]
+    public function testLocateAppliesThePerKindCaseRule(
+        string $fullyQualifiedName,
+        NameKind $kind,
+        bool $shouldResolve,
+    ): void {
+        $path = self::locatorForRoot(self::FIXTURES_ROOT)
+            ->locate(QualifiedName::fromFullyQualified($fullyQualifiedName), $kind);
+
+        if ($shouldResolve) {
+            self::assertNotNull($path, 'class-like and function names are matched case-insensitively');
+            return;
+        }
+
+        self::assertNull($path, 'constant names are matched case-sensitively');
+    }
+
+    /**
+     * @return iterable<string, array{string, NameKind}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function mismatchedKinds(): iterable
+    {
+        yield 'a function asked for as a constant' => ['Fixtures\Helpers\helperFormat', NameKind::Constant];
+        yield 'a function asked for as a class' => ['Fixtures\Helpers\helperFormat', NameKind::ClassLike];
+        yield 'a class asked for as a function' => ['Fixtures\Helpers\HelperContract', NameKind::Function_];
+        yield 'a constant asked for as a class' => ['FIXTURE_GLOBAL_LIMIT', NameKind::ClassLike];
+    }
+
+    /**
+     * PHP has three symbol namespaces, so one spelling can name three different
+     * things. An index that ignored the kind would answer with the wrong file.
+     */
+    #[DataProvider('mismatchedKinds')]
+    public function testLocateResolvesOnlyForTheKindThatDeclaredTheName(
+        string $fullyQualifiedName,
+        NameKind $kind,
+    ): void {
+        $path = self::locatorForRoot(self::FIXTURES_ROOT)
+            ->locate(QualifiedName::fromFullyQualified($fullyQualifiedName), $kind);
+
+        self::assertNull($path, 'a name declared in one symbol namespace must not resolve in another');
+    }
+
+    public function testAProjectWithNoAutoloadFilesResolvesNothing(): void
+    {
+        $path = self::locatorForRoot('/nonexistent/path')
+            ->locate(QualifiedName::fromFullyQualified('FIXTURE_GLOBAL_LIMIT'), NameKind::Constant);
+
+        self::assertNull($path, 'a project with no autoload.files map indexes nothing, and is not an error');
+    }
+
+    public function testAnEntryThatCannotBeReadIsSkipped(): void
+    {
+        // The malformed fixture's only string entry points at a path that does not
+        // exist. Indexing must skip it rather than fail, so one bad entry does not
+        // cost the project every other declaration in the set.
+        $locator = self::locatorForRoot(self::FIXTURES_ROOT . '/MalformedProject');
+
+        $path = $locator->locate(QualifiedName::fromFullyQualified('Whatever'), NameKind::ClassLike);
+
+        self::assertNull($path, 'an unreadable files entry contributes nothing rather than throwing');
+    }
+
+    public function testTheFirstDeclarationOfANameWins(): void
+    {
+        // PHP requires the files in order, so the first declaration is the one that
+        // takes effect; a later guarded redeclaration never runs.
+        [$first, $second] = [self::tempFile('<?php const DUPE_TARGET = 1;'), self::tempFile('<?php const DUPE_TARGET = 2;')];
+
+        try {
+            $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$first, $second]));
+
+            self::assertSame(
+                $first,
+                $locator->locate(QualifiedName::fromFullyQualified('DUPE_TARGET'), NameKind::Constant),
+                'the earlier files entry declares the name that takes effect',
+            );
+        } finally {
+            unlink($first);
+            unlink($second);
+        }
+    }
+
+    public function testInvalidateRebuildsTheIndexFromDisk(): void
+    {
+        $path = self::tempFile('<?php const BEFORE_CHANGE = 1;');
+
+        try {
+            $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$path]));
+            self::assertNotNull(
+                $locator->locate(QualifiedName::fromFullyQualified('BEFORE_CHANGE'), NameKind::Constant),
+                'the eagerly built index must reflect the file as it was read',
+            );
+
+            self::assertNotFalse(file_put_contents($path, '<?php const AFTER_CHANGE = 2;'), 'rewrite must succeed');
+            $locator->invalidate(FileUri::fromPath($path));
+
+            self::assertNotNull(
+                $locator->locate(QualifiedName::fromFullyQualified('AFTER_CHANGE'), NameKind::Constant),
+                'a name added by an external edit must resolve after invalidation (RFC 1 §5.2)',
+            );
+            self::assertNull(
+                $locator->locate(QualifiedName::fromFullyQualified('BEFORE_CHANGE'), NameKind::Constant),
+                'a name the edit removed must stop resolving, not be served from the stale index',
+            );
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function testInvalidatingAFileOutsideTheSetLeavesTheIndexAlone(): void
+    {
+        $path = self::tempFile('<?php const UNTOUCHED = 1;');
+
+        try {
+            $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$path]));
+
+            // Deleting the indexed file proves the index was not rebuilt: a rebuild
+            // would drop the name, since the file can no longer be read.
+            $locator->invalidate('file:///some/other/file.php');
+            unlink($path);
+
+            self::assertNotNull(
+                $locator->locate(QualifiedName::fromFullyQualified('UNTOUCHED'), NameKind::Constant),
+                'a change outside the files set must not cost a rebuild of the whole index',
+            );
+        } finally {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    private static function locatorForRoot(string $projectRoot): AutoloadFilesLocator
+    {
+        return self::locatorForMap(ComposerAutoloadMap::fromProjectRoot($projectRoot));
+    }
+
+    private static function locatorForMap(ComposerAutoloadMap $map): AutoloadFilesLocator
+    {
+        return new AutoloadFilesLocator($map, new ParserService(), new DeclarationScanner());
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function tempFile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'php-lsp-files-');
+        self::assertNotFalse($path, 'a temp file must be creatable');
+        self::assertNotFalse(file_put_contents($path, $contents), 'the temp file must be writable');
+
+        return $path;
+    }
+}

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -182,16 +182,30 @@ final class AutoloadFilesLocatorTest extends TestCase
         self::assertNull($path, 'a project with no autoload.files map indexes nothing, and is not an error');
     }
 
-    public function testAnEntryThatCannotBeReadIsSkipped(): void
+    public function testAnEntryThatCannotBeReadIsSkippedWithoutAbandoningTheRest(): void
     {
-        // The malformed fixture's only string entry points at a path that does not
-        // exist. Indexing must skip it rather than fail, so one bad entry does not
-        // cost the project every other declaration in the set.
-        $locator = self::locatorForRoot(self::FIXTURES_ROOT . '/MalformedProject');
+        // A `files` entry naming a path that is not there — a stale generated map, a
+        // package half-removed. Indexing must skip it and carry on: the entry after
+        // it still has to be indexed, so one bad entry does not cost the project
+        // every other declaration in the set.
+        $readable = self::tempFile('<?php const SURVIVES_A_BAD_ENTRY = 1;');
 
-        $path = $locator->locate(QualifiedName::fromFullyQualified('Whatever'), NameKind::ClassLike);
+        try {
+            $locator = self::locatorForMap(
+                new ComposerAutoloadMap([], [], [], [self::FIXTURES_ROOT . '/no-such-entry.php', $readable]),
+            );
 
-        self::assertNull($path, 'an unreadable files entry contributes nothing rather than throwing');
+            self::assertNull(
+                $locator->locate(QualifiedName::fromFullyQualified('Whatever'), NameKind::ClassLike),
+                'an unreadable files entry contributes nothing rather than throwing',
+            );
+            self::assertNotNull(
+                $locator->locate(QualifiedName::fromFullyQualified('SURVIVES_A_BAD_ENTRY'), NameKind::Constant),
+                'indexing must resume at the next entry rather than stop at the first unreadable one',
+            );
+        } finally {
+            unlink($readable);
+        }
     }
 
     public function testTheFirstDeclarationOfANameWins(): void

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -183,17 +183,21 @@ final class AutoloadFilesLocatorTest extends TestCase
 
     public function testTheFirstDeclarationOfANameWins(): void
     {
-        // PHP requires the files in order, so the first declaration is the one that
-        // takes effect; a later guarded redeclaration never runs.
-        $first = self::tempFile('<?php const DUPE_TARGET = 1;');
-        $second = self::tempFile('<?php const DUPE_TARGET = 2;');
+        // The shape that puts one name in two files without breaking the project:
+        // competing polyfills, each declaring only if nothing else already has.
+        // Two *unconditional* declarations of one name is a project that does not
+        // run, so it is not what this rule is for. Composer requires the entries in
+        // order, so the first file's guard is the one that passes.
+        $polyfill = '<?php if (!function_exists("dupeTarget")) { function dupeTarget(): int { return %d; } }';
+        $first = self::tempFile(sprintf($polyfill, 1));
+        $second = self::tempFile(sprintf($polyfill, 2));
 
         try {
             $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$first, $second]));
 
             self::assertSame(
                 $first,
-                $locator->locate(QualifiedName::fromFullyQualified('DUPE_TARGET'), NameKind::Constant),
+                $locator->locate(QualifiedName::fromFullyQualified('dupeTarget'), NameKind::Function_),
                 'the earlier files entry declares the name that takes effect',
             );
         } finally {

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -115,9 +115,7 @@ final class AutoloadFilesLocatorTest extends TestCase
         // The one kind PHP matches exactly: a differently-cased constant is a
         // different constant, so resolving it would be a false positive.
         yield 'constant' => ['fixture_global_limit', NameKind::Constant, false];
-        // The exact match a constant requires is of its *short name* only. A
-        // namespace path is case-insensitive for every kind, so applying the
-        // constant rule to the whole name would miss a name PHP resolves.
+        // The exact match applies to the short name only; the namespace is not.
         yield 'constant under a recased namespace' => [
             'FIXTURES\HELPERS\HELPER_LIMIT',
             NameKind::Constant,
@@ -184,10 +182,7 @@ final class AutoloadFilesLocatorTest extends TestCase
 
     public function testAnEntryThatCannotBeReadIsSkippedWithoutAbandoningTheRest(): void
     {
-        // A `files` entry naming a path that is not there — a stale generated map, a
-        // package half-removed. Indexing must skip it and carry on: the entry after
-        // it still has to be indexed, so one bad entry does not cost the project
-        // every other declaration in the set.
+        // One bad entry must not cost the project the entries after it.
         $readable = self::tempFile('<?php const SURVIVES_A_BAD_ENTRY = 1;');
 
         try {
@@ -267,10 +262,7 @@ final class AutoloadFilesLocatorTest extends TestCase
         try {
             $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$path]));
 
-            // Deleting the indexed file first is what makes the assertion load
-            // bearing: from here a rebuild can only drop the name, because the file
-            // can no longer be read. Invalidating before the delete would prove
-            // nothing, since the rebuild would find the file still there.
+            // Delete first: from here a rebuild can only drop the name.
             unlink($path);
             $locator->invalidate('file:///some/other/file.php');
 

--- a/tests/Knowledge/CompositeSymbolLocatorTest.php
+++ b/tests/Knowledge/CompositeSymbolLocatorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Knowledge;
+
+use Firehed\PhpLsp\Document\FileUri;
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Index\AutoloadFilesLocator;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
+use Firehed\PhpLsp\Knowledge\CompositeSymbolLocator;
+use Firehed\PhpLsp\Knowledge\SymbolLocator;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A name may be reachable by arithmetic on the autoload maps or only through the
+ * derived `autoload.files` index, so the two routes are chained rather than merged.
+ * These prove the chain takes the first answer, falls through, and fans invalidation
+ * out to the members holding derived state.
+ */
+#[CoversClass(CompositeSymbolLocator::class)]
+final class CompositeSymbolLocatorTest extends TestCase
+{
+    public function testTheFirstLocatorToAnswerWins(): void
+    {
+        $locator = new CompositeSymbolLocator([
+            self::locatorReturning('/first.php'),
+            self::locatorReturning('/second.php'),
+        ]);
+
+        self::assertSame(
+            '/first.php',
+            $locator->locate(self::someName(), NameKind::ClassLike),
+            'the earlier locator is the more authoritative route and must win',
+        );
+    }
+
+    public function testItFallsThroughToALaterLocator(): void
+    {
+        $locator = new CompositeSymbolLocator([
+            self::locatorReturning(null),
+            self::locatorReturning('/second.php'),
+        ]);
+
+        self::assertSame(
+            '/second.php',
+            $locator->locate(self::someName(), NameKind::ClassLike),
+            'a route that cannot address the name must defer to the next one',
+        );
+    }
+
+    public function testItReturnsNullWhenNoLocatorAnswers(): void
+    {
+        $locator = new CompositeSymbolLocator([self::locatorReturning(null), self::locatorReturning(null)]);
+
+        self::assertNull(
+            $locator->locate(self::someName(), NameKind::ClassLike),
+            'a name no route can address has no declaring file',
+        );
+    }
+
+    public function testAnEmptyChainAnswersNothing(): void
+    {
+        self::assertNull(
+            (new CompositeSymbolLocator([]))->locate(self::someName(), NameKind::ClassLike),
+            'a project with no locators resolves nothing, and is not an error',
+        );
+    }
+
+    public function testTheLaterLocatorIsNotConsultedOnceOneAnswers(): void
+    {
+        $second = $this->createMock(SymbolLocator::class);
+        $second->expects($this->never())->method('locate');
+
+        $locator = new CompositeSymbolLocator([self::locatorReturning('/first.php'), $second]);
+
+        self::assertSame(
+            '/first.php',
+            $locator->locate(self::someName(), NameKind::ClassLike),
+            'the chain must stop at the first answer rather than costing every route a lookup',
+        );
+    }
+
+    /**
+     * Driven through the real {@see AutoloadFilesLocator} rather than a mock: it is
+     * the member that actually holds derived state, so this proves the fan-out
+     * reaches the implementation that ships. The leading locator holds none and is
+     * not Invalidatable, which is also the production shape — the chain must skip it
+     * rather than require every member to implement the interface.
+     */
+    public function testInvalidateReachesAMemberHoldingDerivedState(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'php-lsp-chain-');
+        self::assertNotFalse($path, 'a temp file must be creatable');
+
+        try {
+            self::assertNotFalse(
+                file_put_contents($path, '<?php function chainedBefore(): void {}'),
+                'the temp file must be writable',
+            );
+
+            $files = new AutoloadFilesLocator(
+                new ComposerAutoloadMap([], [], [], [$path]),
+                new ParserService(),
+                new DeclarationScanner(),
+            );
+            $locator = new CompositeSymbolLocator([self::locatorReturning(null), $files]);
+
+            self::assertNotFalse(
+                file_put_contents($path, '<?php function chainedAfter(): void {}'),
+                'the rewrite must succeed',
+            );
+            $locator->invalidate(FileUri::fromPath($path));
+
+            self::assertNotNull(
+                $locator->locate(QualifiedName::fromFullyQualified('chainedAfter'), NameKind::Function_),
+                'invalidation must reach the chained index so the external edit is reflected (RFC 1 §5.2)',
+            );
+        } finally {
+            unlink($path);
+        }
+    }
+
+    private static function locatorReturning(?string $path): SymbolLocator
+    {
+        $locator = self::createStub(SymbolLocator::class);
+        $locator->method('locate')->willReturn($path);
+
+        return $locator;
+    }
+
+    private static function someName(): QualifiedName
+    {
+        return QualifiedName::fromFullyQualified('Some\Name');
+    }
+}

--- a/tests/Knowledge/FilesystemBackendTest.php
+++ b/tests/Knowledge/FilesystemBackendTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Knowledge;
 
 use Firehed\PhpLsp\Cache\CacheFactory;
+use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\AutoloadFilesLocator;
 use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerNamespaceSource;
 use Firehed\PhpLsp\Index\ComposerSymbolLocator;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Knowledge\CompositeSymbolLocator;
 use Firehed\PhpLsp\Knowledge\FilesystemBackend;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
@@ -169,6 +173,52 @@ final class FilesystemBackendTest extends TestCase
         } finally {
             unlink($path);
             rmdir($dir);
+        }
+    }
+
+    /**
+     * Driven end to end through the locator chain the stack actually wires, rather
+     * than a mock: the autoload.files index is derived from disk, so an external
+     * change must reach it too. Evicting only the ClassInfo cache would leave the
+     * name -> file map itself stale, and a class added by the edit would stay
+     * invisible however many times it was asked for (RFC 1 §5.2, §5.3).
+     */
+    public function testInvalidateReachesALocatorHoldingDerivedState(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'php-lsp-fsb-files-');
+        self::assertNotFalse($path, 'a temp file must be creatable');
+
+        try {
+            self::assertNotFalse(
+                file_put_contents($path, '<?php class DerivedBefore {}'),
+                'the temp file must be writable',
+            );
+
+            $backend = $this->backendWithLocator(new CompositeSymbolLocator([
+                new AutoloadFilesLocator(
+                    new ComposerAutoloadMap([], [], [], [$path]),
+                    $this->parser,
+                    new DeclarationScanner(),
+                ),
+            ]));
+
+            self::assertNotNull(
+                $backend->lookupClassLike(self::className('DerivedBefore')),
+                'a class-like declared in a files entry must resolve through the derived index',
+            );
+
+            self::assertNotFalse(
+                file_put_contents($path, '<?php class DerivedAfter {}'),
+                'the rewrite must succeed',
+            );
+            $backend->invalidate(FileUri::fromPath($path));
+
+            self::assertNotNull(
+                $backend->lookupClassLike(self::className('DerivedAfter')),
+                'invalidate must re-derive the index so a class added on disk resolves',
+            );
+        } finally {
+            unlink($path);
         }
     }
 

--- a/tests/Knowledge/KnowledgeStackTest.php
+++ b/tests/Knowledge/KnowledgeStackTest.php
@@ -81,11 +81,10 @@ final class KnowledgeStackTest extends TestCase
     }
 
     /**
-     * The index is built eagerly, so its cost is paid once at construction rather
-     * than landing mid-keystroke. Pinning the count is what keeps that a measured
-     * quantity rather than an unwatched one: it goes red if an entry is parsed more
-     * than once, or if indexing ever reaches outside the `files` set into the PSR-4
-     * tree. The fixture project lists two entries, both outside `vendor/`.
+     * The index is built eagerly, so the set is parsed at construction rather than
+     * mid-keystroke. This pins that it happens, and that indexing never reaches
+     * outside the `files` set into the PSR-4 tree. It cannot see the same content
+     * parsed twice — the memo is keyed by content — so it bounds no cost.
      */
     public function testTheAutoloadFilesIndexIsBuiltOnceAtConstruction(): void
     {

--- a/tests/Knowledge/KnowledgeStackTest.php
+++ b/tests/Knowledge/KnowledgeStackTest.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Parser\ParserService;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -44,6 +45,60 @@ final class KnowledgeStackTest extends TestCase
         self::assertNotNull(
             $stack->source->lookupClassLike(self::className('Fixtures\Domain\User')),
             'a fixture class must resolve through the assembled filesystem backend',
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function autoloadFilesClassLikes(): iterable
+    {
+        // Composer's maps address none of these: they are declared in an
+        // `autoload.files` entry, which is keyed by no name at all. Every flavour is
+        // covered, because a scan narrowed to `class` would lose three of them
+        // silently (Plan 0002 §3, #181).
+        yield 'interface' => ['Fixtures\Helpers\HelperContract'];
+        yield 'trait' => ['Fixtures\Helpers\HelperFallback'];
+        yield 'enum' => ['Fixtures\Helpers\HelperMode'];
+        yield 'class' => ['Fixtures\Helpers\HelperRegistry'];
+        yield 'global class' => ['FixtureGlobalRegistry'];
+    }
+
+    #[DataProvider('autoloadFilesClassLikes')]
+    public function testSourceResolvesAClassLikeDeclaredInAnAutoloadFilesEntry(string $fqn): void
+    {
+        $stack = KnowledgeStack::forProject(
+            ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot),
+            $this->fixturesRoot . '/vendor',
+            $this->parser,
+        );
+
+        $info = $stack->source->lookupClassLike(self::className($fqn));
+
+        self::assertNotNull($info, "a class-like declared in an autoload.files entry must resolve: {$fqn}");
+        self::assertSame($fqn, $info->name->fqn, 'the located class-like must be the one asked for');
+    }
+
+    /**
+     * The index is built eagerly, so its cost is paid once at construction rather
+     * than landing mid-keystroke. Pinning the count is what keeps that a measured
+     * quantity rather than an unwatched one: it goes red if an entry is parsed more
+     * than once, or if indexing ever reaches outside the `files` set into the PSR-4
+     * tree. The fixture project lists two entries, both outside `vendor/`.
+     */
+    public function testTheAutoloadFilesIndexIsBuiltOnceAtConstruction(): void
+    {
+        KnowledgeStack::forProject(
+            ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot),
+            $this->fixturesRoot . '/vendor',
+            $this->parser,
+        );
+
+        self::assertSame(
+            2,
+            $this->parser->getMetrics()->getParseCount(),
+            'construction parses each autoload.files entry exactly once',
         );
     }
 

--- a/tests/Parser/ParserServiceTest.php
+++ b/tests/Parser/ParserServiceTest.php
@@ -124,6 +124,55 @@ class ParserServiceTest extends TestCase
         self::assertSame($first, $second, 'the memo returns what the parse returned, on every exit path');
     }
 
+    public function testParseFileReadsAndParsesAFileFromDisk(): void
+    {
+        $parser = new ParserService();
+
+        $ast = $parser->parseFile(dirname(__DIR__) . '/Fixtures/src/Domain/User.php');
+
+        self::assertNotNull($ast, 'a readable PHP file on disk must parse');
+        self::assertSame(1, $parser->getMetrics()->getParseCount(), 'reading a file is metered like any other parse');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function unreadablePaths(): iterable
+    {
+        yield 'no such file' => [__DIR__ . '/does-not-exist.php'];
+        // A directory is readable but not a file; file_get_contents would warn.
+        yield 'a directory' => [__DIR__];
+    }
+
+    #[DataProvider('unreadablePaths')]
+    public function testParseFileReturnsNullForAPathItCannotRead(string $path): void
+    {
+        $parser = new ParserService();
+
+        self::assertNull(
+            $parser->parseFile($path),
+            'a path that cannot be read as a file degrades to null rather than warning or throwing',
+        );
+    }
+
+    /**
+     * The memo is keyed by content, so two paths holding identical content share
+     * one parse — which is what makes the workspace and vendor backends scanning
+     * an overlapping file set cost one parse rather than two.
+     */
+    public function testParseFileSharesTheContentMemo(): void
+    {
+        $parser = new ParserService();
+        $path = dirname(__DIR__) . '/Fixtures/src/Domain/User.php';
+
+        $first = $parser->parseFile($path);
+        $second = $parser->parseFile($path);
+
+        self::assertSame(1, $parser->getMetrics()->getParseCount(), 'the second read is answered from the memo');
+        self::assertSame($first, $second, 'both reads get the same AST');
+    }
+
     public function testDifferingContentIsParsedSeparately(): void
     {
         $parser = new ParserService();

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -352,6 +352,10 @@ class ServerTest extends TestCase
      * below costs exactly one parse: not the two the sync path used to spend on
      * every keystroke, and not one in total, which is the standing cache the
      * Step 0 spike declined to add.
+     *
+     * Measured across `run()` rather than the process, because construction now
+     * eagerly indexes the `autoload.files` set; that cost is gated separately by
+     * KnowledgeStackTest, not folded in here where it would blur this bound.
      */
     public function testParsesAreScopedToOneMessage(): void
     {
@@ -381,12 +385,13 @@ class ServerTest extends TestCase
         $parser = new ParserService();
         $transport = $this->createTransport($input, $outputBuffer);
         $server = Server::forProject($transport, new ServerInfo('test', '1.0'), __DIR__ . '/Fixtures', $parser);
+        $atStartup = $parser->getMetrics()->getParseCount();
 
         $server->run();
 
         self::assertSame(
             3,
-            $parser->getMetrics()->getParseCount(),
+            $parser->getMetrics()->getParseCount() - $atStartup,
             'three sync messages, one parse each',
         );
     }
@@ -428,12 +433,13 @@ class ServerTest extends TestCase
         $parser = new ParserService();
         $transport = $this->createTransport($input, $outputBuffer);
         $server = Server::forProject($transport, new ServerInfo('test', '1.0'), __DIR__ . '/Fixtures', $parser);
+        $atStartup = $parser->getMetrics()->getParseCount();
 
         $server->run();
 
         self::assertSame(
             3,
-            $parser->getMetrics()->getParseCount(),
+            $parser->getMetrics()->getParseCount() - $atStartup,
             'one didOpen and two completion requests, one parse each',
         );
     }


### PR DESCRIPTION
Slice **S3.7d** (`docs/architecture/build-manifest.md`), plan step **3b** (`0002-execution-plan.md`), RFC 1 **§3** (lazy-first / locate-only reach), **§5.2**, **§5.3**.

Composer addresses `autoload.files` entries by no name at all — PHP `require`s each one wholesale at bootstrap and nothing keys them by name — so this is the one place the model must scan rather than resolve. `AutoloadFilesLocator` parses the set and derives the name→file map it lacks, and `CompositeSymbolLocator` chains it behind `ComposerSymbolLocator` so the cheap arithmetic route still answers first.

The index covers all three symbol namespaces, not just functions and constants: once an entry is parsed every kind costs the same walk, and narrowing it would leave a class-like declared there reachable at runtime but invisible here. That class-like half is the observable new behavior in this slice — `lookupFunction` / `lookupConstant` do not exist on `SymbolSource` before S3.8a/S3.8b, which this index is built to serve.

## Acceptance

- [x] `autoload.files` folded into the locator layer, keyed by name and kind
- [x] `lookupClassLike` reaches class-likes declared in a `files` entry (every flavour: class, interface, trait, enum, and global-namespace)
- [x] Per-kind case rules applied — class-likes and functions case-insensitive, constants exact — via the existing `NameKind::isCaseSensitive()`
- [x] External-file-change invalidation re-derives the index (RFC 1 §5.2); a change outside the set costs nothing
- [x] The locate-only limitations hold and are asserted, not just documented: a computed `define()` name, a `define()` *value*, and a name declared only under PSR-4 all resolve to null here
- [x] Existing goldens unchanged — the class-like-lookup corpus holds no `files`-declared name
- [x] New classes at 100% line and method coverage

## Build timing

Built eagerly at stack construction; §3 leaves the choice to this slice. Eager keeps the cost off the keystroke path, at the price of paying it for sessions that never need it.

Because the cost is real, it is pinned rather than left unwatched: a new `KnowledgeStackTest` case asserts construction parses each entry exactly once. Two `ServerTest` parse-scope assertions now measure across `run()` instead of the process lifetime, so the per-message dedup bound they exist to guard stays sharp instead of absorbing startup work. Neither test was weakened — both still bound from both sides.

## Incidental

`ParserService::parseFile()` extracts the read-and-parse that `FilesystemBackend` already did and this slice would otherwise have duplicated. It shares the content-keyed memo. The old unreachable-read branch now throws a `LogicException` rather than returning a null sentinel, per the project rule on dead branches.

## Known gap (not in scope, now owned)

Namespace *enumeration* does not list `files`-declared symbols — `childrenOf` is a directory listing through the PSR-4 map, which these files sit outside of. So a name resolves on hover and definition but never appears in namespace completion. That is now scheduled as **S3.7e** (#398) rather than left as a limitation, since it is the one-surface-knows-more split the series exists to prevent.

## Closes

**Nothing.** #181 was listed here as a candidate; reading its body rather than its title, it is not closable by this slice. It asks for these symbols in *hover and completion*, not merely resolvable: functions need S3.8a/S3.9b, constants S3.8b, namespace completion S3.7e. It also asks for a startup-time benchmark, which this slice's eager index makes a live question — pinning the parse *count*, which this slice does, is not that measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

