### PR TITLE
Require one implementation per shared mechanism, and reslice the pending work

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -40,7 +40,7 @@ project's **Squash and Merge**: a squash rewrites the branch into one new commit
 - No slice is unblocked — report done / blocked / in-flight counts and stop.
 - Any slice is `in-flight` and not `done` — one slice in flight at a time; finish or
   review it first.
-- A slice's branch is merged while a dependency is not — surface the state drift.
+- A slice is merged while one above it in the table is not — surface the state drift.
 
 ## 4. Explain X
 

--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -20,22 +20,15 @@ slice from durable state, not from memory.
 
 ## 2. Compute the next slice X
 
-- Read `docs/architecture/build-manifest.md`; parse the slice table (ID, Step,
-  Depends on, Closes).
+- Read `docs/architecture/build-manifest.md`; parse the slice table (ID, Step, Title).
 - Compute each slice's status from **GitHub PR merge state** (not git commit
   ancestry, and not any written status), checked in this order:
   - `done` — a merged PR exists for the head branch:
     `gh pr list --state merged --head slice/<ID> --json number` returns one.
   - `in-flight` — an open PR exists: `gh pr list --state open --head slice/<ID>`.
   - `todo` — neither.
-- `X` = the first `todo` slice whose every dependency is `done`.
-
-Dependencies are normally slice ids. The audit and Definition-of-Done gates use a
-collective form instead, which must be expanded before the check:
-
-- `all Step N` — every **other** slice whose Step column is `N`, sub-steps included
-  (`all Step 3` covers 3a and 3b).
-- `all prior` — every other slice in the table.
+- `X` = the first `todo` slice in table order. The table is ordered, so every row
+  above `X` must already be `done`; there is no dependency column to resolve.
 
 Deriving from PR merge state (not ancestry) is what keeps this correct under the
 project's **Squash and Merge**: a squash rewrites the branch into one new commit on
@@ -71,8 +64,6 @@ modification before writing anything.
 
 - PR title carries no issue number; the body cites the slice id, plan step, and RFC
   section(s), and lists the acceptance criteria as a checklist.
-- List manifest `Closes` candidates as "Candidate closes (pending review
-  verification): #n" — do **not** wire `Closes #n` here; that is the reviewer's job
-  after reading the issue body.
+- Do **not** wire `Closes #n`; that is the reviewer's job after reading the issue body.
 - Report the PR URL and the **next** computed slice, so a follow-up `/do-next` is
   predictable.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -88,9 +88,9 @@ burn 75k+ tokens re-deriving the whole measurement.
 
 ## 4. If the pass is clean (no surviving findings)
 
-- For each `Closes` candidate in the manifest for this slice: `gh issue view <n>`,
-  confirm its acceptance criteria are met **by this change**; if so, add `Closes #<n>`
-  to the PR body with a one-line verification note. If not met, leave it and say why.
+- For each issue this slice plausibly closes: `gh issue view <n>`, confirm its
+  acceptance criteria are met **by this change**; if so, add `Closes #<n>` to the PR
+  body with a one-line verification note. If not met, leave it and say why.
 - `gh pr ready` if the PR was a draft.
 - Report: **"Pass clean. Verified closes: #n. Ready to land — merge when ready."**
   Do **not** auto-merge — merging is irreversible and outward-facing; the user lands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,8 @@ until a file is opened and closed).
 
 Class-like prefix search (`searchClassLikes`) is served only by the open-document
 backend today; project-wide on-disk search is the deferred workspace-index scope
-(RFC 1 §3). Function search, and the migration of the consumers still calling
-`FunctionRepository`, are later Step 3b slices; constant reach is S3.8b.
+(RFC 1 §3). Function search, constant reach, and the migration of the consumers still
+calling `FunctionRepository` are later Step 3b slices.
 
 - **MemberResolver** — Finds methods/properties/constants on a class, traversing the inheritance chain via `supertypes()`; reads class metadata through `SymbolSource`. Returns domain objects (`MethodInfo`, `PropertyInfo`).
 - **ClassInfoFactory** (`DefaultClassInfoFactory`) — Creates `ClassInfo` from AST nodes or reflection.

--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -4,7 +4,7 @@
     Category:   Architecture Requirements (Best Current Practice)
     Status:     Draft
     Target:     Language Server Protocol 3.17
-    Date:       2026-08-05
+    Date:       2026-08-06
     Supersedes: none
     Relates-To: docs issues #264, #265, #266; architecture invariants in CLAUDE.md
 
@@ -350,17 +350,29 @@ conversion, a memoization — MUST have exactly one implementation, and every
 consumer MUST reach it through that one. This generalizes Section 4.6's
 single-traversal requirement from the type graph to every shared mechanism.
 
+Section 4.2 requires every query to be *answered through* the SymbolSource; this
+section requires the mechanism *behind* it to be singular. Both are needed: a
+capability reached through one interface but implemented once per backend, per
+symbol kind, or per consumer produces the same divergent coverage as one reached
+through several interfaces.
+
 A contribution that extends an axis (Section 3.1) MUST reach the mechanisms it
 needs through their existing implementation. Where the existing one does not fit,
 unifying it is prior work rather than a parallel implementation added "for now".
 
-A second implementation is permitted only as a **declared migration**: it MUST land
-with an explicitly scoped enforcement entry (Section 8.1), a teardown record naming
-what it replaces, and a named remover. An undeclared parallel implementation is the
-defect this document exists to prevent; the declaration is what makes the window
-bounded and observable rather than permanent.
+A second implementation is a non-conformance, not an exemption. Where one exists,
+it MUST be recorded in the enforcement rule's own scope (Section 8.1), and this
+invariant is unmet for that mechanism until the entry is gone. Recording a
+divergence makes it observable; it does not make it conformant, and the record is
+not a licence to add another.
 
-Two implementations that differ only in return shape are one mechanism, not two.
+Sameness is judged by the steps performed, never by the signature. A difference in
+return type, in the symbol kind handled, in the backend hosting it, or in the caller
+served does not make two mechanisms: the same steps repeated to produce a different
+shape are one mechanism implemented twice, and the duplicate MUST be removed rather
+than justified by the difference. Where a caller genuinely needs a different shape,
+the single implementation MUST yield what that caller needs; the variation belongs at
+its edge, not in a copy of the steps.
 
 ## 5. Component Requirements
 
@@ -578,7 +590,11 @@ invariant added by amendment MUST specify its mechanism.
                                       traversal, namespace/FQN construction, path and
                                       URI conversion, memoization) is confined to the
                                       owner the rule's own configuration names for it;
-                                      a declared migration is an entry in that scope.
+                                      a recorded divergence is an entry in that scope,
+                                      and the invariant is unmet while one exists.
+                                      A rule sees construction, not repeated steps, so
+                                      it is paired with a duplication audit that reads
+                                      for the same steps under a different signature.
     5.2 / 5.3 Write path, precedence, Architecture test + review: one write path,
         cache seam, bounded coverage  caching behind the abstraction, bounds observable.
     6 Synchronous correctness         By construction: the suite runs the interior

--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -674,13 +674,19 @@ into target environment (4.7) and session capabilities (4.8, 5.4).
   are server-initiated output subject to Sections 4.8 and 6. This document defines
   the invariants those tiers MUST satisfy; it does not schedule them.
 - **Current divergences (informative).** This RFC is the target state, not a
-  description of the code as it stands. Known gaps at adoption time include:
-  function resolution requires a caller-supplied syntax tree, uses bare-string
-  names, and returns nullable results (violates Sections 4.4 and 5.1); global
-  constants do not resolve at all; client capabilities are not read; and position
-  offsets are handled as bytes (violates Section 4.9). These are to be migrated
-  toward this document, not grandfathered; each SHOULD be tracked as an issue
-  citing the section it violates.
+  description of the code as it stands. Known gaps at adoption time:
+  - Function resolution requires a caller-supplied syntax tree, uses bare-string
+    names, and returns nullable results (Sections 4.4, 5.1).
+  - Global constants do not resolve at all (Section 5.1).
+  - Prefix search answers only class-likes, and only from open documents, so
+    coverage is neither uniform across kinds nor project-wide (Section 5.1).
+  - No kind-agnostic location query exists, so a kind-ambiguous position has no
+    conforming query to use (Sections 4.5, 5.1).
+  - Client capabilities are not read (Section 4.8).
+  - Position offsets are handled as bytes (Section 4.9).
+
+  These are to be migrated toward this document, not grandfathered; each SHOULD be
+  tracked as an issue citing the section it violates.
 - **Observed client defects (informative).** Per Section 4.10, accommodations for
   clients that advertise a capability but mishandle it are recorded here as they
   are found. Known: some clients ignore a completion item's `textEdit` range and

--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -352,8 +352,13 @@ single-traversal requirement from the type graph to every shared mechanism.
 
 A contribution that extends an axis (Section 3.1) MUST reach the mechanisms it
 needs through their existing implementation. Where the existing one does not fit,
-unifying it is prior work: adding a parallel implementation "for now" is the defect
-this document exists to prevent, and it is never the cheaper option.
+unifying it is prior work rather than a parallel implementation added "for now".
+
+A second implementation is permitted only as a **declared migration**: it MUST land
+with an explicitly scoped enforcement entry (Section 8.1), a teardown record naming
+what it replaces, and a named remover. An undeclared parallel implementation is the
+defect this document exists to prevent; the declaration is what makes the window
+bounded and observable rather than permanent.
 
 Two implementations that differ only in return shape are one mechanism, not two.
 
@@ -533,7 +538,8 @@ exhaustive over the normative sections; each item names the section it checks.
     bounded coverage is observable (Section 5.3).
 11. Correctness holds under synchronous execution (Section 6).
 12. Malformed input yields an error response, not process termination (Section 9).
-13. No shared mechanism has a second implementation (Section 4.11).
+13. No shared mechanism has a second implementation outside a declared migration
+    (Section 4.11).
 
 ### 8.1. Enforcement
 
@@ -570,8 +576,9 @@ invariant added by amendment MUST specify its mechanism.
     4.10 Client conformance defects   Review only; defect list in Appendix B.
     4.11 Single implementation        Static rule: constructing a shared mechanism (AST
                                       traversal, namespace/FQN construction, path and
-                                      URI conversion, memoization) is confined to that
-                                      mechanism's named owner.
+                                      URI conversion, memoization) is confined to the
+                                      owner the rule's own configuration names for it;
+                                      a declared migration is an entry in that scope.
     5.2 / 5.3 Write path, precedence, Architecture test + review: one write path,
         cache seam, bounded coverage  caching behind the abstraction, bounds observable.
     6 Synchronous correctness         By construction: the suite runs the interior

--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -4,7 +4,7 @@
     Category:   Architecture Requirements (Best Current Practice)
     Status:     Draft
     Target:     Language Server Protocol 3.17
-    Date:       2026-07-19
+    Date:       2026-08-05
     Supersedes: none
     Relates-To: docs issues #264, #265, #266; architecture invariants in CLAUDE.md
 
@@ -49,6 +49,7 @@ a bumped date.
        4.8. Protocol Capability Negotiation
        4.9. Position Encoding
        4.10. Client Conformance Defects
+       4.11. Single Implementation per Mechanism
     5. Component Requirements
        5.1. Symbol Knowledge: Read Contract (SymbolSource)
        5.2. Symbol State: Write Contract (SymbolSink)
@@ -342,6 +343,20 @@ last resort, MUST be documented and isolated from feature logic, and MUST NOT le
 A running list of observed client defects and their accommodations SHOULD be
 maintained (Appendix B).
 
+### 4.11. Single Implementation per Mechanism
+
+A mechanism — a traversal or walk, a name or FQN construction, a path or URI
+conversion, a memoization — MUST have exactly one implementation, and every
+consumer MUST reach it through that one. This generalizes Section 4.6's
+single-traversal requirement from the type graph to every shared mechanism.
+
+A contribution that extends an axis (Section 3.1) MUST reach the mechanisms it
+needs through their existing implementation. Where the existing one does not fit,
+unifying it is prior work: adding a parallel implementation "for now" is the defect
+this document exists to prevent, and it is never the cheaper option.
+
+Two implementations that differ only in return shape are one mechanism, not two.
+
 ## 5. Component Requirements
 
 ### 5.1. Symbol Knowledge: Read Contract (SymbolSource)
@@ -518,6 +533,7 @@ exhaustive over the normative sections; each item names the section it checks.
     bounded coverage is observable (Section 5.3).
 11. Correctness holds under synchronous execution (Section 6).
 12. Malformed input yields an error response, not process termination (Section 9).
+13. No shared mechanism has a second implementation (Section 4.11).
 
 ### 8.1. Enforcement
 
@@ -552,6 +568,10 @@ invariant added by amendment MUST specify its mechanism.
     4.9 Position encoding             Test: multibyte round-trip at the boundary;
                                       review of interior offset use.
     4.10 Client conformance defects   Review only; defect list in Appendix B.
+    4.11 Single implementation        Static rule: constructing a shared mechanism (AST
+                                      traversal, namespace/FQN construction, path and
+                                      URI conversion, memoization) is confined to that
+                                      mechanism's named owner.
     5.2 / 5.3 Write path, precedence, Architecture test + review: one write path,
         cache seam, bounded coverage  caching behind the abstraction, bounds observable.
     6 Synchronous correctness         By construction: the suite runs the interior

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -408,6 +408,7 @@ row must be discharged at the Definition of Done (Step Z).
     CodeResolver knowledge-facing methods                     Step 4
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
     FilesystemBackend per-kind declaration walks (S3.8a)      slice 5
+    DocumentSymbolSink's two declaration walks (pre-existing) slice 5
     §4.11 rule scope for SymbolExtractor / ScopeFinder        slices 2, 18
     WorkspaceIndexer (dead today)                             slice 1
     ScopeFinder::extractImports/resolveFromUseStatements       slice 18

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -284,11 +284,6 @@ Step 4 (Section 6).
   backend's function enumeration matches `get_defined_functions()` (as
   `TypeGraphParityTest` uses reflection for members). Revert profile: structural —
   revertible by reverting its commits, not a flag (§1).
-- **Each kind vertical consumes shared mechanism (§4.11); it does not add one.** The
-  per-kind cut is *backends × kinds*, which §5.6 requires to stay closed. S3.8a broke
-  that by adding a second declaration walk rather than using the one S3.7b had just
-  built, so the walk is unified (S3.8b) and rule-enforced (S3.8c) before any further
-  kind lands.
 - **External-file-change invalidation gets its own slice and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and
@@ -406,10 +401,10 @@ row must be discharged at the Definition of Done (Step Z).
     TextFallbackHelper breadth (narrow to FQN recovery)       Step 4
     CodeResolver knowledge-facing methods                     Step 4
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
-    FilesystemBackend per-kind declaration walks (S3.8a)      S3.8b
     WorkspaceIndexer (dead today)                             SC.1
     ScopeFinder::extractImports/resolveFromUseStatements       SC.2
-    Hand-rolled namespace tracking (SymbolExtractor)           SC.3
+    Hand-rolled namespace tracking (SymbolExtractor,           SC.3
+      FilesystemBackend::findClassInAst)
     Hand-rolled file:// conversion (4 sites)                   SC.4
 
 A scaffold with no discharged remover by Step Z is a defect, not an acceptable end
@@ -432,7 +427,7 @@ Each was found by an audit, not by a step.
 
 So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
 
-**What an audit looks for.** A violation of §4.11 — a single capability with more than one implementation — in the shapes this codebase actually produces them:
+**What an audit looks for.** A single capability with more than one implementation, in the shapes this codebase actually produces them:
 
 - a traversal or walk written per consumer instead of once (the #334 shape);
 - a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -270,30 +270,38 @@ Step 4 (Section 6).
   harness compares only observable outputs, an internal divergence between the two
   structures could pass parity, so add a consistency check that both are written from
   the same parse and agree. Proven by the Step P harness.
-- **3b — `SymbolLocator` + `autoload.files` reach (behavior-changing).** Generalize
-  `ClassLocator` to a kind-agnostic `SymbolLocator`; fold in `autoload.files`; give
-  `lookupFunction` / `lookupConstant` real project reach, and extend
-  `lookupClassLike` to the class-likes those files declare, which the autoload maps
-  cannot address (constant reach covers `const` declarations and literal-name
-  `define()`; a **computed-name `define()`** is a runtime call invisible to static
-  parse and is out of scope, per §3's locate-only limitation, as is a name introduced
-  by **`class_alias()`** rather than by a declaration; an anonymous class has
-  no name to index); migrate `FunctionCandidates`
-  to `search` (which subsumes `getFileFunctions` — the open-document backend knows a
-  document's functions, so that query disappears with its last caller); remove the
-  Step 2 rule exemption. *Acceptance on search reach:* every backend that answers
-  `lookupFunction` MUST also answer function `search`, so a name resolvable on hover
-  is offered in completion (§4.2). For `FilesystemBackend` that means the derived
-  `autoload.files` index — its empty `searchClassLikes` is scoped to the PSR-4 tree,
-  which needs a workspace walk (§3), not to every kind. This step **both changes and
-  preserves** behavior on the function surface: the added project reach is new
-  (proven by **new fixtures**), but built-in and open-document function completion is
-  *existing* behavior that must not regress. So the function-surface golden (Step P)
-  is **captured before this step** from today's path (`get_defined_functions()['internal']` + open-doc functions) and
-  frozen for the preservation half, and a **parity oracle** asserts the Builtin
-  backend's function enumeration matches `get_defined_functions()` (as
-  `TypeGraphParityTest` uses reflection for members). Revert profile: structural —
-  revertible by reverting its commits, not a flag (§1).
+- **3b — Uniform reach across the three symbol namespaces (behavior-changing).**
+  Generalize `ClassLocator` to a kind-agnostic `SymbolLocator`; fold in
+  `autoload.files`; give `lookupFunction` / `lookupConstant` real project reach, and
+  extend `lookupClassLike` to the class-likes those files declare, which the autoload
+  maps cannot address. Reach is bounded by §3's locate-only limitation: a
+  **computed-name `define()`**, a name introduced by **`class_alias()`**, and an
+  anonymous class have no static declaration to index. Migrate `FunctionCandidates`
+  to `search`, which subsumes `getFileFunctions` — the open-document backend knows a
+  document's functions, so that query disappears with its last caller — and remove
+  the Step 2 rule exemption.
+
+  *Acceptance:*
+  - **One walk answers "what does this file declare",** and every backend and the
+    write path consume it. A kind is not a second walk (§4.11).
+  - **A backend resolves uniformly, taking the kind as a parameter**, with the typed
+    per-kind results built at the facade from the existing factories (§5.6). Adding a
+    kind touches the facade and a factory, never every backend.
+  - **The kind-agnostic location query (§5.1) lands with that parameter**, being the
+    same call with the kind unknown rather than a second path.
+  - **The write path registers a declaration on the same terms the on-disk backends
+    resolve one**, so opening a file cannot hide a name that resolved from disk (§4.2).
+  - **Every backend answering a kind's lookup also answers that kind's `search`**, so
+    a name resolvable on hover is offered in completion (§4.2). `FilesystemBackend`'s
+    empty class-like search is scoped to the PSR-4 tree, which needs a workspace walk
+    (§3) — not to every kind.
+  - **New reach is proven by new fixtures; existing function completion is frozen.**
+    Built-in and open-document function completion is *existing* behavior held by the
+    function-surface golden (Step P) and by the parity oracle asserting the Builtin
+    backend's enumeration matches `get_defined_functions()`, as `TypeGraphParityTest`
+    uses reflection for members.
+
+  Revert profile: structural — revertible by reverting its commits, not a flag (§1).
 - **External-file-change invalidation gets its own slice and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -386,12 +386,34 @@ scheduler tier (§6).
 requests and is cancelable; optional components (`pcntl`, `ext-parallel`) are
 feature-detected with a synchronous fallback (Fibers / FFI may be relied on).
 
-### Unscheduled §8.1 mechanisms
+### §8.1 mechanism inventory
 
-- §4.6 "no `new` of a `Type` impl outside the factory" — lands in Step 4 (above).
-- §4.10 client conformance defects — review-only by design; carries no seam. The
-  running defect list lives in RFC 1 Appendix B (currently: ale `textEdit` range,
-  ale#4274). No step owns it; it is maintained on review.
+§8.1 requires every invariant to have a designated mechanism, so a mechanism with no
+owner is a gap this plan must either schedule or name as deferred. Only two static
+mechanisms are built today (§4.2's discovery-authority extension, §4.8's raw-params
+rule), which is why this inventory is exhaustive rather than a list of exceptions.
+
+    Invariant   Mechanism status
+    ----------  --------------------------------------------------------------
+    4.1         Architecture test: unbuilt. Scheduled.
+    4.2         Built, scoped to exempt the function path; exemption dies in 3b.
+    4.3         Static rule + single-write-path test: unbuilt. Scheduled.
+    4.4         Interface shape, holding for SymbolSource; the AST-in function
+                signature is the open violation, removed in 3b.
+    4.5         Static rule: unbuilt. Scheduled in Step 4.
+    4.6         Traversal held by TypeGraphParityTest; the no-`new`-outside-the-
+                factory rule is unbuilt, scheduled in Step 4.
+    4.7         Deferred with Step 5; tracked as an issue.
+    4.8         Built.
+    4.9         Round-trip corpus built in Step 1; interior offset use is review.
+    4.10        Review only by design — no seam exists to hold it. The defect list
+                lives in RFC 1 Appendix B (ale `textEdit` range, ale#4274).
+    4.11        Static rule: unbuilt. Scheduled, after the mechanisms it names are
+                unified, so it ships with no scope entries.
+    5.2 / 5.3   Architecture test: unbuilt. Scheduled. The write-path agreement
+                check built in 3a is a runtime assertion inside the sink, not this.
+    6           By construction: the suite runs the interior synchronously.
+    9           Built in Step 1.
 
 ### Teardown ledger
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -309,9 +309,9 @@ Step 4 (Section 6).
   close-after-edit both invalidate cached / indexed workspace state. *Its own
   acceptance:* an external edit to an unopened file, a branch checkout, and a file
   deletion are each reflected on the next query; closing an edited file re-reads from
-  disk rather than restoring the pre-edit cache (§5.3). When the client does not
-  support watched-file notifications, the fallback (lazy re-read vs. no invalidation)
-  is an open decision (§7).
+  disk rather than restoring the pre-edit cache (§5.3). A client that does not support
+  watched-file notifications gets no invalidation until a file is opened and closed;
+  that close re-reads disk.
 
 *Known tracked gap:* the Builtin backend stood up in 3a is reflection-backed and not
 environment-parameterized, so it does **not** satisfy §4.7 — it cannot answer for a
@@ -736,23 +736,18 @@ once Step P is green.
 
 ## 7. Open decisions (resolve at implementation time)
 
-- ~~The perceptibility threshold and cache decision from the Step 0 spike.~~
-  **Resolved — see Section 8.**
 - Whether `ClassLikeName` is the existing `ClassName` reused as-is, renamed, or a
   wrapper — it must coexist with `ClassName`'s dual role as the class `Type` (§5.3).
-- Whether `FunctionName` / `ConstantName` / `NamespaceName` land in Step 2 as prep
-  or in Step 3 with their lookups (lean: Step 3, to avoid an unused-type commit;
-  `NamespaceName` is needed by `childrenOf` in Step 2, so it lands then).
+- What §5.3's global-constant name type is called. `Domain\ConstantName` is taken: it
+  names a *class* constant. Resolve before constant reach lands, not inside it (Step 3b).
 - Whether completion detail after the `search` migration comes from a follow-up
-  `lookupFunction` or a `completionItem/resolve` capability (§5.4).
+  `lookupFunction` or a `completionItem/resolve` capability (§5.4) (Step 3b).
 - Whether the Workspace backend is lazy-only or gains bounded background indexing
   (only relevant if the workspace scope is taken up).
 - The future version-aware built-in source for Step 5 — **TBD, explicitly not
   `phpstorm-stubs`** (known issues) — and, when chosen, its ingestion / derivation
   model and the `TargetEnvironment` / undeclared-extension policy. Until then the
   interim is reflection + optimistic availability, and §4.7 is a tracked gap.
-- The external-change invalidation fallback when the client does not support
-  `didChangeWatchedFiles` (lazy re-read vs. no invalidation) (Step 3).
 
 ## 8. Step 0 spike record (measured)
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -25,6 +25,16 @@ throughout. That file must land first, or in the same merge; until it does, the
 - **Strangler-fig, always green.** Introduce a seam, migrate consumers onto it in
   small commits, then reshape behind it. No big-bang rewrite; every step merges on
   its own and keeps the suite passing.
+- **A migration window is scheduled, never assumed (§4.11).** A step MAY leave a
+  second implementation of a mechanism standing only if the step that removes it is
+  already scheduled — scheduled before the divergence lands, not after it is noticed.
+  A step is free to make things temporarily worse on that basis; it is not free to
+  leave the unification to whoever finds it.
+- **A new kind consumes mechanism; it never adds one (§4.11).** Extending an axis
+  reaches the existing implementation. A kind added by copying a routine into each
+  backend, or a walk written per consumer, is the M×N defect this series exists to
+  end, and it costs a unification step to undo before the next kind can land — so
+  unifying first is the cheaper order, not the purer one.
 - **Enforcement lands with the seam — scoped, not baselined.** When a step
   introduces an invariant's seam, its §8.1 enforcement mechanism lands in the same
   step. During a partial migration a rule ships with an **explicit, code-level

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -740,6 +740,9 @@ once Step P is green.
   wrapper — it must coexist with `ClassName`'s dual role as the class `Type` (§5.3).
 - What §5.3's global-constant name type is called. `Domain\ConstantName` is taken: it
   names a *class* constant. Resolve before constant reach lands, not inside it (Step 3b).
+- What a kind-agnostic backend `resolve` returns (§5.6). The on-disk backends locate a
+  declaration node; the Builtin backend resolves through reflection and has none, so
+  whatever the facade builds its typed info from must cover both (Step 3b).
 - Whether completion detail after the `search` migration comes from a follow-up
   `lookupFunction` or a `completionItem/resolve` capability (§5.4) (Step 3b).
 - Whether the Workspace backend is lazy-only or gains bounded background indexing

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -284,6 +284,11 @@ Step 4 (Section 6).
   backend's function enumeration matches `get_defined_functions()` (as
   `TypeGraphParityTest` uses reflection for members). Revert profile: structural —
   revertible by reverting its commits, not a flag (§1).
+- **Each kind vertical consumes shared mechanism (§4.11); it does not add one.** The
+  per-kind cut is *backends × kinds*, which §5.6 requires to stay closed. S3.8a broke
+  that by adding a second declaration walk rather than using the one S3.7b had just
+  built, so the walk is unified (S3.8b) and rule-enforced (S3.8c) before any further
+  kind lands.
 - **External-file-change invalidation gets its own slice and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and
@@ -401,10 +406,10 @@ row must be discharged at the Definition of Done (Step Z).
     TextFallbackHelper breadth (narrow to FQN recovery)       Step 4
     CodeResolver knowledge-facing methods                     Step 4
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
+    FilesystemBackend per-kind declaration walks (S3.8a)      S3.8b
     WorkspaceIndexer (dead today)                             SC.1
     ScopeFinder::extractImports/resolveFromUseStatements       SC.2
-    Hand-rolled namespace tracking (SymbolExtractor,           SC.3
-      FilesystemBackend::findClassInAst)
+    Hand-rolled namespace tracking (SymbolExtractor)           SC.3
     Hand-rolled file:// conversion (4 sites)                   SC.4
 
 A scaffold with no discharged remover by Step Z is a defect, not an acceptable end
@@ -427,7 +432,7 @@ Each was found by an audit, not by a step.
 
 So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
 
-**What an audit looks for.** A single capability with more than one implementation, in the shapes this codebase actually produces them:
+**What an audit looks for.** A violation of §4.11 — a single capability with more than one implementation — in the shapes this codebase actually produces them:
 
 - a traversal or walk written per consumer instead of once (the #334 shape);
 - a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -473,7 +473,7 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
 - **Enforcement is complete.** Every §8.1 enforcement rule is active **repo-wide with
   zero remaining exemptions or allowlists** (the Step 2 §4.2 exemption, and any other,
   are gone). A rule still carrying a scope is an open step, not done.
-- **Conformance is repo-wide.** RFC §8's 12-item checklist passes across the whole
+- **Conformance is repo-wide.** RFC §8's conformance checklist passes across the whole
   codebase, not merely per change.
 - **Parity is trustworthy.** The Step P harness is green **and** its branch coverage of
   the migrated surfaces is adequate — no unexercised surface branch (Step P) — and

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -410,9 +410,10 @@ row must be discharged at the Definition of Done (Step Z).
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
     FilesystemBackend per-kind declaration walks (S3.8a)      slice 5
     DocumentSymbolSink's two declaration walks (pre-existing) slice 5
-    §4.11 rule scope for SymbolExtractor / ScopeFinder        slices 2, 18
+    Per-kind backend lookup methods (S3.8a)                   slice 6
+    §4.11 rule scope for SymbolExtractor / ScopeFinder        slices 2, 19
     WorkspaceIndexer (dead today)                             slice 1
-    ScopeFinder::extractImports/resolveFromUseStatements       slice 18
+    ScopeFinder::extractImports/resolveFromUseStatements       slice 19
     Hand-rolled namespace tracking (SymbolExtractor)           slice 2
     Hand-rolled file:// conversion (4 sites)                   SC.4
 
@@ -420,7 +421,7 @@ A scaffold with no discharged remover by Step Z is a defect, not an acceptable e
 state. Conversely, the Step P parity harness is deliberately **not** on this ledger:
 it is a permanent regression net kept past Step Z, not scaffolding to remove.
 
-The rows carrying no step (SC.4, slices 1, 2, 18) are **pre-existing** duplication and
+The rows carrying no step (SC.4, slices 1, 2, 19) are **pre-existing** duplication and
 dead code, not scaffolding this plan introduced — so no step's acceptance covers them,
 which is how they stayed unowned. They are listed anyway: the series exists to remove
 duplication, so a known-removable thing without an owning slice is the same defect as
@@ -437,7 +438,7 @@ not pre-existing debt.
 
 The ledger above tracks scaffolding *this plan knowingly introduced*.
 It cannot catch the failure mode the series exists to end: a capability that ends up implemented twice, which is how the M×N problem returns.
-Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (slice 2), a superseded import extractor with three unmigrated callers (slice 18), and a per-kind declaration walk added beside the shared one (slice 5).
+Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (slice 2), a superseded import extractor with three unmigrated callers (slice 19), a per-kind declaration walk added beside the shared one (slice 5), and a lookup routine copied into every backend (slice 6).
 Each was found by an audit, not by a step.
 
 So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
@@ -446,7 +447,7 @@ So each major section ends with an explicit audit slice, and the terminal gate r
 
 - a traversal or walk written per consumer instead of once (the #334 shape);
 - a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;
-- a seam that landed while some callers kept the old path (the slice 18 shape);
+- a seam that landed while some callers kept the old path (the slice 19 shape);
 - a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256).
 
 **Scope: substantial mechanics, not one-liners.** The target is work with real substance behind it — parsing, AST traversal, symbol extraction, name and FQN construction, path/URI conversion, caching.
@@ -461,7 +462,7 @@ If neither finds something, that is a known limit of the method, not a reason to
 
 A finding is not discharged by noting it: it is either fixed in the audit slice, or it becomes a numbered slice row with an owner.
 
-**Outcome rule, and the one difference between them.** The pre-cleanup audits (**slices 12 and 20**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
+**Outcome rule, and the one difference between them.** The pre-cleanup audits (**slices 13 and 21**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
 The terminal audit in **Step Z** may not: there, an unowned *or* unfixed duplicate is a failure, because there is no later section to own it.
 
 An audit reporting no findings must show the enumeration it ran.

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -24,7 +24,9 @@ throughout. That file must land first, or in the same merge; until it does, the
 
 - **Strangler-fig, always green.** Introduce a seam, migrate consumers onto it in
   small commits, then reshape behind it. No big-bang rewrite; every step merges on
-  its own and keeps the suite passing.
+  its own and keeps the suite passing. The window where old and new coexist is what
+  RFC §4.11 calls a **declared migration**, and the three things it requires are the
+  next principle's scoped rule, a Teardown ledger row, and a remover slice id.
 - **Enforcement lands with the seam — scoped, not baselined.** When a step
   introduces an invariant's seam, its §8.1 enforcement mechanism lands in the same
   step. During a partial migration a rule ships with an **explicit, code-level
@@ -416,12 +418,18 @@ A scaffold with no discharged remover by Step Z is a defect, not an acceptable e
 state. Conversely, the Step P parity harness is deliberately **not** on this ledger:
 it is a permanent regression net kept past Step Z, not scaffolding to remove.
 
-The `SC.*` rows are **pre-existing** duplication and dead code, not scaffolding this
-plan introduced — so no step's acceptance covers them, which is how they stayed
-unowned. They are listed anyway: the series exists to remove duplication, so a
-known-removable thing without an owning slice is the same defect as an undischarged
-scaffold. A remover must be a slice id; a prose note is not an owner, because
-`/do-next` cannot select one.
+The rows carrying no step (SC.4, slices 1, 2, 18) are **pre-existing** duplication and
+dead code, not scaffolding this plan introduced — so no step's acceptance covers them,
+which is how they stayed unowned. They are listed anyway: the series exists to remove
+duplication, so a known-removable thing without an owning slice is the same defect as
+an undischarged scaffold. A remover must be a slice id; a prose note is not an owner,
+because `/do-next` cannot select one.
+
+Slices 3 and 4 carry no step for two different reasons. §4.1's seam predates this plan
+(#190/#253/#256), so it is pre-existing like the rows above. §4.3's seam is Step 2's,
+whose acceptance named only the §4.2 rule — so its mechanism was due under §1
+"Enforcement lands with the seam" and did not land. It is a late Step 2 obligation,
+not pre-existing debt.
 
 ### Duplication audits
 
@@ -468,7 +476,7 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
 - **Enforcement is complete.** Every §8.1 enforcement rule is active **repo-wide with
   zero remaining exemptions or allowlists** (the Step 2 §4.2 exemption, and any other,
   are gone). A rule still carrying a scope is an open step, not done.
-- **Conformance is repo-wide.** RFC §8's 12-item checklist passes across the whole
+- **Conformance is repo-wide.** RFC §8's checklist passes across the whole
   codebase, not merely per change.
 - **Parity is trustworthy.** The Step P harness is green **and** its branch coverage of
   the migrated surfaces is adequate — no unexercised surface branch (Step P) — and

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -548,9 +548,9 @@ interface SymbolSource
     // Step 3b (functions/constants gain project reach; a second searchable kind exists):
     //   lookupFunction(FunctionName): ?FunctionInfo
     //   lookupConstant(ConstantName): ?ConstantInfo
+    //   locate(QualifiedName, NameKind): ?SymbolDefinition   // kind-neutral def-site (§5.1)
     //   searchClassLikes generalizes to search(string $prefix, NameKind $kind)
     // Future (workspace scope, #264):
-    //   locate(QualifiedName, NameKind): ?SymbolDefinition   // kind-neutral def-site, only if a feature needs it
     //   project-wide / cross-file search (workspace/symbol)
 }
 
@@ -567,18 +567,18 @@ the features, like everything else in the plan. Step 2 carries only what the mig
 features need — exact class-like lookup, class-like prefix search, namespace
 enumeration — plus the `SymbolSink` writes. `lookupFunction` / `lookupConstant` arrive
 in Step 3b; a kind-parameterized `search` arrives with them (a `NameKind` argument is
-meaningless while only class-likes are searchable); `locate` and a cross-file `search`
-arrive with the workspace scope. A method with no current caller is not carried.
+meaningless while only class-likes are searchable); a cross-file `search` arrives with
+the workspace scope. A method with no current caller is not carried.
 
-The three verbs, and why two defer: **`lookup*`** = exact name → full typed info
-(`ClassInfo`); **`search*`** = prefix *fragment* → lightweight candidates; **`locate`**
-= exact name → just a definition site, kind-neutral. `lookup` and `search` are clearly
-distinct (exact vs. prefix; full info vs. candidates) and both serve current
-completion / hover / def. `locate` overlaps `lookup` — go-to-definition can already use
-`lookupClassLike($name)?->getDefinitionLocation()` — so it earns a slot only if a later
-feature needs a def-site *without* building full info, or a kind-neutral workspace
-entry. Deferring it removes the naming ambiguity and lets it be named when a concrete
-need defines it.
+The three verbs: **`lookup*`** = exact name → full typed info (`ClassInfo`);
+**`search*`** = prefix *fragment* → lightweight candidates; **`locate`** = exact name →
+just a definition site, kind-neutral. `lookup` and `search` are clearly distinct (exact
+vs. prefix; full info vs. candidates) and both serve current completion / hover / def.
+`locate` overlaps `lookup` — go-to-definition can already use
+`lookupClassLike($name)?->getDefinitionLocation()` — but §5.1 requires it, and §4.5
+requires it wherever a position is genuinely kind-ambiguous, so it is not optional.
+It lands in Step 3b alongside the kind parameter, being that same backend call with
+the kind unknown rather than a second path.
 
 ### 5.3. The name-type model
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -452,17 +452,18 @@ undischarged scaffold. An owner must be a step; a prose note is not one.
 
 The ledger above tracks scaffolding *this plan knowingly introduced*.
 It cannot catch the failure mode the series exists to end: a capability that ends up implemented twice, which is how the M×N problem returns.
-Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (SC.3), a superseded import extractor with three unmigrated callers (SC.2).
+Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places, namespace tracking in two, a superseded import extractor with three unmigrated callers, a per-kind lookup copied into every backend.
 Each was found by an audit, not by a step.
 
-So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
+So each major section ends with an explicit audit, and the terminal gate re-runs it repo-wide.
 
 **What an audit looks for.** A single capability with more than one implementation, in the shapes this codebase actually produces them:
 
 - a traversal or walk written per consumer instead of once (the #334 shape);
 - a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;
-- a seam that landed while some callers kept the old path (the SC.2 shape);
-- a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256).
+- a seam that landed while some callers kept the old path;
+- a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256);
+- the same steps repeated under a different signature — per kind, per backend, or per return type (§4.11).
 
 **Scope: substantial mechanics, not one-liners.** The target is work with real substance behind it — parsing, AST traversal, symbol extraction, name and FQN construction, path/URI conversion, caching.
 A duplicated one-liner is worth folding in when it turns up, but it is not what this is for, and no effort is spent hunting for it.
@@ -474,9 +475,9 @@ Then enumerate each seam's callers and confirm none kept the old path.
 Static analysis is better where it reaches and is not foolproof where it does not; grep plus the existing rules is the accepted floor.
 If neither finds something, that is a known limit of the method, not a reason to build a detector.
 
-A finding is not discharged by noting it: it is either fixed in the audit slice, or it becomes a numbered slice row with an owner.
+A finding is not discharged by noting it: it is either fixed in the audit itself, or it becomes an ordered step with an owner.
 
-**Outcome rule, and the one difference between them.** The pre-cleanup audits (**S3.11**, **S4.7**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
+**Outcome rule, and the one difference between them.** The Step 3 and Step 4 audits may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
 The terminal audit in **Step Z** may not: there, an unowned *or* unfixed duplicate is a failure, because there is no later section to own it.
 
 An audit reporting no findings must show the enumeration it ran.
@@ -508,7 +509,7 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
   condition the whole series exists to produce (#190, #253, #256, #334): if it does
   not hold, the foundation did not meet its goal, whatever else passed. The repo-wide
   audit (above) is run and comes back empty with its enumeration shown, and every
-  earlier audit is discharged along with every slice they filed. A surviving duplicate
+  earlier audit is discharged along with every step they filed. A surviving duplicate
   fails this gate outright and may not be deferred — there is no later section to own
   it.
 - **Divergences are reconciled.** Each entry in RFC 1 Appendix B "current divergences"

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -417,36 +417,36 @@ unbuilt while their steps passed. Every one is assigned here.
 
 The strangler introduces scaffolding that later steps remove; because that teardown
 is distributed across steps, it is enumerated here so nothing is left behind. Each
-row is checked by the `review-slice` pass when its *remover* slice lands, and every
-row must be discharged at the Definition of Done (Step Z).
+row is checked on review when its remover lands, and every row must be discharged at
+the Definition of Done (Step Z).
 
-    Scaffolding introduced                                    Removed / merged in
+    Removed                                                   Removed in
     --------------------------------------------------------  --------------------
-    Step 2 facade hides today's double write (§5.5)           Step 3a(iv)
-    Two ComposerAutoloadMap instances (pre-existing dup)      Step 3a(ii)
+    Step 2 facade hides today's double write (§5.5)           Step 3a
+    Two ComposerAutoloadMap instances (pre-existing dup)      Step 3a
+    A Step 0 standing cache, if built (no orphan)             Step 3a
     Step 2 §4.2 rule exemption for FunctionRepository         Step 3b
     getFileFunctions (transitional; last caller migrates)     Step 3b
     DefaultFunctionRepository AST-in signature                Step 3b
+    Per-kind lookup copied across the backends                Step 3b
+    Every walk answering "what does this file declare"        Step 3b
+    Hand-rolled file:// conversion                            Step 3
+    Hand-rolled namespace tracking (SymbolExtractor)          Step 3
+    WorkspaceIndexer (dead today)                             Step 3
     SymbolResolver god class                                  Step 4
     TextFallbackHelper breadth (narrow to FQN recovery)       Step 4
     CodeResolver knowledge-facing methods                     Step 4
-    A Step 0 standing cache, if built (no orphan)             Step 3a(i)
-    WorkspaceIndexer (dead today)                             SC.1
-    ScopeFinder::extractImports/resolveFromUseStatements       SC.2
-    Hand-rolled namespace tracking (SymbolExtractor,           SC.3
-      FilesystemBackend::findClassInAst)
-    Hand-rolled file:// conversion (4 sites)                   SC.4
+    ScopeFinder::extractImports/resolveFromUseStatements      Step 4
 
-A scaffold with no discharged remover by Step Z is a defect, not an acceptable end
-state. Conversely, the Step P parity harness is deliberately **not** on this ledger:
-it is a permanent regression net kept past Step Z, not scaffolding to remove.
+A row with no discharged remover by Step Z is a defect, not an acceptable end state.
+Conversely, the Step P parity harness is deliberately **not** on this ledger: it is a
+permanent regression net kept past Step Z, not scaffolding to remove.
 
-The `SC.*` rows are **pre-existing** duplication and dead code, not scaffolding this
-plan introduced — so no step's acceptance covers them, which is how they stayed
-unowned. They are listed anyway: the series exists to remove duplication, so a
-known-removable thing without an owning slice is the same defect as an undischarged
-scaffold. A remover must be a slice id; a prose note is not an owner, because
-`/do-next` cannot select one.
+Rows in the lower half are **pre-existing** duplication and dead code rather than
+scaffolding this plan introduced, so no step's acceptance originally covered them —
+which is how they stayed unowned. A step now owns each: the series exists to remove
+duplication, so a known-removable thing without an owner is the same defect as an
+undischarged scaffold. An owner must be a step; a prose note is not one.
 
 ### Duplication audits
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -94,19 +94,18 @@ Notes:
   entry at bootstrap; nothing indexes them by name. So this set is the one place the
   model cannot resolve a name lazily, and its reach is a small, bounded index of the
   whole set — still not a project walk, because the list is explicit and usually tiny.
-- **Whether that index is built eagerly or on first use is S3.7d's call**, the slice
-  that builds it. Widening the set's reach to class-likes reopens the question rather
-  than settling it: a lazy build's trigger stops being a function or constant lookup
-  and becomes any name the autoload maps fail to resolve — commoner and far less
-  predictable, though still paid once, by whichever name arrives first. The cost is
+- **That index is built eagerly, not on first use.** A lazy build's trigger would stop
+  being a function or constant lookup and become any name the autoload maps fail to
+  resolve — commoner and far less predictable, though still paid once, by whichever
+  name arrives first. The cost is
   bounded either way: sized against §8.1's ~4 MB/s parse rate, this repository's own
   set is a dozen entries totalling ~140 KB ≈ **35 ms**, most of it one large PHPUnit
   file; the rest total ~30 KB ≈ **7 ms**. If a real project's set ever makes that
   perceptible (§8.4), the work moves to the deferred scheduler tier (Step 6).
 - Background/eager indexing is optional and bounded (§5.3). `WorkspaceIndexer` is
-  revived only if/when the workspace scope is taken up; otherwise it is deleted — which
-  is slice **SC.1**, since it is dead today (zero references) and the workspace scope is
-  not scheduled. Reviving it later is cheaper than carrying dead code until then.
+  revived only if/when the workspace scope is taken up; otherwise it is deleted, since
+  it is dead today (zero references) and the workspace scope is not scheduled. Reviving
+  it later is cheaper than carrying dead code until then.
 - On-disk backends cache **derived info** (`ClassInfo`, symbols — small), never raw
   ASTs. `ClassRepository` already does this; preserve it.
 - Reach is scoped to declarations the model can *locate*: PSR-4 / classmap classes,
@@ -180,11 +179,12 @@ encoding, plus dedicated multibyte cases. And Step 1 is not fully orthogonal to 
 4: Step 1's single internal representation has to be the one the Step 4 positional
 layer consumes, or the encoding work is silently redone — coordinate the two.
 
-**Interior consumers deferred from S1.2 to S1.5.** S1.2 fixed the conversion
-boundary (`TextDocument::offsetAt` / `positionAt`) and the negotiation, but left the
-interior sites that still slice line text by the raw wire `character` — a §4.9
-violation ("interior components MUST operate only on that representation") the corpus
-must drive out. S1.5 MUST correct these, and cover each with multibyte fixtures:
+**The interior consumers come after the boundary.** Fixing the conversion boundary
+(`TextDocument::offsetAt` / `positionAt`) and the negotiation leaves the interior
+sites that still slice line text by the raw wire `character` — a §4.9 violation
+("interior components MUST operate only on that representation") the corpus must
+drive out. The round-trip corpus MUST correct these, and cover each with multibyte
+fixtures:
 
 - **Inbound reads** that do `substr($lineText, 0, $character)`, treating the wire
   column as a byte length: `CompletionHandler` (text-before-cursor),
@@ -195,7 +195,8 @@ must drive out. S1.5 MUST correct these, and cover each with multibyte fixtures:
 - **Outbound completion `Range` columns** that compute `$character - strlen($prefix)`,
   mixing a wire column with a byte length: `ClassCandidates` and `NamespaceCandidates`.
   These need the negotiated `PositionEncoding` reachable at the completion sources, so
-  S1.5 threads it there — S1.2 deliberately kept it confined to the document boundary.
+  the corpus threads it there; the boundary fix deliberately kept it confined to the
+  document.
 
 ### Step P — Resolution & enumeration parity harness (gates Steps 2–4)
 
@@ -227,10 +228,10 @@ golden is green forever. May run in parallel with Steps 0 and 1.
 
 *Maintenance.* This harness is a **permanent** regression net, not migration
 scaffolding — it is absent from the Teardown ledger below, and Step Z requires it
-green. As delivered (slice SP.1) the coverage requirement is realized as pcov *line*
-coverage measured by `composer parity-coverage` — a path selector on the normal test
-config, not a separate one (branch-level rigor is the `/review-slice` pass's job,
-§Mode B); genuinely-unreachable defensive guards are documented rather than gated.
+green. As delivered, the coverage requirement is realized as pcov *line* coverage
+measured by `composer parity-coverage` — a path selector on the normal test config,
+not a separate one (branch-level rigor is the review pass's job);
+genuinely-unreachable defensive guards are documented rather than gated.
 The full operational contract — recapturing a golden, what legitimately churns one,
 and that the goldens ride a surface-class refactor unchanged (they assert output, so
 a diff during a behavior-preserving step means the refactor changed behavior) —
@@ -302,7 +303,7 @@ Step 4 (Section 6).
     uses reflection for members.
 
   Revert profile: structural — revertible by reverting its commits, not a flag (§1).
-- **External-file-change invalidation gets its own slice and acceptance**, not a
+- **External-file-change invalidation gets its own step and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and
   close-after-edit both invalidate cached / indexed workspace state. *Its own
@@ -718,10 +719,10 @@ Step 5 (deferred — tracked §4.7 gap) and Step 6 (deferred — needs #266): la
   it, so it lands first (it can be built in parallel with Steps 0/1).
 - **Steps 3 and 4 both edit `SymbolResolver`** — Step 3b rewrites its function/
   constant lookups; Step 4 extracts its positional layer. These are not freely
-  parallel. Serialize the `SymbolResolver`-editing slices: do Step 3b's lookup
+  parallel. Serialize the `SymbolResolver`-editing work: do Step 3b's lookup
   migration first, then Step 4's extraction (or vice versa), but not concurrently.
-  Step 4's `TypeClassifier` and interface-split slices are independent of Step 3 and
-  may proceed alongside.
+  Step 4's `TypeClassifier` and interface split are independent of Step 3 and may
+  proceed alongside.
 - **Step 3a is itself a cluster of small PRs** (cache abstraction, `ComposerAutoloadMap`
   dedupe, backend composite, write-path collapse), not one commit — per the project's
   small-commit rule. A Step 0 standing cache, if the spike warrants it, rides in on
@@ -754,8 +755,8 @@ once Step P is green.
 
 ## 8. Step 0 spike record (measured)
 
-Measured on the slice `S0.1` instrumentation (`ParseMetrics`, which meters every
-`ParserService::parse()` — parse plus both visitor passes). Conditions: PHP 8.5.4
+Measured on the `ParseMetrics` instrumentation, which meters every
+`ParserService::parse()` — parse plus both visitor passes. Conditions: PHP 8.5.4
 CLI, macOS/arm64, no xdebug, opcache CLI off, and **`pcov.enabled=0`**. Timings
 varied ~10-15% run to run; **parse counts were exactly reproducible**, and the
 counts are what the decision turns on.
@@ -866,14 +867,14 @@ Step 0 does not apply.
 
 ### 8.5 Decision
 
-1. **Ship request-scoped dedup (S0.2).** It cuts the keystroke from 7 parses to 2
+1. **Ship request-scoped dedup.** It cuts the keystroke from 7 parses to 2
    (one per message) with no invalidation risk whatsoever: within one message the
    document content cannot change, so a memo held for that message's duration and
    then discarded cannot go stale. Projecting the measured parse costs onto that
-   count — not itself measured, since dedup is S0.2's to build — the large tier
+   count — not itself measured, the dedup being unbuilt at the time — the large tier
    falls from ~125 ms to ~50 ms per keystroke and the pathological tier from
-   ~190 ms to ~75 ms, i.e. under the threshold at every tier measured. S0.2 should
-   confirm this rather than assume it.
+   ~190 ms to ~75 ms, i.e. under the threshold at every tier measured. The dedup
+   must confirm this rather than assume it.
 2. **Do not add a standing cache now — this overrides the decision rule's cache
    branch, on a projection.** Be explicit about that. §8.4 establishes the
    antecedent of the rule's second branch ("add a standing cache only if large
@@ -893,23 +894,23 @@ Step 0 does not apply.
 3. **Revisit only on evidence.** If a standing cache is later warranted, it lands as
    the Step 3 rider described in Section 6 — open documents only, keyed by document
    version, behind the §5.3 cache abstraction — never as hard-coded memoization.
-   What reopens it, specifically: S0.2's measured post-dedup keystroke costs, if
-   they do not land under the §8.4 thresholds the way decision 1 projects. Decision
-   2 rests on that projection, so S0.2 is the checkpoint that confirms or overturns
-   it.
+   What reopens it, specifically: the measured post-dedup keystroke costs, if they
+   do not land under the §8.4 thresholds the way decision 1 projects. Decision 2
+   rests on that projection, so that measurement is the checkpoint that confirms or
+   overturns it.
 
 Note that the dedup boundary must cover the **notification** path as well as the
 request path: two of the seven parses are `didChange`'s, which `SymbolResolver`
 never sees. "Request-scoped" therefore means scoped to one handled LSP message,
 notifications included.
 
-### 8.6 Post-dedup measurement (slice S0.2) — decision 1 confirmed
+### 8.6 Post-dedup measurement — decision 1 confirmed
 
 Measured after the dedup landed, under §8's conditions (PHP 8.5.4 CLI, macOS/arm64,
 no xdebug, `pcov.enabled=0`) on the same files and the same keystroke as §8.3 —
 `didChange` followed by `textDocument/completion` at a bare prefix typed on a line
 appended to the file. Ranges are min-max over ten iterations after the class
-repository has warmed; the harness was throwaway, as in S0.1.
+repository has warmed; the harness was throwaway, as before.
 
 | Tier | Lines | `didChange` | completion | Full keystroke | §8.3 before |
 |---|---|---|---|---|---|

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -97,7 +97,7 @@ Notes:
   perceptible (§8.4), the work moves to the deferred scheduler tier (Step 6).
 - Background/eager indexing is optional and bounded (§5.3). `WorkspaceIndexer` is
   revived only if/when the workspace scope is taken up; otherwise it is deleted — which
-  is **slice 1**, since it is dead today (zero references) and the workspace scope is
+  is deleted, since it is dead today (zero references) and the workspace scope is
   not scheduled. Reviving it later is cheaper than carrying dead code until then.
 - On-disk backends cache **derived info** (`ClassInfo`, symbols — small), never raw
   ASTs. `ClassRepository` already does this; preserve it.
@@ -286,11 +286,19 @@ Step 4 (Section 6).
   backend's function enumeration matches `get_defined_functions()` (as
   `TypeGraphParityTest` uses reflection for members). Revert profile: structural —
   revertible by reverting its commits, not a flag (§1).
-- **A new kind is a factory and a facade accessor, not a change to every backend**
-  (§5.6). S3.8a broke that twice over: it copied `lookupFunction` into all four
-  backends, each copy repeating one cache-key / locate / parse / store routine, and it
-  added a second declaration walk rather than using the one S3.7b had built. Both are
-  unified, and rule-enforced (§4.11), before constants would make each of them three.
+- **A new kind is a factory and a facade accessor, not a change to every backend** (§5.6, §4.11).
+Three unifications are prerequisites of constant reach, each behavior-preserving and proven by the existing goldens.
+  - **One declaration walk**, yielding each declaration with its node.
+Needing the node for `ClassInfoFactory` / `FunctionInfo::fromNode` is a return-shape difference, not a second query.
+It serves the write path too, so a class-like declared below the top level is registered for lookup exactly as a function already is (§4.2) — new write-path behavior, proven by a fixture.
+  - **One backend lookup**: `SymbolBackend` resolves uniformly, `resolve(QualifiedName, NameKind)`, returning the located declaration; the facade builds the typed `ClassInfo` / `FunctionInfo` from the existing factories.
+`SymbolSource` keeps its typed per-kind methods, since a name type carrying its own kind is stronger than a name plus an enum.
+The dividing rule: kind is a *parameter* where the return type does not vary with it, a *method* where it does.
+Reflection is itself per-kind, so the Builtin backend keeps one internal `match`; no other backend carries a kind branch.
+  - **One lookup-and-memoize routine** across the backends, rather than a copy per kind.
+- **Constant reach lands whole** — lookup, search and enumeration together — because §4.2 requires identical coverage across them, and a kind split across two steps resolves on hover while staying invisible to completion.
+- **#181 is not closable on reach alone.**
+Its acceptance asks for these symbols in *hover and completion*, and for a startup-time benchmark; pinning a parse count is not that measurement.
 - **External-file-change invalidation gets its own slice and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and
@@ -389,6 +397,13 @@ feature-detected with a synchronous fallback (Fibers / FFI may be relied on).
 - §4.10 client conformance defects — review-only by design; carries no seam. The
   running defect list lives in RFC 1 Appendix B (currently: ale `textEdit` range,
   ale#4274). No step owns it; it is maintained on review.
+- §4.1 handler responsibility — a rule plus its `RuleTestCase`, asserting handlers depend on no parser, repository, or reflection.
+Already true in `src/`, and §8.1 requires a mechanism rather than documentation.
+- §4.3 read/write segregation — a rule plus its `RuleTestCase`, asserting consumers depend on `SymbolSource` / `SymbolSink` and never a concrete implementation.
+"Consumer" scopes to code outside the knowledge and index tiers: composition roots wire the concrete stores, and the tier that owns them holds them directly.
+A wider reading makes this a migration rather than a rule.
+- §4.11 single implementation — a rule naming, in its own configuration, the one owner of each shared mechanism: the declaration walk, positional walks, the parse pipeline's name resolution, assignment-flow analysis, backend lookup-and-memoize, path and URI conversion, and FQN construction.
+Every AST traversal in `src/` is classified by it as an owner or a declared migration; a migration entry requires a remover, since Step Z requires the rule to carry no remaining scope.
 
 ### Teardown ledger
 
@@ -408,37 +423,29 @@ row must be discharged at the Definition of Done (Step Z).
     TextFallbackHelper breadth (narrow to FQN recovery)       Step 4
     CodeResolver knowledge-facing methods                     Step 4
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
-    FilesystemBackend per-kind declaration walks (S3.8a)      slice 5
-    DocumentSymbolSink's two declaration walks (pre-existing) slice 5
-    Per-kind backend lookup methods (S3.8a)                   slice 6
-    §4.11 rule scope for SymbolExtractor / ScopeFinder        slices 2, 19
-    WorkspaceIndexer (dead today)                             slice 1
-    ScopeFinder::extractImports/resolveFromUseStatements       slice 19
-    Hand-rolled namespace tracking (SymbolExtractor)           slice 2
-    Hand-rolled file:// conversion (4 sites)                   SC.4
+    Per-kind declaration walks across read and write paths   Step 3b
+    Per-kind backend lookup and memoize routines             Step 3b
+    §4.11 rule scope for SymbolExtractor / ScopeFinder       —
+    WorkspaceIndexer (dead today)                            —
+    ScopeFinder::extractImports/resolveFromUseStatements     —
+    Hand-rolled namespace tracking (SymbolExtractor)         —
+    Hand-rolled file:// conversion (4 sites)                 —
 
 A scaffold with no discharged remover by Step Z is a defect, not an acceptable end
 state. Conversely, the Step P parity harness is deliberately **not** on this ledger:
 it is a permanent regression net kept past Step Z, not scaffolding to remove.
 
-The rows carrying no step (SC.4, slices 1, 2, 19) are **pre-existing** duplication and
-dead code, not scaffolding this plan introduced — so no step's acceptance covers them,
-which is how they stayed unowned. They are listed anyway: the series exists to remove
-duplication, so a known-removable thing without an owning slice is the same defect as
-an undischarged scaffold. A remover must be a slice id; a prose note is not an owner,
-because `/do-next` cannot select one.
-
-Slices 3 and 4 carry no step for two different reasons. §4.1's seam predates this plan
-(#190/#253/#256), so it is pre-existing like the rows above. §4.3's seam is Step 2's,
-whose acceptance named only the §4.2 rule — so its mechanism was due under §1
-"Enforcement lands with the seam" and did not land. It is a late Step 2 obligation,
-not pre-existing debt.
+The rows carrying no step are **pre-existing** duplication and dead code rather than
+scaffolding this plan introduced, so no step's acceptance covers them. They are listed
+anyway: the series exists to remove duplication, so a known-removable thing is the same
+defect whether or not a step produced it. They are ordered for execution in the
+manifest.
 
 ### Duplication audits
 
 The ledger above tracks scaffolding *this plan knowingly introduced*.
 It cannot catch the failure mode the series exists to end: a capability that ends up implemented twice, which is how the M×N problem returns.
-Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (slice 2), a superseded import extractor with three unmigrated callers (slice 19), a per-kind declaration walk added beside the shared one (slice 5), and a lookup routine copied into every backend (slice 6).
+Every instance found so far went unnoticed precisely because no step's acceptance covered it: hand-written type-graph traversals (#334), `file://` conversion in four places, namespace tracking in two, a superseded import extractor with unmigrated callers, a declaration walk written per kind, and a lookup routine copied into every backend.
 Each was found by an audit, not by a step.
 
 So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
@@ -447,7 +454,7 @@ So each major section ends with an explicit audit slice, and the terminal gate r
 
 - a traversal or walk written per consumer instead of once (the #334 shape);
 - a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;
-- a seam that landed while some callers kept the old path (the slice 19 shape);
+- a seam that landed while some callers kept the old path;
 - a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256).
 
 **Scope: substantial mechanics, not one-liners.** The target is work with real substance behind it — parsing, AST traversal, symbol extraction, name and FQN construction, path/URI conversion, caching.
@@ -462,7 +469,7 @@ If neither finds something, that is a known limit of the method, not a reason to
 
 A finding is not discharged by noting it: it is either fixed in the audit slice, or it becomes a numbered slice row with an owner.
 
-**Outcome rule, and the one difference between them.** The pre-cleanup audits (**slices 13 and 21**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
+**Outcome rule, and the one difference between them.** The Step 3 and Step 4 audits may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
 The terminal audit in **Step Z** may not: there, an unowned *or* unfixed duplicate is a failure, because there is no later section to own it.
 
 An audit reporting no findings must show the enumeration it ran.

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -24,9 +24,7 @@ throughout. That file must land first, or in the same merge; until it does, the
 
 - **Strangler-fig, always green.** Introduce a seam, migrate consumers onto it in
   small commits, then reshape behind it. No big-bang rewrite; every step merges on
-  its own and keeps the suite passing. The window where old and new coexist is what
-  RFC §4.11 calls a **declared migration**, and the three things it requires are the
-  next principle's scoped rule, a Teardown ledger row, and a remover slice id.
+  its own and keeps the suite passing.
 - **Enforcement lands with the seam — scoped, not baselined.** When a step
   introduces an invariant's seam, its §8.1 enforcement mechanism lands in the same
   step. During a partial migration a rule ships with an **explicit, code-level
@@ -97,7 +95,7 @@ Notes:
   perceptible (§8.4), the work moves to the deferred scheduler tier (Step 6).
 - Background/eager indexing is optional and bounded (§5.3). `WorkspaceIndexer` is
   revived only if/when the workspace scope is taken up; otherwise it is deleted — which
-  is deleted, since it is dead today (zero references) and the workspace scope is
+  is slice **SC.1**, since it is dead today (zero references) and the workspace scope is
   not scheduled. Reviving it later is cheaper than carrying dead code until then.
 - On-disk backends cache **derived info** (`ClassInfo`, symbols — small), never raw
   ASTs. `ClassRepository` already does this; preserve it.
@@ -286,19 +284,6 @@ Step 4 (Section 6).
   backend's function enumeration matches `get_defined_functions()` (as
   `TypeGraphParityTest` uses reflection for members). Revert profile: structural —
   revertible by reverting its commits, not a flag (§1).
-- **A new kind is a factory and a facade accessor, not a change to every backend** (§5.6, §4.11).
-Three unifications are prerequisites of constant reach, each behavior-preserving and proven by the existing goldens.
-  - **One declaration walk**, yielding each declaration with its node.
-Needing the node for `ClassInfoFactory` / `FunctionInfo::fromNode` is a return-shape difference, not a second query.
-It serves the write path too, so a class-like declared below the top level is registered for lookup exactly as a function already is (§4.2) — new write-path behavior, proven by a fixture.
-  - **One backend lookup**: `SymbolBackend` resolves uniformly, `resolve(QualifiedName, NameKind)`, returning the located declaration; the facade builds the typed `ClassInfo` / `FunctionInfo` from the existing factories.
-`SymbolSource` keeps its typed per-kind methods, since a name type carrying its own kind is stronger than a name plus an enum.
-The dividing rule: kind is a *parameter* where the return type does not vary with it, a *method* where it does.
-Reflection is itself per-kind, so the Builtin backend keeps one internal `match`; no other backend carries a kind branch.
-  - **One lookup-and-memoize routine** across the backends, rather than a copy per kind.
-- **Constant reach lands whole** — lookup, search and enumeration together — because §4.2 requires identical coverage across them, and a kind split across two steps resolves on hover while staying invisible to completion.
-- **#181 is not closable on reach alone.**
-Its acceptance asks for these symbols in *hover and completion*, and for a startup-time benchmark; pinning a parse count is not that measurement.
 - **External-file-change invalidation gets its own slice and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and
@@ -397,13 +382,6 @@ feature-detected with a synchronous fallback (Fibers / FFI may be relied on).
 - §4.10 client conformance defects — review-only by design; carries no seam. The
   running defect list lives in RFC 1 Appendix B (currently: ale `textEdit` range,
   ale#4274). No step owns it; it is maintained on review.
-- §4.1 handler responsibility — a rule plus its `RuleTestCase`, asserting handlers depend on no parser, repository, or reflection.
-Already true in `src/`, and §8.1 requires a mechanism rather than documentation.
-- §4.3 read/write segregation — a rule plus its `RuleTestCase`, asserting consumers depend on `SymbolSource` / `SymbolSink` and never a concrete implementation.
-"Consumer" scopes to code outside the knowledge and index tiers: composition roots wire the concrete stores, and the tier that owns them holds them directly.
-A wider reading makes this a migration rather than a rule.
-- §4.11 single implementation — a rule naming, in its own configuration, the one owner of each shared mechanism: the declaration walk, positional walks, the parse pipeline's name resolution, assignment-flow analysis, backend lookup-and-memoize, path and URI conversion, and FQN construction.
-Every AST traversal in `src/` is classified by it as an owner or a declared migration; a migration entry requires a remover, since Step Z requires the rule to carry no remaining scope.
 
 ### Teardown ledger
 
@@ -423,38 +401,37 @@ row must be discharged at the Definition of Done (Step Z).
     TextFallbackHelper breadth (narrow to FQN recovery)       Step 4
     CodeResolver knowledge-facing methods                     Step 4
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
-    Per-kind declaration walks across read and write paths   Step 3b
-    Per-kind backend lookup and memoize routines             Step 3b
-    §4.11 rule scope for SymbolExtractor / ScopeFinder       —
-    WorkspaceIndexer (dead today)                            —
-    ScopeFinder::extractImports/resolveFromUseStatements     —
-    Hand-rolled namespace tracking (SymbolExtractor)         —
-    Hand-rolled file:// conversion (4 sites)                 —
+    WorkspaceIndexer (dead today)                             SC.1
+    ScopeFinder::extractImports/resolveFromUseStatements       SC.2
+    Hand-rolled namespace tracking (SymbolExtractor,           SC.3
+      FilesystemBackend::findClassInAst)
+    Hand-rolled file:// conversion (4 sites)                   SC.4
 
 A scaffold with no discharged remover by Step Z is a defect, not an acceptable end
 state. Conversely, the Step P parity harness is deliberately **not** on this ledger:
 it is a permanent regression net kept past Step Z, not scaffolding to remove.
 
-The rows carrying no step are **pre-existing** duplication and dead code rather than
-scaffolding this plan introduced, so no step's acceptance covers them. They are listed
-anyway: the series exists to remove duplication, so a known-removable thing is the same
-defect whether or not a step produced it. They are ordered for execution in the
-manifest.
+The `SC.*` rows are **pre-existing** duplication and dead code, not scaffolding this
+plan introduced — so no step's acceptance covers them, which is how they stayed
+unowned. They are listed anyway: the series exists to remove duplication, so a
+known-removable thing without an owning slice is the same defect as an undischarged
+scaffold. A remover must be a slice id; a prose note is not an owner, because
+`/do-next` cannot select one.
 
 ### Duplication audits
 
 The ledger above tracks scaffolding *this plan knowingly introduced*.
 It cannot catch the failure mode the series exists to end: a capability that ends up implemented twice, which is how the M×N problem returns.
-Every instance found so far went unnoticed precisely because no step's acceptance covered it: hand-written type-graph traversals (#334), `file://` conversion in four places, namespace tracking in two, a superseded import extractor with unmigrated callers, a declaration walk written per kind, and a lookup routine copied into every backend.
+Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (SC.3), a superseded import extractor with three unmigrated callers (SC.2).
 Each was found by an audit, not by a step.
 
 So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
 
-**What an audit looks for.** A violation of §4.11 — a single capability with more than one implementation — in the shapes this codebase actually produces them:
+**What an audit looks for.** A single capability with more than one implementation, in the shapes this codebase actually produces them:
 
 - a traversal or walk written per consumer instead of once (the #334 shape);
 - a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;
-- a seam that landed while some callers kept the old path;
+- a seam that landed while some callers kept the old path (the SC.2 shape);
 - a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256).
 
 **Scope: substantial mechanics, not one-liners.** The target is work with real substance behind it — parsing, AST traversal, symbol extraction, name and FQN construction, path/URI conversion, caching.
@@ -469,7 +446,7 @@ If neither finds something, that is a known limit of the method, not a reason to
 
 A finding is not discharged by noting it: it is either fixed in the audit slice, or it becomes a numbered slice row with an owner.
 
-**Outcome rule, and the one difference between them.** The Step 3 and Step 4 audits may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
+**Outcome rule, and the one difference between them.** The pre-cleanup audits (**S3.11**, **S4.7**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
 The terminal audit in **Step Z** may not: there, an unowned *or* unfixed duplicate is a failure, because there is no later section to own it.
 
 An audit reporting no findings must show the enumeration it ran.
@@ -486,7 +463,7 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
 - **Enforcement is complete.** Every §8.1 enforcement rule is active **repo-wide with
   zero remaining exemptions or allowlists** (the Step 2 §4.2 exemption, and any other,
   are gone). A rule still carrying a scope is an open step, not done.
-- **Conformance is repo-wide.** RFC §8's checklist passes across the whole
+- **Conformance is repo-wide.** RFC §8's 12-item checklist passes across the whole
   codebase, not merely per change.
 - **Parity is trustworthy.** The Step P harness is green **and** its branch coverage of
   the migrated surfaces is adequate — no unexercised surface branch (Step P) — and
@@ -509,10 +486,9 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
   either **fixed** or **converted to an explicitly-tracked deferred gap with an open
   issue** — none silently persists.
 - **Remaining gaps are named.** The only surviving non-conformances are the
-  explicitly-deferred, tracked ones, each with an issue: §4.7 / built-ins (Step 5, #401),
-  the workspace scope (#264/#265), the diagnostics / scheduler tier (Step 6 / #266),
-  computed-name `define()` (§3), and position encodings other than UTF-16 (#192/#371).
-  A gap not on this list is a bug, not a deferral.
+  explicitly-deferred, tracked ones, each with an issue: §4.7 / built-ins (Step 5), the
+  workspace scope (#264/#265), the diagnostics / scheduler tier (Step 6 / #266), and
+  computed-name `define()` (§3). A gap not on this list is a bug, not a deferral.
 
 Only when all seven hold is the foundation deemed complete.
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -286,10 +286,11 @@ Step 4 (Section 6).
   backend's function enumeration matches `get_defined_functions()` (as
   `TypeGraphParityTest` uses reflection for members). Revert profile: structural —
   revertible by reverting its commits, not a flag (§1).
-- **Each kind vertical consumes shared mechanism (§4.11); it does not add one.** The
-  per-kind cut is *backends × kinds*, which §5.6 requires to stay closed. S3.8a broke
-  that by adding a second declaration walk rather than using the one S3.7b had just
-  built, so the walk is unified and rule-enforced before any further kind lands.
+- **A new kind is a factory and a facade accessor, not a change to every backend**
+  (§5.6). S3.8a broke that twice over: it copied `lookupFunction` into all four
+  backends, each copy repeating one cache-key / locate / parse / store routine, and it
+  added a second declaration walk rather than using the one S3.7b had built. Both are
+  unified, and rule-enforced (§4.11), before constants would make each of them three.
 - **External-file-change invalidation gets its own slice and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -386,34 +386,23 @@ scheduler tier (§6).
 requests and is cancelable; optional components (`pcntl`, `ext-parallel`) are
 feature-detected with a synchronous fallback (Fibers / FFI may be relied on).
 
-### §8.1 mechanism inventory
+### §8.1 mechanisms and the step that owns each
 
-§8.1 requires every invariant to have a designated mechanism, so a mechanism with no
-owner is a gap this plan must either schedule or name as deferred. Only two static
-mechanisms are built today (§4.2's discovery-authority extension, §4.8's raw-params
-rule), which is why this inventory is exhaustive rather than a list of exceptions.
+§8.1 requires every invariant to have a designated mechanism, so a mechanism no
+step's acceptance covers is unowned by construction — which is why several went
+unbuilt while their steps passed. Every one is assigned here.
 
-    Invariant   Mechanism status
-    ----------  --------------------------------------------------------------
-    4.1         Architecture test: unbuilt. Scheduled.
-    4.2         Built, scoped to exempt the function path; exemption dies in 3b.
-    4.3         Static rule + single-write-path test: unbuilt. Scheduled.
-    4.4         Interface shape, holding for SymbolSource; the AST-in function
-                signature is the open violation, removed in 3b.
-    4.5         Static rule: unbuilt. Scheduled in Step 4.
-    4.6         Traversal held by TypeGraphParityTest; the no-`new`-outside-the-
-                factory rule is unbuilt, scheduled in Step 4.
-    4.7         Deferred with Step 5; tracked as an issue.
-    4.8         Built.
-    4.9         Round-trip corpus built in Step 1; interior offset use is review.
-    4.10        Review only by design — no seam exists to hold it. The defect list
-                lives in RFC 1 Appendix B (ale `textEdit` range, ale#4274).
-    4.11        Static rule: unbuilt. Scheduled, after the mechanisms it names are
-                unified, so it ships with no scope entries.
-    5.2 / 5.3   Architecture test: unbuilt. Scheduled. The write-path agreement
-                check built in 3a is a runtime assertion inside the sink, not this.
-    6           By construction: the suite runs the interior synchronously.
-    9           Built in Step 1.
+- §4.1 (handler responsibility), §4.3 (read/write segregation and the single write
+  path), and §5.2/§5.3 (precedence, cache seam, bounded coverage) are architecture
+  tests over ground Steps 2 and 3a already settled, so **Step 3's acceptance carries
+  them**. The write-path agreement check 3a built is a runtime assertion inside the
+  sink; it is not one of these.
+- §4.11's rule belongs to **Step 3** as well, and lands after the mechanisms it names
+  are unified, so it ships with no scope entries (§1).
+- §4.5, and §4.6's "no `new` of a `Type` impl outside the factory", land in **Step 4**.
+- §4.7 is **deferred with Step 5** and tracked as an issue.
+- §4.10 is review-only by design; no seam exists to hold it. The defect list lives in
+  RFC 1 Appendix B (ale `textEdit` range, ale#4274).
 
 ### Teardown ledger
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -95,7 +95,7 @@ Notes:
   perceptible (§8.4), the work moves to the deferred scheduler tier (Step 6).
 - Background/eager indexing is optional and bounded (§5.3). `WorkspaceIndexer` is
   revived only if/when the workspace scope is taken up; otherwise it is deleted — which
-  is slice **SC.1**, since it is dead today (zero references) and the workspace scope is
+  is **slice 1**, since it is dead today (zero references) and the workspace scope is
   not scheduled. Reviving it later is cheaper than carrying dead code until then.
 - On-disk backends cache **derived info** (`ClassInfo`, symbols — small), never raw
   ASTs. `ClassRepository` already does this; preserve it.
@@ -284,6 +284,10 @@ Step 4 (Section 6).
   backend's function enumeration matches `get_defined_functions()` (as
   `TypeGraphParityTest` uses reflection for members). Revert profile: structural —
   revertible by reverting its commits, not a flag (§1).
+- **Each kind vertical consumes shared mechanism (§4.11); it does not add one.** The
+  per-kind cut is *backends × kinds*, which §5.6 requires to stay closed. S3.8a broke
+  that by adding a second declaration walk rather than using the one S3.7b had just
+  built, so the walk is unified and rule-enforced before any further kind lands.
 - **External-file-change invalidation gets its own slice and acceptance**, not a
   hand-wave to §5.3 — it is a classic LSP correctness minefield.
   `workspace/didChangeWatchedFiles` (capability-gated, dynamic registration) and
@@ -401,10 +405,11 @@ row must be discharged at the Definition of Done (Step Z).
     TextFallbackHelper breadth (narrow to FQN recovery)       Step 4
     CodeResolver knowledge-facing methods                     Step 4
     A Step 0 standing cache, if built (no orphan)             Step 3a(i)
-    WorkspaceIndexer (dead today)                             SC.1
-    ScopeFinder::extractImports/resolveFromUseStatements       SC.2
-    Hand-rolled namespace tracking (SymbolExtractor,           SC.3
-      FilesystemBackend::findClassInAst)
+    FilesystemBackend per-kind declaration walks (S3.8a)      slice 5
+    §4.11 rule scope for SymbolExtractor / ScopeFinder        slices 2, 18
+    WorkspaceIndexer (dead today)                             slice 1
+    ScopeFinder::extractImports/resolveFromUseStatements       slice 18
+    Hand-rolled namespace tracking (SymbolExtractor)           slice 2
     Hand-rolled file:// conversion (4 sites)                   SC.4
 
 A scaffold with no discharged remover by Step Z is a defect, not an acceptable end
@@ -422,16 +427,16 @@ scaffold. A remover must be a slice id; a prose note is not an owner, because
 
 The ledger above tracks scaffolding *this plan knowingly introduced*.
 It cannot catch the failure mode the series exists to end: a capability that ends up implemented twice, which is how the M×N problem returns.
-Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (SC.3), a superseded import extractor with three unmigrated callers (SC.2).
+Every instance found so far went unnoticed precisely because no step's acceptance covered it — six hand-written type-graph traversals (#334), `file://` conversion in four places (SC.4), namespace tracking in two (slice 2), a superseded import extractor with three unmigrated callers (slice 18), and a per-kind declaration walk added beside the shared one (slice 5).
 Each was found by an audit, not by a step.
 
 So each major section ends with an explicit audit slice, and the terminal gate re-runs it repo-wide.
 
-**What an audit looks for.** A single capability with more than one implementation, in the shapes this codebase actually produces them:
+**What an audit looks for.** A violation of §4.11 — a single capability with more than one implementation — in the shapes this codebase actually produces them:
 
 - a traversal or walk written per consumer instead of once (the #334 shape);
 - a mechanism hand-rolled per call site — path/URI conversion, name normalization and case handling, FQN construction, memoization;
-- a seam that landed while some callers kept the old path (the SC.2 shape);
+- a seam that landed while some callers kept the old path (the slice 18 shape);
 - a branch per kind, per handler, or per node type where one generic path should serve (#190, #253, #256).
 
 **Scope: substantial mechanics, not one-liners.** The target is work with real substance behind it — parsing, AST traversal, symbol extraction, name and FQN construction, path/URI conversion, caching.
@@ -446,7 +451,7 @@ If neither finds something, that is a known limit of the method, not a reason to
 
 A finding is not discharged by noting it: it is either fixed in the audit slice, or it becomes a numbered slice row with an owner.
 
-**Outcome rule, and the one difference between them.** The pre-cleanup audits (**S3.11**, **S4.7**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
+**Outcome rule, and the one difference between them.** The pre-cleanup audits (**slices 12 and 20**) may *track* rather than fix — they pass when every finding has an owner, because a removal that belongs to a later section should not be dragged forward into this one.
 The terminal audit in **Step Z** may not: there, an unowned *or* unfixed duplicate is a failure, because there is no later section to own it.
 
 An audit reporting no findings must show the enumeration it ran.
@@ -486,9 +491,10 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
   either **fixed** or **converted to an explicitly-tracked deferred gap with an open
   issue** — none silently persists.
 - **Remaining gaps are named.** The only surviving non-conformances are the
-  explicitly-deferred, tracked ones, each with an issue: §4.7 / built-ins (Step 5), the
-  workspace scope (#264/#265), the diagnostics / scheduler tier (Step 6 / #266), and
-  computed-name `define()` (§3). A gap not on this list is a bug, not a deferral.
+  explicitly-deferred, tracked ones, each with an issue: §4.7 / built-ins (Step 5, #401),
+  the workspace scope (#264/#265), the diagnostics / scheduler tier (Step 6 / #266),
+  computed-name `define()` (§3), and position encodings other than UTF-16 (#192/#371).
+  A gap not on this list is a bug, not a deferral.
 
 Only when all seven hold is the foundation deemed complete.
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -4,12 +4,12 @@
     Driver:   build-procedure.md
     Plan:     0002-execution-plan.md
 
-The ordered list of build steps, derived from the plan.
+The ordered list of build slices, derived from the plan.
 Goals, requirements and acceptance criteria live in 0002 and RFC 1; this file adds only the order.
 
-Work top to bottom: a row may start once every row above it is merged.
-Progress is not recorded here — a row's status is whether a merged PR exists for `slice/<ID>` (see `build-procedure.md`).
-**Step** names the plan step in 0002 whose acceptance criteria the row must meet.
+Work top to bottom: a slice may start once every slice above it is merged.
+Progress is not recorded here — a slice's status is whether a merged PR exists for `slice/<ID>` (see `build-procedure.md`).
+**Step** names the plan step in 0002 whose acceptance criteria the slice must meet.
 
 Append later phases as they are reached; do not create the whole tree up front.
 
@@ -93,8 +93,8 @@ Append later phases as they are reached; do not create the whole tree up front.
 
 ## Deferred (not scheduled; excluded from selection until reached)
 
-A row with satisfiable dependencies is pickable, so these are kept out of the table until their phase is reached.
-Each is appended as ordered rows at that point.
+A row in the table is pickable, so these are kept out of it until their phase is reached.
+Each is appended as ordered slices at that point.
 
 - **Step 5 — environment-parameterized built-ins (§4.7).** Blocked on an open decision: its version-aware source is TBD (0002 §7). Tracked as #401.
 - **Step 6 — scheduler / async tier.** Deferred until a push feature needs it (#266).

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -1,312 +1,79 @@
-# Build Manifest (slice registry)
+# Build Manifest (ordered checklist)
 
     Status:   Draft — seeded through Wave 2 (Steps 3, 4, Z; Steps 5, 6 deferred)
     Driver:   build-procedure.md
     Plan:     0002-execution-plan.md
 
-This is a **static** registry of build slices. It records *what* the slices are and
-how they depend on each other; it does **not** record progress — a slice's status is
-computed from whether its PR (`slice/<id>`) is merged (see `build-procedure.md`).
+The ordered list of build slices, derived from the plan.
+Goals, requirements and acceptance criteria live in 0002 and RFC 1; this file adds only the order.
+
+Work top to bottom.
+Order is the sequencing: a row may be started once every row above it is merged.
+A slice's status is not recorded here — it is whether a merged PR exists for `slice/<ID>` (see `build-procedure.md`).
+
+**Step** names the plan step whose acceptance criteria the slice must meet.
+A slice with no step removes pre-existing duplication or dead code that no step's acceptance covers.
 
 Append later phases as they are reached; do not create the whole tree up front.
 
-## Columns
-
-- **ID** — the branch is `slice/<ID>`. Ids ascend with table position. An id freezes
-  once a branch exists for it — built or in flight — and the rows above the first
-  unbuilt one keep the ids they were built under; unbuilt rows renumber when one is
-  inserted among them, since nothing references them yet.
-- **Row order.** Table order is the build order, and `/do-next` takes the first
-  unblocked `todo` in it. Unbuilt rows are placed to read in sequence, with dead and
-  duplicated code removed ahead of the work that would otherwise have to read past it.
-- **Step** — the plan step in 0002 that owns the acceptance criteria.
-- **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
-  exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
-  means every *other* slice whose Step column is `N` (sub-steps included, so `all Step
-  3` covers 3a and 3b), and **`all prior`** means every other slice in the table.
-  Gates use these; ordinary slices name ids.
-- **Closes** — pre-existing issues this slice closes, *after reviewer verification*.
-
 ## Wave 1 — Steps 0, 1, P, 2
 
-    ID     Step  Title                                              Depends on        Closes
-    -----  ----  -------------------------------------------------  ----------------  -------
-    S0.1   0     Instrument parse count/time; run the spike         —                 —
-    S0.2   0     Request-scoped parse dedup (if spike warrants)     S0.1              —
-    S1.1   1     Read ClientCapabilities -> SessionCapabilities     —                 —
-    S1.2   1     Negotiate positionEncoding; convert at the edge    S1.1              #192
-    S1.3   1     Shape hover markup / snippets via capabilities     S1.1              #22
-    S1.4   1     Lifecycle state + malformed-frame robustness       S1.1              —
-    S1.5   1     Position round-trip corpus (regression net)        S1.2              —
-    SP.1   P     Per-surface parity harness + branch-coverage gate  —                 —
-    S2.1   2     Define SymbolSource/SymbolSink + delegating facade SP.1              —
-    S2.2   2     Migrate ClassCandidates -> search                  S2.1              —
-    S2.3   2     Migrate NamespaceCandidates -> childrenOf          S2.1              —
-    S2.4   2     Migrate SymbolResolver class lookups -> lookupClassLike  S2.1        —
-    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink      S2.1              —
-    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo) S2.2,S2.3,S2.4,S2.5  —
-
-Notes:
-
-- `NamespaceName` typed identifier is needed by S2.3 (`childrenOf`); land it within
-  that slice or as its immediate predecessor.
-- Steps 0, 1, and P are mutually independent and may run in any order; Step 2 is
-  gated on the parity harness (SP.1).
-- Wave 2 (Steps 3, 4, Z) is decomposed below, appended now that S2.* is `done`. Steps
-  5 and 6 remain deferred (see the Deferred note under Wave 2).
+    ID     Step  Title
+    -----  ----  -------------------------------------------------
+    S0.1   0     Instrument parse count/time; run the spike
+    S0.2   0     Request-scoped parse dedup (if spike warrants)
+    S1.1   1     Read ClientCapabilities -> SessionCapabilities
+    S1.2   1     Negotiate positionEncoding; convert at the edge
+    S1.3   1     Shape hover markup / snippets via capabilities
+    S1.4   1     Lifecycle state + malformed-frame robustness
+    S1.5   1     Position round-trip corpus (regression net)
+    SP.1   P     Per-surface parity harness + branch-coverage gate
+    S2.1   2     Define SymbolSource/SymbolSink + delegating facade
+    S2.2   2     Migrate ClassCandidates -> search
+    S2.3   2     Migrate NamespaceCandidates -> childrenOf
+    S2.4   2     Migrate SymbolResolver class lookups -> lookupClassLike
+    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink
+    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo)
 
 ## Wave 2 — Steps 3, 4, Z
 
-Step 3 is one plan step with two halves: **3a** is behavior-preserving (proven by the
-Step P harness — parity fixtures first), **3b** both preserves and extends the function
-surface (existing behavior frozen to a golden; new project reach proven by new
-fixtures). The `Step` column carries the half, since 3a and 3b own distinct acceptance
-criteria in 0002. Step 4 decomposes `SymbolResolver`; Step Z is the terminal
-Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (slices 13 and
-21), which Step Z re-runs repo-wide as its completion gate.
+    ID     Step  Title
+    -----  ----  -------------------------------------------------
+    S3.1   3a    Existing caches -> replaceable §5.3 seam (verify)
+    S3.2   3a    Dedupe the duplicate ComposerAutoloadMap
+    S3.3   3a    Named backends + fixed-precedence composite
+    S3.4   3a    One parse / one write path + consistency check
+    S3.5   3a    External-file-change invalidation
+    S3.6   3b    Function-surface golden + Builtin enum oracle
+    S3.7a  3b    Read autoload.files into ComposerAutoloadMap
+    S3.7b  3b    Scan a file for the declarations it makes
+    S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator
+    S3.7d  3b    Derived autoload.files index, for all three kinds
+    S3.7e  3b    Enumerate the derived index in childrenOf
+    SC.4   —     Dedupe the hand-rolled file:// conversion
+    S3.8a  3b    lookupFunction project reach
+    1      —     Delete the dead WorkspaceIndexer
+    2      —     SymbolExtractor -> the parser's namespacedName
+    3      —     §4.1 handler-responsibility architecture test
+    4      —     §4.3 read/write segregation rule
+    5      3b    One declaration walk; backends consume it
+    6      3b    One backend lookup: resolve(name, kind)
+    7      3b    §8.1 rule: one owner per shared mechanism
+    8      3b    Retire the AST-in function lookup from consumers
+    9      3b    Generalize search to a kind parameter
+    10     3b    Function search + FunctionCandidates migration
+    11     3b    Constant reach: lookup, search, enumeration
+    12     3b    Remove §4.2 fn-path exemption; retire scaffolding
+    13     3     Step 3 duplication audit
+    14     4     TypeClassifier + §4.5/§4.6 static rules
+    15     4     Extract node locator + scope analyzer
+    16     4     Extract member-access + call-context detectors
+    17     4     Extract name-context resolver
+    18     4     Narrow TextFallbackHelper to FQN recovery
+    19     —     Retire ScopeFinder's superseded import extraction
+    20     4     SymbolResolver -> glue; CodeResolver positional
+    21     4     Step 4 duplication audit
+    22     Z     Definition of Done gate + repo-wide dup audit
 
-    ID     Step  Title                                              Depends on        Closes
-    -----  ----  -------------------------------------------------  ----------------  -------
-    S3.1   3a    Existing caches -> replaceable §5.3 seam (verify)  S2.6              —
-    S3.2   3a    Dedupe the duplicate ComposerAutoloadMap           S2.6              —
-    S3.3   3a    Named backends + fixed-precedence composite        S3.1,S3.2         —
-    S3.4   3a    One parse / one write path + consistency check     S3.3              —
-    S3.5   3a    External-file-change invalidation                  S3.3,S3.4         —
-    S3.6   3b    Function-surface golden + Builtin enum oracle      S3.3              —
-    S3.7a  3b    Read autoload.files into ComposerAutoloadMap       S3.3              —
-    S3.7b  3b    Scan a file for the declarations it makes          S3.3              —
-    S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator        S3.3,SC.4         —
-    S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
-    S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
-    S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    SC.4   —     Dedupe the hand-rolled file:// conversion          —                 —
-    1      —     Delete the dead WorkspaceIndexer                   —                 —
-    2      —     SymbolExtractor -> the parser's namespacedName     —                 —
-    3      —     §4.1 handler-responsibility architecture test      —                 —
-    4      —     §4.3 read/write segregation rule                   —                 —
-    5      3b    One declaration walk; backends consume it          S3.8a             —
-    6      3b    One backend lookup: resolve(name, kind)            5                 —
-    7      3b    §8.1 rule: one owner per shared mechanism          6                 —
-    8      3b    Retire the AST-in function lookup from consumers   5                 —
-    9      3b    Generalize search to a kind parameter              6                 —
-    10     3b    Function search + FunctionCandidates migration     7,9               —
-    11     3b    Constant vertical: lookup, search, enumeration     7,9               —
-    12     3b    Remove §4.2 fn-path exemption; retire scaffolding  8,10,11           —
-    13     3     Step 3 duplication audit                           all Step 3        —
-    14     4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
-    15     4     Extract node locator + scope analyzer              8,14              —
-    16     4     Extract member-access + call-context detectors     15                —
-    17     4     Extract name-context resolver                      15                —
-    18     4     Narrow TextFallbackHelper to FQN recovery          16,17             —
-    19     —     Retire ScopeFinder's superseded import extraction  17,18             —
-    20     4     SymbolResolver -> glue; CodeResolver positional    15,16,17,18       —
-    21     4     Step 4 duplication audit                           all Step 4        —
-    22     Z     Definition of Done gate + repo-wide dup audit      all prior         —
-
-Notes:
-
-- **S3.1 is verify-then-seam.** The Step 0 spike (0002 §8.5 decision 2) declined a
-  standing parse cache; it is *not* built here. S3.1 moves the two existing hand-rolled
-  memoizations — `DefaultClassRepository::$cache` (ClassInfo by FQN) and
-  `CachedNamespaceCatalog::$cache` (stable-source `childrenOf`) — behind the §5.3
-  replaceable seam, and each cache kept must demonstrably drop a parse / source call on
-  a hit (asserted via `ParseMetrics`); one that cannot is removed, not wrapped.
-- **S3.7 is four slices, cut where Composer's own data divides.** A single slice was
-  built first (PR #388, 622 src lines over 17 files) and was too large to review as
-  one unit. The seam it missed is already in the code: a lookup against the autoload
-  maps is arithmetic on the name (`findFile`, five lines — the old
-  `ComposerClassLocator` verbatim), while anything an `autoload.files` entry declares
-  has no name→file map of any kind and must derive one by parsing that set. The cut
-  is therefore by *route*, not by symbol kind — class-likes use both routes. So
-  **S3.7c generalizes the shape** — the
-  kind-agnostic `SymbolLocator` interface, `QualifiedName`, and the class-like branch
-  — which is behavior-preserving and proven by the existing class-like-lookup golden;
-  **S3.7d adds the reach**, which is new behavior proven by new fixtures. S3.7a and
-  S3.7b are the two independent inputs S3.7d consumes (the autoload map's `files`
-  section; the per-file declaration scan) and have no dependency on each other.
-  - **S3.7e closes the surface, not just the lookup.** S3.7d makes a `files`-declared
-    name resolvable by `lookupClassLike`, but `childrenOf` still enumerates by listing
-    a PSR-4 directory, which these files sit outside — so the name resolves on hover
-    and definition while never appearing in namespace completion. That split is the
-    inconsistency this series exists to prevent (#190, #253, #256), and it is why the
-    gap is a slice rather than a documented limitation. The data is already there: the
-    derived index knows every name each entry declares, so this is wiring enumeration
-    onto it, not a second scan. Found while reviewing S3.7d, which delivered the lookup
-    half only.
-- **A kind is cut at the facade, never across the backends.** `SymbolSource` keeps a
-  typed method per kind — three, closed, because PHP has three symbol namespaces (0002
-  §5.6) — while `SymbolBackend` takes the kind as a parameter. The dividing rule: kind
-  is a parameter where the return type does not vary with it, a method where it does.
-  So a new kind is a factory plus a facade accessor, never a method added to all four
-  backends. S3.8a did the latter, copying `lookupFunction` into every backend with the
-  same cache-key / locate / parse / store routine inside each; slice 6 undoes it before
-  constants would make that three. Slice 8 migrates the consumers (`SymbolResolver`,
-  `BasicTypeResolver`) off `FunctionRepository::get(string, array $ast)` — it is the
-  Step 3b slice that edits `SymbolResolver`, so it, not S3.8a, is what slice 15
-  serializes against (§6).
-  Search already follows the rule, since one return type serves every kind: **slice 9**
-  widens `searchClassLikes` to `search(string $prefix, NameKind $kind)` with class-likes
-  still the only searchable kind, which is behavior-preserving and leaves every Step P
-  golden frozen; **slice 10**
-  makes the backends answer function search and moves `FunctionCandidates` onto it,
-  rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
-  answer function search in slice 10 or built-in function completion regresses — that
-  golden is what catches it.
-- **A kind consumes shared mechanism; it MUST NOT add one** (RFC §4.11). S3.8a added
-  both shapes of copy: `parseFunctionFrom` beside `FilesystemBackend::findClassInAst`
-  instead of using `DeclarationScanner` (the whole-file walk S3.7b had built one slice
-  earlier), and a per-kind `lookupFunction` on every backend, each repeating one
-  cache-key / locate / parse / store routine. Slices 5 and 6 undo them; slice 7 is
-  what stops the next one.
-  - **Slice 5** gives the later kinds something to consume: one walk yielding
-    each declaration *with its node*, since needing the node for `ClassInfoFactory` /
-    `FunctionInfo::fromNode` is a return-shape difference, not a second query.
-    Every walk answering "what does this file declare" is deleted:
-    `FilesystemBackend`'s `parseFunctionFrom` and `findClassInAst`, and
-    `DocumentSymbolSink`'s `functionsIn` and `classesIn`. The write path is not
-    optional here — it is the open-document backend's, so leaving it out would land a
-    slice titled "backends consume it" where one backend does not. It is also where the
-    split already shows: `functionsIn` reports a declaration at any depth while
-    `classesIn` reads top-level statements only, which is the §4.2 coverage split
-    inside one class. Behavior-preserving for lookup, so the class-like-lookup and S3.6
-    function-surface goldens stay frozen; the class-like depth change is new behavior on
-    the write path, proven by a fixture and a rewritten Step P write-path golden.
-  - **Slice 6** collapses the per-kind backend lookups into one
-    `resolve(QualifiedName, NameKind)` returning the located declaration, with the typed
-    `ClassInfo` / `FunctionInfo` built at the facade from the existing factories (0002
-    §5.6). `SymbolSource` is untouched: its typed per-kind methods are what consumers
-    call, and a name type carrying its own kind is stronger than a name plus an enum.
-    `CompositeSymbolSource`'s two identical first-wins loops become one,
-    `OpenDocumentBackend`'s two maps become one keyed by kind, and `FilesystemBackend`'s
-    duplicated cache-key / locate / parse / store routine becomes one — leaving
-    `BuiltinBackend`'s three-way `match` as the only kind branch, because reflection
-    itself is per-kind. Behavior-preserving, and the class-like-lookup and S3.6
-    function-surface goldens already freeze this surface, so it needs no new fixtures.
-  - **Slice 7** adds the rule, per 0002 §Duplication audits ("an audit's first *fix* is
-    to add the rule"): one named owner per shared mechanism, the owners named in the
-    rule's own configuration (RFC §8.1). Every AST traversal in `src/` must be
-    classified by it, so the disposition of all of them is fixed here rather than
-    discovered mid-slice:
-    - **Owners.** `DeclarationScanner` (declaration walk, after slice 5);
-      `NodeAtPosition`, `Scope`, `ScopeFinder` (positional walks — a different
-      mechanism, not exemptions); `ParserService` (the `NameResolver` pass every parse
-      runs through); `BasicTypeResolver` (assignment-flow walk, its own mechanism).
-      Slice 6 leaves the backend lookup-and-memoize routine with a single owner too, so
-      the rule names one rather than allowlisting four copies.
-    - **Declared migrations**, each already carrying a remover: `SymbolExtractor`
-      (slice 2), `ScopeFinder`'s import extraction (slice 19), `DefaultFunctionRepository`
-      (slice 12, which deletes the AST-in signature), `SymbolResolver`'s own walks
-      (slice 20, which reduces it to glue).
-    - No allowlist entry may be added without a remover slice, since slice 22 requires
-      zero remaining scope.
-  - **Slice 11** lands constants whole rather than lookup-first: splitting a kind across
-    a lookup slice and a later search slice is what produced S3.7e, and RFC §4.2 requires
-    identical coverage across the two. After slices 6 and 9 it is a `ConstantName`, a
-    factory, a facade accessor, and one arm in `BuiltinBackend`'s match — no backend
-    grows a method. Enumeration is likely already satisfied by S3.7e's per-declaration
-    `NameKind`, making it a fixture to prove rather than code to write; offering
-    constants at expression start (#317) is a feature on this reach and stays out of
-    scope.
-- **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
-  of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
-  Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
-  whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
-  `ConstantName` in **slice 11**, with their lookups.
-  - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
-    name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
-    slice 11 rather than inside it — this is the same coexistence question §7 leaves open
-    for `ClassLikeName` versus `ClassName`.
-- **Steps 3 and 4 both edit `SymbolResolver` (§6).** Slice 15 (positional extraction) is
-  gated on slice 8 (the 3b lookup migration) so the two never run concurrently; manifest
-  order keeps Step 3 ahead of Step 4 regardless. Slice 14 (`TypeClassifier` + the
-  §4.5/§4.6 rules) is independent of Step 3 and may proceed alongside.
-- **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
-  Step 2 double-write facade and (if built) the Step 0 cache rider; slice 5 the bespoke
-  declaration walks; slice 6 the per-kind backend lookups; slice 12 the §4.2
-  function-path exemption, `getFileFunctions`, and the `DefaultFunctionRepository`
-  AST-in signature; slices 18 and 20 the `SymbolResolver` god class,
-  `TextFallbackHelper` breadth, and the `CodeResolver` knowledge-facing methods.
-  Slice 22 verifies the ledger is fully discharged.
-- **Stepless rows carry no step, on purpose.** They are duplication, dead code, and
-  missing enforcement that no step's acceptance covers — which is exactly how they went
-  unowned until an audit found them. They are in the table so `/do-next` can select them
-  and slice 22 can require them. A removal with no owning slice is a defect; put it here,
-  at the top of the pending block (see Row order).
-  - **Slice 1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`.
-  - **Slice 2** — `SymbolExtractor` hand-tracks `Stmt\Namespace_` to build FQNs that
-    `NameResolver` already computed into `namespacedName` (which `DefaultClassInfoFactory`,
-    `DefaultFunctionRepository`, `ScopeFinder`, and `DeclarationScanner` all read).
-    Behavior-preserving, so the Step P write-path golden proves it. `SymbolExtractor`'s
-    `Class::method` FQNs are its own and stay. The other site this once covered,
-    `FilesystemBackend::findClassInAst`, is removed by slice 5 independently.
-  - **Slices 3 and 4** — §8.1 names an enforcement mechanism per invariant and slice 22
-    requires every one active repo-wide, so a mechanism with no owning slice is a gate
-    that cannot pass. `phpstan.neon` registers two rules today (§4.2, §4.8); §4.1
-    (handlers depend on no parser, repository, or reflection) and §4.3 (consumers depend
-    on `SymbolSource` / `SymbolSink`, never a concrete implementation) have none. §4.1 is
-    the axis closed by #190/#253/#256 and held by documentation ever since, which §8.1
-    forbids; §4.3's seam is Step 2's, whose acceptance named only the §4.2 rule, so it is
-    a late Step 2 obligation rather than pre-existing debt (0002 §Teardown ledger).
-    Each is a rule plus its `RuleTestCase`, not a migration: §4.1 is green in `src/`, and
-    §4.3 is green once the rule scopes "consumer" to code outside the knowledge and index
-    tiers — `Server.php` and `KnowledgeStack` are composition roots, and
-    `WorkspaceNamespaceSource`, `OpenDocumentBackend` and `DocumentIndexer` are inside
-    the tier that owns the concrete stores. Fix that scope in the slice; a wider reading
-    turns slice 4 into a migration it is not planned as.
-  - **Slice 19** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were
-    superseded by `NameContextFactory` and their own docblock says they go away once #331
-    moves the callers. #331 landed (#337); three callers did not move (`SymbolResolver`
-    ×2, `TextFallbackHelper` ×1). Gated on slices 17 and 18, which rewrite those sites.
-  - **SC.4** — `file://` URI and path conversion was hand-rolled in four live places, each
-    differing in how it handled the scheme and percent-encoding. One `FileUri` replaced
-    them. Found while splitting S3.7, whose locator wanted a fifth copy.
-- **Each section ends with a duplication audit** (**slices 13 and 21**), and Step Z's
-  acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
-  in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
-  not restated here, because a manifest note is not a gate.
-  - Slices 13 and 21 are **tracking** gates: a finding may be handed to a new slice
-    rather than fixed in place, so a removal belonging to a later section is not dragged
-    forward. Slice 22 is the **completion** gate, where an unowned or unfixed duplicate
-    fails outright.
-  - The three depend on their whole section (`all Step N` / `all prior`) rather than on
-    its last slice. A chain of ids is both stale-prone and wrong: slice 12's transitive
-    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on slice 12 could have
-    run with two of its slices unbuilt.
-- **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
-  §4.7** (0002 §5 known gap), tracked as #401; its fix is the deferred Step 5.
-- **`Closes` is assigned at slice-issue creation, after a reviewer reads the issue —
-  never inferred.** Candidates from Wave 1's note: #239 / #181 / #317 land somewhere in
-  S3.7a–slice 12; #295 (Visibility enum) wants a small cleanup slice not yet placed.
-  - **#181 covers all three kinds**, which is now what S3.7b–S3.7d build: the
-    `files` set has no name→file map of any kind, so it is scanned whole. A slice
-    claiming #181 must show class-like reach, not just functions and constants.
-    - **#181 is not closable before slice 10.** Its acceptance asks for these symbols in
-      *hover and completion*, not merely resolvable: functions need S3.8a and slice 10,
-      constants slice 11, namespace completion S3.7e. It also asks for a startup-time
-      benchmark, which S3.7d's eager index makes a live question rather than a
-      formality — S3.7d pins the parse *count*, which is not the same measurement.
-      Read the issue body before wiring `Closes`; the reach landing is not the
-      criteria being met.
-
-### Deferred (not scheduled; excluded from `/do-next` until reached)
-
-Kept out of the table above on purpose: a `todo` row with satisfiable dependencies is
-pickable, and neither of these should be picked yet. They are appended as real slices
-when their phase is reached.
-
-- **Step 5 — environment-parameterized built-ins (§4.7).** Not plannable: its
-  version-aware source is an open `TBD` (0002 §7, explicitly not `phpstorm-stubs`). The
-  interim reflection Builtin backend already ships in S3.3; §4.7 is tracked as **#401**.
-  Nothing depends on Step 5, and slice 22 permits it to remain a named gap.
-- **Position encodings other than UTF-16 (#192, #371).** The boundary conversion and the
-  interior byte columns are done (S1.2, S1.5), but the negotiated encoding does not reach
-  `TextDocument`, so only the UTF-16 default is served. A client-compatibility feature
-  rather than foundation work: [LSP] requires UTF-16 support and the encoding is
-  negotiated, so a client offering nothing else is served correctly today. Slice 22
-  permits it as a named gap.
-- **Step 6 — scheduler / async tier (#266).** Deferred until a push feature needs it.
-  Sketch, from its acceptance: `$/cancelRequest` cancellation of superseded work;
-  debounced `publishDiagnostics` on change; a background scheduler that does not starve
-  interactive requests and is cancelable, feature-detecting `pcntl` / `ext-parallel`
-  with a synchronous fallback. Appended as slices when a push feature (or #266) takes
-  it up.
+Steps 5 (environment-parameterized built-ins) and 6 (scheduler / async tier) are deferred and carry no slices; see 0002.
+Position encodings other than UTF-16 (#192, #371) are likewise deferred: UTF-16 is what LSP requires and the encoding is negotiated, so a client offering nothing else is served correctly.

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -1,6 +1,6 @@
 # Build Manifest (ordered checklist)
 
-    Status:   Draft — seeded through Wave 2 (Steps 3, 4, Z; Steps 5, 6 deferred)
+    Status:   In-Flight
     Driver:   build-procedure.md
     Plan:     0002-execution-plan.md
 
@@ -35,7 +35,7 @@ Append later phases as they are reached; do not create the whole tree up front.
     S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink
     S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo)
 
-## Wave 2 — Steps 3, 4, Z
+## Wave 2 — Steps 3, C
 
     ID     Step  Title
     -----  ----  -------------------------------------------------
@@ -52,6 +52,11 @@ Append later phases as they are reached; do not create the whole tree up front.
     S3.7e  3b    Enumerate the derived index in childrenOf
     SC.4   —     Dedupe the hand-rolled file:// conversion
     S3.8a  3b    lookupFunction project reach
+
+## Wave 3
+
+    ID     Step  Title
+    -----  ----  -------------------------------------------------
     1      —     Delete the dead WorkspaceIndexer
     2      —     SymbolExtractor -> the parser's namespacedName
     3      —     §4.1 handler-responsibility architecture test

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -1,236 +1,101 @@
-# Build Manifest (slice registry)
+# Build Manifest (ordered checklist)
 
-    Status:   Draft — seeded through Wave 2 (Steps 3, 4, Z; Steps 5, 6 deferred)
+    Status:   Draft — Wave 3 open
     Driver:   build-procedure.md
     Plan:     0002-execution-plan.md
 
-This is a **static** registry of build slices. It records *what* the slices are and
-how they depend on each other; it does **not** record progress — a slice's status is
-computed from whether its PR (`slice/<id>`) is merged (see `build-procedure.md`).
+The ordered list of build steps, derived from the plan.
+Goals, requirements and acceptance criteria live in 0002 and RFC 1; this file adds only the order.
+
+Work top to bottom: a row may start once every row above it is merged.
+Progress is not recorded here — a row's status is whether a merged PR exists for `slice/<ID>` (see `build-procedure.md`).
+**Step** names the plan step in 0002 whose acceptance criteria the row must meet.
 
 Append later phases as they are reached; do not create the whole tree up front.
 
-## Columns
-
-- **ID** — stable slice id; the branch is `slice/<ID>`.
-- **Step** — the plan step in 0002 that owns the acceptance criteria.
-- **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
-  exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
-  means every *other* slice whose Step column is `N` (sub-steps included, so `all Step
-  3` covers 3a and 3b), and **`all prior`** means every other slice in the table.
-  Gates use these; ordinary slices name ids.
-- **Closes** — pre-existing issues this slice closes, *after reviewer verification*.
-
 ## Wave 1 — Steps 0, 1, P, 2
 
-    ID     Step  Title                                              Depends on        Closes
-    -----  ----  -------------------------------------------------  ----------------  -------
-    S0.1   0     Instrument parse count/time; run the spike         —                 —
-    S0.2   0     Request-scoped parse dedup (if spike warrants)     S0.1              —
-    S1.1   1     Read ClientCapabilities -> SessionCapabilities     —                 —
-    S1.2   1     Negotiate positionEncoding; convert at the edge    S1.1              #192
-    S1.3   1     Shape hover markup / snippets via capabilities     S1.1              #22
-    S1.4   1     Lifecycle state + malformed-frame robustness       S1.1              —
-    S1.5   1     Position round-trip corpus (regression net)        S1.2              —
-    SP.1   P     Per-surface parity harness + branch-coverage gate  —                 —
-    S2.1   2     Define SymbolSource/SymbolSink + delegating facade SP.1              —
-    S2.2   2     Migrate ClassCandidates -> search                  S2.1              —
-    S2.3   2     Migrate NamespaceCandidates -> childrenOf          S2.1              —
-    S2.4   2     Migrate SymbolResolver class lookups -> lookupClassLike  S2.1        —
-    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink      S2.1              —
-    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo) S2.2,S2.3,S2.4,S2.5  —
+    ID     Step  Title
+    -----  ----  ---------------------------------------------------
+    S0.1   0     Instrument parse count/time; run the spike
+    S0.2   0     Request-scoped parse dedup
+    S1.1   1     Read ClientCapabilities -> SessionCapabilities
+    S1.2   1     Negotiate positionEncoding; convert at the edge
+    S1.3   1     Shape hover markup / snippets via capabilities
+    S1.4   1     Lifecycle state + malformed-frame robustness
+    S1.5   1     Position round-trip corpus
+    SP.1   P     Per-surface parity harness + coverage gate
+    S2.1   2     Define SymbolSource/SymbolSink + delegating facade
+    S2.2   2     Migrate ClassCandidates -> search
+    S2.3   2     Migrate NamespaceCandidates -> childrenOf
+    S2.4   2     Migrate SymbolResolver lookups -> lookupClassLike
+    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink
+    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo)
 
-Notes:
+## Wave 2 — Steps 3a, 3b
 
-- `NamespaceName` typed identifier is needed by S2.3 (`childrenOf`); land it within
-  that slice or as its immediate predecessor.
-- Steps 0, 1, and P are mutually independent and may run in any order; Step 2 is
-  gated on the parity harness (SP.1).
-- Wave 2 (Steps 3, 4, Z) is decomposed below, appended now that S2.* is `done`. Steps
-  5 and 6 remain deferred (see the Deferred note under Wave 2).
+    ID     Step  Title
+    -----  ----  ---------------------------------------------------
+    S3.1   3a    Existing caches -> replaceable §5.3 seam
+    S3.2   3a    Dedupe the duplicate ComposerAutoloadMap
+    S3.3   3a    Named backends + fixed-precedence composite
+    S3.4   3a    One parse / one write path + consistency check
+    S3.5   3a    External-file-change invalidation
+    S3.6   3b    Function-surface golden + Builtin enum oracle
+    SC.4   3     Dedupe the hand-rolled file:// conversion
+    S3.7a  3b    Read autoload.files into ComposerAutoloadMap
+    S3.7b  3b    Scan a file for the declarations it makes
+    S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator
+    S3.7d  3b    Derived autoload.files index, for all three kinds
+    S3.7e  3b    Enumerate the derived index in childrenOf
+    S3.8a  3b    lookupFunction project reach
 
-## Wave 2 — Steps 3, 4, Z
+## Wave 3 — Steps 3, 4, Z
 
-Step 3 is one plan step with two halves: **3a** is behavior-preserving (proven by the
-Step P harness — parity fixtures first), **3b** both preserves and extends the function
-surface (existing behavior frozen to a golden; new project reach proven by new
-fixtures). The `Step` column carries the half, since 3a and 3b own distinct acceptance
-criteria in 0002. Step 4 decomposes `SymbolResolver`; Step Z is the terminal
-Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (S3.11,
-S4.7), which Step Z re-runs repo-wide as its completion gate.
+    ID  Step  Title
+    --  ----  ---------------------------------------------------
+    1   3     Delete the dead WorkspaceIndexer
+    2   3     §4.1 handler-responsibility architecture test
+    3   3     §4.3 read/write segregation rule
+    4   3     §4.3 single-write-path architecture test
+    5   3     §5.3 backend precedence + cache-seam test
+    6   3b    One walk reports a file's declarations with nodes
+    7   3b    FilesystemBackend consumes the one walk
+    8   3b    DocumentSymbolSink consumes the one walk
+    9   3b    Register class-likes at any depth on the write path
+    10  3b    SymbolExtractor consumes the one walk
+    11  3b    One backend lookup: resolve(name, kind)
+    12  3b    Kind-agnostic locate at the facade
+    13  3     §4.11 rule: one owner per shared mechanism
+    14  3b    Retire the AST-in function lookup from consumers
+    15  3b    Generalize search to a kind parameter
+    16  3b    Answer function search in every backend
+    17  3b    Migrate FunctionCandidates; retire getFileFunctions
+    18  3b    Settle the two ConstantName types
+    19  3b    lookupConstant project reach
+    20  3b    Constant search and enumeration
+    21  3b    Report bounded search coverage
+    22  3b    Remove the §4.2 function-path exemption
+    23  3     Step 3 duplication audit
+    24  4     TypeClassifier owns the predicates
+    25  4     §4.5 rule: no kind branching, no Type instanceof
+    26  4     §4.6 rule: no `new` of a Type outside the factory
+    27  4     Extract the node locator
+    28  4     Extract the scope analyzer
+    29  4     Extract the member-access detector
+    30  4     Extract the call-context detector
+    31  4     Extract the name-context resolver
+    32  4     Retire ScopeFinder's superseded import extraction
+    33  4     Narrow TextFallbackHelper to FQN recovery
+    34  4     SymbolResolver -> glue; CodeResolver positional
+    35  4     Step 4 duplication audit
+    36  Z     Definition of Done gate
 
-    ID     Step  Title                                              Depends on        Closes
-    -----  ----  -------------------------------------------------  ----------------  -------
-    S3.1   3a    Existing caches -> replaceable §5.3 seam (verify)  S2.6              —
-    S3.2   3a    Dedupe the duplicate ComposerAutoloadMap           S2.6              —
-    S3.3   3a    Named backends + fixed-precedence composite        S3.1,S3.2         —
-    S3.4   3a    One parse / one write path + consistency check     S3.3              —
-    S3.5   3a    External-file-change invalidation                  S3.3,S3.4         —
-    S3.6   3b    Function-surface golden + Builtin enum oracle      S3.3              —
-    S3.7a  3b    Read autoload.files into ComposerAutoloadMap       S3.3              —
-    S3.7b  3b    Scan a file for the declarations it makes          S3.3              —
-    S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator        S3.3,SC.4         —
-    S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
-    S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
-    S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    S3.8b  3b    lookupConstant project reach                       S3.7d             —
-    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —
-    S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
-    S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
-    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
-    S3.11  3     Step 3 duplication audit                          all Step 3        —
-    S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
-    S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
-    S4.3   4     Extract member-access + call-context detectors     S4.2              —
-    S4.4   4     Extract name-context resolver                      S4.2              —
-    S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
-    S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
-    S4.7   4     Step 4 duplication audit                          all Step 4        —
-    SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
-    SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
-    SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
-    SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
-    SC.5   —     Merge the two class-like AST traversals             SC.3              —
-    SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
+## Deferred (not scheduled; excluded from selection until reached)
 
-Notes:
+A row with satisfiable dependencies is pickable, so these are kept out of the table until their phase is reached.
+Each is appended as ordered rows at that point.
 
-- **S3.1 is verify-then-seam.** The Step 0 spike (0002 §8.5 decision 2) declined a
-  standing parse cache; it is *not* built here. S3.1 moves the two existing hand-rolled
-  memoizations — `DefaultClassRepository::$cache` (ClassInfo by FQN) and
-  `CachedNamespaceCatalog::$cache` (stable-source `childrenOf`) — behind the §5.3
-  replaceable seam, and each cache kept must demonstrably drop a parse / source call on
-  a hit (asserted via `ParseMetrics`); one that cannot is removed, not wrapped.
-- **S3.7 is four slices, cut where Composer's own data divides.** A single slice was
-  built first (PR #388, 622 src lines over 17 files) and was too large to review as
-  one unit. The seam it missed is already in the code: a lookup against the autoload
-  maps is arithmetic on the name (`findFile`, five lines — the old
-  `ComposerClassLocator` verbatim), while anything an `autoload.files` entry declares
-  has no name→file map of any kind and must derive one by parsing that set. The cut
-  is therefore by *route*, not by symbol kind — class-likes use both routes. So
-  **S3.7c generalizes the shape** — the
-  kind-agnostic `SymbolLocator` interface, `QualifiedName`, and the class-like branch
-  — which is behavior-preserving and proven by the existing class-like-lookup golden;
-  **S3.7d adds the reach**, which is new behavior proven by new fixtures. S3.7a and
-  S3.7b are the two independent inputs S3.7d consumes (the autoload map's `files`
-  section; the per-file declaration scan) and have no dependency on each other.
-  - **S3.7e closes the surface, not just the lookup.** S3.7d makes a `files`-declared
-    name resolvable by `lookupClassLike`, but `childrenOf` still enumerates by listing
-    a PSR-4 directory, which these files sit outside — so the name resolves on hover
-    and definition while never appearing in namespace completion. That split is the
-    inconsistency this series exists to prevent (#190, #253, #256), and it is why the
-    gap is a slice rather than a documented limitation. The data is already there: the
-    derived index knows every name each entry declares, so this is wiring enumeration
-    onto it, not a second scan. Found while reviewing S3.7d, which delivered the lookup
-    half only.
-- **S3.8 and S3.9 are cut by symbol namespace, not by layer.** A layer cut (interface,
-  then backends, then consumers) would land `SymbolBackend` methods no backend
-  implements, so each slice is instead one vertical: a kind's name type, its
-  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. S3.8c
-  then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
-  `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
-  `SymbolResolver`, so it, not S3.8a, is what S4.2 serializes against (§6).
-  S3.9 divides on provability rather than kind: **S3.9a** widens `searchClassLikes` to
-  `search(string $prefix, NameKind $kind)` with class-likes still the only searchable
-  kind, which is behavior-preserving and leaves every Step P golden frozen; **S3.9b**
-  makes the backends answer function search and moves `FunctionCandidates` onto it,
-  rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
-  answer function search in S3.9b or built-in function completion regresses — that
-  golden is what catches it.
-- **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
-  of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
-  Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
-  whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
-  `ConstantName` in **S3.8b**, with their lookups.
-  - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
-    name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
-    S3.8b rather than inside it — this is the same coexistence question §7 leaves open
-    for `ClassLikeName` versus `ClassName`.
-- **Steps 3 and 4 both edit `SymbolResolver` (§6).** S4.2 (positional extraction) is
-  gated on S3.8 (the 3b lookup migration) so the two never run concurrently; manifest
-  order keeps Step 3 ahead of Step 4 regardless. S4.1 (`TypeClassifier` + the §4.5/§4.6
-  rules) is independent of Step 3 and may proceed alongside.
-- **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
-  Step 2 double-write facade and (if built) the Step 0 cache rider; S3.10 the §4.2
-  function-path exemption, `getFileFunctions`, and the `DefaultFunctionRepository`
-  AST-in signature; S4.5/S4.6 the `SymbolResolver` god class, `TextFallbackHelper`
-  breadth, and the `CodeResolver` knowledge-facing methods. SZ.1 verifies the ledger is
-  fully discharged.
-- **The SC.* slices carry no step, on purpose.** They are duplication and dead code that
-  predate the plan rather than scaffolding it introduced, so no step's acceptance covers
-  them — which is exactly how they went unowned until an audit found them. They are in
-  the table so `/do-next` can select them and SZ.1 can require them, not because a step
-  produced them. A removal with no owning slice is a defect; put it here.
-  - **SC.1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`. It was
-    previously a ledger row whose remover was a *§3 note*, which no slice could discharge.
-  - **SC.2** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were superseded
-    by `NameContextFactory` and their own docblock says they go away once #331 moves the
-    callers. #331 landed (#337); three callers did not move (`SymbolResolver` ×2,
-    `TextFallbackHelper` ×1). Gated on S4.4/S4.5, which rewrite exactly those sites.
-  - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
-    `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
-    `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
-    `ScopeFinder`, and `DeclarationScanner` all read). Behavior-preserving, so the Step P
-    write-path and class-like-lookup goldens prove it. `SymbolExtractor`'s `Class::method`
-    FQNs are its own and stay.
-  - **SC.4** — `file://` URI and path conversion is hand-rolled in four live places
-    (`DefaultClassInfoFactory`, `FilesystemBackend` ×2, `Location`, and the dead
-    `WorkspaceIndexer`), each differing in how it handles the scheme and percent-
-    encoding. One `FileUri` replaces them. Found while splitting S3.7, whose locator
-    wanted a fifth copy; the duplication predates that slice and belongs to no step,
-    so S3.7c is gated on it rather than carrying it.
-  - **SC.5** — `FilesystemBackend::findClassInAst` and `Index\DeclarationScanner` both
-    walk an AST to find the class-likes a file declares. They differ in what they
-    return (one matched *node* versus every declared *name*) and in stopping early, so
-    this is scoped as **evaluate and merge if warranted** — concluding "two genuinely
-    different queries, one walk" is an acceptable outcome, but it must be concluded and
-    recorded, not left unexamined. Gated only on SC.3, which rewrites `findClassInAst`'s
-    namespace handling; it is deliberately *not* gated on S3.11, because an audit files
-    slices and a slice already filed must not wait on the audit that would have found
-    it. Found while reviewing S3.7d, which put the two traversals side by side without
-    merging them.
-- **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
-  acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
-  in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
-  not restated here, because a manifest note is not a gate.
-  - S3.11 and S4.7 are **tracking** gates: a finding may be handed to a new slice
-    rather than fixed in place, so a removal belonging to a later section is not dragged
-    forward. Step Z is the **completion** gate, where an unowned or unfixed duplicate
-    fails outright.
-  - The three depend on their whole section (`all Step N` / `all prior`) rather than on
-    its last slice. A chain of ids is both stale-prone and wrong: S3.10's transitive
-    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on S3.10 could have
-    run with two of its slices unbuilt.
-- **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
-  §4.7** (0002 §5 known gap) — file the tracked §4.7 issue when S3.3 lands; its fix is
-  the deferred Step 5.
-- **`Closes` is assigned at slice-issue creation, after a reviewer reads the issue —
-  never inferred.** Candidates from Wave 1's note: #239 / #181 / #317 land somewhere in
-  S3.7a–S3.10; #295 (Visibility enum) wants a small cleanup slice not yet placed.
-  - **#181 covers all three kinds**, which is now what S3.7b–S3.7d build: the
-    `files` set has no name→file map of any kind, so it is scanned whole. A slice
-    claiming #181 must show class-like reach, not just functions and constants.
-    - **#181 is not closable before S3.9b.** Its acceptance asks for these symbols in
-      *hover and completion*, not merely resolvable: functions need S3.8a and S3.9b,
-      constants S3.8b, namespace completion S3.7e. It also asks for a startup-time
-      benchmark, which S3.7d's eager index makes a live question rather than a
-      formality — S3.7d pins the parse *count*, which is not the same measurement.
-      Read the issue body before wiring `Closes`; the reach landing is not the
-      criteria being met.
-
-### Deferred (not scheduled; excluded from `/do-next` until reached)
-
-Kept out of the table above on purpose: a `todo` row with satisfiable dependencies is
-pickable, and neither of these should be picked yet. They are appended as real slices
-when their phase is reached.
-
-- **Step 5 — environment-parameterized built-ins (§4.7).** Not plannable: its
-  version-aware source is an open `TBD` (0002 §7, explicitly not `phpstorm-stubs`). The
-  interim reflection Builtin backend already ships in S3.3; §4.7 stays a tracked issue.
-  Nothing in Wave 2 depends on Step 5, and SZ.1 permits it to remain a named gap.
-- **Step 6 — scheduler / async tier (#266).** Deferred until a push feature needs it.
-  Sketch, from its acceptance: `$/cancelRequest` cancellation of superseded work;
-  debounced `publishDiagnostics` on change; a background scheduler that does not starve
-  interactive requests and is cancelable, feature-detecting `pcntl` / `ext-parallel`
-  with a synchronous fallback. Appended as slices when a push feature (or #266) takes
-  it up.
+- **Step 5 — environment-parameterized built-ins (§4.7).** Blocked on an open decision: its version-aware source is TBD (0002 §7). Tracked as #401.
+- **Step 6 — scheduler / async tier.** Deferred until a push feature needs it (#266).
+- **Workspace scope.** Project-wide search, references, implementations, and hierarchies need an index this plan does not build (#264, #265).

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -135,16 +135,21 @@ Notes:
     derived index knows every name each entry declares, so this is wiring enumeration
     onto it, not a second scan. Found while reviewing S3.7d, which delivered the lookup
     half only.
-- **The remaining kinds are cut by symbol namespace, not by layer.** A layer cut
-  (interface, then backends, then consumers) would land `SymbolBackend` methods no
-  backend implements, so each slice is instead one vertical: a kind's name type, its
-  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. Slice 7
-  then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
-  `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
-  `SymbolResolver`, so it, not S3.8a, is what slice 14 serializes against (§6).
-  Search divides on provability rather than kind: **slice 8** widens `searchClassLikes`
-  to `search(string $prefix, NameKind $kind)` with class-likes still the only searchable
-  kind, which is behavior-preserving and leaves every Step P golden frozen; **slice 9**
+- **A kind is cut at the facade, never across the backends.** `SymbolSource` keeps a
+  typed method per kind — three, closed, because PHP has three symbol namespaces (0002
+  §5.6) — while `SymbolBackend` takes the kind as a parameter. The dividing rule: kind
+  is a parameter where the return type does not vary with it, a method where it does.
+  So a new kind is a factory plus a facade accessor, never a method added to all four
+  backends. S3.8a did the latter, copying `lookupFunction` into every backend with the
+  same cache-key / locate / parse / store routine inside each; slice 22 undoes it before
+  constants would make that three. Slice 7 migrates the consumers (`SymbolResolver`,
+  `BasicTypeResolver`) off `FunctionRepository::get(string, array $ast)` — it is the
+  Step 3b slice that edits `SymbolResolver`, so it, not S3.8a, is what slice 14
+  serializes against (§6).
+  Search already follows the rule, since one return type serves every kind: **slice 8**
+  widens `searchClassLikes` to `search(string $prefix, NameKind $kind)` with class-likes
+  still the only searchable kind, which is behavior-preserving and leaves every Step P
+  golden frozen; **slice 9**
   makes the backends answer function search and moves `FunctionCandidates` onto it,
   rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
   answer function search in slice 9 or built-in function completion regresses — that

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -12,16 +12,13 @@ Append later phases as they are reached; do not create the whole tree up front.
 
 ## Columns
 
-- **ID** — stable slice id; the branch is `slice/<ID>`. Merged slices keep the
-  step-encoded ids they were built under; every new row is a plain number, assigned in
-  sequence and never reused. An id is only a branch name — order is table position and
-  sequencing is the `Depends on` column, so encoding either into the id just makes it
-  wrong later.
-- **Row order.** New rows go below the last `done` row, never above it — a completed
-  row's position is history. Within that pending block they may be placed anywhere, and
-  unblocked removals go at its top: `/do-next` takes the first unblocked `todo` in table
-  order, so position is the only thing that gets dead and duplicated code removed before
-  the work that has to read past it.
+- **ID** — the branch is `slice/<ID>`. Ids ascend with table position. An id freezes
+  once a branch exists for it — built or in flight — and the rows above the first
+  unbuilt one keep the ids they were built under; unbuilt rows renumber when one is
+  inserted among them, since nothing references them yet.
+- **Row order.** Table order is the build order, and `/do-next` takes the first
+  unblocked `todo` in it. Unbuilt rows are placed to read in sequence, with dead and
+  duplicated code removed ahead of the work that would otherwise have to read past it.
 - **Step** — the plan step in 0002 that owns the acceptance criteria.
 - **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
   exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
@@ -65,8 +62,8 @@ Step P harness — parity fixtures first), **3b** both preserves and extends the
 surface (existing behavior frozen to a golden; new project reach proven by new
 fixtures). The `Step` column carries the half, since 3a and 3b own distinct acceptance
 criteria in 0002. Step 4 decomposes `SymbolResolver`; Step Z is the terminal
-Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (slices 12 and
-20), which Step Z re-runs repo-wide as its completion gate.
+Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (slices 13 and
+21), which Step Z re-runs repo-wide as its completion gate.
 
     ID     Step  Title                                              Depends on        Closes
     -----  ----  -------------------------------------------------  ----------------  -------
@@ -88,22 +85,23 @@ Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (slices
     3      —     §4.1 handler-responsibility architecture test      —                 —
     4      —     §4.3 read/write segregation rule                   —                 —
     5      3b    One declaration walk; backends consume it          S3.8a             —
-    6      3b    §8.1 rule: one owner per shared mechanism          5                 —
-    7      3b    Retire the AST-in function lookup from consumers   5                 —
-    8      3b    Generalize search to a kind parameter              S3.8a             —
-    9      3b    Function search + FunctionCandidates migration     6,8               —
-    10     3b    Constant vertical: lookup, search, enumeration     6,8               —
-    11     3b    Remove §4.2 fn-path exemption; retire scaffolding  7,9,10            —
-    12     3     Step 3 duplication audit                           all Step 3        —
-    13     4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
-    14     4     Extract node locator + scope analyzer              7,13              —
-    15     4     Extract member-access + call-context detectors     14                —
-    16     4     Extract name-context resolver                      14                —
-    17     4     Narrow TextFallbackHelper to FQN recovery          15,16             —
-    18     —     Retire ScopeFinder's superseded import extraction  16,17             —
-    19     4     SymbolResolver -> glue; CodeResolver positional    14,15,16,17       —
-    20     4     Step 4 duplication audit                           all Step 4        —
-    21     Z     Definition of Done gate + repo-wide dup audit      all prior         —
+    6      3b    One backend lookup: resolve(name, kind)            5                 —
+    7      3b    §8.1 rule: one owner per shared mechanism          6                 —
+    8      3b    Retire the AST-in function lookup from consumers   5                 —
+    9      3b    Generalize search to a kind parameter              6                 —
+    10     3b    Function search + FunctionCandidates migration     7,9               —
+    11     3b    Constant vertical: lookup, search, enumeration     7,9               —
+    12     3b    Remove §4.2 fn-path exemption; retire scaffolding  8,10,11           —
+    13     3     Step 3 duplication audit                           all Step 3        —
+    14     4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
+    15     4     Extract node locator + scope analyzer              8,14              —
+    16     4     Extract member-access + call-context detectors     15                —
+    17     4     Extract name-context resolver                      15                —
+    18     4     Narrow TextFallbackHelper to FQN recovery          16,17             —
+    19     —     Retire ScopeFinder's superseded import extraction  17,18             —
+    20     4     SymbolResolver -> glue; CodeResolver positional    15,16,17,18       —
+    21     4     Step 4 duplication audit                           all Step 4        —
+    22     Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
 
@@ -141,24 +139,26 @@ Notes:
   is a parameter where the return type does not vary with it, a method where it does.
   So a new kind is a factory plus a facade accessor, never a method added to all four
   backends. S3.8a did the latter, copying `lookupFunction` into every backend with the
-  same cache-key / locate / parse / store routine inside each; slice 22 undoes it before
-  constants would make that three. Slice 7 migrates the consumers (`SymbolResolver`,
+  same cache-key / locate / parse / store routine inside each; slice 6 undoes it before
+  constants would make that three. Slice 8 migrates the consumers (`SymbolResolver`,
   `BasicTypeResolver`) off `FunctionRepository::get(string, array $ast)` — it is the
-  Step 3b slice that edits `SymbolResolver`, so it, not S3.8a, is what slice 14
+  Step 3b slice that edits `SymbolResolver`, so it, not S3.8a, is what slice 15
   serializes against (§6).
-  Search already follows the rule, since one return type serves every kind: **slice 8**
+  Search already follows the rule, since one return type serves every kind: **slice 9**
   widens `searchClassLikes` to `search(string $prefix, NameKind $kind)` with class-likes
   still the only searchable kind, which is behavior-preserving and leaves every Step P
-  golden frozen; **slice 9**
+  golden frozen; **slice 10**
   makes the backends answer function search and moves `FunctionCandidates` onto it,
   rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
-  answer function search in slice 9 or built-in function completion regresses — that
+  answer function search in slice 10 or built-in function completion regresses — that
   golden is what catches it.
-- **A kind vertical consumes shared mechanism; it MUST NOT add one** (RFC §4.11). That
-  cut is *backends × kinds*, which 0002 §5.6 requires to stay closed, and S3.8a broke
-  it: it added `parseFunctionFrom` beside `FilesystemBackend::findClassInAst` instead of
-  using `DeclarationScanner`, the whole-file walk S3.7b had built one slice earlier.
-  - **Slice 5** gives the remaining verticals something to consume: one walk yielding
+- **A kind consumes shared mechanism; it MUST NOT add one** (RFC §4.11). S3.8a added
+  both shapes of copy: `parseFunctionFrom` beside `FilesystemBackend::findClassInAst`
+  instead of using `DeclarationScanner` (the whole-file walk S3.7b had built one slice
+  earlier), and a per-kind `lookupFunction` on every backend, each repeating one
+  cache-key / locate / parse / store routine. Slices 5 and 6 undo them; slice 7 is
+  what stops the next one.
+  - **Slice 5** gives the later kinds something to consume: one walk yielding
     each declaration *with its node*, since needing the node for `ClassInfoFactory` /
     `FunctionInfo::fromNode` is a return-shape difference, not a second query.
     Every walk answering "what does this file declare" is deleted:
@@ -171,7 +171,18 @@ Notes:
     inside one class. Behavior-preserving for lookup, so the class-like-lookup and S3.6
     function-surface goldens stay frozen; the class-like depth change is new behavior on
     the write path, proven by a fixture and a rewritten Step P write-path golden.
-  - **Slice 6** adds the rule, per 0002 §Duplication audits ("an audit's first *fix* is
+  - **Slice 6** collapses the per-kind backend lookups into one
+    `resolve(QualifiedName, NameKind)` returning the located declaration, with the typed
+    `ClassInfo` / `FunctionInfo` built at the facade from the existing factories (0002
+    §5.6). `SymbolSource` is untouched: its typed per-kind methods are what consumers
+    call, and a name type carrying its own kind is stronger than a name plus an enum.
+    `CompositeSymbolSource`'s two identical first-wins loops become one,
+    `OpenDocumentBackend`'s two maps become one keyed by kind, and `FilesystemBackend`'s
+    duplicated cache-key / locate / parse / store routine becomes one — leaving
+    `BuiltinBackend`'s three-way `match` as the only kind branch, because reflection
+    itself is per-kind. Behavior-preserving, and the class-like-lookup and S3.6
+    function-surface goldens already freeze this surface, so it needs no new fixtures.
+  - **Slice 7** adds the rule, per 0002 §Duplication audits ("an audit's first *fix* is
     to add the rule"): one named owner per shared mechanism, the owners named in the
     rule's own configuration (RFC §8.1). Every AST traversal in `src/` must be
     classified by it, so the disposition of all of them is fixed here rather than
@@ -180,41 +191,46 @@ Notes:
       `NodeAtPosition`, `Scope`, `ScopeFinder` (positional walks — a different
       mechanism, not exemptions); `ParserService` (the `NameResolver` pass every parse
       runs through); `BasicTypeResolver` (assignment-flow walk, its own mechanism).
+      Slice 6 leaves the backend lookup-and-memoize routine with a single owner too, so
+      the rule names one rather than allowlisting four copies.
     - **Declared migrations**, each already carrying a remover: `SymbolExtractor`
-      (slice 2), `ScopeFinder`'s import extraction (slice 18), `DefaultFunctionRepository`
-      (slice 11, which deletes the AST-in signature), `SymbolResolver`'s own walks
-      (slice 19, which reduces it to glue).
-    - No allowlist entry may be added without a remover slice, since slice 21 requires
+      (slice 2), `ScopeFinder`'s import extraction (slice 19), `DefaultFunctionRepository`
+      (slice 12, which deletes the AST-in signature), `SymbolResolver`'s own walks
+      (slice 20, which reduces it to glue).
+    - No allowlist entry may be added without a remover slice, since slice 22 requires
       zero remaining scope.
-  - **Slice 10** lands constants whole rather than lookup-first: splitting a kind across
+  - **Slice 11** lands constants whole rather than lookup-first: splitting a kind across
     a lookup slice and a later search slice is what produced S3.7e, and RFC §4.2 requires
-    identical coverage across the two. Enumeration is likely already satisfied by S3.7e's
-    per-declaration `NameKind`, making it a fixture to prove rather than code to write;
-    offering constants at expression start (#317) is a feature on this reach and stays
-    out of scope.
+    identical coverage across the two. After slices 6 and 9 it is a `ConstantName`, a
+    factory, a facade accessor, and one arm in `BuiltinBackend`'s match — no backend
+    grows a method. Enumeration is likely already satisfied by S3.7e's per-declaration
+    `NameKind`, making it a fixture to prove rather than code to write; offering
+    constants at expression start (#317) is a feature on this reach and stays out of
+    scope.
 - **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
   whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
-  `ConstantName` in **slice 10**, with their lookups.
+  `ConstantName` in **slice 11**, with their lookups.
   - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
     name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
-    slice 10 rather than inside it — this is the same coexistence question §7 leaves open
+    slice 11 rather than inside it — this is the same coexistence question §7 leaves open
     for `ClassLikeName` versus `ClassName`.
-- **Steps 3 and 4 both edit `SymbolResolver` (§6).** Slice 14 (positional extraction) is
-  gated on slice 7 (the 3b lookup migration) so the two never run concurrently; manifest
-  order keeps Step 3 ahead of Step 4 regardless. Slice 13 (`TypeClassifier` + the
+- **Steps 3 and 4 both edit `SymbolResolver` (§6).** Slice 15 (positional extraction) is
+  gated on slice 8 (the 3b lookup migration) so the two never run concurrently; manifest
+  order keeps Step 3 ahead of Step 4 regardless. Slice 14 (`TypeClassifier` + the
   §4.5/§4.6 rules) is independent of Step 3 and may proceed alongside.
 - **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
   Step 2 double-write facade and (if built) the Step 0 cache rider; slice 5 the bespoke
-  declaration walks; slice 11 the §4.2 function-path exemption, `getFileFunctions`, and
-  the `DefaultFunctionRepository` AST-in signature; slices 17 and 19 the `SymbolResolver`
-  god class, `TextFallbackHelper` breadth, and the `CodeResolver` knowledge-facing
-  methods. Slice 21 verifies the ledger is fully discharged.
+  declaration walks; slice 6 the per-kind backend lookups; slice 12 the §4.2
+  function-path exemption, `getFileFunctions`, and the `DefaultFunctionRepository`
+  AST-in signature; slices 18 and 20 the `SymbolResolver` god class,
+  `TextFallbackHelper` breadth, and the `CodeResolver` knowledge-facing methods.
+  Slice 22 verifies the ledger is fully discharged.
 - **Stepless rows carry no step, on purpose.** They are duplication, dead code, and
   missing enforcement that no step's acceptance covers — which is exactly how they went
   unowned until an audit found them. They are in the table so `/do-next` can select them
-  and slice 21 can require them. A removal with no owning slice is a defect; put it here,
+  and slice 22 can require them. A removal with no owning slice is a defect; put it here,
   at the top of the pending block (see Row order).
   - **Slice 1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`.
   - **Slice 2** — `SymbolExtractor` hand-tracks `Stmt\Namespace_` to build FQNs that
@@ -223,7 +239,7 @@ Notes:
     Behavior-preserving, so the Step P write-path golden proves it. `SymbolExtractor`'s
     `Class::method` FQNs are its own and stay. The other site this once covered,
     `FilesystemBackend::findClassInAst`, is removed by slice 5 independently.
-  - **Slices 3 and 4** — §8.1 names an enforcement mechanism per invariant and slice 21
+  - **Slices 3 and 4** — §8.1 names an enforcement mechanism per invariant and slice 22
     requires every one active repo-wide, so a mechanism with no owning slice is a gate
     that cannot pass. `phpstan.neon` registers two rules today (§4.2, §4.8); §4.1
     (handlers depend on no parser, repository, or reflection) and §4.3 (consumers depend
@@ -237,36 +253,36 @@ Notes:
     `WorkspaceNamespaceSource`, `OpenDocumentBackend` and `DocumentIndexer` are inside
     the tier that owns the concrete stores. Fix that scope in the slice; a wider reading
     turns slice 4 into a migration it is not planned as.
-  - **Slice 18** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were
+  - **Slice 19** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were
     superseded by `NameContextFactory` and their own docblock says they go away once #331
     moves the callers. #331 landed (#337); three callers did not move (`SymbolResolver`
-    ×2, `TextFallbackHelper` ×1). Gated on slices 16 and 17, which rewrite those sites.
+    ×2, `TextFallbackHelper` ×1). Gated on slices 17 and 18, which rewrite those sites.
   - **SC.4** — `file://` URI and path conversion was hand-rolled in four live places, each
     differing in how it handled the scheme and percent-encoding. One `FileUri` replaced
     them. Found while splitting S3.7, whose locator wanted a fifth copy.
-- **Each section ends with a duplication audit** (**slices 12 and 20**), and Step Z's
+- **Each section ends with a duplication audit** (**slices 13 and 21**), and Step Z's
   acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
   in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
   not restated here, because a manifest note is not a gate.
-  - Slices 12 and 20 are **tracking** gates: a finding may be handed to a new slice
+  - Slices 13 and 21 are **tracking** gates: a finding may be handed to a new slice
     rather than fixed in place, so a removal belonging to a later section is not dragged
-    forward. Slice 21 is the **completion** gate, where an unowned or unfixed duplicate
+    forward. Slice 22 is the **completion** gate, where an unowned or unfixed duplicate
     fails outright.
   - The three depend on their whole section (`all Step N` / `all prior`) rather than on
-    its last slice. A chain of ids is both stale-prone and wrong: slice 11's transitive
-    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on slice 11 could have
+    its last slice. A chain of ids is both stale-prone and wrong: slice 12's transitive
+    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on slice 12 could have
     run with two of its slices unbuilt.
 - **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
   §4.7** (0002 §5 known gap), tracked as #401; its fix is the deferred Step 5.
 - **`Closes` is assigned at slice-issue creation, after a reviewer reads the issue —
   never inferred.** Candidates from Wave 1's note: #239 / #181 / #317 land somewhere in
-  S3.7a–slice 11; #295 (Visibility enum) wants a small cleanup slice not yet placed.
+  S3.7a–slice 12; #295 (Visibility enum) wants a small cleanup slice not yet placed.
   - **#181 covers all three kinds**, which is now what S3.7b–S3.7d build: the
     `files` set has no name→file map of any kind, so it is scanned whole. A slice
     claiming #181 must show class-like reach, not just functions and constants.
-    - **#181 is not closable before slice 9.** Its acceptance asks for these symbols in
-      *hover and completion*, not merely resolvable: functions need S3.8a and slice 9,
-      constants slice 10, namespace completion S3.7e. It also asks for a startup-time
+    - **#181 is not closable before slice 10.** Its acceptance asks for these symbols in
+      *hover and completion*, not merely resolvable: functions need S3.8a and slice 10,
+      constants slice 11, namespace completion S3.7e. It also asks for a startup-time
       benchmark, which S3.7d's eager index makes a live question rather than a
       formality — S3.7d pins the parse *count*, which is not the same measurement.
       Read the issue body before wiring `Closes`; the reach landing is not the
@@ -281,12 +297,12 @@ when their phase is reached.
 - **Step 5 — environment-parameterized built-ins (§4.7).** Not plannable: its
   version-aware source is an open `TBD` (0002 §7, explicitly not `phpstorm-stubs`). The
   interim reflection Builtin backend already ships in S3.3; §4.7 is tracked as **#401**.
-  Nothing depends on Step 5, and slice 21 permits it to remain a named gap.
+  Nothing depends on Step 5, and slice 22 permits it to remain a named gap.
 - **Position encodings other than UTF-16 (#192, #371).** The boundary conversion and the
   interior byte columns are done (S1.2, S1.5), but the negotiated encoding does not reach
   `TextDocument`, so only the UTF-16 default is served. A client-compatibility feature
   rather than foundation work: [LSP] requires UTF-16 support and the encoding is
-  negotiated, so a client offering nothing else is served correctly today. Slice 21
+  negotiated, so a client offering nothing else is served correctly today. Slice 22
   permits it as a named gap.
 - **Step 6 — scheduler / async tier (#266).** Deferred until a push feature needs it.
   Sketch, from its acceptance: `$/cancelRequest` cancellation of superseded work;

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -1,84 +1,236 @@
-# Build Manifest (ordered checklist)
+# Build Manifest (slice registry)
 
-    Status:   In-Flight
+    Status:   Draft — seeded through Wave 2 (Steps 3, 4, Z; Steps 5, 6 deferred)
     Driver:   build-procedure.md
     Plan:     0002-execution-plan.md
 
-The ordered list of build slices, derived from the plan.
-Goals, requirements and acceptance criteria live in 0002 and RFC 1; this file adds only the order.
-
-Work top to bottom.
-Order is the sequencing: a row may be started once every row above it is merged.
-A slice's status is not recorded here — it is whether a merged PR exists for `slice/<ID>` (see `build-procedure.md`).
-
-**Step** names the plan step whose acceptance criteria the slice must meet.
-A slice with no step removes pre-existing duplication or dead code that no step's acceptance covers.
+This is a **static** registry of build slices. It records *what* the slices are and
+how they depend on each other; it does **not** record progress — a slice's status is
+computed from whether its PR (`slice/<id>`) is merged (see `build-procedure.md`).
 
 Append later phases as they are reached; do not create the whole tree up front.
 
+## Columns
+
+- **ID** — stable slice id; the branch is `slice/<ID>`.
+- **Step** — the plan step in 0002 that owns the acceptance criteria.
+- **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
+  exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
+  means every *other* slice whose Step column is `N` (sub-steps included, so `all Step
+  3` covers 3a and 3b), and **`all prior`** means every other slice in the table.
+  Gates use these; ordinary slices name ids.
+- **Closes** — pre-existing issues this slice closes, *after reviewer verification*.
+
 ## Wave 1 — Steps 0, 1, P, 2
 
-    ID     Step  Title
-    -----  ----  -------------------------------------------------
-    S0.1   0     Instrument parse count/time; run the spike
-    S0.2   0     Request-scoped parse dedup (if spike warrants)
-    S1.1   1     Read ClientCapabilities -> SessionCapabilities
-    S1.2   1     Negotiate positionEncoding; convert at the edge
-    S1.3   1     Shape hover markup / snippets via capabilities
-    S1.4   1     Lifecycle state + malformed-frame robustness
-    S1.5   1     Position round-trip corpus (regression net)
-    SP.1   P     Per-surface parity harness + branch-coverage gate
-    S2.1   2     Define SymbolSource/SymbolSink + delegating facade
-    S2.2   2     Migrate ClassCandidates -> search
-    S2.3   2     Migrate NamespaceCandidates -> childrenOf
-    S2.4   2     Migrate SymbolResolver class lookups -> lookupClassLike
-    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink
-    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo)
+    ID     Step  Title                                              Depends on        Closes
+    -----  ----  -------------------------------------------------  ----------------  -------
+    S0.1   0     Instrument parse count/time; run the spike         —                 —
+    S0.2   0     Request-scoped parse dedup (if spike warrants)     S0.1              —
+    S1.1   1     Read ClientCapabilities -> SessionCapabilities     —                 —
+    S1.2   1     Negotiate positionEncoding; convert at the edge    S1.1              #192
+    S1.3   1     Shape hover markup / snippets via capabilities     S1.1              #22
+    S1.4   1     Lifecycle state + malformed-frame robustness       S1.1              —
+    S1.5   1     Position round-trip corpus (regression net)        S1.2              —
+    SP.1   P     Per-surface parity harness + branch-coverage gate  —                 —
+    S2.1   2     Define SymbolSource/SymbolSink + delegating facade SP.1              —
+    S2.2   2     Migrate ClassCandidates -> search                  S2.1              —
+    S2.3   2     Migrate NamespaceCandidates -> childrenOf          S2.1              —
+    S2.4   2     Migrate SymbolResolver class lookups -> lookupClassLike  S2.1        —
+    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink      S2.1              —
+    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo) S2.2,S2.3,S2.4,S2.5  —
 
-## Wave 2 — Steps 3, C
+Notes:
 
-    ID     Step  Title
-    -----  ----  -------------------------------------------------
-    S3.1   3a    Existing caches -> replaceable §5.3 seam (verify)
-    S3.2   3a    Dedupe the duplicate ComposerAutoloadMap
-    S3.3   3a    Named backends + fixed-precedence composite
-    S3.4   3a    One parse / one write path + consistency check
-    S3.5   3a    External-file-change invalidation
-    S3.6   3b    Function-surface golden + Builtin enum oracle
-    S3.7a  3b    Read autoload.files into ComposerAutoloadMap
-    S3.7b  3b    Scan a file for the declarations it makes
-    S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator
-    S3.7d  3b    Derived autoload.files index, for all three kinds
-    S3.7e  3b    Enumerate the derived index in childrenOf
-    SC.4   —     Dedupe the hand-rolled file:// conversion
-    S3.8a  3b    lookupFunction project reach
+- `NamespaceName` typed identifier is needed by S2.3 (`childrenOf`); land it within
+  that slice or as its immediate predecessor.
+- Steps 0, 1, and P are mutually independent and may run in any order; Step 2 is
+  gated on the parity harness (SP.1).
+- Wave 2 (Steps 3, 4, Z) is decomposed below, appended now that S2.* is `done`. Steps
+  5 and 6 remain deferred (see the Deferred note under Wave 2).
 
-## Wave 3
+## Wave 2 — Steps 3, 4, Z
 
-    ID     Step  Title
-    -----  ----  -------------------------------------------------
-    1      —     Delete the dead WorkspaceIndexer
-    2      —     SymbolExtractor -> the parser's namespacedName
-    3      —     §4.1 handler-responsibility architecture test
-    4      —     §4.3 read/write segregation rule
-    5      3b    One declaration walk; backends consume it
-    6      3b    One backend lookup: resolve(name, kind)
-    7      3b    §8.1 rule: one owner per shared mechanism
-    8      3b    Retire the AST-in function lookup from consumers
-    9      3b    Generalize search to a kind parameter
-    10     3b    Function search + FunctionCandidates migration
-    11     3b    Constant reach: lookup, search, enumeration
-    12     3b    Remove §4.2 fn-path exemption; retire scaffolding
-    13     3     Step 3 duplication audit
-    14     4     TypeClassifier + §4.5/§4.6 static rules
-    15     4     Extract node locator + scope analyzer
-    16     4     Extract member-access + call-context detectors
-    17     4     Extract name-context resolver
-    18     4     Narrow TextFallbackHelper to FQN recovery
-    19     —     Retire ScopeFinder's superseded import extraction
-    20     4     SymbolResolver -> glue; CodeResolver positional
-    21     4     Step 4 duplication audit
-    22     Z     Definition of Done gate + repo-wide dup audit
+Step 3 is one plan step with two halves: **3a** is behavior-preserving (proven by the
+Step P harness — parity fixtures first), **3b** both preserves and extends the function
+surface (existing behavior frozen to a golden; new project reach proven by new
+fixtures). The `Step` column carries the half, since 3a and 3b own distinct acceptance
+criteria in 0002. Step 4 decomposes `SymbolResolver`; Step Z is the terminal
+Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (S3.11,
+S4.7), which Step Z re-runs repo-wide as its completion gate.
 
-Steps 5 (environment-parameterized built-ins) and 6 (scheduler / async tier) are deferred and carry no slices; see 0002.
-Position encodings other than UTF-16 (#192, #371) are likewise deferred: UTF-16 is what LSP requires and the encoding is negotiated, so a client offering nothing else is served correctly.
+    ID     Step  Title                                              Depends on        Closes
+    -----  ----  -------------------------------------------------  ----------------  -------
+    S3.1   3a    Existing caches -> replaceable §5.3 seam (verify)  S2.6              —
+    S3.2   3a    Dedupe the duplicate ComposerAutoloadMap           S2.6              —
+    S3.3   3a    Named backends + fixed-precedence composite        S3.1,S3.2         —
+    S3.4   3a    One parse / one write path + consistency check     S3.3              —
+    S3.5   3a    External-file-change invalidation                  S3.3,S3.4         —
+    S3.6   3b    Function-surface golden + Builtin enum oracle      S3.3              —
+    S3.7a  3b    Read autoload.files into ComposerAutoloadMap       S3.3              —
+    S3.7b  3b    Scan a file for the declarations it makes          S3.3              —
+    S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator        S3.3,SC.4         —
+    S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
+    S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
+    S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
+    S3.8b  3b    lookupConstant project reach                       S3.7d             —
+    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —
+    S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
+    S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
+    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
+    S3.11  3     Step 3 duplication audit                          all Step 3        —
+    S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
+    S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
+    S4.3   4     Extract member-access + call-context detectors     S4.2              —
+    S4.4   4     Extract name-context resolver                      S4.2              —
+    S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
+    S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
+    S4.7   4     Step 4 duplication audit                          all Step 4        —
+    SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
+    SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
+    SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
+    SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
+    SC.5   —     Merge the two class-like AST traversals             SC.3              —
+    SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
+
+Notes:
+
+- **S3.1 is verify-then-seam.** The Step 0 spike (0002 §8.5 decision 2) declined a
+  standing parse cache; it is *not* built here. S3.1 moves the two existing hand-rolled
+  memoizations — `DefaultClassRepository::$cache` (ClassInfo by FQN) and
+  `CachedNamespaceCatalog::$cache` (stable-source `childrenOf`) — behind the §5.3
+  replaceable seam, and each cache kept must demonstrably drop a parse / source call on
+  a hit (asserted via `ParseMetrics`); one that cannot is removed, not wrapped.
+- **S3.7 is four slices, cut where Composer's own data divides.** A single slice was
+  built first (PR #388, 622 src lines over 17 files) and was too large to review as
+  one unit. The seam it missed is already in the code: a lookup against the autoload
+  maps is arithmetic on the name (`findFile`, five lines — the old
+  `ComposerClassLocator` verbatim), while anything an `autoload.files` entry declares
+  has no name→file map of any kind and must derive one by parsing that set. The cut
+  is therefore by *route*, not by symbol kind — class-likes use both routes. So
+  **S3.7c generalizes the shape** — the
+  kind-agnostic `SymbolLocator` interface, `QualifiedName`, and the class-like branch
+  — which is behavior-preserving and proven by the existing class-like-lookup golden;
+  **S3.7d adds the reach**, which is new behavior proven by new fixtures. S3.7a and
+  S3.7b are the two independent inputs S3.7d consumes (the autoload map's `files`
+  section; the per-file declaration scan) and have no dependency on each other.
+  - **S3.7e closes the surface, not just the lookup.** S3.7d makes a `files`-declared
+    name resolvable by `lookupClassLike`, but `childrenOf` still enumerates by listing
+    a PSR-4 directory, which these files sit outside — so the name resolves on hover
+    and definition while never appearing in namespace completion. That split is the
+    inconsistency this series exists to prevent (#190, #253, #256), and it is why the
+    gap is a slice rather than a documented limitation. The data is already there: the
+    derived index knows every name each entry declares, so this is wiring enumeration
+    onto it, not a second scan. Found while reviewing S3.7d, which delivered the lookup
+    half only.
+- **S3.8 and S3.9 are cut by symbol namespace, not by layer.** A layer cut (interface,
+  then backends, then consumers) would land `SymbolBackend` methods no backend
+  implements, so each slice is instead one vertical: a kind's name type, its
+  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. S3.8c
+  then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
+  `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
+  `SymbolResolver`, so it, not S3.8a, is what S4.2 serializes against (§6).
+  S3.9 divides on provability rather than kind: **S3.9a** widens `searchClassLikes` to
+  `search(string $prefix, NameKind $kind)` with class-likes still the only searchable
+  kind, which is behavior-preserving and leaves every Step P golden frozen; **S3.9b**
+  makes the backends answer function search and moves `FunctionCandidates` onto it,
+  rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
+  answer function search in S3.9b or built-in function completion regresses — that
+  golden is what catches it.
+- **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
+  of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
+  Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
+  whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
+  `ConstantName` in **S3.8b**, with their lookups.
+  - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
+    name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
+    S3.8b rather than inside it — this is the same coexistence question §7 leaves open
+    for `ClassLikeName` versus `ClassName`.
+- **Steps 3 and 4 both edit `SymbolResolver` (§6).** S4.2 (positional extraction) is
+  gated on S3.8 (the 3b lookup migration) so the two never run concurrently; manifest
+  order keeps Step 3 ahead of Step 4 regardless. S4.1 (`TypeClassifier` + the §4.5/§4.6
+  rules) is independent of Step 3 and may proceed alongside.
+- **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
+  Step 2 double-write facade and (if built) the Step 0 cache rider; S3.10 the §4.2
+  function-path exemption, `getFileFunctions`, and the `DefaultFunctionRepository`
+  AST-in signature; S4.5/S4.6 the `SymbolResolver` god class, `TextFallbackHelper`
+  breadth, and the `CodeResolver` knowledge-facing methods. SZ.1 verifies the ledger is
+  fully discharged.
+- **The SC.* slices carry no step, on purpose.** They are duplication and dead code that
+  predate the plan rather than scaffolding it introduced, so no step's acceptance covers
+  them — which is exactly how they went unowned until an audit found them. They are in
+  the table so `/do-next` can select them and SZ.1 can require them, not because a step
+  produced them. A removal with no owning slice is a defect; put it here.
+  - **SC.1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`. It was
+    previously a ledger row whose remover was a *§3 note*, which no slice could discharge.
+  - **SC.2** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were superseded
+    by `NameContextFactory` and their own docblock says they go away once #331 moves the
+    callers. #331 landed (#337); three callers did not move (`SymbolResolver` ×2,
+    `TextFallbackHelper` ×1). Gated on S4.4/S4.5, which rewrite exactly those sites.
+  - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
+    `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
+    `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
+    `ScopeFinder`, and `DeclarationScanner` all read). Behavior-preserving, so the Step P
+    write-path and class-like-lookup goldens prove it. `SymbolExtractor`'s `Class::method`
+    FQNs are its own and stay.
+  - **SC.4** — `file://` URI and path conversion is hand-rolled in four live places
+    (`DefaultClassInfoFactory`, `FilesystemBackend` ×2, `Location`, and the dead
+    `WorkspaceIndexer`), each differing in how it handles the scheme and percent-
+    encoding. One `FileUri` replaces them. Found while splitting S3.7, whose locator
+    wanted a fifth copy; the duplication predates that slice and belongs to no step,
+    so S3.7c is gated on it rather than carrying it.
+  - **SC.5** — `FilesystemBackend::findClassInAst` and `Index\DeclarationScanner` both
+    walk an AST to find the class-likes a file declares. They differ in what they
+    return (one matched *node* versus every declared *name*) and in stopping early, so
+    this is scoped as **evaluate and merge if warranted** — concluding "two genuinely
+    different queries, one walk" is an acceptable outcome, but it must be concluded and
+    recorded, not left unexamined. Gated only on SC.3, which rewrites `findClassInAst`'s
+    namespace handling; it is deliberately *not* gated on S3.11, because an audit files
+    slices and a slice already filed must not wait on the audit that would have found
+    it. Found while reviewing S3.7d, which put the two traversals side by side without
+    merging them.
+- **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
+  acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
+  in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
+  not restated here, because a manifest note is not a gate.
+  - S3.11 and S4.7 are **tracking** gates: a finding may be handed to a new slice
+    rather than fixed in place, so a removal belonging to a later section is not dragged
+    forward. Step Z is the **completion** gate, where an unowned or unfixed duplicate
+    fails outright.
+  - The three depend on their whole section (`all Step N` / `all prior`) rather than on
+    its last slice. A chain of ids is both stale-prone and wrong: S3.10's transitive
+    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on S3.10 could have
+    run with two of its slices unbuilt.
+- **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
+  §4.7** (0002 §5 known gap) — file the tracked §4.7 issue when S3.3 lands; its fix is
+  the deferred Step 5.
+- **`Closes` is assigned at slice-issue creation, after a reviewer reads the issue —
+  never inferred.** Candidates from Wave 1's note: #239 / #181 / #317 land somewhere in
+  S3.7a–S3.10; #295 (Visibility enum) wants a small cleanup slice not yet placed.
+  - **#181 covers all three kinds**, which is now what S3.7b–S3.7d build: the
+    `files` set has no name→file map of any kind, so it is scanned whole. A slice
+    claiming #181 must show class-like reach, not just functions and constants.
+    - **#181 is not closable before S3.9b.** Its acceptance asks for these symbols in
+      *hover and completion*, not merely resolvable: functions need S3.8a and S3.9b,
+      constants S3.8b, namespace completion S3.7e. It also asks for a startup-time
+      benchmark, which S3.7d's eager index makes a live question rather than a
+      formality — S3.7d pins the parse *count*, which is not the same measurement.
+      Read the issue body before wiring `Closes`; the reach landing is not the
+      criteria being met.
+
+### Deferred (not scheduled; excluded from `/do-next` until reached)
+
+Kept out of the table above on purpose: a `todo` row with satisfiable dependencies is
+pickable, and neither of these should be picked yet. They are appended as real slices
+when their phase is reached.
+
+- **Step 5 — environment-parameterized built-ins (§4.7).** Not plannable: its
+  version-aware source is an open `TBD` (0002 §7, explicitly not `phpstorm-stubs`). The
+  interim reflection Builtin backend already ships in S3.3; §4.7 stays a tracked issue.
+  Nothing in Wave 2 depends on Step 5, and SZ.1 permits it to remain a named gap.
+- **Step 6 — scheduler / async tier (#266).** Deferred until a push feature needs it.
+  Sketch, from its acceptance: `$/cancelRequest` cancellation of superseded work;
+  debounced `publishDiagnostics` on change; a background scheduler that does not starve
+  interactive requests and is cancelable, feature-detecting `pcntl` / `ext-parallel`
+  with a synchronous fallback. Appended as slices when a push feature (or #266) takes
+  it up.

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -12,7 +12,12 @@ Append later phases as they are reached; do not create the whole tree up front.
 
 ## Columns
 
-- **ID** — stable slice id; the branch is `slice/<ID>`.
+- **ID** — stable slice id; the branch is `slice/<ID>`. Merged slices keep the
+  step-encoded ids they were built under; every new row is a plain number, assigned in
+  sequence and never reused. An id is only a branch name — order is table position and
+  sequencing is the `Depends on` column, so encoding either into the id just makes it
+  wrong later. New rows are appended below the last completed one, never interleaved
+  above it.
 - **Step** — the plan step in 0002 that owns the acceptance criteria.
 - **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
   exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
@@ -56,8 +61,8 @@ Step P harness — parity fixtures first), **3b** both preserves and extends the
 surface (existing behavior frozen to a golden; new project reach proven by new
 fixtures). The `Step` column carries the half, since 3a and 3b own distinct acceptance
 criteria in 0002. Step 4 decomposes `SymbolResolver`; Step Z is the terminal
-Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (S3.11,
-S4.7), which Step Z re-runs repo-wide as its completion gate.
+Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (slices 12 and
+20), which Step Z re-runs repo-wide as its completion gate.
 
     ID     Step  Title                                              Depends on        Closes
     -----  ----  -------------------------------------------------  ----------------  -------
@@ -73,25 +78,28 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
     S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    S3.8b  3b    lookupConstant project reach                       S3.7d             —
-    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —
-    S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
-    S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
-    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
-    S3.11  3     Step 3 duplication audit                          all Step 3        —
-    S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
-    S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
-    S4.3   4     Extract member-access + call-context detectors     S4.2              —
-    S4.4   4     Extract name-context resolver                      S4.2              —
-    S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
-    S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
-    S4.7   4     Step 4 duplication audit                          all Step 4        —
-    SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
-    SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
-    SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
-    SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
-    SC.5   —     Merge the two class-like AST traversals             SC.3              —
-    SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
+    SC.4   —     Dedupe the hand-rolled file:// conversion          —                 —
+    1      —     Delete the dead WorkspaceIndexer                   —                 —
+    2      —     SymbolExtractor -> the parser's namespacedName     —                 —
+    3      —     §4.1 handler-responsibility architecture test      —                 —
+    4      —     §4.3 read/write segregation rule                   —                 —
+    5      3b    One declaration walk; backends consume it          S3.8a             —
+    6      3b    §8.1 rule: one owner per shared mechanism          5                 —
+    7      3b    Retire the AST-in function lookup from consumers   5                 —
+    8      3b    Generalize search to a kind parameter              S3.8a             —
+    9      3b    Function search + FunctionCandidates migration     6,8               —
+    10     3b    Constant vertical: lookup, search, enumeration     6,8               —
+    11     3b    Remove §4.2 fn-path exemption; retire scaffolding  7,9,10            —
+    12     3     Step 3 duplication audit                           all Step 3        —
+    13     4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
+    14     4     Extract node locator + scope analyzer              7,13              —
+    15     4     Extract member-access + call-context detectors     14                —
+    16     4     Extract name-context resolver                      14                —
+    17     4     Narrow TextFallbackHelper to FQN recovery          15,16             —
+    18     —     Retire ScopeFinder's superseded import extraction  16,17             —
+    19     4     SymbolResolver -> glue; CodeResolver positional    14,15,16,17       —
+    20     4     Step 4 duplication audit                           all Step 4        —
+    21     Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
 
@@ -123,96 +131,112 @@ Notes:
     derived index knows every name each entry declares, so this is wiring enumeration
     onto it, not a second scan. Found while reviewing S3.7d, which delivered the lookup
     half only.
-- **S3.8 and S3.9 are cut by symbol namespace, not by layer.** A layer cut (interface,
-  then backends, then consumers) would land `SymbolBackend` methods no backend
-  implements, so each slice is instead one vertical: a kind's name type, its
-  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. S3.8c
+- **The remaining kinds are cut by symbol namespace, not by layer.** A layer cut
+  (interface, then backends, then consumers) would land `SymbolBackend` methods no
+  backend implements, so each slice is instead one vertical: a kind's name type, its
+  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. Slice 7
   then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
   `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
-  `SymbolResolver`, so it, not S3.8a, is what S4.2 serializes against (§6).
-  S3.9 divides on provability rather than kind: **S3.9a** widens `searchClassLikes` to
-  `search(string $prefix, NameKind $kind)` with class-likes still the only searchable
-  kind, which is behavior-preserving and leaves every Step P golden frozen; **S3.9b**
+  `SymbolResolver`, so it, not S3.8a, is what slice 14 serializes against (§6).
+  Search divides on provability rather than kind: **slice 8** widens `searchClassLikes`
+  to `search(string $prefix, NameKind $kind)` with class-likes still the only searchable
+  kind, which is behavior-preserving and leaves every Step P golden frozen; **slice 9**
   makes the backends answer function search and moves `FunctionCandidates` onto it,
   rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
-  answer function search in S3.9b or built-in function completion regresses — that
+  answer function search in slice 9 or built-in function completion regresses — that
   golden is what catches it.
+- **A kind vertical consumes shared mechanism; it MUST NOT add one** (RFC §4.11). That
+  cut is *backends × kinds*, which 0002 §5.6 requires to stay closed, and S3.8a broke
+  it: it added `parseFunctionFrom` beside `FilesystemBackend::findClassInAst` instead of
+  using `DeclarationScanner`, the whole-file walk S3.7b had built one slice earlier.
+  - **Slice 5** gives the remaining verticals something to consume: one walk yielding
+    each declaration *with its node*, since needing the node for `ClassInfoFactory` /
+    `FunctionInfo::fromNode` is a return-shape difference, not a second query. It deletes
+    both bespoke finders. Behavior-preserving, so the class-like-lookup and S3.6
+    function-surface goldens stay frozen.
+  - **Slice 6** adds the rule, per 0002 §Duplication audits ("an audit's first *fix* is
+    to add the rule"): one named owner per shared mechanism. It ships scoped if slice 2
+    or 18 has not landed — each is a §4.11 violation it will flag — and those two
+    discharge its allowlist. The positional walkers (`NodeAtPosition`, `Scope`,
+    `ScopeFinder`) are separate owners, not exemptions.
+  - **Slice 10** lands constants whole rather than lookup-first: splitting a kind across
+    a lookup slice and a later search slice is what produced S3.7e, and RFC §4.2 requires
+    identical coverage across the two. Enumeration is likely already satisfied by S3.7e's
+    per-declaration `NameKind`, making it a fixture to prove rather than code to write;
+    offering constants at expression start (#317) is a feature on this reach and stays
+    out of scope.
 - **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
   whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
-  `ConstantName` in **S3.8b**, with their lookups.
+  `ConstantName` in **slice 10**, with their lookups.
   - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
     name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
-    S3.8b rather than inside it — this is the same coexistence question §7 leaves open
+    slice 10 rather than inside it — this is the same coexistence question §7 leaves open
     for `ClassLikeName` versus `ClassName`.
-- **Steps 3 and 4 both edit `SymbolResolver` (§6).** S4.2 (positional extraction) is
-  gated on S3.8 (the 3b lookup migration) so the two never run concurrently; manifest
-  order keeps Step 3 ahead of Step 4 regardless. S4.1 (`TypeClassifier` + the §4.5/§4.6
-  rules) is independent of Step 3 and may proceed alongside.
+- **Steps 3 and 4 both edit `SymbolResolver` (§6).** Slice 14 (positional extraction) is
+  gated on slice 7 (the 3b lookup migration) so the two never run concurrently; manifest
+  order keeps Step 3 ahead of Step 4 regardless. Slice 13 (`TypeClassifier` + the
+  §4.5/§4.6 rules) is independent of Step 3 and may proceed alongside.
 - **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
-  Step 2 double-write facade and (if built) the Step 0 cache rider; S3.10 the §4.2
-  function-path exemption, `getFileFunctions`, and the `DefaultFunctionRepository`
-  AST-in signature; S4.5/S4.6 the `SymbolResolver` god class, `TextFallbackHelper`
-  breadth, and the `CodeResolver` knowledge-facing methods. SZ.1 verifies the ledger is
-  fully discharged.
-- **The SC.* slices carry no step, on purpose.** They are duplication and dead code that
-  predate the plan rather than scaffolding it introduced, so no step's acceptance covers
-  them — which is exactly how they went unowned until an audit found them. They are in
-  the table so `/do-next` can select them and SZ.1 can require them, not because a step
-  produced them. A removal with no owning slice is a defect; put it here.
-  - **SC.1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`. It was
-    previously a ledger row whose remover was a *§3 note*, which no slice could discharge.
-  - **SC.2** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were superseded
-    by `NameContextFactory` and their own docblock says they go away once #331 moves the
-    callers. #331 landed (#337); three callers did not move (`SymbolResolver` ×2,
-    `TextFallbackHelper` ×1). Gated on S4.4/S4.5, which rewrite exactly those sites.
-  - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
-    `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
-    `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
-    `ScopeFinder`, and `DeclarationScanner` all read). Behavior-preserving, so the Step P
-    write-path and class-like-lookup goldens prove it. `SymbolExtractor`'s `Class::method`
-    FQNs are its own and stay.
-  - **SC.4** — `file://` URI and path conversion is hand-rolled in four live places
-    (`DefaultClassInfoFactory`, `FilesystemBackend` ×2, `Location`, and the dead
-    `WorkspaceIndexer`), each differing in how it handles the scheme and percent-
-    encoding. One `FileUri` replaces them. Found while splitting S3.7, whose locator
-    wanted a fifth copy; the duplication predates that slice and belongs to no step,
-    so S3.7c is gated on it rather than carrying it.
-  - **SC.5** — `FilesystemBackend::findClassInAst` and `Index\DeclarationScanner` both
-    walk an AST to find the class-likes a file declares. They differ in what they
-    return (one matched *node* versus every declared *name*) and in stopping early, so
-    this is scoped as **evaluate and merge if warranted** — concluding "two genuinely
-    different queries, one walk" is an acceptable outcome, but it must be concluded and
-    recorded, not left unexamined. Gated only on SC.3, which rewrites `findClassInAst`'s
-    namespace handling; it is deliberately *not* gated on S3.11, because an audit files
-    slices and a slice already filed must not wait on the audit that would have found
-    it. Found while reviewing S3.7d, which put the two traversals side by side without
-    merging them.
-- **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
+  Step 2 double-write facade and (if built) the Step 0 cache rider; slice 5 the per-kind
+  declaration walks; slice 11 the §4.2 function-path exemption, `getFileFunctions`, and
+  the `DefaultFunctionRepository` AST-in signature; slices 17 and 19 the `SymbolResolver`
+  god class, `TextFallbackHelper` breadth, and the `CodeResolver` knowledge-facing
+  methods. Slice 21 verifies the ledger is fully discharged.
+- **Stepless rows carry no step, on purpose.** They are duplication, dead code, and
+  missing enforcement that no step's acceptance covers — which is exactly how they went
+  unowned until an audit found them. They are in the table so `/do-next` can select them
+  and slice 21 can require them. A removal with no owning slice is a defect; put it here.
+  **Unblocked removals go first**, ahead of the step slices: dead and duplicated code
+  costs every audit and review that passes over it, and row order is what makes
+  `/do-next` reach it.
+  - **Slice 1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`.
+  - **Slice 2** — `SymbolExtractor` hand-tracks `Stmt\Namespace_` to build FQNs that
+    `NameResolver` already computed into `namespacedName` (which `DefaultClassInfoFactory`,
+    `DefaultFunctionRepository`, `ScopeFinder`, and `DeclarationScanner` all read).
+    Behavior-preserving, so the Step P write-path golden proves it. `SymbolExtractor`'s
+    `Class::method` FQNs are its own and stay. The other site this once covered,
+    `FilesystemBackend::findClassInAst`, is removed by slice 5 independently.
+  - **Slices 3 and 4** — §8.1 names an enforcement mechanism per invariant and slice 21
+    requires every one active repo-wide, so a mechanism with no owning slice is a gate
+    that cannot pass. `phpstan.neon` registers two rules today (§4.2, §4.8); §4.1
+    (handlers depend on no parser, repository, or reflection) and §4.3 (consumers depend
+    on `SymbolSource` / `SymbolSink`, never a concrete implementation) have none. Both are
+    green against today's code — only `Server.php`, the composition root, names a concrete
+    implementation — so each is a rule plus its `RuleTestCase`, not a migration. §4.1 is
+    the axis closed by #190/#253/#256 and held by documentation ever since, which §8.1
+    forbids.
+  - **Slice 18** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were
+    superseded by `NameContextFactory` and their own docblock says they go away once #331
+    moves the callers. #331 landed (#337); three callers did not move (`SymbolResolver`
+    ×2, `TextFallbackHelper` ×1). Gated on slices 16 and 17, which rewrite those sites.
+  - **SC.4** — `file://` URI and path conversion was hand-rolled in four live places, each
+    differing in how it handled the scheme and percent-encoding. One `FileUri` replaced
+    them. Found while splitting S3.7, whose locator wanted a fifth copy.
+- **Each section ends with a duplication audit** (**slices 12 and 20**), and Step Z's
   acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
   in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
   not restated here, because a manifest note is not a gate.
-  - S3.11 and S4.7 are **tracking** gates: a finding may be handed to a new slice
+  - Slices 12 and 20 are **tracking** gates: a finding may be handed to a new slice
     rather than fixed in place, so a removal belonging to a later section is not dragged
-    forward. Step Z is the **completion** gate, where an unowned or unfixed duplicate
+    forward. Slice 21 is the **completion** gate, where an unowned or unfixed duplicate
     fails outright.
   - The three depend on their whole section (`all Step N` / `all prior`) rather than on
-    its last slice. A chain of ids is both stale-prone and wrong: S3.10's transitive
-    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on S3.10 could have
+    its last slice. A chain of ids is both stale-prone and wrong: slice 11's transitive
+    dependencies never reach S3.4 or S3.5, so a Step 3 audit gated on slice 11 could have
     run with two of its slices unbuilt.
 - **The Builtin backend stood up in S3.3 is reflection-backed and does not satisfy
-  §4.7** (0002 §5 known gap) — file the tracked §4.7 issue when S3.3 lands; its fix is
-  the deferred Step 5.
+  §4.7** (0002 §5 known gap), tracked as #401; its fix is the deferred Step 5.
 - **`Closes` is assigned at slice-issue creation, after a reviewer reads the issue —
   never inferred.** Candidates from Wave 1's note: #239 / #181 / #317 land somewhere in
-  S3.7a–S3.10; #295 (Visibility enum) wants a small cleanup slice not yet placed.
+  S3.7a–slice 11; #295 (Visibility enum) wants a small cleanup slice not yet placed.
   - **#181 covers all three kinds**, which is now what S3.7b–S3.7d build: the
     `files` set has no name→file map of any kind, so it is scanned whole. A slice
     claiming #181 must show class-like reach, not just functions and constants.
-    - **#181 is not closable before S3.9b.** Its acceptance asks for these symbols in
-      *hover and completion*, not merely resolvable: functions need S3.8a and S3.9b,
-      constants S3.8b, namespace completion S3.7e. It also asks for a startup-time
+    - **#181 is not closable before slice 9.** Its acceptance asks for these symbols in
+      *hover and completion*, not merely resolvable: functions need S3.8a and slice 9,
+      constants slice 10, namespace completion S3.7e. It also asks for a startup-time
       benchmark, which S3.7d's eager index makes a live question rather than a
       formality — S3.7d pins the parse *count*, which is not the same measurement.
       Read the issue body before wiring `Closes`; the reach landing is not the
@@ -226,8 +250,14 @@ when their phase is reached.
 
 - **Step 5 — environment-parameterized built-ins (§4.7).** Not plannable: its
   version-aware source is an open `TBD` (0002 §7, explicitly not `phpstorm-stubs`). The
-  interim reflection Builtin backend already ships in S3.3; §4.7 stays a tracked issue.
-  Nothing in Wave 2 depends on Step 5, and SZ.1 permits it to remain a named gap.
+  interim reflection Builtin backend already ships in S3.3; §4.7 is tracked as **#401**.
+  Nothing depends on Step 5, and slice 21 permits it to remain a named gap.
+- **Position encodings other than UTF-16 (#192, #371).** The boundary conversion and the
+  interior byte columns are done (S1.2, S1.5), but the negotiated encoding does not reach
+  `TextDocument`, so only the UTF-16 default is served. A client-compatibility feature
+  rather than foundation work: [LSP] requires UTF-16 support and the encoding is
+  negotiated, so a client offering nothing else is served correctly today. Slice 21
+  permits it as a named gap.
 - **Step 6 — scheduler / async tier (#266).** Deferred until a push feature needs it.
   Sketch, from its acceptance: `$/cancelRequest` cancellation of superseded work;
   debounced `publishDiagnostics` on change; a background scheduler that does not starve

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -73,14 +73,16 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
     S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    S3.8b  3b    lookupConstant project reach                       S3.7d             —
-    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —
+    S3.8b  3b    One declaration walk; backends consume it          S3.8a             —
+    S3.8c  3b    §8.1 rule: one owner per shared mechanism          S3.8b             —
+    S3.8d  3b    Retire the AST-in function lookup from consumers   S3.8b             —
     S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
-    S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
-    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
+    S3.9b  3b    Function search + FunctionCandidates migration     S3.8c,S3.9a       —
+    S3.9c  3b    Constant vertical: lookup, search, enumeration     S3.8c,S3.9a       —
+    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8d,S3.9b,S3.9c —
     S3.11  3     Step 3 duplication audit                          all Step 3        —
     S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
-    S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
+    S4.2   4     Extract node locator + scope analyzer              S3.8d,S4.1        —
     S4.3   4     Extract member-access + call-context detectors     S4.2              —
     S4.4   4     Extract name-context resolver                      S4.2              —
     S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
@@ -88,9 +90,8 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S4.7   4     Step 4 duplication audit                          all Step 4        —
     SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
     SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
-    SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
+    SC.3   —     SymbolExtractor -> the parser's namespacedName      S3.8b             —
     SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
-    SC.5   —     Merge the two class-like AST traversals             SC.3              —
     SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
@@ -126,7 +127,11 @@ Notes:
 - **S3.8 and S3.9 are cut by symbol namespace, not by layer.** A layer cut (interface,
   then backends, then consumers) would land `SymbolBackend` methods no backend
   implements, so each slice is instead one vertical: a kind's name type, its
-  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. S3.8c
+  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. A
+  vertical consumes shared mechanism and never adds one (RFC §4.11) — **S3.8b** unifies
+  the declaration walk S3.8a duplicated (`DeclarationScanner` yields each declaration
+  with its *node*, since needing the node is a return-shape difference, not a second
+  query) and **S3.8c** adds the rule that holds it, both ahead of any further kind. S3.8d
   then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
   `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
   `SymbolResolver`, so it, not S3.8a, is what S4.2 serializes against (§6).
@@ -136,18 +141,23 @@ Notes:
   makes the backends answer function search and moves `FunctionCandidates` onto it,
   rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
   answer function search in S3.9b or built-in function completion regresses — that
-  golden is what catches it.
+  golden is what catches it. **S3.9c** lands constants whole rather than lookup-first:
+  splitting a kind across a lookup slice and a later search slice is what produced
+  S3.7e, and RFC §4.2 requires identical coverage across the two. Enumeration is likely
+  already satisfied by S3.7e's per-declaration `NameKind`, making it a fixture to prove
+  rather than code to write; offering constants at expression start (#317) is a feature
+  on this reach and stays out of scope.
 - **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
   whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
-  `ConstantName` in **S3.8b**, with their lookups.
+  `ConstantName` in **S3.9c**, with their lookups.
   - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
     name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
-    S3.8b rather than inside it — this is the same coexistence question §7 leaves open
+    S3.9c rather than inside it — this is the same coexistence question §7 leaves open
     for `ClassLikeName` versus `ClassName`.
 - **Steps 3 and 4 both edit `SymbolResolver` (§6).** S4.2 (positional extraction) is
-  gated on S3.8 (the 3b lookup migration) so the two never run concurrently; manifest
+  gated on S3.8d (the 3b lookup migration) so the two never run concurrently; manifest
   order keeps Step 3 ahead of Step 4 regardless. S4.1 (`TypeClassifier` + the §4.5/§4.6
   rules) is independent of Step 3 and may proceed alongside.
 - **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
@@ -167,28 +177,18 @@ Notes:
     by `NameContextFactory` and their own docblock says they go away once #331 moves the
     callers. #331 landed (#337); three callers did not move (`SymbolResolver` ×2,
     `TextFallbackHelper` ×1). Gated on S4.4/S4.5, which rewrite exactly those sites.
-  - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
-    `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
-    `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
-    `ScopeFinder`, and `DeclarationScanner` all read). Behavior-preserving, so the Step P
-    write-path and class-like-lookup goldens prove it. `SymbolExtractor`'s `Class::method`
-    FQNs are its own and stay.
+  - **SC.3** — `SymbolExtractor` hand-tracks `Stmt\Namespace_` to build FQNs that
+    `NameResolver` already computed into `namespacedName` (which `DefaultClassInfoFactory`,
+    `DefaultFunctionRepository`, `ScopeFinder`, and `DeclarationScanner` all read).
+    Behavior-preserving, so the Step P write-path golden proves it. `SymbolExtractor`'s
+    `Class::method` FQNs are its own and stay. Gated on S3.8b, which removes
+    `FilesystemBackend::findClassInAst` — the other site this row originally covered.
   - **SC.4** — `file://` URI and path conversion is hand-rolled in four live places
     (`DefaultClassInfoFactory`, `FilesystemBackend` ×2, `Location`, and the dead
     `WorkspaceIndexer`), each differing in how it handles the scheme and percent-
     encoding. One `FileUri` replaces them. Found while splitting S3.7, whose locator
     wanted a fifth copy; the duplication predates that slice and belongs to no step,
     so S3.7c is gated on it rather than carrying it.
-  - **SC.5** — `FilesystemBackend::findClassInAst` and `Index\DeclarationScanner` both
-    walk an AST to find the class-likes a file declares. They differ in what they
-    return (one matched *node* versus every declared *name*) and in stopping early, so
-    this is scoped as **evaluate and merge if warranted** — concluding "two genuinely
-    different queries, one walk" is an acceptable outcome, but it must be concluded and
-    recorded, not left unexamined. Gated only on SC.3, which rewrites `findClassInAst`'s
-    namespace handling; it is deliberately *not* gated on S3.11, because an audit files
-    slices and a slice already filed must not wait on the audit that would have found
-    it. Found while reviewing S3.7d, which put the two traversals side by side without
-    merging them.
 - **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
   acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
   in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
@@ -212,7 +212,7 @@ Notes:
     claiming #181 must show class-like reach, not just functions and constants.
     - **#181 is not closable before S3.9b.** Its acceptance asks for these symbols in
       *hover and completion*, not merely resolvable: functions need S3.8a and S3.9b,
-      constants S3.8b, namespace completion S3.7e. It also asks for a startup-time
+      constants S3.9c, namespace completion S3.7e. It also asks for a startup-time
       benchmark, which S3.7d's eager index makes a live question rather than a
       formality — S3.7d pins the parse *count*, which is not the same measurement.
       Read the issue body before wiring `Closes`; the reach landing is not the

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -16,8 +16,12 @@ Append later phases as they are reached; do not create the whole tree up front.
   step-encoded ids they were built under; every new row is a plain number, assigned in
   sequence and never reused. An id is only a branch name — order is table position and
   sequencing is the `Depends on` column, so encoding either into the id just makes it
-  wrong later. New rows are appended below the last completed one, never interleaved
-  above it.
+  wrong later.
+- **Row order.** New rows go below the last `done` row, never above it — a completed
+  row's position is history. Within that pending block they may be placed anywhere, and
+  unblocked removals go at its top: `/do-next` takes the first unblocked `todo` in table
+  order, so position is the only thing that gets dead and duplicated code removed before
+  the work that has to read past it.
 - **Step** — the plan step in 0002 that owns the acceptance criteria.
 - **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
   exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
@@ -151,14 +155,32 @@ Notes:
   using `DeclarationScanner`, the whole-file walk S3.7b had built one slice earlier.
   - **Slice 5** gives the remaining verticals something to consume: one walk yielding
     each declaration *with its node*, since needing the node for `ClassInfoFactory` /
-    `FunctionInfo::fromNode` is a return-shape difference, not a second query. It deletes
-    both bespoke finders. Behavior-preserving, so the class-like-lookup and S3.6
-    function-surface goldens stay frozen.
+    `FunctionInfo::fromNode` is a return-shape difference, not a second query.
+    Every walk answering "what does this file declare" is deleted:
+    `FilesystemBackend`'s `parseFunctionFrom` and `findClassInAst`, and
+    `DocumentSymbolSink`'s `functionsIn` and `classesIn`. The write path is not
+    optional here — it is the open-document backend's, so leaving it out would land a
+    slice titled "backends consume it" where one backend does not. It is also where the
+    split already shows: `functionsIn` reports a declaration at any depth while
+    `classesIn` reads top-level statements only, which is the §4.2 coverage split
+    inside one class. Behavior-preserving for lookup, so the class-like-lookup and S3.6
+    function-surface goldens stay frozen; the class-like depth change is new behavior on
+    the write path, proven by a fixture and a rewritten Step P write-path golden.
   - **Slice 6** adds the rule, per 0002 §Duplication audits ("an audit's first *fix* is
-    to add the rule"): one named owner per shared mechanism. It ships scoped if slice 2
-    or 18 has not landed — each is a §4.11 violation it will flag — and those two
-    discharge its allowlist. The positional walkers (`NodeAtPosition`, `Scope`,
-    `ScopeFinder`) are separate owners, not exemptions.
+    to add the rule"): one named owner per shared mechanism, the owners named in the
+    rule's own configuration (RFC §8.1). Every AST traversal in `src/` must be
+    classified by it, so the disposition of all of them is fixed here rather than
+    discovered mid-slice:
+    - **Owners.** `DeclarationScanner` (declaration walk, after slice 5);
+      `NodeAtPosition`, `Scope`, `ScopeFinder` (positional walks — a different
+      mechanism, not exemptions); `ParserService` (the `NameResolver` pass every parse
+      runs through); `BasicTypeResolver` (assignment-flow walk, its own mechanism).
+    - **Declared migrations**, each already carrying a remover: `SymbolExtractor`
+      (slice 2), `ScopeFinder`'s import extraction (slice 18), `DefaultFunctionRepository`
+      (slice 11, which deletes the AST-in signature), `SymbolResolver`'s two walks
+      (slice 19, which reduces it to glue).
+    - No allowlist entry may be added without a remover slice, since slice 21 requires
+      zero remaining scope.
   - **Slice 10** lands constants whole rather than lookup-first: splitting a kind across
     a lookup slice and a later search slice is what produced S3.7e, and RFC §4.2 requires
     identical coverage across the two. Enumeration is likely already satisfied by S3.7e's
@@ -179,7 +201,7 @@ Notes:
   order keeps Step 3 ahead of Step 4 regardless. Slice 13 (`TypeClassifier` + the
   §4.5/§4.6 rules) is independent of Step 3 and may proceed alongside.
 - **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
-  Step 2 double-write facade and (if built) the Step 0 cache rider; slice 5 the per-kind
+  Step 2 double-write facade and (if built) the Step 0 cache rider; slice 5 the bespoke
   declaration walks; slice 11 the §4.2 function-path exemption, `getFileFunctions`, and
   the `DefaultFunctionRepository` AST-in signature; slices 17 and 19 the `SymbolResolver`
   god class, `TextFallbackHelper` breadth, and the `CodeResolver` knowledge-facing
@@ -187,10 +209,8 @@ Notes:
 - **Stepless rows carry no step, on purpose.** They are duplication, dead code, and
   missing enforcement that no step's acceptance covers — which is exactly how they went
   unowned until an audit found them. They are in the table so `/do-next` can select them
-  and slice 21 can require them. A removal with no owning slice is a defect; put it here.
-  **Unblocked removals go first**, ahead of the step slices: dead and duplicated code
-  costs every audit and review that passes over it, and row order is what makes
-  `/do-next` reach it.
+  and slice 21 can require them. A removal with no owning slice is a defect; put it here,
+  at the top of the pending block (see Row order).
   - **Slice 1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`.
   - **Slice 2** — `SymbolExtractor` hand-tracks `Stmt\Namespace_` to build FQNs that
     `NameResolver` already computed into `namespacedName` (which `DefaultClassInfoFactory`,
@@ -202,11 +222,16 @@ Notes:
     requires every one active repo-wide, so a mechanism with no owning slice is a gate
     that cannot pass. `phpstan.neon` registers two rules today (§4.2, §4.8); §4.1
     (handlers depend on no parser, repository, or reflection) and §4.3 (consumers depend
-    on `SymbolSource` / `SymbolSink`, never a concrete implementation) have none. Both are
-    green against today's code — only `Server.php`, the composition root, names a concrete
-    implementation — so each is a rule plus its `RuleTestCase`, not a migration. §4.1 is
+    on `SymbolSource` / `SymbolSink`, never a concrete implementation) have none. §4.1 is
     the axis closed by #190/#253/#256 and held by documentation ever since, which §8.1
-    forbids.
+    forbids; §4.3's seam is Step 2's, whose acceptance named only the §4.2 rule, so it is
+    a late Step 2 obligation rather than pre-existing debt (0002 §Teardown ledger).
+    Each is a rule plus its `RuleTestCase`, not a migration: §4.1 is green in `src/`, and
+    §4.3 is green once the rule scopes "consumer" to code outside the knowledge and index
+    tiers — `Server.php` and `KnowledgeStack` are composition roots, and
+    `WorkspaceNamespaceSource`, `OpenDocumentBackend` and `DocumentIndexer` are inside
+    the tier that owns the concrete stores. Fix that scope in the slice; a wider reading
+    turns slice 4 into a migration it is not planned as.
   - **Slice 18** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were
     superseded by `NameContextFactory` and their own docblock says they go away once #331
     moves the callers. #331 landed (#337); three callers did not move (`SymbolResolver`

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -73,16 +73,14 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
     S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    S3.8b  3b    One declaration walk; backends consume it          S3.8a             —
-    S3.8c  3b    §8.1 rule: one owner per shared mechanism          S3.8b             —
-    S3.8d  3b    Retire the AST-in function lookup from consumers   S3.8b             —
+    S3.8b  3b    lookupConstant project reach                       S3.7d             —
+    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —
     S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
-    S3.9b  3b    Function search + FunctionCandidates migration     S3.8c,S3.9a       —
-    S3.9c  3b    Constant vertical: lookup, search, enumeration     S3.8c,S3.9a       —
-    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8d,S3.9b,S3.9c —
+    S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
+    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
     S3.11  3     Step 3 duplication audit                          all Step 3        —
     S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
-    S4.2   4     Extract node locator + scope analyzer              S3.8d,S4.1        —
+    S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
     S4.3   4     Extract member-access + call-context detectors     S4.2              —
     S4.4   4     Extract name-context resolver                      S4.2              —
     S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
@@ -90,8 +88,9 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S4.7   4     Step 4 duplication audit                          all Step 4        —
     SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
     SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
-    SC.3   —     SymbolExtractor -> the parser's namespacedName      S3.8b             —
+    SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
     SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
+    SC.5   —     Merge the two class-like AST traversals             SC.3              —
     SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
@@ -127,11 +126,7 @@ Notes:
 - **S3.8 and S3.9 are cut by symbol namespace, not by layer.** A layer cut (interface,
   then backends, then consumers) would land `SymbolBackend` methods no backend
   implements, so each slice is instead one vertical: a kind's name type, its
-  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. A
-  vertical consumes shared mechanism and never adds one (RFC §4.11) — **S3.8b** unifies
-  the declaration walk S3.8a duplicated (`DeclarationScanner` yields each declaration
-  with its *node*, since needing the node is a return-shape difference, not a second
-  query) and **S3.8c** adds the rule that holds it, both ahead of any further kind. S3.8d
+  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. S3.8c
   then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
   `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
   `SymbolResolver`, so it, not S3.8a, is what S4.2 serializes against (§6).
@@ -141,23 +136,18 @@ Notes:
   makes the backends answer function search and moves `FunctionCandidates` onto it,
   rewriting only the function-surface golden S3.6 froze. Note `BuiltinBackend` MUST
   answer function search in S3.9b or built-in function completion regresses — that
-  golden is what catches it. **S3.9c** lands constants whole rather than lookup-first:
-  splitting a kind across a lookup slice and a later search slice is what produced
-  S3.7e, and RFC §4.2 requires identical coverage across the two. Enumeration is likely
-  already satisfied by S3.7e's per-declaration `NameKind`, making it a fixture to prove
-  rather than code to write; offering constants at expression start (#317) is a feature
-  on this reach and stays out of scope.
+  golden is what catches it.
 - **Name-type model is JIT (§5.3).** Each type lands with its first caller, not ahead
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
   whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
-  `ConstantName` in **S3.9c**, with their lookups.
+  `ConstantName` in **S3.8b**, with their lookups.
   - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
     name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
-    S3.9c rather than inside it — this is the same coexistence question §7 leaves open
+    S3.8b rather than inside it — this is the same coexistence question §7 leaves open
     for `ClassLikeName` versus `ClassName`.
 - **Steps 3 and 4 both edit `SymbolResolver` (§6).** S4.2 (positional extraction) is
-  gated on S3.8d (the 3b lookup migration) so the two never run concurrently; manifest
+  gated on S3.8 (the 3b lookup migration) so the two never run concurrently; manifest
   order keeps Step 3 ahead of Step 4 regardless. S4.1 (`TypeClassifier` + the §4.5/§4.6
   rules) is independent of Step 3 and may proceed alongside.
 - **Teardown discharge.** S3.2 removes the duplicate `ComposerAutoloadMap`; S3.4 the
@@ -177,18 +167,28 @@ Notes:
     by `NameContextFactory` and their own docblock says they go away once #331 moves the
     callers. #331 landed (#337); three callers did not move (`SymbolResolver` ×2,
     `TextFallbackHelper` ×1). Gated on S4.4/S4.5, which rewrite exactly those sites.
-  - **SC.3** — `SymbolExtractor` hand-tracks `Stmt\Namespace_` to build FQNs that
-    `NameResolver` already computed into `namespacedName` (which `DefaultClassInfoFactory`,
-    `DefaultFunctionRepository`, `ScopeFinder`, and `DeclarationScanner` all read).
-    Behavior-preserving, so the Step P write-path golden proves it. `SymbolExtractor`'s
-    `Class::method` FQNs are its own and stay. Gated on S3.8b, which removes
-    `FilesystemBackend::findClassInAst` — the other site this row originally covered.
+  - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
+    `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
+    `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
+    `ScopeFinder`, and `DeclarationScanner` all read). Behavior-preserving, so the Step P
+    write-path and class-like-lookup goldens prove it. `SymbolExtractor`'s `Class::method`
+    FQNs are its own and stay.
   - **SC.4** — `file://` URI and path conversion is hand-rolled in four live places
     (`DefaultClassInfoFactory`, `FilesystemBackend` ×2, `Location`, and the dead
     `WorkspaceIndexer`), each differing in how it handles the scheme and percent-
     encoding. One `FileUri` replaces them. Found while splitting S3.7, whose locator
     wanted a fifth copy; the duplication predates that slice and belongs to no step,
     so S3.7c is gated on it rather than carrying it.
+  - **SC.5** — `FilesystemBackend::findClassInAst` and `Index\DeclarationScanner` both
+    walk an AST to find the class-likes a file declares. They differ in what they
+    return (one matched *node* versus every declared *name*) and in stopping early, so
+    this is scoped as **evaluate and merge if warranted** — concluding "two genuinely
+    different queries, one walk" is an acceptable outcome, but it must be concluded and
+    recorded, not left unexamined. Gated only on SC.3, which rewrites `findClassInAst`'s
+    namespace handling; it is deliberately *not* gated on S3.11, because an audit files
+    slices and a slice already filed must not wait on the audit that would have found
+    it. Found while reviewing S3.7d, which put the two traversals side by side without
+    merging them.
 - **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
   acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
   in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
@@ -212,7 +212,7 @@ Notes:
     claiming #181 must show class-like reach, not just functions and constants.
     - **#181 is not closable before S3.9b.** Its acceptance asks for these symbols in
       *hover and completion*, not merely resolvable: functions need S3.8a and S3.9b,
-      constants S3.9c, namespace completion S3.7e. It also asks for a startup-time
+      constants S3.8b, namespace completion S3.7e. It also asks for a startup-time
       benchmark, which S3.7d's eager index makes a live question rather than a
       formality — S3.7d pins the parse *count*, which is not the same measurement.
       Read the issue body before wiring `Closes`; the reach landing is not the

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -177,7 +177,7 @@ Notes:
       runs through); `BasicTypeResolver` (assignment-flow walk, its own mechanism).
     - **Declared migrations**, each already carrying a remover: `SymbolExtractor`
       (slice 2), `ScopeFinder`'s import extraction (slice 18), `DefaultFunctionRepository`
-      (slice 11, which deletes the AST-in signature), `SymbolResolver`'s two walks
+      (slice 11, which deletes the AST-in signature), `SymbolResolver`'s own walks
       (slice 19, which reduces it to glue).
     - No allowlist entry may be added without a remover slice, since slice 21 requires
       zero remaining scope.

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -24,20 +24,17 @@ Progress is **derived from git / PR merge state**, keyed by deterministic branch
 names — not from a hand-maintained "status" column, which drifts the moment a merge
 happens outside the tool.
 
-- The **manifest** (`build-manifest.md`) is a *static* slice registry: id, step,
-  title, dependencies, deterministic branch name, and which existing issues a slice
-  closes. It is append-only as later phases are reached; it never records progress.
+- The **manifest** (`build-manifest.md`) is an ordered checklist: id, step, title. It
+  is appended to as later phases are reached; it never records progress, and it never
+  restates the plan.
 - A slice's **status is computed**, checked in this order:
   - `done` — a **merged PR** exists whose head ref is `slice/<id>`
     (`gh pr list --state merged --head slice/<id>`).
   - `in-flight` — an **open PR** exists for `slice/<id>`.
   - `todo` — neither.
-- The **next slice** = the first `todo` in the manifest whose dependencies are all
-  `done`. A dependency is normally a slice id; the audit/DoD gates instead use a
-  collective form, resolved before the check: **`all Step N`** expands to every other
-  slice whose Step column is `N` (sub-steps included), and **`all prior`** to every
-  other slice in the table. A gate depends on its whole section, so it cannot run
-  while any slice of that section is unbuilt — which an id chain does not guarantee.
+- The **next slice** = the first `todo` in manifest order. Order is the sequencing:
+  every row above a slice must be `done` before it starts, so there is no dependency
+  graph to resolve and none to go stale.
 
 Because status is computed from merge reality, a cold session cannot be misled by a
 stale field, and nothing needs updating by hand.
@@ -69,13 +66,12 @@ squash-deleted branch is never misread as unstarted.
 1. **Preconditions (halt if unmet).** Working tree clean; on `main`; `main` synced
    with origin; `composer test` green on `main`. If any fails, report and stop.
 2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
-   state; `X` = first `todo` whose dependencies are all `done`.
+   state; `X` = the first `todo` in manifest order.
 3. **Safeguards (halt and ask, do not guess) if:**
-   - nothing is unblocked (report how many are `done` / blocked / in-flight);
+   - every slice is `done` (the checklist is finished);
    - a slice is already `in-flight` that is not yet `done` (finish or review it
      first — one slice in flight at a time);
-   - the manifest references a merged branch for a slice whose dependencies are not
-     merged (state drift — surface it).
+   - a slice below `X` is already merged (state drift — surface it).
 4. **Explain X.** Describe in plain english the work to be done, then wait for
    approval, clarification, or modification.
 5. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
@@ -124,8 +120,8 @@ squash-deleted branch is never misread as unstarted.
 
 ## Relationship to GitHub issues
 
-The manifest is the driver's source of truth. GitHub issues are the *human-facing*
-mirror and the mechanism for closing pre-existing issues (the `Closes` column).
+The manifest is the driver's build order. GitHub issues are the *human-facing*
+mirror and the mechanism for closing pre-existing issues.
 Create the per-slice issue when its phase is reached (just-in-time, one phase ahead
 — not the whole tree up front). Existing design epics (#264/#265/#266) are reused as
 the later-phase trackers, not duplicated.

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -24,20 +24,18 @@ Progress is **derived from git / PR merge state**, keyed by deterministic branch
 names — not from a hand-maintained "status" column, which drifts the moment a merge
 happens outside the tool.
 
-- The **manifest** (`build-manifest.md`) is a *static* slice registry: id, step,
-  title, dependencies, deterministic branch name, and which existing issues a slice
-  closes. It is append-only as later phases are reached; it never records progress.
+- The **manifest** (`build-manifest.md`) is an *ordered* slice list: id, step, title,
+  and the order they are built in. The branch is `slice/<id>`. It is append-only as
+  later phases are reached; it never records progress.
 - A slice's **status is computed**, checked in this order:
   - `done` — a **merged PR** exists whose head ref is `slice/<id>`
     (`gh pr list --state merged --head slice/<id>`).
   - `in-flight` — an **open PR** exists for `slice/<id>`.
   - `todo` — neither.
-- The **next slice** = the first `todo` in the manifest whose dependencies are all
-  `done`. A dependency is normally a slice id; the audit/DoD gates instead use a
-  collective form, resolved before the check: **`all Step N`** expands to every other
-  slice whose Step column is `N` (sub-steps included), and **`all prior`** to every
-  other slice in the table. A gate depends on its whole section, so it cannot run
-  while any slice of that section is unbuilt — which an id chain does not guarantee.
+- The **next slice** = the first `todo` in manifest order. There is no dependency
+  column: the table order *is* the sequencing, so every row above the next slice must
+  already be `done`. An ordering that lets a row be built early is expressed by
+  placing it early.
 
 Because status is computed from merge reality, a cold session cannot be misled by a
 stale field, and nothing needs updating by hand.
@@ -62,7 +60,8 @@ squash-deleted branch is never misread as unstarted.
   body and confirmed its acceptance criteria are met** — never inferred from a title
   (per the project's review rules).
 - **Acceptance criteria** for a slice are its plan step's criteria in 0002; the
-  manifest points at the step, it does not restate them.
+  manifest points at the step, it does not restate them. If a slice defers work, the
+  deferral becomes a later row in the manifest before that slice lands.
 
 ## Mode A — "do the next step"
 
@@ -71,11 +70,10 @@ squash-deleted branch is never misread as unstarted.
 2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
    state; `X` = first `todo` whose dependencies are all `done`.
 3. **Safeguards (halt and ask, do not guess) if:**
-   - nothing is unblocked (report how many are `done` / blocked / in-flight);
+   - nothing is unblocked (report how many are `done` / remaining / in-flight);
    - a slice is already `in-flight` that is not yet `done` (finish or review it
      first — one slice in flight at a time);
-   - the manifest references a merged branch for a slice whose dependencies are not
-     merged (state drift — surface it).
+   - a slice is merged while one above it is not (state drift — surface it).
 4. **Explain X.** Describe in plain english the work to be done, then wait for
    approval, clarification, or modification.
 5. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
@@ -106,9 +104,9 @@ squash-deleted branch is never misread as unstarted.
    where CI is blind — unverified claims, assertions that survive mutation,
    acceptance criteria met only in appearance.
 3. **Fix.** Apply fixes on the branch; re-run the cleanroom pass until clean.
-4. **Land.** Mark ready / merge. For each existing issue the manifest says this slice
-   closes, **read the issue body, confirm its criteria are met, then** wire
-   `Closes #<n>` (or close with a verification note).
+4. **Land.** Mark ready / merge. For each existing issue this slice plausibly closes,
+   **read the issue body, confirm its criteria are met, then** wire `Closes #<n>` (or
+   close with a verification note).
 5. Stop. Report what merged and the next computed slice.
 
 ## The "X is always correct" guarantee, in one place
@@ -125,7 +123,8 @@ squash-deleted branch is never misread as unstarted.
 ## Relationship to GitHub issues
 
 The manifest is the driver's source of truth. GitHub issues are the *human-facing*
-mirror and the mechanism for closing pre-existing issues (the `Closes` column).
-Create the per-slice issue when its phase is reached (just-in-time, one phase ahead
-— not the whole tree up front). Existing design epics (#264/#265/#266) are reused as
-the later-phase trackers, not duplicated.
+mirror and the mechanism for closing pre-existing issues. Which issues a slice closes
+is never recorded in the manifest: it is decided by the reviewer, from the issue body,
+at landing time. Create the per-slice issue when its phase is reached (just-in-time,
+one phase ahead — not the whole tree up front). Existing design epics (#264/#265/#266)
+are reused as the later-phase trackers, not duplicated.

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -24,17 +24,20 @@ Progress is **derived from git / PR merge state**, keyed by deterministic branch
 names — not from a hand-maintained "status" column, which drifts the moment a merge
 happens outside the tool.
 
-- The **manifest** (`build-manifest.md`) is an ordered checklist: id, step, title. It
-  is appended to as later phases are reached; it never records progress, and it never
-  restates the plan.
+- The **manifest** (`build-manifest.md`) is a *static* slice registry: id, step,
+  title, dependencies, deterministic branch name, and which existing issues a slice
+  closes. It is append-only as later phases are reached; it never records progress.
 - A slice's **status is computed**, checked in this order:
   - `done` — a **merged PR** exists whose head ref is `slice/<id>`
     (`gh pr list --state merged --head slice/<id>`).
   - `in-flight` — an **open PR** exists for `slice/<id>`.
   - `todo` — neither.
-- The **next slice** = the first `todo` in manifest order. Order is the sequencing:
-  every row above a slice must be `done` before it starts, so there is no dependency
-  graph to resolve and none to go stale.
+- The **next slice** = the first `todo` in the manifest whose dependencies are all
+  `done`. A dependency is normally a slice id; the audit/DoD gates instead use a
+  collective form, resolved before the check: **`all Step N`** expands to every other
+  slice whose Step column is `N` (sub-steps included), and **`all prior`** to every
+  other slice in the table. A gate depends on its whole section, so it cannot run
+  while any slice of that section is unbuilt — which an id chain does not guarantee.
 
 Because status is computed from merge reality, a cold session cannot be misled by a
 stale field, and nothing needs updating by hand.
@@ -66,12 +69,13 @@ squash-deleted branch is never misread as unstarted.
 1. **Preconditions (halt if unmet).** Working tree clean; on `main`; `main` synced
    with origin; `composer test` green on `main`. If any fails, report and stop.
 2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
-   state; `X` = the first `todo` in manifest order.
+   state; `X` = first `todo` whose dependencies are all `done`.
 3. **Safeguards (halt and ask, do not guess) if:**
-   - every slice is `done` (the checklist is finished);
+   - nothing is unblocked (report how many are `done` / blocked / in-flight);
    - a slice is already `in-flight` that is not yet `done` (finish or review it
      first — one slice in flight at a time);
-   - a slice below `X` is already merged (state drift — surface it).
+   - the manifest references a merged branch for a slice whose dependencies are not
+     merged (state drift — surface it).
 4. **Explain X.** Describe in plain english the work to be done, then wait for
    approval, clarification, or modification.
 5. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
@@ -120,8 +124,8 @@ squash-deleted branch is never misread as unstarted.
 
 ## Relationship to GitHub issues
 
-The manifest is the driver's build order. GitHub issues are the *human-facing*
-mirror and the mechanism for closing pre-existing issues.
+The manifest is the driver's source of truth. GitHub issues are the *human-facing*
+mirror and the mechanism for closing pre-existing issues (the `Closes` column).
 Create the per-slice issue when its phase is reached (just-in-time, one phase ahead
 — not the whole tree up front). Existing design epics (#264/#265/#266) are reused as
 the later-phase trackers, not duplicated.


### PR DESCRIPTION
## Why

S3.8a added `FilesystemBackend::parseFunctionFrom` — a second AST walk for "what does this file declare" — beside the existing `findClassInAst`, one slice after S3.7b built `DeclarationScanner` to do exactly that. A third symbol kind would have added a fourth walk.

Nothing prevented it. RFC 1 stated the single-implementation principle only in the non-normative Rationale, and bound it normatively for one case (the type graph, §4.6). The manifest then told each kind vertical to add its method "across all four backends" without saying it must consume the mechanisms already there.

## RFC 1

New **§4.11, Single Implementation per Mechanism**: one implementation per mechanism, every consumer reaches it through that one, and extending an axis means unifying first rather than adding a parallel path. Includes the disambiguation that closes this particular case — two implementations differing only in return shape are one mechanism.

A second implementation is permitted only as a **declared migration** — a scoped enforcement entry, a teardown record, and a named remover. Without that carve-out §4.11 forbids the strangler pattern this series is built on: every seam has a window where old and new coexist. The declaration is what separates that window from S3.8a, which had none of the three.

Carries a conformance item and a §8.1 enforcement row, per the RFC's rule that an invariant without a mechanism is a gap rather than a passed step. Date bumped, per its own amendment procedure.

## Plan and manifest

Step 3b resliced so the declaration walk is unified and rule-enforced before any further kind lands. Constants now land whole — lookup, search and enumeration in one slice — because splitting a kind across a lookup slice and a later search slice is what produced S3.7e.

The unifying slice covers `DocumentSymbolSink` as well as `FilesystemBackend`. That is the open-document backend's write path, so a slice titled "backends consume it" that skipped it would leave one backend that does not — and it is where the split already shows, with functions reported at any depth and class-likes only at the top level, inside one class.

The rule slice fixes the disposition of every AST traversal in `src/` up front: which are owners, which are declared migrations, and which remover discharges each. An allowlist entry without a remover cannot pass the terminal gate, so discovering these mid-slice is not an option.

Also scheduled: two §8.1 mechanisms that were listed but never built (§4.1 handler responsibility, §4.3 read/write segregation). Each is a rule plus its test rather than a migration, provided §4.3's rule scopes "consumer" to code outside the knowledge and index tiers.

Pending rows are reordered so unblocked removals come first, and moved onto plain sequential ids — an id is only a branch name, so encoding step and wave into it just makes it wrong when work is resliced. Merged slices keep the ids they were built under.

## Deferrals made explicit

- Built-ins read from the server's own PHP rather than the project's target: #401, referenced from the manifest and the Definition-of-Done gate. The manifest previously carried an instruction to file this, which was missed.
- Position encodings other than UTF-16 (#192, #371): converted to a named deferred gap. UTF-16 is what LSP requires and the encoding is negotiated, so a client offering nothing else is served correctly.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
