### PR TITLE
Add duplication audits and gate Step Z on the project goal

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -30,6 +30,13 @@ slice from durable state, not from memory.
   - `todo` — neither.
 - `X` = the first `todo` slice whose every dependency is `done`.
 
+Dependencies are normally slice ids. The audit and Definition-of-Done gates use a
+collective form instead, which must be expanded before the check:
+
+- `all Step N` — every **other** slice whose Step column is `N`, sub-steps included
+  (`all Step 3` covers 3a and 3b).
+- `all prior` — every other slice in the table.
+
 Deriving from PR merge state (not ancestry) is what keeps this correct under the
 project's **Squash and Merge**: a squash rewrites the branch into one new commit on
 `main`, so an ancestry check would report squashed slices as `todo` forever. Check

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -430,8 +430,16 @@ So each major section ends with an explicit audit slice, and the terminal gate r
 - a seam that landed while some callers kept the old path (the SC.2 shape);
 - a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256).
 
-**Method.** For every seam the section introduced, enumerate its callers and confirm no bypass survives; where a §8.1 rule can enforce the seam, that rule must exist and carry no exemption.
-Then sweep the section's code for the shapes above.
+**Scope: substantial mechanics, not one-liners.** The target is work with real substance behind it — parsing, AST traversal, symbol extraction, name and FQN construction, path/URI conversion, caching.
+A duplicated one-liner is worth folding in when it turns up, but it is not what this is for, and no effort is spent hunting for it.
+
+**Method: grep and the rules already present. No new tooling.** Where a §8.1 PHPStan rule can encode a seam, that rule is worth more than any sweep, because it prevents recurrence rather than detecting it — so an audit's first question is whether the section's seams are rule-enforced, and its first *fix* is to add the rule.
+For the rest, grep for the mechanism rather than the name: `NodeVisitorAbstract` / `NodeTraverser` implementations, a `file_get_contents` paired with a parse, `Stmt\Namespace_` handling, `strtolower` applied to a symbol name, `file://` and `rawurldecode`, hand-rolled memo arrays.
+Then enumerate each seam's callers and confirm none kept the old path.
+
+Static analysis is better where it reaches and is not foolproof where it does not; grep plus the existing rules is the accepted floor.
+If neither finds something, that is a known limit of the method, not a reason to build a detector.
+
 A finding is not discharged by noting it: it is either fixed in the audit slice, or it becomes a numbered slice row with an owner.
 
 **Outcome rule, and the one difference between them.** The pre-cleanup audits (**S3.11**, **S4.7**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
@@ -459,12 +467,16 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
 - **Teardown is discharged.** Every row of the Teardown ledger is removed; a scan
   confirms no facade-only delegations, no double writes, and no dead transitional
   classes (`DefaultFunctionRepository`, etc.) survive.
-- **No capability is implemented twice.** The duplication audit (above) is run
-  repo-wide and comes back empty, with its enumeration shown. Every earlier audit
-  (S3.11, S4.7) is discharged, and so is every slice they filed. This is the goal the
-  series exists to reach — the other gates verify the *route* was followed, this one
-  verifies the *destination*. A surviving duplicate fails the gate even if every
-  other item passes, and it may not be deferred: there is no later section to own it.
+- **No duplicate implementations, and no M×N paths.** No substantial mechanism —
+  parsing, AST traversal, symbol extraction, name/FQN construction, path conversion,
+  caching — exists in more than one place, and no capability is implemented per
+  handler, per node type, or per symbol kind where one path serves. This is the
+  condition the whole series exists to produce (#190, #253, #256, #334): if it does
+  not hold, the foundation did not meet its goal, whatever else passed. The repo-wide
+  audit (above) is run and comes back empty with its enumeration shown, and every
+  earlier audit is discharged along with every slice they filed. A surviving duplicate
+  fails this gate outright and may not be deferred — there is no later section to own
+  it.
 - **Divergences are reconciled.** Each entry in RFC 1 Appendix B "current divergences"
   (byte offsets, functions-need-AST, constants-unresolved, capabilities-unread) is
   either **fixed** or **converted to an explicitly-tracked deferred gap with an open

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -414,6 +414,32 @@ known-removable thing without an owning slice is the same defect as an undischar
 scaffold. A remover must be a slice id; a prose note is not an owner, because
 `/do-next` cannot select one.
 
+### Duplication audits
+
+The ledger above tracks scaffolding *this plan knowingly introduced*.
+It cannot catch the failure mode the series exists to end: a capability that ends up implemented twice, which is how the M×N problem returns.
+Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (SC.3), a superseded import extractor with three unmigrated callers (SC.2).
+Each was found by an audit, not by a step.
+
+So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
+
+**What an audit looks for.** A single capability with more than one implementation, in the shapes this codebase actually produces them:
+
+- a traversal or walk written per consumer instead of once (the #334 shape);
+- a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;
+- a seam that landed while some callers kept the old path (the SC.2 shape);
+- a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256).
+
+**Method.** For every seam the section introduced, enumerate its callers and confirm no bypass survives; where a §8.1 rule can enforce the seam, that rule must exist and carry no exemption.
+Then sweep the section's code for the shapes above.
+A finding is not discharged by noting it: it is either fixed in the audit slice, or it becomes a numbered slice row with an owner.
+
+**Outcome rule, and the one difference between them.** The pre-cleanup audits (**S3.11**, **S4.7**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
+The terminal audit in **Step Z** may not: there, an unowned *or* unfixed duplicate is a failure, because there is no later section to own it.
+
+An audit reporting no findings must show the enumeration it ran.
+"None found" without evidence is indistinguishable from not looking, which is exactly how these survived to be found by audit in the first place.
+
 ### Step Z — Definition of Done (final verification gate)
 
 The steps above end the *work*; this gate declares the foundation *complete*. It is a
@@ -433,6 +459,12 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
 - **Teardown is discharged.** Every row of the Teardown ledger is removed; a scan
   confirms no facade-only delegations, no double writes, and no dead transitional
   classes (`DefaultFunctionRepository`, etc.) survive.
+- **No capability is implemented twice.** The duplication audit (above) is run
+  repo-wide and comes back empty, with its enumeration shown. Every earlier audit
+  (S3.11, S4.7) is discharged, and so is every slice they filed. This is the goal the
+  series exists to reach — the other gates verify the *route* was followed, this one
+  verifies the *destination*. A surviving duplicate fails the gate even if every
+  other item passes, and it may not be deferred: there is no later section to own it.
 - **Divergences are reconciled.** Each entry in RFC 1 Appendix B "current divergences"
   (byte offsets, functions-need-AST, constants-unresolved, capabilities-unread) is
   either **fixed** or **converted to an explicitly-tracked deferred gap with an open
@@ -442,7 +474,7 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
   workspace scope (#264/#265), the diagnostics / scheduler tier (Step 6 / #266), and
   computed-name `define()` (§3). A gap not on this list is a bug, not a deferral.
 
-Only when all six hold is the foundation deemed complete.
+Only when all seven hold is the foundation deemed complete.
 
 ## 5. Step 2 in depth
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -52,7 +52,8 @@ Step P harness — parity fixtures first), **3b** both preserves and extends the
 surface (existing behavior frozen to a golden; new project reach proven by new
 fixtures). The `Step` column carries the half, since 3a and 3b own distinct acceptance
 criteria in 0002. Step 4 decomposes `SymbolResolver`; Step Z is the terminal
-Definition-of-Done gate.
+Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (S3.11,
+S4.7), which Step Z re-runs repo-wide as its completion gate.
 
     ID     Step  Title                                              Depends on        Closes
     -----  ----  -------------------------------------------------  ----------------  -------
@@ -72,17 +73,20 @@ Definition-of-Done gate.
     S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
     S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
     S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
+    S3.11  3     Step 3 duplication audit                          S3.10             —
     S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
     S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
     S4.3   4     Extract member-access + call-context detectors     S4.2              —
     S4.4   4     Extract name-context resolver                      S4.2              —
     S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
     S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
+    S4.7   4     Step 4 duplication audit                          S4.6              —
     SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
     SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
     SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
     SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
-    SZ.1   Z     Definition of Done gate                            S3.10,S4.6,SC.1,SC.2,SC.3,SC.4  —
+    SC.5   —     Merge the two class-like AST traversals             SC.3              —
+    SZ.1   Z     Definition of Done gate + repo-wide dup audit      S3.11,S4.7,SC.1,SC.2,SC.3,SC.4,SC.5  —
 
 Notes:
 
@@ -161,6 +165,31 @@ Notes:
     encoding. One `FileUri` replaces them. Found while splitting S3.7, whose locator
     wanted a fifth copy; the duplication predates that slice and belongs to no step,
     so S3.7c is gated on it rather than carrying it.
+  - **SC.5** — `FilesystemBackend::findClassInAst` and `Index\DeclarationScanner` both
+    walk an AST to find the class-likes a file declares. They differ in what they
+    return (one matched *node* versus every declared *name*) and in stopping early, so
+    this is scoped as **evaluate and merge if warranted** — concluding "two genuinely
+    different queries, one walk" is an acceptable outcome, but it must be concluded and
+    recorded, not left unexamined. Gated only on SC.3, which rewrites `findClassInAst`'s
+    namespace handling; it is deliberately *not* gated on S3.11, because an audit files
+    slices and a slice already filed must not wait on the audit that would have found
+    it. Found while reviewing S3.7d, which put the two traversals side by side without
+    merging them.
+- **Each section ends with a duplication audit** (**S3.11**, **S4.7**, and the repo-wide
+  one inside **SZ.1**); their shared method and outcome rule are defined once in 0002
+  §Duplication audits, so the three rows do not restate it. The teardown ledger tracks
+  scaffolding the plan *knowingly* introduced; the audits catch what it cannot — a
+  capability that ended up implemented twice, which is the M×N failure the whole series
+  exists to end. Every such instance found so far (#334, SC.2, SC.3, SC.4, SC.5) was
+  found by an audit rather than by a step's acceptance, which is why the audits are
+  slices with owners rather than a review habit.
+  - S3.11 and S4.7 are **tracking** gates: a finding may be handed to a new slice
+    instead of fixed in place, so a removal belonging to a later section is not dragged
+    forward. SZ.1 is the **completion** gate: there, an unowned or unfixed duplicate
+    fails the step outright, since no later section can own it.
+  - SZ.1's dependencies are the two audits rather than S3.10/S4.6 directly — the audits
+    already depend on those, and gating on the audit is what makes "the section is
+    finished" mean "the section was swept", not merely "its last feature landed".
 - **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
   §4.7** (0002 §5 known gap) — file the tracked §4.7 issue when S3.3 lands; its fix is
   the deferred Step 5.

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -14,7 +14,11 @@ Append later phases as they are reached; do not create the whole tree up front.
 
 - **ID** — stable slice id; the branch is `slice/<ID>`.
 - **Step** — the plan step in 0002 that owns the acceptance criteria.
-- **Depends on** — slice ids that must be `done` (merged) first.
+- **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
+  exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
+  means every *other* slice whose Step column is `N` (sub-steps included, so `all Step
+  3` covers 3a and 3b), and **`all prior`** means every other slice in the table.
+  Gates use these; ordinary slices name ids.
 - **Closes** — pre-existing issues this slice closes, *after reviewer verification*.
 
 ## Wave 1 — Steps 0, 1, P, 2
@@ -73,20 +77,20 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
     S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
     S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
-    S3.11  3     Step 3 duplication audit                          S3.10             —
+    S3.11  3     Step 3 duplication audit                          all Step 3        —
     S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
     S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
     S4.3   4     Extract member-access + call-context detectors     S4.2              —
     S4.4   4     Extract name-context resolver                      S4.2              —
     S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
     S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
-    S4.7   4     Step 4 duplication audit                          S4.6              —
+    S4.7   4     Step 4 duplication audit                          all Step 4        —
     SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
     SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
     SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
     SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
     SC.5   —     Merge the two class-like AST traversals             SC.3              —
-    SZ.1   Z     Definition of Done gate + repo-wide dup audit      S3.11,S4.7,SC.1,SC.2,SC.3,SC.4,SC.5  —
+    SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
 
@@ -175,21 +179,18 @@ Notes:
     slices and a slice already filed must not wait on the audit that would have found
     it. Found while reviewing S3.7d, which put the two traversals side by side without
     merging them.
-- **Each section ends with a duplication audit** (**S3.11**, **S4.7**, and the repo-wide
-  one inside **SZ.1**); their shared method and outcome rule are defined once in 0002
-  §Duplication audits, so the three rows do not restate it. The teardown ledger tracks
-  scaffolding the plan *knowingly* introduced; the audits catch what it cannot — a
-  capability that ended up implemented twice, which is the M×N failure the whole series
-  exists to end. Every such instance found so far (#334, SC.2, SC.3, SC.4, SC.5) was
-  found by an audit rather than by a step's acceptance, which is why the audits are
-  slices with owners rather than a review habit.
+- **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
+  acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
+  in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
+  not restated here, because a manifest note is not a gate.
   - S3.11 and S4.7 are **tracking** gates: a finding may be handed to a new slice
-    instead of fixed in place, so a removal belonging to a later section is not dragged
-    forward. SZ.1 is the **completion** gate: there, an unowned or unfixed duplicate
-    fails the step outright, since no later section can own it.
-  - SZ.1's dependencies are the two audits rather than S3.10/S4.6 directly — the audits
-    already depend on those, and gating on the audit is what makes "the section is
-    finished" mean "the section was swept", not merely "its last feature landed".
+    rather than fixed in place, so a removal belonging to a later section is not dragged
+    forward. Step Z is the **completion** gate, where an unowned or unfixed duplicate
+    fails outright.
+  - The three depend on their whole section (`all Step N` / `all prior`) rather than on
+    its last slice. A chain of ids is both stale-prone and wrong: S3.10's transitive
+    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on S3.10 could have
+    run with two of its slices unbuilt.
 - **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
   §4.7** (0002 §5 known gap) — file the tracked §4.7 issue when S3.3 lands; its fix is
   the deferred Step 5.

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -33,7 +33,11 @@ happens outside the tool.
   - `in-flight` — an **open PR** exists for `slice/<id>`.
   - `todo` — neither.
 - The **next slice** = the first `todo` in the manifest whose dependencies are all
-  `done`.
+  `done`. A dependency is normally a slice id; the audit/DoD gates instead use a
+  collective form, resolved before the check: **`all Step N`** expands to every other
+  slice whose Step column is `N` (sub-steps included), and **`all prior`** to every
+  other slice in the table. A gate depends on its whole section, so it cannot run
+  while any slice of that section is unbuilt — which an id chain does not guarantee.
 
 Because status is computed from merge reality, a cold session cannot be misled by a
 stale field, and nothing needs updating by hand.


### PR DESCRIPTION
The teardown ledger tracks scaffolding the plan *knowingly* introduced. It cannot catch the failure the series exists to end: a capability implemented twice. Step Z had six acceptance items and none of them said that — so the project's actual goal had no completion gate.

Every duplicate found so far was found by an audit, never by a step's acceptance: six type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (SC.3), a superseded import extractor with three unmigrated callers (SC.2). That is a pattern, not a run of bad luck — nothing was watching for it.

## The gate

A seventh Step Z acceptance item: **no duplicate implementations, and no M×N paths**. No substantial mechanism exists in more than one place, and no capability is implemented per handler, per node type, or per symbol kind where one path serves. If it does not hold, the foundation did not meet its goal, whatever else passed. It lives in the plan's Definition of Done, not in a manifest note.

## Scope and method

Deliberately unambitious, because the alternative is building a detector nobody asked for.

**Scope is substantial mechanics** — parsing, AST traversal, symbol extraction, name/FQN construction, path conversion, caching. A duplicated one-liner is worth folding in when it turns up, but no effort goes into hunting for it.

**Method is grep plus the rules already present.** Where a §8.1 PHPStan rule can encode a seam it beats any sweep, because it prevents recurrence rather than detecting it — so an audit's first question is whether the section's seams are rule-enforced, and its first *fix* is to add the rule. For the rest: grep for the mechanism rather than the name (`NodeVisitorAbstract` implementations, `file_get_contents` paired with a parse, `Stmt\Namespace_` handling, `strtolower` on a symbol name, `file://` / `rawurldecode`, hand-rolled memo arrays), then enumerate each seam's callers. If neither finds something, that is an accepted limit of the method, not a reason to build tooling.

An audit reporting nothing must show the enumeration it ran.

## Slices

| Slice | Scope | Kind |
|---|---|---|
| S3.11 | End of Step 3 | tracking |
| S4.7 | End of Step 4 | tracking |
| SZ.1 | Repo-wide | completion gate |

Tracking audits may hand a finding to a new slice rather than fix it, so a removal belonging to a later section is not dragged forward. Step Z may not: an unowned *or* unfixed duplicate fails outright.

**SC.5** — `FilesystemBackend::findClassInAst` and `DeclarationScanner` both walk an AST for the class-likes a file declares. Scoped as *evaluate and merge if warranted*: they differ in return type (matched node vs. every declared name) and in stopping early, so "two genuinely different queries over one walk" is an acceptable conclusion, provided it is concluded rather than left unexamined. Surfaced while reviewing S3.7d.

## Dependencies

Gates now depend on their whole section — `all Step 3`, `all Step 4`, `all prior` — rather than on a chain of ids. That is not only less stale-prone but fixes a real defect: `S3.10`'s transitive dependencies never reach `S3.4` or `S3.5`, so a Step 3 audit gated on `S3.10` could have run with two of its slices unbuilt.

The two collective forms are defined in the manifest's Columns section, and `build-procedure.md` plus the `do-next` skill were updated to expand them — otherwise the notation would silently break next-slice computation.

`SC.5` is gated only on `SC.3`, deliberately *not* on `S3.11`: an audit files slices, so a slice already filed must not wait on the audit that would have found it.

No code changes. Does not touch #396, which can go to review independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
