### PR TITLE
Give lookupFunction project reach through the symbol backends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,10 @@ says how to write it.
 
 ### Symbol Backends
 
-Class-like lookup, namespace enumeration, and class-like prefix search flow through the
-**`SymbolSource`** read seam (`src/Knowledge/`), implemented by **`CompositeSymbolSource`**
-over a fixed-precedence list of **`SymbolBackend`s** (RFC 1 §5.3):
+Class-like lookup, function lookup, namespace enumeration, and class-like prefix search
+flow through the **`SymbolSource`** read seam (`src/Knowledge/`), implemented by
+**`CompositeSymbolSource`** over a fixed-precedence list of **`SymbolBackend`s**
+(RFC 1 §5.3):
 
 1. **`OpenDocumentBackend`** — the editor's open documents (never cached); its answer overrides the rest.
 2. **`FilesystemBackend`** (workspace) — the project's own on-disk code, resolved via Composer's non-`vendor/` autoload prefixes: locate one file and parse it.
@@ -113,7 +114,16 @@ over a fixed-precedence list of **`SymbolBackend`s** (RFC 1 §5.3):
 A lookup takes the first backend that answers; enumeration and search merge every
 backend, the earlier (more authoritative) one winning a name clash. Caching is a
 per-backend PSR-16 policy (`src/Cache/`); on-disk and built-in results are cached, open
-documents never.
+documents never. A cache key carries the `NameKind` (`SymbolCacheKey`): PHP's three
+symbol namespaces are independent, so a class and a function may share a name.
+
+Lookup is **per-kind**, taking a name type that carries its kind (`ClassName`,
+`FunctionName`) rather than a name plus a `NameKind` argument. `lookupFunction` reaches
+open documents, the `autoload.files` set, and PHP's built-ins — the last filtered to
+`isInternal()`, because reflection also sees the functions the *server's* own
+dependencies declare, which are not the project's. A function in an unopened PSR-4 file
+has no name→file route at all: Composer's maps address class-likes only, which is
+RFC 1 §3's locate-only limitation, not a backend gap.
 
 Each `FilesystemBackend` finds its file through a **`CompositeSymbolLocator`** chaining
 two routes, cheapest first: `ComposerSymbolLocator` (PSR-4/PSR-0/classmap — arithmetic
@@ -121,7 +131,7 @@ on the name) and `AutoloadFilesLocator`. The latter exists because `autoload.fil
 entries are addressed by *no* name at all, so the only route is to parse the set and
 derive the map; it is built eagerly, covers all three symbol namespaces (a name-keyed
 route cannot know which kind a file declares), and applies PHP's per-kind case rules via
-`NameKind::isCaseSensitive()`. A test pins the parse *count* at construction, which is
+`NameKind::normalize()`. A test pins the parse *count* at construction, which is
 not a cost measurement; the set is explicit and usually tiny.
 
 The same derived index also answers the backend's `childrenOf`, merged with the
@@ -129,8 +139,11 @@ directory listing by `CompositeNamespaceCatalog`. Enumeration is not optional: �
 requires lookup and enumeration to draw on the same backends, so a name that resolved
 on hover while being invisible to completion is the split this tier exists to prevent.
 
-The write path is **`SymbolSink`** (`DocumentSymbolSink`), which
-registers class metadata and indexes symbols from one document.
+The write path is **`SymbolSink`** (`DocumentSymbolSink`), which registers class and
+function metadata and indexes symbols from one document. A declaration at any depth is
+registered, not just a top-level one — a polyfill guarded by `function_exists` is a name
+the file validly declares, and the on-disk backends resolve one, so opening the file must
+not make it disappear.
 **`KnowledgeStack::forProject`** assembles the read composite and the write sink,
 sharing one open-document backend and symbol index.
 
@@ -138,8 +151,8 @@ sharing one open-document backend and symbol index.
 producer alongside the editor lifecycle. `SymbolSink extends Cache\Invalidatable`, so
 `invalidate($uri)` drops the on-disk cache for a file changed outside the editor and
 the next query re-reads disk. It fans out to the cached on-disk backends (also
-`Invalidatable`): `FilesystemBackend` evicts that file's class-likes (a path→key
-reverse map), `CachedNamespaceCatalog` drops its listings, and the locator chain
+`Invalidatable`): `FilesystemBackend` evicts that file's class-likes and functions (a
+path→key reverse map), `CachedNamespaceCatalog` drops its listings, and the locator chain
 re-derives the `autoload.files` index if the changed file is in that set — evicting
 only the `ClassInfo` cache would leave the name→file map itself stale.
 Two triggers reach it:
@@ -152,7 +165,8 @@ until a file is opened and closed).
 
 Class-like prefix search (`searchClassLikes`) is served only by the open-document
 backend today; project-wide on-disk search is the deferred workspace-index scope
-(RFC 1 §3). Function/constant reach is Step 3b.
+(RFC 1 §3). Function search, and the migration of the consumers still calling
+`FunctionRepository`, are later Step 3b slices; constant reach is S3.8b.
 
 - **MemberResolver** — Finds methods/properties/constants on a class, traversing the inheritance chain via `supertypes()`; reads class metadata through `SymbolSource`. Returns domain objects (`MethodInfo`, `PropertyInfo`).
 - **ClassInfoFactory** (`DefaultClassInfoFactory`) — Creates `ClassInfo` from AST nodes or reflection.

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -271,11 +271,15 @@ Step 4 (Section 6).
   no name to index); migrate `FunctionCandidates`
   to `search` (which subsumes `getFileFunctions` — the open-document backend knows a
   document's functions, so that query disappears with its last caller); remove the
-  Step 2 rule exemption. This step **both changes and preserves** behavior on the
-  function surface: the added project reach is new (proven by **new fixtures**), but
-  built-in and open-document function completion is *existing* behavior that must not
-  regress. So the function-surface golden (Step P) is **captured before this step**
-  from today's path (`get_defined_functions()['internal']` + open-doc functions) and
+  Step 2 rule exemption. *Acceptance on search reach:* every backend that answers
+  `lookupFunction` MUST also answer function `search`, so a name resolvable on hover
+  is offered in completion (§4.2). For `FilesystemBackend` that means the derived
+  `autoload.files` index — its empty `searchClassLikes` is scoped to the PSR-4 tree,
+  which needs a workspace walk (§3), not to every kind. This step **both changes and
+  preserves** behavior on the function surface: the added project reach is new
+  (proven by **new fixtures**), but built-in and open-document function completion is
+  *existing* behavior that must not regress. So the function-surface golden (Step P)
+  is **captured before this step** from today's path (`get_defined_functions()['internal']` + open-doc functions) and
   frozen for the preservation half, and a **parity oracle** asserts the Builtin
   backend's function enumeration matches `get_defined_functions()` (as
   `TypeGraphParityTest` uses reflection for members). Revert profile: structural —

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -137,11 +137,6 @@ Notes:
   rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
   answer function search in S3.9b or built-in function completion regresses — that
   golden is what catches it.
-  - **`FilesystemBackend` MUST answer function search from the derived
-    `autoload.files` index.** Its empty `searchClassLikes` is about the PSR-4 tree,
-    which needs a walk (§3); the `files` index is already derived, so searching it is
-    a filter. Omitting it hides a name `lookupFunction` resolves — S3.7e's split, one
-    symbol namespace over.
 - **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -137,6 +137,11 @@ Notes:
   rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
   answer function search in S3.9b or built-in function completion regresses — that
   golden is what catches it.
+  - **`FilesystemBackend` MUST answer function search from the derived
+    `autoload.files` index.** Its empty `searchClassLikes` is about the PSR-4 tree,
+    which needs a walk (§3); the `files` index is already derived, so searching it is
+    a filter. Omitting it hides a name `lookupFunction` resolves — S3.7e's split, one
+    symbol namespace over.
 - **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,

--- a/src/Domain/FunctionInfo.php
+++ b/src/Domain/FunctionInfo.php
@@ -26,7 +26,12 @@ final readonly class FunctionInfo implements Formattable
     ) {
     }
 
-    public static function fromNode(Stmt\Function_ $node): self
+    /**
+     * @param ?string $file the declaring file, which the node does not carry;
+     *        supplied when the function was resolved from a known file rather than
+     *        from the document already being read
+     */
+    public static function fromNode(Stmt\Function_ $node, ?string $file = null): self
     {
         $params = [];
         foreach ($node->params as $position => $param) {
@@ -41,7 +46,7 @@ final readonly class FunctionInfo implements Formattable
             parameters: $params,
             returnType: TypeFactory::fromNode($node->returnType),
             docblock: $node->getDocComment()?->getText(),
-            file: null,
+            file: $file,
             line: $node->getStartLine(),
         );
     }

--- a/src/Domain/FunctionName.php
+++ b/src/Domain/FunctionName.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use Firehed\PhpLsp\Resolution\NameKind;
+
+/**
+ * The fully-qualified name of a standalone function (Plan 0002 §5.3): a
+ * {@see QualifiedName} that carries its {@see NameKind} intrinsically, so a lookup
+ * taking one needs no separate kind argument. `Foo\bar` names a different symbol as
+ * a function than as a constant, and the type is what says which.
+ */
+final readonly class FunctionName
+{
+    public function __construct(
+        public QualifiedName $qualifiedName,
+    ) {
+    }
+
+    public static function fromFullyQualified(string $fullyQualifiedName): self
+    {
+        return new self(QualifiedName::fromFullyQualified($fullyQualifiedName));
+    }
+
+    public function fullyQualifiedName(): string
+    {
+        return $this->qualifiedName->fullyQualifiedName();
+    }
+
+    public function kind(): NameKind
+    {
+        return NameKind::Function_;
+    }
+}

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -10,7 +10,6 @@ use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Resolution\NameKind;
-use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * Locates a declaration in Composer's `autoload.files` set, by deriving the

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -91,7 +91,7 @@ final class AutoloadFilesLocator implements SymbolLocator, NamespaceCatalog, Inv
     public function locate(QualifiedName $name, NameKind $kind): ?string
     {
         $declarations = $this->index[$kind->name];
-        $key = self::key($name, $kind);
+        $key = $kind->normalize($name);
 
         return array_key_exists($key, $declarations) ? $declarations[$key] : null;
     }
@@ -119,23 +119,12 @@ final class AutoloadFilesLocator implements SymbolLocator, NamespaceCatalog, Inv
     }
 
     /**
-     * Only constant short names are matched exactly. A namespace path is
-     * case-insensitive for every kind, so the rule applies to the short name alone.
-     */
-    private static function key(QualifiedName $name, NameKind $kind): string
-    {
-        $shortName = $kind->isCaseSensitive() ? $name->shortName : strtolower($name->shortName);
-
-        return NamespacePath::join(strtolower($name->namespace), $shortName);
-    }
-
-    /**
      * @param list<QualifiedName> $names
      */
     private function record(NameKind $kind, array $names, string $path): void
     {
         foreach ($names as $name) {
-            $key = self::key($name, $kind);
+            $key = $kind->normalize($name);
 
             // Composer requires the entries in order, so the first declaration of a
             // name is the one that takes effect; a later guarded redeclaration of

--- a/src/Knowledge/BuiltinBackend.php
+++ b/src/Knowledge/BuiltinBackend.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Knowledge;
 
-use Firehed\PhpLsp\Cache\CacheKey;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
+use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
+use Firehed\PhpLsp\Resolution\NameKind;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionFunction;
 
 /**
  * The lowest-precedence {@see SymbolBackend}: the symbols built into PHP and its
@@ -45,7 +49,7 @@ final class BuiltinBackend implements SymbolBackend
 
     public function lookupClassLike(ClassName $name): ?ClassInfo
     {
-        $cacheKey = CacheKey::from(strtolower(ltrim($name->fqn, '\\')));
+        $cacheKey = SymbolCacheKey::for(QualifiedName::fromClassName($name), NameKind::ClassLike);
 
         $cached = $this->cache->get($cacheKey);
         if ($cached !== null) {
@@ -61,6 +65,37 @@ final class BuiltinBackend implements SymbolBackend
         $this->cache->set($cacheKey, $classInfo);
 
         return $classInfo;
+    }
+
+    public function lookupFunction(FunctionName $name): ?FunctionInfo
+    {
+        $cacheKey = SymbolCacheKey::for($name->qualifiedName, $name->kind());
+
+        $cached = $this->cache->get($cacheKey);
+        if ($cached !== null) {
+            assert($cached instanceof FunctionInfo);
+            return $cached;
+        }
+
+        try {
+            $function = new ReflectionFunction($name->fullyQualifiedName());
+        } catch (ReflectionException) {
+            return null;
+        }
+
+        // Reflection sees every function loaded in the *server's* process, which
+        // includes the ones its own dependencies declare. Those are not the
+        // project's, and this backend enumerates only internal functions
+        // (BuiltinFunctionParityTest) — a lookup that answered more broadly would
+        // resolve a name completion never offers (RFC 1 §4.2).
+        if (!$function->isInternal()) {
+            return null;
+        }
+
+        $functionInfo = FunctionInfo::fromReflection($function);
+        $this->cache->set($cacheKey, $functionInfo);
+
+        return $functionInfo;
     }
 
     /**

--- a/src/Knowledge/CompositeSymbolSource.php
+++ b/src/Knowledge/CompositeSymbolSource.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
 
@@ -64,6 +66,18 @@ final class CompositeSymbolSource implements SymbolSource
     {
         foreach ($this->backends as $backend) {
             $info = $backend->lookupClassLike($name);
+            if ($info !== null) {
+                return $info;
+            }
+        }
+
+        return null;
+    }
+
+    public function lookupFunction(FunctionName $name): ?FunctionInfo
+    {
+        foreach ($this->backends as $backend) {
+            $info = $backend->lookupFunction($name);
             if ($info !== null) {
                 return $info;
             }

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -80,10 +80,11 @@ final class DocumentSymbolSink implements SymbolSink
         $ast = $this->parser->parse($document) ?? [];
 
         $classes = $this->classesIn($ast, $document->uri);
-        $this->backend->updateDocument($document->uri, $classes, $this->functionsIn($ast, $document->uri));
+        $functions = $this->functionsIn($ast, $document->uri);
+        $this->backend->updateDocument($document->uri, $classes, $functions);
         $this->indexer->indexParsed($document, $ast);
 
-        $this->assertStoresAgree($classes);
+        $this->assertStoresAgree($classes, $functions);
     }
 
     /**
@@ -96,25 +97,43 @@ final class DocumentSymbolSink implements SymbolSink
      * superset — it also records class-likes declared inside conditional or nested
      * statements, which the top-level lookup registration does not.
      *
+     * Functions are checked on the same terms, and need it more: the two stores
+     * qualify a function name by different routes — the parser's `namespacedName`
+     * here, a hand-tracked enclosing namespace in {@see \Firehed\PhpLsp\Index\SymbolExtractor} —
+     * so agreement is a property of two implementations rather than of one.
+     *
      * @param list<ClassInfo> $classes
+     * @param array<string, FunctionInfo> $functions
      */
-    private function assertStoresAgree(array $classes): void
+    private function assertStoresAgree(array $classes, array $functions): void
     {
         foreach ($classes as $classInfo) {
-            if ($this->index->findByFqn($classInfo->name->fqn) === null) {
-                // Unreachable: both stores derive their class-likes from the one AST
-                // parsed above, so a class registered for lookup is always indexed. The
-                // guard fails loudly if that ever ceases to hold.
-                // @codeCoverageIgnoreStart
-                throw new \LogicException(sprintf(
-                    'Write-path divergence: class-like %s is registered for lookup but absent '
-                    . 'from the symbol index; the two stores are written from one parse and '
-                    . 'must agree (RFC 1 §4.3).',
-                    $classInfo->name->fqn,
-                ));
-                // @codeCoverageIgnoreEnd
-            }
+            $this->assertIndexed('class-like', $classInfo->name->fqn);
         }
+
+        foreach (array_keys($functions) as $fqn) {
+            $this->assertIndexed('function', $fqn);
+        }
+    }
+
+    private function assertIndexed(string $kind, string $fqn): void
+    {
+        if ($this->index->findByFqn($fqn) !== null) {
+            return;
+        }
+
+        // Unreachable: both stores derive their symbols from the one AST parsed
+        // above, so a name registered for lookup is always indexed. The guard fails
+        // loudly if that ever ceases to hold.
+        // @codeCoverageIgnoreStart
+        throw new \LogicException(sprintf(
+            'Write-path divergence: %s %s is registered for lookup but absent from the '
+            . 'symbol index; the two stores are written from one parse and must agree '
+            . '(RFC 1 §4.3).',
+            $kind,
+            $fqn,
+        ));
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -7,12 +7,14 @@ namespace Firehed\PhpLsp\Knowledge;
 use Firehed\PhpLsp\Cache\Invalidatable;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
+use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
 
 /**
  * The single write path for open-document symbol state (RFC 1 §4.3, §5.2): document
@@ -78,7 +80,7 @@ final class DocumentSymbolSink implements SymbolSink
         $ast = $this->parser->parse($document) ?? [];
 
         $classes = $this->classesIn($ast, $document->uri);
-        $this->backend->updateDocument($document->uri, $classes);
+        $this->backend->updateDocument($document->uri, $classes, $this->functionsIn($ast, $document->uri));
         $this->indexer->indexParsed($document, $ast);
 
         $this->assertStoresAgree($classes);
@@ -113,6 +115,25 @@ final class DocumentSymbolSink implements SymbolSink
                 // @codeCoverageIgnoreEnd
             }
         }
+    }
+
+    /**
+     * A declaration at any depth counts, matching what the on-disk backends resolve
+     * (a polyfill guarded by `function_exists` is the common shape). Opening a file
+     * must not make a name that already resolved disappear (RFC 1 §4.2).
+     *
+     * @param array<Stmt> $ast
+     * @return array<string, FunctionInfo> Fully-qualified name -> metadata
+     */
+    private function functionsIn(array $ast, string $uri): array
+    {
+        $functions = [];
+        foreach ((new NodeFinder())->findInstanceOf($ast, Stmt\Function_::class) as $node) {
+            $fqn = ($node->namespacedName ?? $node->name)->toString();
+            $functions[$fqn] ??= FunctionInfo::fromNode($node, $uri);
+        }
+
+        return $functions;
     }
 
     /**

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -143,8 +143,9 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
     }
 
     /**
-     * Empty by contract: project-wide prefix search over on-disk files needs an
-     * index this backend does not build (RFC 1 §3, §5.3).
+     * Empty by contract: a prefix search over the PSR-4 tree needs a workspace walk
+     * this backend does not do (RFC 1 §3, §5.3). Scoped to the tree, not to every
+     * kind — the derived `autoload.files` index is a filter, not a walk.
      *
      * @return list<never>
      */

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Knowledge;
 
-use Firehed\PhpLsp\Cache\CacheKey;
 use Firehed\PhpLsp\Cache\Invalidatable;
 use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceContents;
@@ -17,6 +18,7 @@ use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Resolution\NameKind;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use Psr\SimpleCache\CacheInterface;
@@ -69,7 +71,8 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
 
     public function lookupClassLike(ClassName $name): ?ClassInfo
     {
-        $cacheKey = CacheKey::from(strtolower(ltrim($name->fqn, '\\')));
+        $qualifiedName = QualifiedName::fromClassName($name);
+        $cacheKey = SymbolCacheKey::for($qualifiedName, NameKind::ClassLike);
 
         $cached = $this->cache->get($cacheKey);
         if ($cached !== null) {
@@ -77,7 +80,7 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
             return $cached;
         }
 
-        $filePath = $this->locator->locate(QualifiedName::fromClassName($name), NameKind::ClassLike);
+        $filePath = $this->locator->locate($qualifiedName, NameKind::ClassLike);
         if ($filePath === null) {
             return null;
         }
@@ -89,6 +92,30 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
         }
 
         return $classInfo;
+    }
+
+    public function lookupFunction(FunctionName $name): ?FunctionInfo
+    {
+        $cacheKey = SymbolCacheKey::for($name->qualifiedName, $name->kind());
+
+        $cached = $this->cache->get($cacheKey);
+        if ($cached !== null) {
+            assert($cached instanceof FunctionInfo);
+            return $cached;
+        }
+
+        $filePath = $this->locator->locate($name->qualifiedName, $name->kind());
+        if ($filePath === null) {
+            return null;
+        }
+
+        $functionInfo = $this->parseFunctionFrom($name, $filePath);
+        if ($functionInfo !== null) {
+            $this->cache->set($cacheKey, $functionInfo);
+            $this->cacheKeysByPath[$filePath][] = $cacheKey;
+        }
+
+        return $functionInfo;
     }
 
     /**
@@ -124,6 +151,37 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
     public function searchClassLikes(string $prefix): array
     {
         return [];
+    }
+
+    /**
+     * A declaration at any depth counts, not just a top-level one: the shape most
+     * `autoload.files` entries take is a polyfill declared inside an
+     * `if (!function_exists(...))`, and that is a name the file validly declares
+     * (matching {@see \Firehed\PhpLsp\Index\DeclarationScanner}, which derived the
+     * name -> file map this lookup arrived through).
+     */
+    private function parseFunctionFrom(FunctionName $name, string $filePath): ?FunctionInfo
+    {
+        $ast = $this->parser->parseFile($filePath);
+        if ($ast === null) {
+            return null;
+        }
+
+        $kind = $name->kind();
+        $target = $kind->normalize($name->qualifiedName);
+
+        $node = (new NodeFinder())->findFirst(
+            $ast,
+            static fn(Node $node): bool => $node instanceof Stmt\Function_
+                && $kind->normalize(
+                    QualifiedName::fromFullyQualified(($node->namespacedName ?? $node->name)->toString()),
+                ) === $target,
+        );
+        if (!$node instanceof Stmt\Function_) {
+            return null;
+        }
+
+        return FunctionInfo::fromNode($node, $filePath);
     }
 
     private function parseClassFrom(ClassName $name, string $filePath): ?ClassInfo

--- a/src/Knowledge/OpenDocumentBackend.php
+++ b/src/Knowledge/OpenDocumentBackend.php
@@ -8,11 +8,13 @@ use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\FunctionName;
+use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Index\WorkspaceNamespaceSource;
+use Firehed\PhpLsp\Resolution\NameKind;
 
 /**
  * The highest-precedence {@see SymbolBackend}: the documents the editor has open
@@ -69,12 +71,12 @@ final class OpenDocumentBackend implements SymbolBackend
 
     public function lookupClassLike(ClassName $name): ?ClassInfo
     {
-        return $this->byFqn[self::normalizeKey($name->fqn)] ?? null;
+        return $this->byFqn[self::key(NameKind::ClassLike, $name->fqn)] ?? null;
     }
 
     public function lookupFunction(FunctionName $name): ?FunctionInfo
     {
-        return $this->functionsByFqn[self::normalizeKey($name->fullyQualifiedName())] ?? null;
+        return $this->functionsByFqn[$name->kind()->normalize($name->qualifiedName)] ?? null;
     }
 
     /**
@@ -101,7 +103,7 @@ final class OpenDocumentBackend implements SymbolBackend
 
         $keys = [];
         foreach ($classes as $classInfo) {
-            $key = self::normalizeKey($classInfo->name->fqn);
+            $key = self::key(NameKind::ClassLike, $classInfo->name->fqn);
             $this->byFqn[$key] = $classInfo;
             $keys[] = $key;
         }
@@ -109,7 +111,7 @@ final class OpenDocumentBackend implements SymbolBackend
 
         $functionKeys = [];
         foreach ($functions as $fqn => $functionInfo) {
-            $key = self::normalizeKey($fqn);
+            $key = self::key(NameKind::Function_, $fqn);
             $this->functionsByFqn[$key] = $functionInfo;
             $functionKeys[] = $key;
         }
@@ -129,8 +131,14 @@ final class OpenDocumentBackend implements SymbolBackend
         unset($this->functionFqnsByUri[$uri]);
     }
 
-    private static function normalizeKey(string $fqn): string
+    /**
+     * Registration and lookup must agree on the case rule, and that rule differs by
+     * kind, so both go through {@see NameKind::normalize()} rather than a local
+     * lowercasing of the whole FQN — which is right for these two kinds and wrong
+     * for a constant.
+     */
+    private static function key(NameKind $kind, string $fqn): string
     {
-        return strtolower(ltrim($fqn, '\\'));
+        return $kind->normalize(QualifiedName::fromFullyQualified($fqn));
     }
 }

--- a/src/Knowledge/OpenDocumentBackend.php
+++ b/src/Knowledge/OpenDocumentBackend.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
 use Firehed\PhpLsp\Index\SymbolIndex;
@@ -46,6 +48,12 @@ final class OpenDocumentBackend implements SymbolBackend
     /** @var array<string, list<string>> URI -> the lowercase FQNs it declared */
     private array $fqnsByUri = [];
 
+    /** @var array<string, FunctionInfo> Lowercase FQN -> function metadata */
+    private array $functionsByFqn = [];
+
+    /** @var array<string, list<string>> URI -> the lowercase function FQNs it declared */
+    private array $functionFqnsByUri = [];
+
     private readonly WorkspaceNamespaceSource $namespaces;
 
     public function __construct(
@@ -64,6 +72,11 @@ final class OpenDocumentBackend implements SymbolBackend
         return $this->byFqn[self::normalizeKey($name->fqn)] ?? null;
     }
 
+    public function lookupFunction(FunctionName $name): ?FunctionInfo
+    {
+        return $this->functionsByFqn[self::normalizeKey($name->fullyQualifiedName())] ?? null;
+    }
+
     /**
      * @return list<Symbol>
      */
@@ -73,12 +86,16 @@ final class OpenDocumentBackend implements SymbolBackend
     }
 
     /**
-     * Register the class-likes declared in an open document for lookup, replacing
-     * any previously registered for the same URI.
+     * Register the class-likes and functions declared in an open document for
+     * lookup, replacing any previously registered for the same URI.
+     *
+     * Functions arrive keyed because {@see FunctionInfo} carries only the short
+     * name; the caller read the qualified one from the declaration.
      *
      * @param list<ClassInfo> $classes
+     * @param array<string, FunctionInfo> $functions Fully-qualified name -> metadata
      */
-    public function updateDocument(string $uri, array $classes): void
+    public function updateDocument(string $uri, array $classes, array $functions = []): void
     {
         $this->removeDocument($uri);
 
@@ -89,6 +106,14 @@ final class OpenDocumentBackend implements SymbolBackend
             $keys[] = $key;
         }
         $this->fqnsByUri[$uri] = $keys;
+
+        $functionKeys = [];
+        foreach ($functions as $fqn => $functionInfo) {
+            $key = self::normalizeKey($fqn);
+            $this->functionsByFqn[$key] = $functionInfo;
+            $functionKeys[] = $key;
+        }
+        $this->functionFqnsByUri[$uri] = $functionKeys;
     }
 
     public function removeDocument(string $uri): void
@@ -97,6 +122,11 @@ final class OpenDocumentBackend implements SymbolBackend
             unset($this->byFqn[$key]);
         }
         unset($this->fqnsByUri[$uri]);
+
+        foreach ($this->functionFqnsByUri[$uri] ?? [] as $key) {
+            unset($this->functionsByFqn[$key]);
+        }
+        unset($this->functionFqnsByUri[$uri]);
     }
 
     private static function normalizeKey(string $fqn): string

--- a/src/Knowledge/SymbolBackend.php
+++ b/src/Knowledge/SymbolBackend.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
 
@@ -24,10 +26,10 @@ use Firehed\PhpLsp\Index\Symbol;
  * vendored file, and the built-ins — is the composite's concern, not the
  * backend's: each answers only for its own source.
  *
- * The query set is the class-like subset today's features need. Function and
- * constant reach (Plan 0002 §5.2, Step 3b) generalizes these to a kind-agnostic
- * resolve when a second searchable kind first exists; a method with no caller is
- * not carried ahead.
+ * Lookup is per-kind: PHP's symbol namespaces are independent, so one name may be
+ * both a class and a function, and the query says which is meant. Constant lookup
+ * and a kind-parameterized search arrive with the slices that first need them
+ * (Plan 0002 §5.2); a method with no caller is not carried ahead.
  */
 interface SymbolBackend
 {
@@ -43,6 +45,12 @@ interface SymbolBackend
      * cannot reach a declaration of $name (RFC 1 §5.3: absence is a bare null).
      */
     public function lookupClassLike(ClassName $name): ?ClassInfo;
+
+    /**
+     * Full metadata for a standalone function this backend declares, or `null` when
+     * it cannot reach a declaration of $name (RFC 1 §5.3).
+     */
+    public function lookupFunction(FunctionName $name): ?FunctionInfo;
 
     /**
      * The class-likes this backend can enumerate whose short name begins with

--- a/src/Knowledge/SymbolCacheKey.php
+++ b/src/Knowledge/SymbolCacheKey.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Knowledge;
+
+use Firehed\PhpLsp\Cache\CacheKey;
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Resolution\NameKind;
+
+/**
+ * The cache key a backend stores a resolved symbol under (RFC 1 §5.3).
+ *
+ * A name alone does not identify a symbol: PHP's three symbol namespaces are
+ * independent, so one file may declare both a class and a function called `Foo`.
+ * The kind is therefore part of the key, not just of the query — without it a
+ * cached class would be served to a function lookup.
+ */
+final class SymbolCacheKey
+{
+    public static function for(QualifiedName $name, NameKind $kind): string
+    {
+        return CacheKey::from($kind->name . '|' . $kind->normalize($name));
+    }
+}

--- a/src/Knowledge/SymbolSource.php
+++ b/src/Knowledge/SymbolSource.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
 
@@ -18,10 +20,10 @@ use Firehed\PhpLsp\Index\Symbol;
  * a cursor position or a syntax tree. Turning "`Foo` in this namespace with these
  * imports" into a candidate FQN is the positional layer's job, not this interface's.
  *
- * The method set is the Step-2 subset the migrated features need — exact class-like
- * lookup, class-like prefix search, and namespace enumeration. Per-kind function and
- * constant lookup, and a kind-parameterized search, arrive with the features that
- * first need them (Plan 0002 §5.2); a method with no caller is not carried ahead.
+ * Lookup is per-kind, because PHP's three symbol namespaces are independent: the
+ * name type says which is meant, so no separate kind argument travels with it.
+ * Constant lookup and a kind-parameterized search arrive with the slices that first
+ * need them (Plan 0002 §5.2); a method with no caller is not carried ahead.
  */
 interface SymbolSource
 {
@@ -47,6 +49,17 @@ interface SymbolSource
      * source can reach declares it (RFC 1 §5.3: absence is a bare null).
      */
     public function lookupClassLike(ClassName $name): ?ClassInfo;
+
+    /**
+     * Full metadata for a standalone function by its exact name, or null when
+     * nothing the source can reach declares it (RFC 1 §5.3).
+     *
+     * Reach is what a name can be resolved *through*: an open document, an
+     * `autoload.files` entry, or a built-in. A function in an unopened PSR-4 file
+     * has no name -> file route at all, which is Plan 0002 §3's locate-only
+     * limitation rather than an absence.
+     */
+    public function lookupFunction(FunctionName $name): ?FunctionInfo;
 
     /**
      * The class-likes whose short name begins with $prefix. The prefix is the partial

--- a/src/Resolution/NameKind.php
+++ b/src/Resolution/NameKind.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Resolution;
 
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Utility\NamespacePath;
+
 /**
  * The category of symbol a name refers to, which determines how PHP resolves it
  * when unqualified.
@@ -43,5 +46,17 @@ enum NameKind
     public function isCaseSensitive(): bool
     {
         return $this === self::Constant;
+    }
+
+    /**
+     * The name as a lookup key under this kind's case rule. A namespace path is
+     * case-insensitive whatever it qualifies, so the rule applies to the short
+     * name alone.
+     */
+    public function normalize(QualifiedName $name): string
+    {
+        $shortName = $this->isCaseSensitive() ? $name->shortName : strtolower($name->shortName);
+
+        return NamespacePath::join(strtolower($name->namespace), $shortName);
     }
 }

--- a/tests/BuildsSymbolInfoTrait.php
+++ b/tests/BuildsSymbolInfoTrait.php
@@ -7,13 +7,14 @@ namespace Firehed\PhpLsp\Tests;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
 
 /**
- * Builds minimal {@see ClassInfo} value objects for tests that need class-likes
- * without a real parse — only the identity and, where a subtype walk is under
- * test, the parent and interface edges.
+ * Builds minimal domain value objects for tests that need symbols without a real
+ * parse — only the identity, the declaring file where precedence is under test,
+ * and, for a class-like, the parent and interface edges a subtype walk follows.
  */
-trait BuildsClassInfoTrait
+trait BuildsSymbolInfoTrait
 {
     /**
      * @param list<string> $interfaces
@@ -43,6 +44,11 @@ trait BuildsClassInfoTrait
             file: $file,
             line: null,
         );
+    }
+
+    private static function functionInfo(string $shortName, ?string $file = null): FunctionInfo
+    {
+        return new FunctionInfo($shortName, [], null, null, $file, 1);
     }
 
     /**

--- a/tests/Domain/FunctionInfoTest.php
+++ b/tests/Domain/FunctionInfoTest.php
@@ -128,6 +128,26 @@ class FunctionInfoTest extends TestCase
         self::assertSame([], $func->parameters);
         self::assertNull($func->returnType);
         self::assertNull($func->docblock);
+        self::assertNull($func->file, 'a node carries no file of its own');
+    }
+
+    public function testFromNodeRecordsTheDeclaringFile(): void
+    {
+        $node = new Stmt\Function_(
+            name: new Identifier('myFunc'),
+            subNodes: [
+                'params' => [],
+                'returnType' => null,
+            ],
+        );
+
+        $func = FunctionInfo::fromNode($node, '/path/to/helpers.php');
+
+        self::assertSame(
+            '/path/to/helpers.php',
+            $func->file,
+            'a function resolved from a file needs its definition site',
+        );
     }
 
     public function testFromNodeWithParams(): void

--- a/tests/Domain/FunctionNameTest.php
+++ b/tests/Domain/FunctionNameTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Domain;
+
+use Firehed\PhpLsp\Domain\FunctionName;
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FunctionName::class)]
+final class FunctionNameTest extends TestCase
+{
+    public function testCarriesItsKindIntrinsically(): void
+    {
+        $name = FunctionName::fromFullyQualified('Fixtures\Helpers\helperFormat');
+
+        self::assertSame(
+            NameKind::Function_,
+            $name->kind(),
+            'a function name must say what it names without being told',
+        );
+    }
+
+    public function testWrapsTheKindNeutralName(): void
+    {
+        $name = FunctionName::fromFullyQualified('\Fixtures\Helpers\helperFormat');
+
+        self::assertEquals(
+            new QualifiedName('Fixtures\Helpers', 'helperFormat'),
+            $name->qualifiedName,
+            'the wrapped name should be split and normalized by QualifiedName',
+        );
+        self::assertSame('Fixtures\Helpers\helperFormat', $name->fullyQualifiedName());
+    }
+
+    public function testGlobalFunctionHasNoNamespace(): void
+    {
+        $name = FunctionName::fromFullyQualified('str_contains');
+
+        self::assertSame('', $name->qualifiedName->namespace);
+        self::assertSame('str_contains', $name->fullyQualifiedName());
+    }
+}

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -22,6 +22,8 @@ use Firehed\PhpLsp\Handler\CompletionHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\NamespaceContents;
@@ -657,6 +659,11 @@ class CompletionHandlerTest extends TestCase
             }
 
             public function lookupClassLike(ClassName $name): ?ClassInfo
+            {
+                return null;
+            }
+
+            public function lookupFunction(FunctionName $name): ?FunctionInfo
             {
                 return null;
             }

--- a/tests/Knowledge/BuiltinBackendTest.php
+++ b/tests/Knowledge/BuiltinBackendTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 
 use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Knowledge\BuiltinBackend;
@@ -54,6 +55,78 @@ final class BuiltinBackendTest extends TestCase
 
         self::assertNotNull($first, 'the first lookup must resolve so the cache is populated');
         self::assertSame($first, $second, 'a second lookup must return the cached instance, not re-reflect');
+    }
+
+    public function testLookupFunctionReflectsABuiltinFunction(): void
+    {
+        $info = $this->backend(self::createStub(NamespaceCatalog::class))
+            ->lookupFunction(FunctionName::fromFullyQualified('str_contains'));
+
+        self::assertNotNull($info, 'a built-in function must resolve through reflection');
+        self::assertSame('str_contains', $info->name);
+        self::assertCount(2, $info->parameters, 'the reflected signature must be carried');
+    }
+
+    public function testLookupFunctionIsCaseInsensitive(): void
+    {
+        self::assertNotNull(
+            $this->backend(self::createStub(NamespaceCatalog::class))
+                ->lookupFunction(FunctionName::fromFullyQualified('STR_CONTAINS')),
+            'PHP matches function names case-insensitively',
+        );
+    }
+
+    public function testLookupFunctionIgnoresFunctionsOnlyTheServerHasLoaded(): void
+    {
+        // The server is itself a PHP program, so reflection can see every function
+        // its own dependencies declare. Those are not the project's, and answering
+        // for one would report a function the user's code cannot call. The backend
+        // enumerates only internal functions (BuiltinFunctionParityTest), so lookup
+        // must agree or a name resolves on hover yet never appears in completion
+        // (RFC 1 §4.2).
+        require_once dirname(__DIR__) . '/Domain/Fixtures/documented_function.php';
+
+        self::assertNull(
+            $this->backend(self::createStub(NamespaceCatalog::class))
+                ->lookupFunction(FunctionName::fromFullyQualified('testDocumentedFunction')),
+            'a userland function loaded in the server process is not a built-in',
+        );
+    }
+
+    public function testLookupFunctionReturnsNullForAnUnknownFunction(): void
+    {
+        self::assertNull(
+            $this->backend(self::createStub(NamespaceCatalog::class))
+                ->lookupFunction(FunctionName::fromFullyQualified('no_such_builtin')),
+            'a name reflection cannot load is absent from this backend (RFC 1 §5.3)',
+        );
+    }
+
+    public function testLookupFunctionCachesAResolvedFunction(): void
+    {
+        $backend = $this->backend(self::createStub(NamespaceCatalog::class));
+        $name = FunctionName::fromFullyQualified('str_contains');
+
+        $first = $backend->lookupFunction($name);
+        $second = $backend->lookupFunction($name);
+
+        self::assertNotNull($first, 'the first lookup must resolve so the cache is populated');
+        self::assertSame($first, $second, 'a second lookup must return the cached instance, not re-reflect');
+    }
+
+    public function testFunctionAndClassLikeCachesDoNotCollide(): void
+    {
+        // PHP's three symbol namespaces are independent, so one name can be both a
+        // class and a function. A cache keyed on the name alone would serve a
+        // ClassInfo to a function lookup.
+        $backend = $this->backend(self::createStub(NamespaceCatalog::class));
+
+        $backend->lookupClassLike(self::className(\ArrayObject::class));
+
+        self::assertNull(
+            $backend->lookupFunction(FunctionName::fromFullyQualified('ArrayObject')),
+            'a cached class-like must not answer a function lookup of the same name',
+        );
     }
 
     public function testSearchClassLikesIsEmpty(): void

--- a/tests/Knowledge/CompositeSymbolSourceTest.php
+++ b/tests/Knowledge/CompositeSymbolSourceTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Knowledge;
 
-use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\Location;
@@ -14,7 +13,7 @@ use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Knowledge\CompositeSymbolSource;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Resolution\NameKind;
-use Firehed\PhpLsp\Tests\BuildsClassInfoTrait;
+use Firehed\PhpLsp\Tests\BuildsSymbolInfoTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -27,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class CompositeSymbolSourceTest extends TestCase
 {
-    use BuildsClassInfoTrait;
+    use BuildsSymbolInfoTrait;
 
     public function testLookupClassLikeTakesTheFirstBackendThatAnswers(): void
     {
@@ -268,11 +267,6 @@ final class CompositeSymbolSourceTest extends TestCase
             'app\ifacea' => self::classInfo('App\IfaceA', interfaces: ['App\IfaceBase']),
             'app\ifacebase' => self::classInfo('App\IfaceBase'),
         ]);
-    }
-
-    private static function functionInfo(string $shortName, string $file): FunctionInfo
-    {
-        return new FunctionInfo($shortName, [], null, null, $file, 1);
     }
 
     private static function symbol(string $fqn, string $file): Symbol

--- a/tests/Knowledge/CompositeSymbolSourceTest.php
+++ b/tests/Knowledge/CompositeSymbolSourceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Knowledge;
 
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\NamespaceContents;
@@ -61,6 +63,44 @@ final class CompositeSymbolSourceTest extends TestCase
 
         self::assertNull(
             $source->lookupClassLike(self::className('App\Absent')),
+            'absence across every backend is a bare null, not an error (RFC 1 §5.3)',
+        );
+    }
+
+    public function testLookupFunctionTakesTheFirstBackendThatAnswers(): void
+    {
+        $open = new FakeSymbolBackend(functions: ['app\format' => self::functionInfo('format', 'open.php')]);
+        $vendor = new FakeSymbolBackend(functions: ['app\format' => self::functionInfo('format', 'vendor.php')]);
+        $source = new CompositeSymbolSource([$open, $vendor]);
+
+        $info = $source->lookupFunction(FunctionName::fromFullyQualified('App\format'));
+
+        self::assertNotNull($info, 'the function is declared, so the lookup must resolve');
+        self::assertSame(
+            'open.php',
+            $info->file,
+            'the earlier backend must win: an unsaved edit overrides the file it shadows (RFC 1 §5.3)',
+        );
+    }
+
+    public function testLookupFunctionFallsThroughToALaterBackend(): void
+    {
+        $open = new FakeSymbolBackend();
+        $vendor = new FakeSymbolBackend(functions: ['app\format' => self::functionInfo('format', 'vendor.php')]);
+        $source = new CompositeSymbolSource([$open, $vendor]);
+
+        $info = $source->lookupFunction(FunctionName::fromFullyQualified('App\format'));
+
+        self::assertNotNull($info, 'a later backend must answer when an earlier one cannot');
+        self::assertSame('vendor.php', $info->file, 'the answer must come from the backend that declares it');
+    }
+
+    public function testLookupFunctionReturnsNullWhenNoBackendAnswers(): void
+    {
+        $source = new CompositeSymbolSource([new FakeSymbolBackend(), new FakeSymbolBackend()]);
+
+        self::assertNull(
+            $source->lookupFunction(FunctionName::fromFullyQualified('App\absent')),
             'absence across every backend is a bare null, not an error (RFC 1 §5.3)',
         );
     }
@@ -228,6 +268,11 @@ final class CompositeSymbolSourceTest extends TestCase
             'app\ifacea' => self::classInfo('App\IfaceA', interfaces: ['App\IfaceBase']),
             'app\ifacebase' => self::classInfo('App\IfaceBase'),
         ]);
+    }
+
+    private static function functionInfo(string $shortName, string $file): FunctionInfo
+    {
+        return new FunctionInfo($shortName, [], null, null, $file, 1);
     }
 
     private static function symbol(string $fqn, string $file): Symbol

--- a/tests/Knowledge/DocumentSymbolSinkTest.php
+++ b/tests/Knowledge/DocumentSymbolSinkTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
@@ -61,6 +62,63 @@ final class DocumentSymbolSinkTest extends TestCase
         self::assertNotNull(
             $this->index->findByFqn('V\Widget'),
             'openDocument must also index the document — the second of the double write',
+        );
+    }
+
+    public function testOpenDocumentRegistersFunctionsUnderTheirQualifiedNames(): void
+    {
+        $content = "<?php\nnamespace V;\nfunction helper(): void {}\n";
+
+        $this->sink->openDocument(new TextDocument('file:///helpers.php', 'php', 1, $content));
+
+        self::assertNotNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\helper')),
+            'openDocument must register the document\'s functions for lookup',
+        );
+        self::assertNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('helper')),
+            'a namespaced function must not be registered under its short name',
+        );
+    }
+
+    public function testOpenDocumentRegistersADeclarationBelowTheTopLevel(): void
+    {
+        // A conditionally declared polyfill is a name the file validly declares, and
+        // the on-disk backends resolve one. An open document must agree, or opening
+        // a file would make a name that already resolved disappear (RFC 1 §4.2).
+        $content = "<?php\nif (!function_exists('polyfill')) {\n    function polyfill(): void {}\n}\n";
+
+        $this->sink->openDocument(new TextDocument('file:///polyfill.php', 'php', 1, $content));
+
+        self::assertNotNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('polyfill')),
+            'a conditionally declared function must be registered like any other declaration',
+        );
+    }
+
+    public function testUpdatingAwayFromAFunctionDropsItsRegistration(): void
+    {
+        $uri = 'file:///helpers.php';
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, "<?php\nfunction helper(): void {}\n"));
+
+        $this->sink->updateDocument(new TextDocument($uri, 'php', 2, "<?php\n"));
+
+        self::assertNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('helper')),
+            'a document that no longer declares the function must drop its registration',
+        );
+    }
+
+    public function testCloseDocumentDropsItsFunctions(): void
+    {
+        $uri = 'file:///helpers.php';
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, "<?php\nfunction helper(): void {}\n"));
+
+        $this->sink->closeDocument($uri);
+
+        self::assertNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('helper')),
+            'close must drop the registered functions from lookup',
         );
     }
 

--- a/tests/Knowledge/FakeSymbolBackend.php
+++ b/tests/Knowledge/FakeSymbolBackend.php
@@ -6,6 +6,8 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
@@ -22,11 +24,13 @@ final class FakeSymbolBackend implements SymbolBackend
      * @param array<string, ClassInfo> $classLikes Lowercased FQN -> info
      * @param array<string, NamespaceContents> $namespaces Path -> contents
      * @param list<Symbol> $searchResults Returned (prefix-filtered on short name)
+     * @param array<string, FunctionInfo> $functions Lowercased FQN -> info
      */
     public function __construct(
         private readonly array $classLikes = [],
         private readonly array $namespaces = [],
         private readonly array $searchResults = [],
+        private readonly array $functions = [],
     ) {
     }
 
@@ -38,6 +42,11 @@ final class FakeSymbolBackend implements SymbolBackend
     public function lookupClassLike(ClassName $name): ?ClassInfo
     {
         return $this->classLikes[strtolower(ltrim($name->fqn, '\\'))] ?? null;
+    }
+
+    public function lookupFunction(FunctionName $name): ?FunctionInfo
+    {
+        return $this->functions[strtolower($name->fullyQualifiedName())] ?? null;
     }
 
     /**

--- a/tests/Knowledge/FilesystemBackendTest.php
+++ b/tests/Knowledge/FilesystemBackendTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\AutoloadFilesLocator;
 use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
@@ -95,6 +96,143 @@ final class FilesystemBackendTest extends TestCase
         self::assertNull(
             $backend->lookupClassLike(self::className('Fixtures\TypeInference\NotDeclaredHere')),
             'a located file that does not declare the requested class resolves to null',
+        );
+    }
+
+    public function testLookupFunctionResolvesAFunctionDeclaredInAnAutoloadFilesEntry(): void
+    {
+        $info = $this->backend()->lookupFunction(
+            FunctionName::fromFullyQualified('Fixtures\Helpers\helperFormat'),
+        );
+
+        self::assertNotNull($info, 'a function in the files set must resolve through the derived index');
+        self::assertCount(1, $info->parameters, 'the parsed signature must be carried');
+        self::assertSame(
+            $this->fixturesRoot . '/AutoloadFiles/helpers.php',
+            $info->file,
+            'a function resolved from disk must carry its definition site',
+        );
+    }
+
+    public function testLookupFunctionResolvesADeclarationBelowTheTopLevel(): void
+    {
+        // The shape most `autoload.files` entries take: a polyfill declares itself
+        // only where the runtime lacks it, so the declaration is nested. A scan
+        // narrowed to top-level statements would miss it, and the name would resolve
+        // from an open document but not from disk.
+        self::assertNotNull(
+            $this->backend()->lookupFunction(FunctionName::fromFullyQualified('fixtureConditionalHelper')),
+            'a conditionally declared function must resolve like any other declaration',
+        );
+    }
+
+    public function testLookupFunctionIsCaseInsensitive(): void
+    {
+        self::assertNotNull(
+            $this->backend()->lookupFunction(
+                FunctionName::fromFullyQualified('FIXTURES\HELPERS\HELPERFORMAT'),
+            ),
+            'PHP matches function names case-insensitively',
+        );
+    }
+
+    public function testLookupFunctionReturnsNullForAFunctionOnlyAPsr4FileDeclares(): void
+    {
+        // Composer's PSR-4, PSR-0 and classmap entries all address class-likes, so a
+        // function in an unopened PSR-4 file has no name -> file route at all. That
+        // is Plan 0002 §3's locate-only limitation, not a gap in the backend.
+        self::assertNull(
+            $this->backend()->lookupFunction(
+                FunctionName::fromFullyQualified('Fixtures\Completion\calculateSum'),
+            ),
+            'no autoload map addresses a function by name outside the files set',
+        );
+    }
+
+    public function testLookupFunctionReturnsNullForAnAbsentFunction(): void
+    {
+        self::assertNull(
+            $this->backend()->lookupFunction(FunctionName::fromFullyQualified('Fixtures\no_such_helper')),
+            'a name no locator can reach is absent from this backend (RFC 1 §5.3)',
+        );
+    }
+
+    public function testLookupFunctionReturnsNullWhenTheLocatedFileDoesNotDeclareIt(): void
+    {
+        $backend = $this->backendWithLocator(
+            $this->locatorReturning($this->fixturesRoot . '/src/Domain/User.php'),
+        );
+
+        self::assertNull(
+            $backend->lookupFunction(FunctionName::fromFullyQualified('notInThisFile')),
+            'a located file that does not declare the requested function resolves to null',
+        );
+    }
+
+    public function testLookupFunctionReturnsNullWhenTheLocatedFileIsUnreadable(): void
+    {
+        $backend = $this->backendWithLocator($this->locatorReturning('/no/such/file/helpers.php'));
+
+        self::assertNull(
+            $backend->lookupFunction(FunctionName::fromFullyQualified('ghostHelper')),
+            'a located path that is not readable degrades to not-found rather than an error',
+        );
+    }
+
+    public function testLookupFunctionCachesAResolvedFunction(): void
+    {
+        $backend = $this->backend();
+        $name = FunctionName::fromFullyQualified('Fixtures\Helpers\helperFormat');
+
+        $first = $backend->lookupFunction($name);
+        $second = $backend->lookupFunction($name);
+
+        self::assertNotNull($first, 'the first lookup must resolve so the cache is populated');
+        self::assertSame($first, $second, 'a second lookup must return the cached instance, not re-parse');
+    }
+
+    public function testFunctionAndClassLikeCachesDoNotCollide(): void
+    {
+        // PHP's symbol namespaces are independent, so one file may declare a class
+        // and a function of the same name. A cache keyed on the name alone would
+        // serve whichever was resolved first to both queries.
+        $path = tempnam(sys_get_temp_dir(), 'php-lsp-fsb-dual-');
+        self::assertNotFalse($path, 'a temp file must be creatable');
+
+        try {
+            self::assertNotFalse(
+                file_put_contents($path, "<?php\nclass Dual {}\nfunction Dual(): void {}\n"),
+                'the temp file must be writable',
+            );
+
+            $backend = $this->backendWithLocator($this->locatorReturning($path));
+
+            $class = $backend->lookupClassLike(self::className('Dual'));
+            $function = $backend->lookupFunction(FunctionName::fromFullyQualified('Dual'));
+
+            self::assertNotNull($class, 'the class-like must resolve');
+            self::assertNotNull($function, 'the function must resolve rather than hit the class entry');
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function testInvalidateEvictsTheCachedFunctionSoTheNextLookupReParses(): void
+    {
+        $backend = $this->backend();
+        $name = FunctionName::fromFullyQualified('Fixtures\Helpers\helperFormat');
+
+        $first = $backend->lookupFunction($name);
+        self::assertNotNull($first, 'the first lookup must resolve so the cache is populated');
+
+        $backend->invalidate(FileUri::fromPath($this->fixturesRoot . '/AutoloadFiles/helpers.php'));
+        $second = $backend->lookupFunction($name);
+
+        self::assertNotNull($second, 'the function must resolve again after invalidation');
+        self::assertNotSame(
+            $first,
+            $second,
+            'invalidate must evict cached functions too, or an edited file is served stale (RFC 1 §5.3)',
         );
     }
 
@@ -293,12 +431,20 @@ final class FilesystemBackendTest extends TestCase
         );
     }
 
+    /**
+     * Wired with the same locator chain {@see \Firehed\PhpLsp\Knowledge\KnowledgeStack}
+     * gives it: the autoload maps address class-likes by name, and the derived index
+     * covers the `files` set, which they address by no name at all.
+     */
     private function backend(): FilesystemBackend
     {
         $map = ComposerAutoloadMap::fromProjectRoot($this->fixturesRoot);
 
         return new FilesystemBackend(
-            new ComposerSymbolLocator($map),
+            new CompositeSymbolLocator([
+                new ComposerSymbolLocator($map),
+                new AutoloadFilesLocator($map, $this->parser, new DeclarationScanner()),
+            ]),
             new ComposerNamespaceSource($map),
             $this->parser,
             $this->factory,

--- a/tests/Knowledge/OpenDocumentBackendTest.php
+++ b/tests/Knowledge/OpenDocumentBackendTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Knowledge;
 
+use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\Symbol;
 use Firehed\PhpLsp\Index\SymbolIndex;
@@ -89,6 +91,81 @@ final class OpenDocumentBackendTest extends TestCase
         );
     }
 
+    public function testLookupFunctionReturnsARegisteredFunction(): void
+    {
+        $this->backend->updateDocument('file:///helpers.php', [], ['V\format' => self::functionInfo('format')]);
+
+        $info = $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\format'));
+
+        self::assertNotNull($info, 'a registered function must resolve');
+        self::assertSame('format', $info->name, 'the registered function must be returned unchanged');
+    }
+
+    public function testLookupFunctionIsCaseInsensitive(): void
+    {
+        $this->backend->updateDocument('file:///helpers.php', [], ['V\format' => self::functionInfo('format')]);
+
+        self::assertNotNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\FORMAT')),
+            'PHP matches function names case-insensitively',
+        );
+    }
+
+    public function testLookupFunctionReturnsNullForAnUnregisteredFunction(): void
+    {
+        self::assertNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\absent')),
+            'a name no open document declares is absent from this backend (RFC 1 §5.3)',
+        );
+    }
+
+    public function testFunctionAndClassLikeRegistrationsDoNotCollide(): void
+    {
+        $this->backend->updateDocument(
+            'file:///Dual.php',
+            [self::classInfo('V\Dual')],
+            ['V\Dual' => self::functionInfo('Dual')],
+        );
+
+        self::assertNotNull(
+            $this->backend->lookupClassLike(self::className('V\Dual')),
+            'the class-like must resolve',
+        );
+        self::assertNotNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\Dual')),
+            'a function sharing the name must resolve too: the symbol namespaces are independent',
+        );
+    }
+
+    public function testUpdateDocumentReplacesThePriorFunctionsForThatUri(): void
+    {
+        $uri = 'file:///helpers.php';
+        $this->backend->updateDocument($uri, [], ['V\alpha' => self::functionInfo('alpha')]);
+        $this->backend->updateDocument($uri, [], ['V\beta' => self::functionInfo('beta')]);
+
+        self::assertNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\alpha')),
+            'the prior function must be dropped when the document is re-registered',
+        );
+        self::assertNotNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\beta')),
+            'the new function must be registered',
+        );
+    }
+
+    public function testRemoveDocumentDropsItsFunctions(): void
+    {
+        $uri = 'file:///helpers.php';
+        $this->backend->updateDocument($uri, [], ['V\ephemeral' => self::functionInfo('ephemeral')]);
+
+        $this->backend->removeDocument($uri);
+
+        self::assertNull(
+            $this->backend->lookupFunction(FunctionName::fromFullyQualified('V\ephemeral')),
+            'closing a document must drop the functions it registered',
+        );
+    }
+
     public function testSearchClassLikesFiltersByPrefixAndToClassLikeKindsOnly(): void
     {
         $this->addSymbol('User', 'App\User', SymbolKind::Class_);
@@ -126,6 +203,11 @@ final class OpenDocumentBackendTest extends TestCase
             $contents->childNamespaces,
             'a namespace with a deeper declaration must be listed as a child',
         );
+    }
+
+    private static function functionInfo(string $shortName): FunctionInfo
+    {
+        return new FunctionInfo($shortName, [], null, null, null, 1);
     }
 
     private function addSymbol(string $name, string $fqn, SymbolKind $kind): void

--- a/tests/Knowledge/OpenDocumentBackendTest.php
+++ b/tests/Knowledge/OpenDocumentBackendTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Knowledge;
 
-use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\Symbol;
@@ -12,7 +11,7 @@ use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Knowledge\OpenDocumentBackend;
-use Firehed\PhpLsp\Tests\BuildsClassInfoTrait;
+use Firehed\PhpLsp\Tests\BuildsSymbolInfoTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class OpenDocumentBackendTest extends TestCase
 {
-    use BuildsClassInfoTrait;
+    use BuildsSymbolInfoTrait;
 
     private SymbolIndex $index;
     private OpenDocumentBackend $backend;
@@ -203,11 +202,6 @@ final class OpenDocumentBackendTest extends TestCase
             $contents->childNamespaces,
             'a namespace with a deeper declaration must be listed as a child',
         );
-    }
-
-    private static function functionInfo(string $shortName): FunctionInfo
-    {
-        return new FunctionInfo($shortName, [], null, null, null, 1);
     }
 
     private function addSymbol(string $name, string $fqn, SymbolKind $kind): void

--- a/tests/Resolution/NameKindTest.php
+++ b/tests/Resolution/NameKindTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Resolution;
+
+use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Resolution\NameKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NameKind::class)]
+final class NameKindTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{NameKind, QualifiedName, string}>
+     * @codeCoverageIgnore data provider runs before coverage begins
+     */
+    public static function normalizations(): iterable
+    {
+        $namespaced = new QualifiedName('Fixtures\Helpers', 'HelperFormat');
+        $global = new QualifiedName('', 'HELPER_LIMIT');
+
+        yield 'class-like' => [NameKind::ClassLike, $namespaced, 'fixtures\helpers\helperformat'];
+        yield 'function' => [NameKind::Function_, $namespaced, 'fixtures\helpers\helperformat'];
+        // Only the short name of a constant survives normalization: the namespace
+        // path is case-insensitive for every kind.
+        yield 'constant' => [NameKind::Constant, $namespaced, 'fixtures\helpers\HelperFormat'];
+        yield 'global constant' => [NameKind::Constant, $global, 'HELPER_LIMIT'];
+        yield 'global function' => [NameKind::Function_, $global, 'helper_limit'];
+    }
+
+    #[DataProvider('normalizations')]
+    public function testNormalizeAppliesTheKindsCaseRule(
+        NameKind $kind,
+        QualifiedName $name,
+        string $expected,
+    ): void {
+        self::assertSame($expected, $kind->normalize($name));
+    }
+}


### PR DESCRIPTION
Slice **S3.8a** — Plan 0002 Step 3b (`docs/architecture/build-manifest.md`); RFC 1 §4.2, §5.1, §5.3, and §3's locate-only limitation.

Step 3b is cut by symbol namespace rather than by layer, so this is one vertical: the function name type, `lookupFunction` across all four backends, and its tests. No consumer moves off `FunctionRepository::get(string, array $ast)` — that is S3.8c, which is the Step 3b slice that edits `SymbolResolver` and the one S4.2 serializes against. Function *search* / completion is S3.9.

## Acceptance

- [x] `Domain\FunctionName` wraps `QualifiedName` and carries `NameKind::Function_` intrinsically, so the lookup takes no separate kind argument (Plan §5.3).
- [x] `SymbolSource::lookupFunction` / `SymbolBackend::lookupFunction` added, answered by all four backends.
- [x] `OpenDocumentBackend` resolves functions the write path registers; `DocumentSymbolSink` registers them from the same single parse that feeds class registration and the index.
- [x] `FilesystemBackend` (workspace and vendor) resolves a function through `SymbolLocator::locate(..., NameKind::Function_)`, which reaches the `autoload.files` derived index S3.7d built, and carries the declaring file so the definition site exists.
- [x] `BuiltinBackend` resolves built-in functions via reflection.
- [x] Case-insensitive matching, per PHP's rule for function names.
- [x] Every Step P golden is unchanged: no consumer is migrated, so no observable surface moves.

## Decisions

**The builtin backend answers only for `isInternal()` functions.** The server is itself a PHP program, so reflection sees the functions its own dependencies declare. Those are not the project's. Where a dependency is genuinely shared, the vendor backend outranks the builtin one and answers with the user's installed copy, so the filter never applies; it only bites when the server has a library the project does not, where answering is simply wrong. It also keeps lookup consistent with what the backend enumerates, which `BuiltinFunctionParityTest` already pins to `get_defined_functions()['internal']`.

**A declaration at any depth counts.** A polyfill guarded by `function_exists` is the shape most `autoload.files` entries take, and `DeclarationScanner` already reports it, so the on-disk backends resolve one. The open-document write path matches, or opening a file would make a resolvable name disappear (§4.2).

**Cache keys carry the kind** (`SymbolCacheKey`). One name may be both a class and a function; the previous key was the lowercased FQN alone, which would have served a `ClassInfo` to a function lookup. `FilesystemBackend`'s path→key reverse map records function entries too, so external-change invalidation evicts them.

**`NameKind::normalize()`** now owns PHP's per-kind case rule, replacing the private copy in `AutoloadFilesLocator` rather than adding a second one.

## Reach, and what stays out

`lookupFunction` reaches open documents, the `autoload.files` set, and built-ins. A function in an unopened PSR-4 file has no name→file route of any kind — Composer's maps address class-likes only — which is §3's locate-only limitation, pinned by a test rather than left in prose.

## Noted, not fixed (outside this slice)

`FunctionInfo->name` holds the short name when built from a node and the fully-qualified one when built from reflection. That predates this slice (`DefaultFunctionRepository::get` has both behaviors), and changing it would move the function-surface golden this step must preserve. It is why `OpenDocumentBackend::updateDocument` takes functions keyed by FQN. Worth folding into the S3.11 duplication audit or S3.9's rewrite of that golden.

No `Closes` candidates. The manifest places #239 / #181 / #317 somewhere in S3.7a–S3.10, and records that #181 is not closable before S3.9b: its acceptance asks for these symbols in hover *and* completion, plus a startup benchmark.
