### PR TITLE
Enumerate autoload.files declarations in childrenOf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,9 @@ the symbols declared directly in it.
 - **ReflectionNamespaceSource** — the language's built-ins. Filter to `isInternal()` (the
   server's own classes are loaded in the same process), and file each symbol under the
   namespace its reflected name carries — **internal does not imply global** (`Random\Randomizer`).
+- **AutoloadFilesLocator** — the `autoload.files` set, which sits outside every PSR-4 and
+  PSR-0 prefix, so no directory listing reaches it. It enumerates the index it already
+  derived for lookup, reporting each declaration's own `NameKind` rather than a guess.
 Each source is wrapped as a `SymbolBackend` (see Symbol Backends below): the
 `CompositeSymbolSource` merges and deduplicates their `childrenOf` results, and
 **CachedNamespaceCatalog** wraps the stable sources (workspace-on-disk, vendor,
@@ -120,6 +123,11 @@ derive the map; it is built eagerly, covers all three symbol namespaces (a name-
 route cannot know which kind a file declares), and applies PHP's per-kind case rules via
 `NameKind::isCaseSensitive()`. A test pins the parse *count* at construction, which is
 not a cost measurement; the set is explicit and usually tiny.
+
+The same derived index also answers the backend's `childrenOf`, merged with the
+directory listing by `CompositeNamespaceCatalog`. Enumeration is not optional: §4.2
+requires lookup and enumeration to draw on the same backends, so a name that resolved
+on hover while being invisible to completion is the split this tier exists to prevent.
 
 The write path is **`SymbolSink`** (`DocumentSymbolSink`), which
 registers class metadata and indexes symbols from one document.

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -26,9 +26,25 @@ use Firehed\PhpLsp\Utility\NamespacePath;
  * is parsed every kind costs the same walk, so indexing only functions and constants
  * would leave a class-like declared there reachable at runtime but invisible here,
  * for no saving. The cost is bounded because the set is explicit and usually tiny.
+ *
+ * The same index answers both reads of it — {@see locate()} for a known name and
+ * {@see childrenOf()} for a namespace's contents. Enumerating it is not optional:
+ * these files sit outside every PSR-4 and PSR-0 prefix, so a directory listing
+ * cannot see them, and a name that resolved on hover while being invisible to
+ * completion is exactly the lookup/enumeration split RFC 1 §4.2 forbids. The kind
+ * reported is the declaration's own, not the coarse guess a directory listing makes.
  */
-final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
+final class AutoloadFilesLocator implements SymbolLocator, NamespaceCatalog, Invalidatable
 {
+    /**
+     * Every name the set declares, as the declaration spells it: the index is keyed
+     * for lookup under PHP's per-kind case rules, which loses the casing a
+     * completion item has to insert.
+     *
+     * @var list<CatalogSymbol>
+     */
+    private array $declarations;
+
     /**
      * Kind => normalized name => declaring file.
      *
@@ -36,12 +52,27 @@ final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
      */
     private array $index;
 
+    /**
+     * Built on first enumeration rather than alongside the index: a project that
+     * never navigates a namespace never pays for the grouping.
+     *
+     * @var array<string, NamespaceContents>|null Lowercase namespace -> contents
+     */
+    private ?array $namespaces = null;
+
     public function __construct(
         private readonly ComposerAutoloadMap $map,
         private readonly ParserService $parser,
         private readonly DeclarationScanner $scanner,
     ) {
-        $this->index = $this->buildIndex();
+        $this->buildIndex();
+    }
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        $this->namespaces ??= NamespaceContents::indexByNamespace($this->declarations);
+
+        return $this->namespaces[strtolower($namespace)] ?? new NamespaceContents();
     }
 
     /**
@@ -54,7 +85,7 @@ final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
             return;
         }
 
-        $this->index = $this->buildIndex();
+        $this->buildIndex();
     }
 
     public function locate(QualifiedName $name, NameKind $kind): ?string
@@ -65,15 +96,14 @@ final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
         return array_key_exists($key, $declarations) ? $declarations[$key] : null;
     }
 
-    /**
-     * @return array<string, array<string, string>>
-     */
-    private function buildIndex(): array
+    private function buildIndex(): void
     {
-        $index = [];
+        $this->index = [];
         foreach (NameKind::cases() as $kind) {
-            $index[$kind->name] = [];
+            $this->index[$kind->name] = [];
         }
+        $this->declarations = [];
+        $this->namespaces = null;
 
         foreach ($this->map->autoloadFiles() as $path) {
             $ast = $this->parser->parseFile($path);
@@ -82,12 +112,10 @@ final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
             }
 
             $declarations = $this->scanner->scan($ast);
-            self::record($index, NameKind::ClassLike, $declarations->classLikes, $path);
-            self::record($index, NameKind::Function_, $declarations->functions, $path);
-            self::record($index, NameKind::Constant, $declarations->constants, $path);
+            $this->record(NameKind::ClassLike, $declarations->classLikes, $path);
+            $this->record(NameKind::Function_, $declarations->functions, $path);
+            $this->record(NameKind::Constant, $declarations->constants, $path);
         }
-
-        return $index;
     }
 
     /**
@@ -102,20 +130,23 @@ final class AutoloadFilesLocator implements SymbolLocator, Invalidatable
     }
 
     /**
-     * @param array<string, array<string, string>> $index
      * @param list<QualifiedName> $names
      */
-    private static function record(array &$index, NameKind $kind, array $names, string $path): void
+    private function record(NameKind $kind, array $names, string $path): void
     {
         foreach ($names as $name) {
             $key = self::key($name, $kind);
 
             // Composer requires the entries in order, so the first declaration of a
             // name is the one that takes effect; a later guarded redeclaration of
-            // the same name never runs.
-            if (!array_key_exists($key, $index[$kind->name])) {
-                $index[$kind->name][$key] = $path;
+            // the same name never runs. Enumeration reports the winner for the same
+            // reason, and so a name declared twice is not offered twice.
+            if (array_key_exists($key, $this->index[$kind->name])) {
+                continue;
             }
+
+            $this->index[$kind->name][$key] = $path;
+            $this->declarations[] = new CatalogSymbol($name->fullyQualifiedName(), $kind);
         }
     }
 }

--- a/src/Index/CompositeNamespaceCatalog.php
+++ b/src/Index/CompositeNamespaceCatalog.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+/**
+ * The union of what several catalogs report about a namespace.
+ *
+ * One backend can reach a namespace by more than one route: Composer's autoload maps
+ * turn a namespace into a directory listing, while the `autoload.files` set is
+ * addressed by no name at all and is enumerated from a derived index instead. Both
+ * describe the same namespace, so enumeration is their merge — the same shape
+ * {@see \Firehed\PhpLsp\Knowledge\CompositeSymbolLocator} gives the lookup half.
+ *
+ * Catalogs are passed in order of authority, so the earlier one settles a name they
+ * both report ({@see NamespaceContents::merge()}).
+ */
+final class CompositeNamespaceCatalog implements NamespaceCatalog
+{
+    /**
+     * @param list<NamespaceCatalog> $catalogs In precedence order
+     */
+    public function __construct(
+        private readonly array $catalogs,
+    ) {
+    }
+
+    public function childrenOf(string $namespace): NamespaceContents
+    {
+        return NamespaceContents::merge(array_map(
+            static fn(NamespaceCatalog $catalog): NamespaceContents => $catalog->childrenOf($namespace),
+            $this->catalogs,
+        ));
+    }
+}

--- a/src/Knowledge/KnowledgeStack.php
+++ b/src/Knowledge/KnowledgeStack.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\ComposerNamespaceSource;
 use Firehed\PhpLsp\Index\ComposerSymbolLocator;
+use Firehed\PhpLsp\Index\CompositeNamespaceCatalog;
 use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\ReflectionNamespaceSource;
@@ -92,6 +93,11 @@ final readonly class KnowledgeStack
      * The two routes to a declaration, cheapest first: Composer's autoload maps
      * address class-likes by arithmetic on the name, and the derived index covers
      * the `autoload.files` set, which they address by no name at all (Plan 0002 §3).
+     *
+     * Both routes answer enumeration as well as lookup, from the one derived index
+     * — the `files` set sits outside every PSR-4 and PSR-0 prefix, so the directory
+     * listing cannot see it, and a name reachable by only one of the two surfaces is
+     * the split RFC 1 §4.2 forbids.
      */
     private static function filesystemBackend(
         ComposerAutoloadMap $map,
@@ -99,12 +105,20 @@ final readonly class KnowledgeStack
         ClassInfoFactory $classInfoFactory,
         DeclarationScanner $scanner,
     ): FilesystemBackend {
+        $autoloadFiles = new AutoloadFilesLocator($map, $parser, $scanner);
+
         return new FilesystemBackend(
             new CompositeSymbolLocator([
                 new ComposerSymbolLocator($map),
-                new AutoloadFilesLocator($map, $parser, $scanner),
+                $autoloadFiles,
             ]),
-            new CachedNamespaceCatalog(new ComposerNamespaceSource($map), CacheFactory::inMemory()),
+            new CachedNamespaceCatalog(
+                new CompositeNamespaceCatalog([
+                    new ComposerNamespaceSource($map),
+                    $autoloadFiles,
+                ]),
+                CacheFactory::inMemory(),
+            ),
             $parser,
             $classInfoFactory,
             CacheFactory::inMemory(),

--- a/tests/Fixtures/Namespacing/CatalogProbe.php
+++ b/tests/Fixtures/Namespacing/CatalogProbe.php
@@ -20,4 +20,9 @@ class CatalogProbe
     {
         new \Fixtures\Catalog\F/*|ondisk_phantom*/
     }
+
+    public function autoloadFiles(): void
+    {
+        new \Fixtures\Helpers\Helper/*|ondisk_autoload_files*/
+    }
 }

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -423,6 +423,31 @@ class CompletionHandlerTest extends TestCase
         );
     }
 
+    public function testNavigationOffersClassLikesDeclaredInAnAutoloadFilesEntry(): void
+    {
+        // Fixtures\Helpers is declared by an `autoload.files` entry, so it sits
+        // outside every PSR-4 prefix and no directory listing can reach it. Its
+        // class-likes resolve on hover and definition, so completion must see them
+        // too (RFC 1 §4.2). The `new` filter still applies: of the four flavours the
+        // entry declares, only the class is instantiable.
+        $cursor = $this->openFixtureAtCursor('Namespacing/CatalogProbe.php', 'ondisk_autoload_files');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        $labels = array_column($result['items'], 'label');
+        self::assertContains(
+            'HelperRegistry',
+            $labels,
+            'a class declared in an autoload.files entry is offered, not just resolvable',
+        );
+        self::assertNotContains(
+            'HelperContract',
+            $labels,
+            'an interface from the same entry is filtered by the `new` predicate like any other',
+        );
+    }
+
     #[DataProvider('provideAbsoluteNavigationMarkers')]
     public function testAbsoluteNavigationFiresInEveryClassPosition(string $marker): void
     {

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -328,6 +328,7 @@ final class AutoloadFilesLocatorTest extends TestCase
                 ['FixtureGlobalRegistry', 'ClassLike'],
                 ['fixtureGlobalHelper', 'Function_'],
                 ['fixtureConditionalHelper', 'Function_'],
+                ['fixtureBootstrap', 'Function_'],
                 ['fixtureNestedHelper', 'Function_'],
                 // `define()` takes its whole name from the literal, so this one is
                 // global despite being written under a namespace.

--- a/tests/Index/AutoloadFilesLocatorTest.php
+++ b/tests/Index/AutoloadFilesLocatorTest.php
@@ -7,8 +7,10 @@ namespace Firehed\PhpLsp\Tests\Index;
 use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Index\AutoloadFilesLocator;
+use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\DeclarationScanner;
+use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Resolution\NameKind;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -21,6 +23,10 @@ use PHPUnit\Framework\TestCase;
  * map. These prove the derived index reaches all three symbol namespaces, applies
  * PHP's per-kind case rules, and does not overreach into names it never saw
  * (Plan 0002 §3, Step 3b).
+ *
+ * The index answers both reads of it: `locate` for a known name, and `childrenOf`
+ * for what a namespace contains. Enumerating it is what keeps a `files`-declared
+ * name from resolving on hover while staying invisible to completion (RFC 1 §4.2).
  */
 #[CoversClass(AutoloadFilesLocator::class)]
 final class AutoloadFilesLocatorTest extends TestCase
@@ -275,6 +281,179 @@ final class AutoloadFilesLocatorTest extends TestCase
                 unlink($path);
             }
         }
+    }
+
+    /**
+     * The exact contents of each namespace the fixture `files` entries reach. Exact
+     * rather than containment, so a name the scan must *not* reach — a computed
+     * `define()`, a `define()` value mistaken for its name, an anonymous class —
+     * fails here as loudly as a missing one.
+     *
+     * @return iterable<string, array{string, list<string>, list<array{string, string}>}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function enumeratedNamespaces(): iterable
+    {
+        yield 'namespaced entry' => [
+            'Fixtures\Helpers',
+            [],
+            [
+                ['Fixtures\Helpers\HELPER_LIMIT', 'Constant'],
+                ['Fixtures\Helpers\HELPER_DEFINED_QUALIFIED', 'Constant'],
+                ['Fixtures\Helpers\HelperContract', 'ClassLike'],
+                ['Fixtures\Helpers\HelperFallback', 'ClassLike'],
+                ['Fixtures\Helpers\HelperMode', 'ClassLike'],
+                ['Fixtures\Helpers\HelperRegistry', 'ClassLike'],
+                ['Fixtures\Helpers\helperFormat', 'Function_'],
+                ['Fixtures\Helpers\helperNormalize', 'Function_'],
+            ],
+        ];
+
+        // A namespace the set declares nothing directly in is still reachable,
+        // because the namespace on the way to a declaration is a child of its parent.
+        yield 'an intermediate namespace' => ['Fixtures', ['Fixtures\Helpers'], []];
+
+        yield 'the global namespace' => [
+            '',
+            ['Fixtures'],
+            [
+                ['FIXTURE_GLOBAL_LIMIT', 'Constant'],
+                ['FIXTURE_GLOBAL_ALPHA', 'Constant'],
+                ['FIXTURE_GLOBAL_BETA', 'Constant'],
+                ['FIXTURE_DEFINED_LIMIT', 'Constant'],
+                ['FIXTURE_UPPERCASE_DEFINED_LIMIT', 'Constant'],
+                ['FIXTURE_NAMED_LIMIT', 'Constant'],
+                ['FIXTURE_REORDERED_LIMIT', 'Constant'],
+                ['FIXTURE_BODY_LIMIT', 'Constant'],
+                ['FixtureGlobalRegistry', 'ClassLike'],
+                ['fixtureGlobalHelper', 'Function_'],
+                ['fixtureConditionalHelper', 'Function_'],
+                ['fixtureNestedHelper', 'Function_'],
+                // `define()` takes its whole name from the literal, so this one is
+                // global despite being written under a namespace.
+                ['FIXTURE_HELPER_DEFINED', 'Constant'],
+            ],
+        ];
+
+        yield 'a namespace the set does not reach' => ['Fixtures\Domain', [], []];
+    }
+
+    /**
+     * Enumeration must cover exactly what lookup covers: a name the `files` set
+     * declares resolves by hover and definition, so it must also appear in the
+     * namespace it is declared in (RFC 1 §4.2 — lookup and enumeration draw on the
+     * same backends so their coverage is identical).
+     *
+     * @param list<string> $expectedChildNamespaces
+     * @param list<array{string, string}> $expectedSymbols
+     */
+    #[DataProvider('enumeratedNamespaces')]
+    public function testChildrenOfEnumeratesWhatTheAutoloadFilesSetDeclares(
+        string $namespace,
+        array $expectedChildNamespaces,
+        array $expectedSymbols,
+    ): void {
+        $contents = self::locatorForRoot(self::FIXTURES_ROOT)->childrenOf($namespace);
+
+        self::assertSame(
+            self::sorted($expectedChildNamespaces),
+            self::sorted($contents->childNamespaces),
+            'the namespaces on the way to a declaration must be enumerated as children',
+        );
+        self::assertSame(
+            self::sortedSymbols($expectedSymbols),
+            self::sortedSymbols(self::asPairs($contents)),
+            'every name the set declares in the namespace must be enumerated, under its own kind',
+        );
+    }
+
+    /**
+     * The names are keyed for lookup under PHP's per-kind case rules, but reported
+     * for enumeration as the declaration spells them — a completion item inserts a
+     * name, and `helperregistry` is not the name the file declares.
+     */
+    public function testChildrenOfReportsNamesAsDeclaredRatherThanNormalized(): void
+    {
+        $contents = self::locatorForRoot(self::FIXTURES_ROOT)->childrenOf('Fixtures\Helpers');
+
+        $fqns = array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $contents->symbols,
+        );
+        self::assertContains('Fixtures\Helpers\HelperRegistry', $fqns, 'a class-like keeps its declared casing');
+        self::assertContains('Fixtures\Helpers\helperFormat', $fqns, 'a function keeps its declared casing');
+    }
+
+    public function testChildrenOfMatchesANamespaceInAnyCase(): void
+    {
+        $locator = self::locatorForRoot(self::FIXTURES_ROOT);
+
+        self::assertEquals(
+            $locator->childrenOf('Fixtures\Helpers'),
+            $locator->childrenOf('FIXTURES\helpers'),
+            'PHP namespaces are case-insensitive, so one namespace is not two listings',
+        );
+    }
+
+    public function testInvalidateRebuildsWhatIsEnumeratedAsWellAsWhatIsLocated(): void
+    {
+        $path = self::tempFile('<?php namespace Rebuilt; class Before {}');
+
+        try {
+            $locator = self::locatorForMap(new ComposerAutoloadMap([], [], [], [$path]));
+            self::assertSame(
+                [['Rebuilt\Before', 'ClassLike']],
+                self::asPairs($locator->childrenOf('Rebuilt')),
+                'the eagerly built index must enumerate the file as it was read',
+            );
+
+            self::assertNotFalse(
+                file_put_contents($path, '<?php namespace Rebuilt; class After {}'),
+                'rewrite must succeed',
+            );
+            $locator->invalidate(FileUri::fromPath($path));
+
+            self::assertSame(
+                [['Rebuilt\After', 'ClassLike']],
+                self::asPairs($locator->childrenOf('Rebuilt')),
+                'enumeration must reflect the rebuilt index, not a memo of the pre-change one',
+            );
+        } finally {
+            unlink($path);
+        }
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    private static function asPairs(NamespaceContents $contents): array
+    {
+        return array_map(
+            static fn(CatalogSymbol $symbol): array => [$symbol->fullyQualifiedName, $symbol->kind->name],
+            $contents->symbols,
+        );
+    }
+
+    /**
+     * @param list<string> $values
+     * @return list<string>
+     */
+    private static function sorted(array $values): array
+    {
+        sort($values);
+
+        return $values;
+    }
+
+    /**
+     * @param list<array{string, string}> $symbols
+     * @return list<array{string, string}>
+     */
+    private static function sortedSymbols(array $symbols): array
+    {
+        usort($symbols, static fn(array $a, array $b): int => strcmp($a[0], $b[0]));
+
+        return $symbols;
     }
 
     private static function locatorForRoot(string $projectRoot): AutoloadFilesLocator

--- a/tests/Index/CompositeNamespaceCatalogTest.php
+++ b/tests/Index/CompositeNamespaceCatalogTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\CompositeNamespaceCatalog;
+use Firehed\PhpLsp\Index\NamespaceCatalog;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * One backend can reach a namespace's contents by more than one route — Composer's
+ * autoload maps address most names by arithmetic, and the derived `autoload.files`
+ * index covers what they structurally cannot. Enumeration must report their union,
+ * or a symbol is reachable by lookup and invisible to completion (RFC 1 §4.2).
+ */
+#[CoversClass(CompositeNamespaceCatalog::class)]
+final class CompositeNamespaceCatalogTest extends TestCase
+{
+    public function testChildrenOfMergesEveryCatalog(): void
+    {
+        $catalog = new CompositeNamespaceCatalog([
+            self::catalogOf(['App\Http'], ['App\User']),
+            self::catalogOf(['App\Cli'], ['App\helper']),
+        ]);
+
+        $contents = $catalog->childrenOf('App');
+
+        self::assertSame(
+            ['App\Http', 'App\Cli'],
+            $contents->childNamespaces,
+            'a child namespace reported by any route must be enumerated',
+        );
+        self::assertSame(
+            ['App\User', 'App\helper'],
+            self::fqns($contents),
+            'a symbol reported by any route must be enumerated',
+        );
+    }
+
+    public function testTheEarlierCatalogWinsANameReportedByBoth(): void
+    {
+        $first = new CatalogSymbol('App\Shared', NameKind::ClassLike);
+        $second = new CatalogSymbol('App\Shared', NameKind::Function_);
+
+        $contents = (new CompositeNamespaceCatalog([
+            self::catalogOfSymbols([$first]),
+            self::catalogOfSymbols([$second]),
+        ]))->childrenOf('App');
+
+        self::assertSame(
+            [$first],
+            $contents->symbols,
+            'catalogs are passed in order of authority, so the earlier one settles a clash',
+        );
+    }
+
+    public function testEveryCatalogIsAskedAboutTheSameNamespace(): void
+    {
+        $counting = new CountingNamespaceCatalog();
+
+        $contents = (new CompositeNamespaceCatalog([$counting, $counting]))->childrenOf('Psr\Log');
+
+        self::assertSame(2, $counting->calls, 'each catalog is consulted, not just the first to answer');
+        self::assertSame(
+            ['Psr\Log\Child'],
+            $contents->childNamespaces,
+            'the namespace asked for must be passed through unchanged',
+        );
+    }
+
+    public function testACompositeOverNoCatalogsIsEmpty(): void
+    {
+        $contents = (new CompositeNamespaceCatalog([]))->childrenOf('App');
+
+        self::assertSame([], $contents->childNamespaces, 'no route means no children');
+        self::assertSame([], $contents->symbols, 'no route means no symbols');
+    }
+
+    /**
+     * @param list<string> $childNamespaces
+     * @param list<string> $symbolFqns
+     */
+    private static function catalogOf(array $childNamespaces, array $symbolFqns): NamespaceCatalog
+    {
+        return self::catalogReturning(new NamespaceContents(
+            $childNamespaces,
+            array_map(
+                static fn(string $fqn): CatalogSymbol => new CatalogSymbol($fqn, NameKind::ClassLike),
+                $symbolFqns,
+            ),
+        ));
+    }
+
+    /**
+     * @param list<CatalogSymbol> $symbols
+     */
+    private static function catalogOfSymbols(array $symbols): NamespaceCatalog
+    {
+        return self::catalogReturning(new NamespaceContents([], $symbols));
+    }
+
+    private static function catalogReturning(NamespaceContents $contents): NamespaceCatalog
+    {
+        $catalog = self::createStub(NamespaceCatalog::class);
+        $catalog->method('childrenOf')->willReturn($contents);
+
+        return $catalog;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function fqns(NamespaceContents $contents): array
+    {
+        return array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $contents->symbols,
+        );
+    }
+}

--- a/tests/Integration/ExternalFileChangeInvalidationTest.php
+++ b/tests/Integration/ExternalFileChangeInvalidationTest.php
@@ -7,8 +7,10 @@ namespace Firehed\PhpLsp\Tests\Integration;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Handler\DidChangeWatchedFilesHandler;
+use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
+use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Knowledge\SymbolSource;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
@@ -139,6 +141,56 @@ class ExternalFileChangeInvalidationTest extends TestCase
             $reopened->methods,
             'closing an edited file must re-read disk, not restore the pre-edit cached class (RFC 1 §5.3)',
         );
+    }
+
+    /**
+     * Two derived structures stand between an `autoload.files` entry and a
+     * completion list — the name -> file index and the cached namespace listing —
+     * and either one left stale hides the edit. Enumeration is held to the same
+     * next-query rule as lookup (RFC 1 §5.2, §5.3).
+     */
+    public function testAnExternalEditToAnAutoloadFilesEntryIsReflectedInEnumeration(): void
+    {
+        $path = $this->workspace . '/bootstrap.php';
+        $this->writeFile($path, "<?php\nnamespace Temp;\nclass FilesBefore {}\n");
+
+        $stack = KnowledgeStack::forProject(
+            new ComposerAutoloadMap(files: [$path]),
+            $this->workspace . '/vendor',
+            $this->parser,
+        );
+        $handler = new DidChangeWatchedFilesHandler($stack->sink);
+
+        self::assertSame(
+            ['Temp\FilesBefore'],
+            $this->enumerate($stack->source),
+            'the class the entry declares must be enumerated before the edit',
+        );
+
+        $this->writeFile($path, "<?php\nnamespace Temp;\nclass FilesAfter {}\n");
+        $handler->handle($this->changed('bootstrap'));
+
+        self::assertSame(
+            ['Temp\FilesAfter'],
+            $this->enumerate($stack->source),
+            'the edit must reach both the derived index and the cached namespace listing',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function enumerate(SymbolSource $source): array
+    {
+        return array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $source->childrenOf(new NamespaceName('Temp'))->symbols,
+        );
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        self::assertNotFalse(file_put_contents($path, $contents), "the fixture file {$path} must be writable");
     }
 
     private function warm(SymbolSource $source, string ...$shortNames): void

--- a/tests/Knowledge/KnowledgeStackTest.php
+++ b/tests/Knowledge/KnowledgeStackTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\Symbol;
@@ -14,6 +15,7 @@ use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Utility\NamespacePath;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -78,6 +80,90 @@ final class KnowledgeStackTest extends TestCase
 
         self::assertNotNull($info, "a class-like declared in an autoload.files entry must resolve: {$fqn}");
         self::assertSame($fqn, $info->name->fqn, 'the located class-like must be the one asked for');
+    }
+
+    /**
+     * RFC 1 §4.2: lookup and enumeration are distinct operations that must draw on
+     * the same backends, so their coverage is identical. A `files`-declared name
+     * that resolved on hover while being absent from namespace completion is exactly
+     * the per-surface split this series exists to prevent.
+     */
+    #[DataProvider('autoloadFilesClassLikes')]
+    public function testAClassLikeInAnAutoloadFilesEntryIsEnumeratedWhereverItResolves(string $fqn): void
+    {
+        $stack = KnowledgeStack::forProject(
+            ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot),
+            $this->fixturesRoot . '/vendor',
+            $this->parser,
+        );
+
+        self::assertNotNull(
+            $stack->source->lookupClassLike(self::className($fqn)),
+            "lookup must reach the name for enumeration to be held to it: {$fqn}",
+        );
+
+        $namespace = NamespacePath::namespaceOf($fqn);
+        $fqns = array_map(
+            static fn(CatalogSymbol $symbol): string => $symbol->fullyQualifiedName,
+            $stack->source->childrenOf(new NamespaceName($namespace))->symbols,
+        );
+        self::assertContains(
+            $fqn,
+            $fqns,
+            "a resolvable name must also be enumerated in its own namespace: {$fqn}",
+        );
+    }
+
+    /**
+     * `autoload.files` entries sit outside every PSR-4 and PSR-0 prefix, so the
+     * namespace they declare into cannot be reached by a directory listing. Both
+     * routes must survive the merge: the composer source keeps enumerating the
+     * PSR-4 tree, and the derived index adds what it structurally cannot see.
+     */
+    public function testAnAutoloadFilesNamespaceIsReachableAlongsideThePsr4Tree(): void
+    {
+        $stack = KnowledgeStack::forProject(
+            ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot),
+            $this->fixturesRoot . '/vendor',
+            $this->parser,
+        );
+
+        $children = $stack->source->childrenOf(new NamespaceName('Fixtures'))->childNamespaces;
+
+        self::assertContains(
+            'Fixtures\Helpers',
+            $children,
+            'a namespace declared only by an autoload.files entry must be navigable',
+        );
+        self::assertContains(
+            'Fixtures\Domain',
+            $children,
+            'merging the derived index must not displace the directory listing',
+        );
+    }
+
+    /**
+     * The manifest scopes this as wiring enumeration onto data already derived, not
+     * a second scan: the set is parsed once at construction and enumerating it
+     * groups what is already in memory.
+     */
+    public function testEnumeratingTheAutoloadFilesSetCostsNoFurtherParse(): void
+    {
+        $stack = KnowledgeStack::forProject(
+            ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot),
+            $this->fixturesRoot . '/vendor',
+            $this->parser,
+        );
+        $afterConstruction = $this->parser->getMetrics()->getParseCount();
+
+        $stack->source->childrenOf(new NamespaceName('Fixtures\Helpers'));
+        $stack->source->childrenOf(new NamespaceName('Fixtures'));
+
+        self::assertSame(
+            $afterConstruction,
+            $this->parser->getMetrics()->getParseCount(),
+            'enumeration reads the index built at construction rather than re-scanning the set',
+        );
     }
 
     /**

--- a/tests/Parity/ChildrenOfParityTest.php
+++ b/tests/Parity/ChildrenOfParityTest.php
@@ -54,10 +54,16 @@ final class ChildrenOfParityTest extends TestCase
      * PHP matrix. Between them they exercise every composer branch: a PSR-4 leaf
      * with symbols, a namespace above a PSR-4 prefix, PSR-0, and the classmap.
      *
+     * `Fixtures\Helpers` is the `autoload.files` route, which no autoload map
+     * addresses by name and no directory listing reaches: it exists only in the
+     * index derived by parsing that set. Its entry is a dedicated fixture file, so
+     * it is as stable as the rest.
+     *
      * @var list<string>
      */
     private const array NAMESPACES = [
         'Fixtures\Catalog',
+        'Fixtures\Helpers',
         'Fixtures\Model',
         'Fixtures\Model\Env',
         'Fixtures\Model\OpenOnly',

--- a/tests/Parity/goldens/children-of.json
+++ b/tests/Parity/goldens/children-of.json
@@ -16,6 +16,43 @@
             }
         ]
     },
+    "Fixtures\\Helpers": {
+        "childNamespaces": [],
+        "symbols": [
+            {
+                "fqn": "Fixtures\\Helpers\\HELPER_DEFINED_QUALIFIED",
+                "kind": "Constant"
+            },
+            {
+                "fqn": "Fixtures\\Helpers\\HELPER_LIMIT",
+                "kind": "Constant"
+            },
+            {
+                "fqn": "Fixtures\\Helpers\\HelperContract",
+                "kind": "ClassLike"
+            },
+            {
+                "fqn": "Fixtures\\Helpers\\HelperFallback",
+                "kind": "ClassLike"
+            },
+            {
+                "fqn": "Fixtures\\Helpers\\HelperMode",
+                "kind": "ClassLike"
+            },
+            {
+                "fqn": "Fixtures\\Helpers\\HelperRegistry",
+                "kind": "ClassLike"
+            },
+            {
+                "fqn": "Fixtures\\Helpers\\helperFormat",
+                "kind": "Function_"
+            },
+            {
+                "fqn": "Fixtures\\Helpers\\helperNormalize",
+                "kind": "Function_"
+            }
+        ]
+    },
     "Fixtures\\Model": {
         "childNamespaces": [
             "Fixtures\\Model\\Env",


### PR DESCRIPTION
Slice **S3.7e** — plan step **3b** (`docs/architecture/0002-execution-plan.md`), RFC 1 **§4.2** (Symbol Discovery Authority), **§5.3** (backends and the replaceable cache seam), **§5.2** (invalidation).

S3.7d made a name declared in an `autoload.files` entry resolvable by `lookupClassLike`, but `childrenOf` still enumerated by listing the PSR-4/PSR-0 directory a namespace maps to — which these files sit outside. So the name resolved on hover and definition while never appearing in namespace completion. §4.2 requires lookup and enumeration to draw on the same backends so their coverage is identical; this closes that split.

The data was already derived, so this is wiring enumeration onto it rather than a second scan:

- `AutoloadFilesLocator` keeps each declaration's name as written alongside the normalized lookup key, and implements `NamespaceCatalog` over the index it already builds. The kind reported is the declaration's own, not the coarse `ClassLike` a directory listing has to guess.
- `CompositeNamespaceCatalog` merges catalogs in precedence order, mirroring `CompositeSymbolLocator` on the lookup side.
- `KnowledgeStack` passes the one locator instance into both routes, so the set is still parsed once at construction and invalidation still rebuilds it exactly once.

## Acceptance

- [x] A class-like declared in an `autoload.files` entry appears in `childrenOf` for its namespace, wherever it resolves by lookup
- [x] Functions and constants are enumerated under their own `NameKind` (class completion filters non-class-likes as before; function completion reach is S3.9b)
- [x] A namespace declared only by the `files` set is navigable from its parent, without displacing the directory listing
- [x] Names are reported as declared, not as normalized for the per-kind case rules
- [x] Enumeration costs no parse beyond the eager index build
- [x] An external edit to a `files` entry reaches both the derived index and the cached namespace listing
- [x] Step P `children-of` golden extended with the `autoload.files` route; no other golden churns
- [x] 100% coverage on changed source

Candidate closes (pending review verification): none — the manifest lists no `Closes` for this slice. Per its notes, #181 is not closable before S3.9b; namespace completion for these symbols is the part S3.7e contributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
