### PR TITLE
Close the per-kind duplication gaps ahead of constants

### DIFF
--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -17,6 +17,12 @@ runs `/clear` then `/review-slice` again. Only a pass that finds nothing is "cle
 - Check out the branch; ensure it is current with `main` (merge/rebase-free: if
   behind, merge `main` in or report).
 - Compute the diff under review: `git diff main...slice/<id>`.
+- Collect the slice's **owed items** from `0002`: anything the plan attaches by name to
+  this slice id or its step — the step's owed regression tests, and the duplication a step
+  is required to remove (e.g. Step 3b's "Regression tests the 3b corrections owe", Step
+  4's "Named duplication this step must remove"). These are acceptance criteria, not
+  suggestions; carry them into the panel verbatim. A slice that leaves one undone is a
+  finding even if every criterion on its own row is met.
 
 ## 2. Cleanroom review (this is the safeguard — keep it clean)
 
@@ -27,6 +33,8 @@ reasoning, or any implementer rationale — that is what makes it cleanroom. Run
 diverse panel in parallel:
 
 - **Acceptance** — is every acceptance criterion actually met, not just plausibly?
+  Including each owed item from step 1: the named test exists, and it fails against the
+  code it replaces (check that by reverting the fix locally, not by reading the test).
 - **Conformance** — §8.1 conformance for the invariants the slice touches (no
   forbidden reflection/index access, no `instanceof` on a concrete `Type`, no branch
   on a resolved kind, no raw `initialize` params outside the negotiation component,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,13 @@ per-backend PSR-16 policy (`src/Cache/`); on-disk and built-in results are cache
 documents never. A cache key carries the `NameKind` (`SymbolCacheKey`): PHP's three
 symbol namespaces are independent, so a class and a function may share a name.
 
-Lookup is **per-kind**, taking a name type that carries its kind (`ClassName`,
-`FunctionName`) rather than a name plus a `NameKind` argument. `lookupFunction` reaches
+Lookup is **per-kind at the `SymbolSource` facade** — a typed method per kind, taking a
+name type that carries its kind (`ClassName`, `FunctionName`), because RFC 1 §5.1 requires
+a concrete return type rather than a type-erased union — and **kind-parameterized at
+`SymbolBackend`**, so a new kind is never a change to every backend. The backends still
+carry a method per kind today; S3.8d collapses them (Plan 0002 §5.6). Do not read the
+facade's closed method set as licence to add a per-kind backend method.
+`lookupFunction` reaches
 open documents, the `autoload.files` set, and PHP's built-ins — the last filtered to
 `isInternal()`, because reflection also sees the functions the *server's* own
 dependencies declare, which are not the project's. A function in an unopened PSR-4 file

--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -552,6 +552,11 @@ invariant added by amendment MUST specify its mechanism.
     4.9 Position encoding             Test: multibyte round-trip at the boundary;
                                       review of interior offset use.
     4.10 Client conformance defects   Review only; defect list in Appendix B.
+    5.1 Uniform coverage across kinds Test: a backend x kind x query grid, each cell either
+                                      answering over the fixtures or explicitly registered
+                                      as not-applicable with its reason; and a name a
+                                      backend can look up is returned by that backend's
+                                      search and appears in its namespace enumeration.
     5.2 / 5.3 Write path, precedence, Architecture test + review: one write path,
         cache seam, bounded coverage  caching behind the abstraction, bounds observable.
     6 Synchronous correctness         By construction: the suite runs the interior

--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -552,10 +552,12 @@ invariant added by amendment MUST specify its mechanism.
     4.9 Position encoding             Test: multibyte round-trip at the boundary;
                                       review of interior offset use.
     4.10 Client conformance defects   Review only; defect list in Appendix B.
-    5.1 Uniform coverage across kinds Test: a backend x kind x query grid, each cell either
-                                      answering over the fixtures or explicitly registered
-                                      as not-applicable with its reason; and a name a
-                                      backend can look up is returned by that backend's
+    5.1 Uniform coverage across kinds Test: a backend x kind x query grid, its axes derived
+                                      from the kind enum and the backend registry rather
+                                      than listed, each cell either answering over the
+                                      fixtures or registered not-applicable against a named
+                                      blocker, and an unregistered cell failing; and a name
+                                      a backend can look up is returned by that backend's
                                       search and appears in its namespace enumeration.
     5.2 / 5.3 Write path, precedence, Architecture test + review: one write path,
         cache seam, bounded coverage  caching behind the abstraction, bounds observable.

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -580,6 +580,10 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
   explicitly-deferred, tracked ones, each with an issue: §4.7 / built-ins (Step 5), the
   workspace scope (#264/#265), the diagnostics / scheduler tier (Step 6 / #266), and
   computed-name `define()` (§3). A gap not on this list is a bug, not a deferral.
+  The §5.1 coverage grid is read against this list: every cell still registered
+  not-applicable must name one of these deferrals, so a registration whose blocker has
+  landed fails the gate. Otherwise the grid's own escape hatch outlives what it was
+  granted for, and a hole is certified rather than exposed.
 
 Only when all seven hold is the foundation deemed complete.
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -275,7 +275,13 @@ Step 4 (Section 6).
   `lookupFunction` MUST also answer function `search`, so a name resolvable on hover
   is offered in completion (§4.2). For `FilesystemBackend` that means the derived
   `autoload.files` index — its empty `searchClassLikes` is scoped to the PSR-4 tree,
-  which needs a workspace walk (§3), not to every kind. This step **both changes and
+  which needs a workspace walk (§3), not to every kind.
+  That clause was written by hand after S3.7e had already been filed for the same reason —
+  the same rule failing twice, patched twice, because §5.1's uniformity requirement had no
+  entry in §8.1's mechanism table. It now has one, and **S3.8d carries it**: the
+  backend × kind × query grid, per the rule that a seam ships with its enforcement. Once
+  the grid exists this paragraph is a description of what the test asserts, not an
+  instruction to remember. This step **both changes and
   preserves** behavior on the function surface: the added project reach is new
   (proven by **new fixtures**), but built-in and open-document function completion is
   *existing* behavior that must not regress. So the function-surface golden (Step P)

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -294,6 +294,24 @@ Step 4 (Section 6).
   support watched-file notifications, the fallback (lazy re-read vs. no invalidation)
   is an open decision (§7).
 
+*Regression tests the 3b corrections owe.* Each of the following fixes a defect that is
+invisible to a green suite, so the slice is not done until its test exists and has been
+shown to fail against the code it replaces. `/review-slice` checks for these by name.
+
+- **SC.2** — a class and a function sharing a short name, both imported in one file,
+  resolve independently. Fails today: `extractImports` folds the three import tables into
+  one.
+- **SC.5** — a function declared inside `if (!function_exists(...))` appears in completion,
+  not only on hover. This is the one correction here that **changes** behaviour: it
+  rewrites the function-surface golden S3.6 froze, and every other golden stays frozen.
+  Recapture deliberately and review that diff rather than accepting it.
+- **SC.6** — two constants differing only in case stay distinct through the composite's
+  merge and through the subtype walk's visited set. It cannot fail until constants exist,
+  so it lands with S3.8b, and S3.8b must show it failing against the `strtolower` SC.6
+  removed.
+- **S3.8d** — the coverage grid below, plus the S3.8b criterion that a new kind's diff
+  touches no backend.
+
 *Known tracked gap:* the Builtin backend stood up in 3a is reflection-backed and not
 environment-parameterized, so it does **not** satisfy §4.7 — it cannot answer for a
 target version or extension the server process lacks. This is **deferred** (Step 5)
@@ -493,6 +511,14 @@ The terminal audit in **Step Z** may not: there, an unowned *or* unfixed duplica
 
 An audit reporting no findings must show the enumeration it ran.
 "None found" without evidence is indistinguishable from not looking, which is exactly how these survived to be found by audit in the first place.
+
+**The enumeration has a floor**, set by what the audits have actually caught rather than by what seems thorough.
+It must cover, at minimum: AST traversal (every `NodeVisitorAbstract`, `NodeTraverser` and `NodeFinder` site), namespace and FQN construction (`Stmt\Namespace_` handling against the parser's `namespacedName`), case normalization (`strtolower` / `strcasecmp` on a symbol name, against `NameKind::normalize`), prefix matching, member-hierarchy walks, and path/URI conversion.
+Each of those has already produced a finding, several of them silently wrong rather than merely redundant.
+
+Two questions distinguish a duplicate that is worth folding from one that is a defect, and the audits must ask both.
+Not "is this the same code" but **"do these agree?"** — the five declaration finders were tolerable as five until they were found to disagree about nested declarations, at which point one of them was serving wrong completion results.
+And not "is this reachable" but **"which of these does each surface reach?"** — a mechanism duplicated across an AST path and a text-fallback path is two answers to one question, and the fallback is exactly where a divergence hides, because it only runs on code the parser could not handle.
 
 ### Step Z — Definition of Done (final verification gate)
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -329,6 +329,38 @@ below the glue, not beside the handler.
 independently testable units (e.g. node locator, scope analyzer, member-access
 detector, call-context detector, name-context resolver, text fallback).
 
+*Named duplication this step must remove.* An audit found the following already present
+across `SymbolResolver`, `TextFallbackHelper`, `ScopeFinder` and `Scope`. It is recorded
+here, rather than as `SC.*` slices, because these are the exact sites the decomposition
+rewrites — but without naming them the step can be declared done with every one intact,
+since "the class is thin now" says nothing about where its contents went.
+
+- **S4.2 — one node locator.** "Innermost node containing an offset" exists three times:
+  `Index\NodeAtPosition` (unfiltered), `Scope::findEnclosingFunctionLike` (filtered to
+  function-likes), `SymbolResolver::findCallAtPosition` (filtered to call nodes, plus
+  argument analysis). Identical containment predicate, identical last-write-wins descent.
+  One locator taking a type filter serves all three; the argument analysis is genuinely
+  extra and stays with the call-context detector.
+- **S4.4 — one answer per positional question.** "Find the enclosing class at a line"
+  exists three times **and all three disagree on which nodes count**:
+  `ScopeFinder::findClassAtLine` (`Stmt\Class_` only),
+  `SymbolResolver::findEnclosingClassForLine` (class, trait, enum), and
+  `TextFallbackHelper::findEnclosingClassFromContent` (all four, by regex). That is a
+  "works in a class, not in a trait" defect standing in the code now, so its tests must
+  cover a trait and an interface, not only a class. "Find the namespace at a line" exists
+  twice, and the text copy mishandles braced namespaces, which the AST one documents
+  carefully. "Short name to FQN via imports then namespace" exists twice
+  (`SymbolResolver::resolveNameFromText`, `TextFallbackHelper::resolveClassName`).
+- **S4.5 — the text fallback keeps its resilience, not its copies.**
+  `extractMethods` / `extractProperties` / `extractConstants` repeat the visibility,
+  static and filter logic three times. `getInheritedMembers` duplicates
+  `SymbolResolver::getMembersForClass` **and diverges from it** — it omits enum cases, so
+  inherited enum cases vanish whenever the fallback path is taken.
+  `extractUseStatementsFromText` re-derives PHP's `use` grammar (group use, aliases,
+  partial qualification) in ~65 lines of regex. That last one is legitimate where no AST
+  exists, so the requirement is that it share the *shape* of the AST path, not that it be
+  deleted.
+
 ### Step 5 — Environment-parameterized built-ins (deferred; tracked §4.7 gap)
 
 *Status:* **deferred.** §4.7 (built-in knowledge parameterized by the project's
@@ -417,6 +449,16 @@ unowned. They are listed anyway: the series exists to remove duplication, so a
 known-removable thing without an owning slice is the same defect as an undischarged
 scaffold. A remover must be a slice id; a prose note is not an owner, because
 `/do-next` cannot select one.
+
+**This ledger is not a duplication register, and must not be read as one.** It tracks
+what this plan knowingly introduced; it is structurally blind to everything that was
+already there. The blindness is not theoretical — a single audit of the knowledge and
+resolution tiers found ten duplicated mechanisms with no owner between them, one of which
+returns a wrong answer today (a `function_exists`-guarded function resolves on hover and
+is absent from completion, because the five hand-written declaration finders disagree on
+whether a nested declaration counts). Four became `SC.*` rows; the rest became acceptance
+criteria on the Step 4 rows. Neither the ledger nor a green suite would have surfaced any
+of them. Only the audits below do, which is why they are gates and not suggestions.
 
 ### Duplication audits
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -275,13 +275,10 @@ Step 4 (Section 6).
   `lookupFunction` MUST also answer function `search`, so a name resolvable on hover
   is offered in completion (§4.2). For `FilesystemBackend` that means the derived
   `autoload.files` index — its empty `searchClassLikes` is scoped to the PSR-4 tree,
-  which needs a workspace walk (§3), not to every kind.
-  That clause was written by hand after S3.7e had already been filed for the same reason —
-  the same rule failing twice, patched twice, because §5.1's uniformity requirement had no
-  entry in §8.1's mechanism table. It now has one, and **S3.8d carries it**: the
-  backend × kind × query grid, per the rule that a seam ships with its enforcement. Once
-  the grid exists this paragraph is a description of what the test asserts, not an
-  instruction to remember. This step **both changes and
+  which needs a workspace walk (§3), not to every kind. **S3.8d carries the mechanism**
+  that makes this general — §8.1's backend × kind × query grid — after which this clause
+  describes what the test asserts rather than a rule to remember.
+  This step **both changes and
   preserves** behavior on the function surface: the added project reach is new
   (proven by **new fixtures**), but built-in and open-document function completion is
   *existing* behavior that must not regress. So the function-surface golden (Step P)
@@ -313,27 +310,23 @@ shown to fail against the code it replaces. `/review-slice` checks for these by 
   Recapture deliberately and review that diff rather than accepting it.
 - **SC.6** — two constants differing only in case stay distinct through every key derived
   from a symbol name: the composite's search merge and subtype visited set, and the
-  namespace enumeration path. It fails **today** rather than once constants exist —
-  `CatalogSymbol` already carries `NameKind::Constant`, and S3.7e already enumerates
-  constants from the derived `autoload.files` index, so `NamespaceContents::merge`
-  collapses `Foo\BAR` and `Foo\bar` now. The test lands with SC.6 itself.
-- **S3.8d** — the §5.1 coverage grid, which is §8.1's mechanism for that invariant and
-  which this slice carries. Its axes are **derived, not listed**: rows from the composite's
-  own ordered backend list, columns from `NameKind::cases()` crossed with the query set
-  (`lookup`, `search`, `childrenOf`). Every cell is either an assertion over the fixtures
-  or a not-applicable registration naming its blocker as a slice id or an RFC section, and
-  an **unregistered cell fails** — that is what makes a new kind or a new backend break the
-  grid rather than quietly leaving a hole in it. A hand-listed grid would reproduce the
-  failure the mechanism exists to close.
+  namespace enumeration path. It fails against today's code, not only once constants are
+  looked up — `CatalogSymbol` carries `NameKind::Constant` and S3.7e enumerates constants,
+  so `NamespaceContents::merge` collapses `Foo\BAR` and `Foo\bar` already.
+- **S3.8d** — the §5.1 coverage grid, §8.1's mechanism for that invariant. Its axes are
+  **derived, not listed**: rows from the composite's own ordered backend list, columns from
+  `NameKind::cases()` crossed with the query set (`lookup`, `search`, `childrenOf`). Every
+  cell is either an assertion over the fixtures or a not-applicable registration naming its
+  blocker as a slice id or an RFC section, and an **unregistered cell fails** — which is
+  what makes a new kind or a new backend break the grid rather than leave a hole in it. A
+  hand-listed grid enforces nothing a hand-written clause did not.
 
-  SZ.1 requires every surviving not-applicable to still name a live deferral. Without
-  that, the block `searchClassLikes` must carry until S3.9b and the §3 workspace walk
-  calcifies into a permanent exemption, and the grid certifies the hole it was added to
-  expose.
+  SZ.1 requires every surviving not-applicable to still name a live deferral, so the block
+  `searchClassLikes` carries until S3.9b and the §3 workspace walk cannot calcify into a
+  permanent exemption.
 
-  S3.8b's proof — **its diff touches no `SymbolBackend` implementation** — belongs with
-  the grid but is not a test: it is a claim about the diff's shape, checked by reading the
-  diff, with nothing it could fail against.
+  S3.8b's proof — **its diff touches no `SymbolBackend` implementation** — is a claim about
+  the diff's shape rather than a test, so it is checked by reading the diff.
 
 *Known tracked gap:* the Builtin backend stood up in 3a is reflection-backed and not
 environment-parameterized, so it does **not** satisfy §4.7 — it cannot answer for a
@@ -370,11 +363,11 @@ below the glue, not beside the handler.
 independently testable units (e.g. node locator, scope analyzer, member-access
 detector, call-context detector, name-context resolver, text fallback).
 
-*Named duplication this step must remove.* An audit found the following already present
-across `SymbolResolver`, `TextFallbackHelper`, `ScopeFinder` and `Scope`. It is recorded
-here, rather than as `SC.*` slices, because these are the exact sites the decomposition
-rewrites — but without naming them the step can be declared done with every one intact,
-since "the class is thin now" says nothing about where its contents went.
+*Named duplication this step must remove.* The following already exists across
+`SymbolResolver`, `TextFallbackHelper`, `ScopeFinder` and `Scope`. It belongs on these
+rows rather than in an `SC.*` slice, because the decomposition rewrites exactly these
+sites; naming it is what stops the step being declared done with every one intact, since
+"the class is thin now" says nothing about where its contents went.
 
 - **S4.2 — one node locator.** "Innermost node containing an offset" exists three times:
   `Index\NodeAtPosition` (unfiltered), `Scope::findEnclosingFunctionLike` (filtered to
@@ -492,14 +485,9 @@ scaffold. A remover must be a slice id; a prose note is not an owner, because
 `/do-next` cannot select one.
 
 **This ledger is not a duplication register, and must not be read as one.** It tracks
-what this plan knowingly introduced; it is structurally blind to everything that was
-already there. The blindness is not theoretical — a single audit of the knowledge and
-resolution tiers found ten duplicated mechanisms with no owner between them, one of which
-returns a wrong answer today (a `function_exists`-guarded function resolves on hover and
-is absent from completion, because the five hand-written declaration finders disagree on
-whether a nested declaration counts). Four became `SC.*` rows; the rest became acceptance
-criteria on the Step 4 rows. Neither the ledger nor a green suite would have surfaced any
-of them. Only the audits below do, which is why they are gates and not suggestions.
+what this plan knowingly introduced, and is structurally blind to everything that was
+already there. Only the audits below reach that, which is why they are gates rather than
+suggestions.
 
 ### Duplication audits
 
@@ -537,11 +525,10 @@ An audit reporting no findings must show the enumeration it ran.
 
 **The enumeration has a floor**, set by what the audits have actually caught rather than by what seems thorough.
 It must cover, at minimum: AST traversal (every `NodeVisitorAbstract`, `NodeTraverser` and `NodeFinder` site), namespace and FQN construction (`Stmt\Namespace_` handling against the parser's `namespacedName`), case normalization (`strtolower` / `strcasecmp` on a symbol name, against `NameKind::normalize`), prefix matching, member-hierarchy walks, and path/URI conversion.
-Each of those has already produced a finding, several of them silently wrong rather than merely redundant.
 
 Two questions distinguish a duplicate that is worth folding from one that is a defect, and the audits must ask both.
-Not "is this the same code" but **"do these agree?"** — the five declaration finders were tolerable as five until they were found to disagree about nested declarations, at which point one of them was serving wrong completion results.
-And not "is this reachable" but **"which of these does each surface reach?"** — a mechanism duplicated across an AST path and a text-fallback path is two answers to one question, and the fallback is exactly where a divergence hides, because it only runs on code the parser could not handle.
+Not "is this the same code" but **"do these agree?"** — copies that agree are redundant, and copies that disagree are serving a wrong answer on whichever surface reaches the wrong one.
+And not "is this reachable" but **"which of these does each surface reach?"** — a mechanism duplicated across an AST path and a text-fallback path is two answers to one question, and the fallback is where a divergence hides, because it only runs on code the parser could not handle.
 
 ### Step Z — Definition of Done (final verification gate)
 
@@ -747,23 +734,19 @@ Consumer migration (construction moves to `Server.php`):
   routing), *backends × kinds*, and *kinds × operations*. A new kind is a name type, an
   info type, and one factory case — never a change to every backend.
 
-  **This was got wrong once.** S3.8a read the first paragraph and added a second per-kind
-  method to `SymbolBackend`, giving `FilesystemBackend` and `BuiltinBackend` the same
-  twenty lines twice and `OpenDocumentBackend` two parallel array pairs. S3.8d reverts that
-  shape before a third kind triples it. Do not re-derive the discarded reading from the
-  facade's closed method set.
+  **Do not re-derive the per-kind backend method from the facade's closed method set.**
+  That reading is the one the guardrail exists to rule out; `SymbolBackend` carries it
+  today and S3.8d removes it, before a third kind triples the copies.
 
   *The shape, so S3.8d does not have to invent it.* The backend takes
   `lookup(QualifiedName $name, NameKind $kind): ?SymbolInfo`, where `SymbolInfo` is a new
   marker on `ClassInfo`, `FunctionInfo` and the global-constant info type. `Formattable`
   is already on all three and must not be reused for this: it is about rendering, not
   about being a symbol. The facade's typed method narrows the result once, with an
-  `assert`. That is O(kinds) narrowings at a single site against the O(kinds × backends)
-  methods the discarded shape produces, which is the whole of the guardrail — a narrowing
-  the facade already knows the answer to is not the cost being avoided. §4.5's `instanceof`
-  ban is scoped to concrete `Type` implementations and `ClassInfo` is not a `Type`, so the
-  assert is in bounds; it is recorded here because a conformance reviewer would otherwise
-  be right to flag it.
+  `assert`: O(kinds) narrowings at one site, against the O(kinds × backends) methods the
+  per-kind shape produces. §4.5's `instanceof` ban is scoped to concrete `Type`
+  implementations and `ClassInfo` is not a `Type`, so the assert is in bounds — recorded
+  here because a conformance reviewer would otherwise be right to flag it.
 - **No `lookupNamespace`.** A namespace has no declaration site; it exists iff
   something is declared under it. "What is in `Psr\Log`" is `childrenOf`, and
   existence is that being non-empty (add a thin `namespaceExists` only if hot).

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -636,19 +636,30 @@ Consumer migration (construction moves to `Server.php`):
   carries a `ClassKind` discriminator. A future struct is a new `ClassKind` case
   reached through the same method, predicates, and `supertypes()` traversal (§4.5) —
   not a new method.
-- **The method set is closed.** PHP has exactly three symbol namespaces, so the
-  lookup set is those three and cannot grow with new kinds. That is the structural
-  answer to "do per-kind methods recreate M×N": they mirror the language's own
-  symbol table, which does not expand.
+- **Per-kind at the facade, kind-parameterized at the backends.** These are different
+  answers to the same question, and the split is deliberate.
+
+  `SymbolSource` carries a typed method per kind, and that set is **closed**: PHP has
+  exactly three symbol namespaces, so it cannot grow with new kinds, and §5.1 requires a
+  concrete return type rather than a type-erased union. That is the structural answer to
+  "do per-kind methods recreate M×N" *at the facade*.
+
+  It is not the answer one layer down. `SymbolBackend` takes **one** kind-parameterized
+  lookup, because the kind changes only the case rule (`NameKind::normalize`), the
+  unqualified-fallback rule, and which factory builds the metadata — never how a declaring
+  file is found or how a namespace is listed. Three cross-products stay closed:
+  *consumers × kinds* (one kind-dispatch point in the glue, per §4.5's syntactic-position
+  routing), *backends × kinds*, and *kinds × operations*. A new kind is a name type, an
+  info type, and one factory case — never a change to every backend.
+
+  **This was got wrong once.** S3.8a read the first paragraph and added a second per-kind
+  method to `SymbolBackend`, giving `FilesystemBackend` and `BuiltinBackend` the same
+  twenty lines twice and `OpenDocumentBackend` two parallel array pairs. S3.8d reverts that
+  shape before a third kind triples it. Do not re-derive the discarded reading from the
+  facade's closed method set.
 - **No `lookupNamespace`.** A namespace has no declaration site; it exists iff
   something is declared under it. "What is in `Psr\Log`" is `childrenOf`, and
   existence is that being non-empty (add a thin `namespaceExists` only if hot).
-- **Backends stay kind-agnostic — the M×N guardrail.** Two cross-products must stay
-  closed: *consumers × kinds* (one kind-dispatch point in the glue, per §4.5's
-  syntactic-position routing) and *backends × kinds* (backends resolve uniformly —
-  one `resolve(QualifiedName, NameKind)` — with the typed `ClassInfo` / `FunctionInfo`
-  constructed at the facade via the existing factories, §4.6). A new kind is then a
-  factory + a facade accessor, never a change to every backend.
 
 ### 5.7. Why functions and constants are deferred to Step 3
 

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -311,12 +311,29 @@ shown to fail against the code it replaces. `/review-slice` checks for these by 
   not only on hover. This is the one correction here that **changes** behaviour: it
   rewrites the function-surface golden S3.6 froze, and every other golden stays frozen.
   Recapture deliberately and review that diff rather than accepting it.
-- **SC.6** — two constants differing only in case stay distinct through the composite's
-  merge and through the subtype walk's visited set. It cannot fail until constants exist,
-  so it lands with S3.8b, and S3.8b must show it failing against the `strtolower` SC.6
-  removed.
-- **S3.8d** — the coverage grid below, plus the S3.8b criterion that a new kind's diff
-  touches no backend.
+- **SC.6** — two constants differing only in case stay distinct through every key derived
+  from a symbol name: the composite's search merge and subtype visited set, and the
+  namespace enumeration path. It fails **today** rather than once constants exist —
+  `CatalogSymbol` already carries `NameKind::Constant`, and S3.7e already enumerates
+  constants from the derived `autoload.files` index, so `NamespaceContents::merge`
+  collapses `Foo\BAR` and `Foo\bar` now. The test lands with SC.6 itself.
+- **S3.8d** — the §5.1 coverage grid, which is §8.1's mechanism for that invariant and
+  which this slice carries. Its axes are **derived, not listed**: rows from the composite's
+  own ordered backend list, columns from `NameKind::cases()` crossed with the query set
+  (`lookup`, `search`, `childrenOf`). Every cell is either an assertion over the fixtures
+  or a not-applicable registration naming its blocker as a slice id or an RFC section, and
+  an **unregistered cell fails** — that is what makes a new kind or a new backend break the
+  grid rather than quietly leaving a hole in it. A hand-listed grid would reproduce the
+  failure the mechanism exists to close.
+
+  SZ.1 requires every surviving not-applicable to still name a live deferral. Without
+  that, the block `searchClassLikes` must carry until S3.9b and the §3 workspace walk
+  calcifies into a permanent exemption, and the grid certifies the hole it was added to
+  expose.
+
+  S3.8b's proof — **its diff touches no `SymbolBackend` implementation** — belongs with
+  the grid but is not a test: it is a claim about the diff's shape, checked by reading the
+  diff, with nothing it could fail against.
 
 *Known tracked gap:* the Builtin backend stood up in 3a is reflection-backed and not
 environment-parameterized, so it does **not** satisfy §4.7 — it cannot answer for a

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -731,6 +731,18 @@ Consumer migration (construction moves to `Server.php`):
   twenty lines twice and `OpenDocumentBackend` two parallel array pairs. S3.8d reverts that
   shape before a third kind triples it. Do not re-derive the discarded reading from the
   facade's closed method set.
+
+  *The shape, so S3.8d does not have to invent it.* The backend takes
+  `lookup(QualifiedName $name, NameKind $kind): ?SymbolInfo`, where `SymbolInfo` is a new
+  marker on `ClassInfo`, `FunctionInfo` and the global-constant info type. `Formattable`
+  is already on all three and must not be reused for this: it is about rendering, not
+  about being a symbol. The facade's typed method narrows the result once, with an
+  `assert`. That is O(kinds) narrowings at a single site against the O(kinds × backends)
+  methods the discarded shape produces, which is the whole of the guardrail — a narrowing
+  the facade already knows the answer to is not the cost being avoided. §4.5's `instanceof`
+  ban is scoped to concrete `Type` implementations and `ClassInfo` is not a `Type`, so the
+  assert is in bounds; it is recorded here because a conformance reviewer would otherwise
+  be right to flag it.
 - **No `lookupNamespace`.** A namespace has no declaration site; it exists iff
   something is declared under it. "What is in `Psr\Log`" is `childrenOf`, and
   existence is that being non-empty (add a thin `namespaceExists` only if hot).

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -130,15 +130,14 @@ Notes:
     derived index knows every name each entry declares, so this is wiring enumeration
     onto it, not a second scan. Found while reviewing S3.7d, which delivered the lookup
     half only.
-- **S3.8d corrects the shape S3.8a landed.** S3.8a gave `SymbolBackend` a second per-kind
-  method, following the note below; 0002 §5.6's other half says backends take one
-  kind-parameterized lookup and that a new kind is "never a change to every backend". The
-  contradiction is resolved in 0002 in favour of the guardrail: the public `SymbolSource`
-  keeps a typed method per kind (§5.1 requires concrete return types), the backends behind
-  it take one. Today `FilesystemBackend` and `BuiltinBackend` each carry the same twenty
-  lines twice and `OpenDocumentBackend` two parallel array pairs; after SC.5 those differ
-  only in which factory builds the metadata. S3.8d also carries the §8.1 mechanism for §5.1
-  (see 0002), per the rule that a seam ships with its enforcement.
+- **S3.8d collapses `SymbolBackend`'s per-kind methods to one.** The split is settled in
+  0002 §5.6: the public `SymbolSource` keeps a typed method per kind (§5.1 requires
+  concrete return types), the backends behind it take one kind-parameterized lookup, so a
+  new kind is never a change to every backend. `FilesystemBackend` and `BuiltinBackend`
+  each carry the same twenty lines twice today and `OpenDocumentBackend` two parallel array
+  pairs; after SC.5 those differ only in which factory builds the metadata. S3.8d also
+  carries the §8.1 mechanism for §5.1 (see 0002), per the rule that a seam ships with its
+  enforcement.
   - **S3.8b is the proof.** Its acceptance carries one criterion that cannot be met by
     appearance: **its diff must touch no `SymbolBackend` implementation.** If it does,
     S3.8d did not work.
@@ -146,7 +145,7 @@ Notes:
   then backends, then consumers) would land `SymbolBackend` methods no backend
   implements, so each slice is instead one vertical: a kind's name type, its
   `SymbolSource` method, its extraction, and its tests — **not** a `SymbolBackend` method
-  per kind, which is what S3.8a built and S3.8d undoes. S3.8c
+  per kind, which S3.8d removes. S3.8c
   then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
   `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
   `SymbolResolver`, so it, not S3.8a, is what S4.2 serializes against (§6).
@@ -181,24 +180,22 @@ Notes:
   them — which is exactly how they went unowned until an audit found them. They are in
   the table so `/do-next` can select them and SZ.1 can require them, not because a step
   produced them. A removal with no owning slice is a defect; put it here.
-  - **SC.2, SC.5 and SC.6 sit up in the Step 3b rows, not here.** They are `SC.*` by origin
-    — all three predate the plan — but each is a live defect rather than a redundancy, and
-    row order is what `/do-next` uses to break ties between unblocked slices. Left in this
-    block they would be picked after S4.1, which is unblocked and listed earlier, so wrong
-    completion results would stand for another slice or two for no reason. Their notes stay
-    below with the rest of the `SC.*` explanations.
+  - **SC.2, SC.5 and SC.6 sit up in the Step 3b rows, not here.** Each is a live defect
+    rather than a redundancy, and row order is what `/do-next` uses to break ties between
+    unblocked slices — in this block they would be picked after S4.1, leaving wrong
+    completion results standing for another slice or two. Keep them ahead of S3.8b; their
+    notes stay below with the rest of the `SC.*` explanations.
 
     Their Step column stays `—`, so `all Step 3` does not expand to include them and S3.11
-    is not gated on them. That is correct and not an oversight: they are not Step 3's work,
-    they merely run during it. `all prior` does reach them, so SZ.1 still requires them.
+    is not gated on them. That is deliberate: they are not Step 3's work, they merely run
+    during it. `all prior` does reach them, so SZ.1 still requires them.
 
     S3.8b omits SC.5 from its `Depends on` because S3.8d already carries it; the two rows
     sit adjacent so the chain is visible. Restore it if S3.8d's dependencies ever change.
-  - **SC.1 and SC.3 are still undone**, and both predate the rows added since. Neither is
-    blocked by anything. SC.3 narrows once SC.5 lands, which removes its
-    `FilesystemBackend::findClassInAst` half and leaves `SymbolExtractor` — where the FQN
-    is rebuilt by string concatenation in three places, against a `namespacedName` the
-    parser already computed and four other sites already read.
+  - **SC.1 and SC.3 are unblocked and unbuilt.** SC.3 narrows once SC.5 lands, which
+    removes its `FilesystemBackend::findClassInAst` half and leaves `SymbolExtractor` —
+    where the FQN is rebuilt by string concatenation in three places, against a
+    `namespacedName` the parser already computed and four other sites already read.
   - **Duplication that Step 4 will touch anyway is not filed here.** It is recorded as
     acceptance criteria on the S4.2 / S4.4 / S4.5 rows in 0002 instead, so the
     decomposition cannot be declared done while it survives. Filing it twice would put a
@@ -232,18 +229,15 @@ Notes:
     `SymbolResolver::getFileFunctions`. What the backends need beyond the scanner is the
     declaring *node*, so metadata can be built; that is the one thing to add.
 
-    Originally scoped to two class-like traversals and framed as "evaluate and merge if
-    warranted". A later audit found the other three and, with them, the reason this is not
-    optional: **the five disagree.** `getFileFunctions` feeds completion and iterates
-    top-level statements only, while `parseFunctionFrom` and `functionsIn` walk all depths,
-    so a `function_exists`-guarded polyfill resolves on hover and never appears in
-    completion. That is a §4.2 violation in the code today, which is why this now precedes
-    S3.8b and S3.8c rather than trailing them.
+    **The five disagree**, so this is a defect and not a tidy-up: `getFileFunctions` feeds
+    completion and iterates top-level statements only, while `parseFunctionFrom` and
+    `functionsIn` walk all depths, so a `function_exists`-guarded polyfill resolves on
+    hover and never appears in completion. That is a §4.2 violation in the code, which is
+    why it precedes S3.8b and S3.8c.
 
-    Ungated. It no longer depends on SC.3 — it *removes* the `findClassInAst` half of SC.3,
-    narrowing that slice to `SymbolExtractor` alone. Deliberately not gated on S3.11: an
-    audit files slices, and a slice already filed must not wait on the audit that would
-    have found it.
+    Ungated. It *removes* the `findClassInAst` half of SC.3, narrowing that slice to
+    `SymbolExtractor` alone. Deliberately not gated on S3.11: an audit files slices, and a
+    slice already filed must not wait on the audit that would have found it.
   - **SC.6** — every key derived from a symbol name routes through
     `NameKind::normalize()`, which owns PHP's per-kind case rule. A whole-FQN `strtolower`
     is hand-rolled instead in `CompositeSymbolSource` (the `searchClassLikes` merge, and
@@ -252,12 +246,11 @@ Notes:
     `normalize`, with a comment noting that whole-FQN lowercasing is right for class-likes
     and functions and wrong for a constant.
 
-    Constants are case-sensitive, so `Foo\BAR` and `Foo\bar` collapse — and that is **live
-    now, not a consequence of S3.8b**: `CatalogSymbol` already carries the `NameKind` these
-    sites discard, and S3.7e already enumerates constants from the derived `autoload.files`
-    index. Scoping this to `CompositeSymbolSource` alone would leave the collapse standing
-    on the enumeration path and let S3.8b land on top of it, so the row is the case rule
-    everywhere, not two lines. Ahead of S3.8b for that reason.
+    Constants are case-sensitive, so `Foo\BAR` and `Foo\bar` collapse — **already, not as a
+    consequence of S3.8b**: `CatalogSymbol` carries the `NameKind` these sites discard, and
+    S3.7e enumerates constants from the derived `autoload.files` index. The row is the case
+    rule everywhere rather than one class, so the collapse cannot survive on the
+    enumeration path for S3.8b to land on top of. Ahead of S3.8b for that reason.
   - **SC.7** — `MemberResolver` has six near-identical hierarchy walks:
     `find{Method,Property,Constant}InHierarchy` and `collect{Methods,Properties,Constants}`,
     each a seen-check, a scan of the class's own members, and a recursion over

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -76,6 +76,9 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
     S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
+    SC.2   —     Retire ScopeFinder's superseded import extraction   —                 —
+    SC.5   —     One declaration finder for the five hand-written    —                 —
+    SC.6   —     CompositeSymbolSource case rule -> NameKind         —                 —
     S3.8d  3b    Collapse per-kind lookup to one kind-parameterized call  SC.5        —
     S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.5,SC.6,S3.8d  —
     S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
@@ -91,11 +94,8 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
     S4.7   4     Step 4 duplication audit                          all Step 4        —
     SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
-    SC.2   —     Retire ScopeFinder's superseded import extraction   —                 —
     SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
     SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
-    SC.5   —     One declaration finder for the five hand-written    —                 —
-    SC.6   —     CompositeSymbolSource case rule -> NameKind         —                 —
     SC.7   —     Six member-hierarchy walks -> one                   —                 —
     SC.8   —     Prefix matching: SymbolIndex -> PrefixMatcher       —                 —
     SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
@@ -181,6 +181,16 @@ Notes:
   them — which is exactly how they went unowned until an audit found them. They are in
   the table so `/do-next` can select them and SZ.1 can require them, not because a step
   produced them. A removal with no owning slice is a defect; put it here.
+  - **SC.2, SC.5 and SC.6 sit up in the Step 3b rows, not here.** They are `SC.*` by origin
+    — all three predate the plan — but each is a live defect rather than a redundancy, and
+    row order is what `/do-next` uses to break ties between unblocked slices. Left in this
+    block they would be picked after S4.1, which is unblocked and listed earlier, so wrong
+    completion results would stand for another slice or two for no reason. Their notes stay
+    below with the rest of the `SC.*` explanations.
+
+    Their Step column stays `—`, so `all Step 3` does not expand to include them and S3.11
+    is not gated on them. That is correct and not an oversight: they are not Step 3's work,
+    they merely run during it. `all prior` does reach them, so SZ.1 still requires them.
   - **SC.1 and SC.3 are still undone**, and both predate the rows added since. Neither is
     blocked by anything. SC.3 narrows once SC.5 lands, which removes its
     `FilesystemBackend::findClassInAst` half and leaves `SymbolExtractor` — where the FQN

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -76,11 +76,11 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
     S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    SC.2   —     Retire ScopeFinder's superseded import extraction   —                 —
-    SC.5   —     One declaration finder for the five hand-written    —                 —
-    SC.6   —     CompositeSymbolSource case rule -> NameKind         —                 —
-    S3.8d  3b    Collapse per-kind lookup to one kind-parameterized call  SC.5        —
-    S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.5,SC.6,S3.8d  —
+    SC.2   —     Retire ScopeFinder's superseded import extraction  —                 —
+    SC.5   —     One declaration finder, not five hand-written      —                 —
+    SC.6   —     CompositeSymbolSource case rule -> NameKind        —                 —
+    S3.8d  3b    Collapse per-kind lookup to one call               SC.5              —
+    S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.6,S3.8d  —
     S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
     S3.9a  3b    Generalize search to a kind parameter              S3.8a,S3.8d       —
     S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
@@ -191,6 +191,9 @@ Notes:
     Their Step column stays `—`, so `all Step 3` does not expand to include them and S3.11
     is not gated on them. That is correct and not an oversight: they are not Step 3's work,
     they merely run during it. `all prior` does reach them, so SZ.1 still requires them.
+
+    S3.8b omits SC.5 from its `Depends on` because S3.8d already carries it; the two rows
+    sit adjacent so the chain is visible. Restore it if S3.8d's dependencies ever change.
   - **SC.1 and SC.3 are still undone**, and both predate the rows added since. Neither is
     blocked by anything. SC.3 narrows once SC.5 lands, which removes its
     `FilesystemBackend::findClassInAst` half and leaves `SymbolExtractor` — where the FQN

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -12,7 +12,10 @@ Append later phases as they are reached; do not create the whole tree up front.
 
 ## Columns
 
-- **ID** — stable slice id; the branch is `slice/<ID>`.
+- **ID** — stable slice id; the branch is `slice/<ID>`. An id is assigned when the slice is
+  filed and never changes, because a merged slice is found by it. It therefore does **not**
+  imply execution order: order is this table's row order plus `Depends on`, so a row can be
+  inserted anywhere without renumbering merged work.
 - **Step** — the plan step in 0002 that owns the acceptance criteria.
 - **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
   exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -78,7 +78,7 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
     SC.2   —     Retire ScopeFinder's superseded import extraction  —                 —
     SC.5   —     One declaration finder, not five hand-written      —                 —
-    SC.6   —     CompositeSymbolSource case rule -> NameKind        —                 —
+    SC.6   —     Symbol-name keys -> NameKind::normalize           —                 —
     S3.8d  3b    Collapse per-kind lookup to one call               SC.5              —
     S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.6,S3.8d  —
     S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
@@ -244,12 +244,20 @@ Notes:
     narrowing that slice to `SymbolExtractor` alone. Deliberately not gated on S3.11: an
     audit files slices, and a slice already filed must not wait on the audit that would
     have found it.
-  - **SC.6** — `CompositeSymbolSource` lowercases a whole FQN in two places (the
-    `searchClassLikes` merge, and the subtype walk's visited set). `NameKind::normalize()`
-    owns PHP's per-kind case rule, and `OpenDocumentBackend` already routes through it,
-    with a comment noting that whole-FQN lowercasing is right for class-likes and functions
-    and wrong for a constant. Constants are case-sensitive, so `FOO` and `foo` would
-    collapse. Ahead of S3.8b for that reason.
+  - **SC.6** — every key derived from a symbol name routes through
+    `NameKind::normalize()`, which owns PHP's per-kind case rule. A whole-FQN `strtolower`
+    is hand-rolled instead in `CompositeSymbolSource` (the `searchClassLikes` merge, and
+    the subtype walk's visited set), in `NamespaceContents` (`merge` and
+    `indexByNamespace`), and in `SymbolIndex`. `OpenDocumentBackend` already routes through
+    `normalize`, with a comment noting that whole-FQN lowercasing is right for class-likes
+    and functions and wrong for a constant.
+
+    Constants are case-sensitive, so `Foo\BAR` and `Foo\bar` collapse — and that is **live
+    now, not a consequence of S3.8b**: `CatalogSymbol` already carries the `NameKind` these
+    sites discard, and S3.7e already enumerates constants from the derived `autoload.files`
+    index. Scoping this to `CompositeSymbolSource` alone would leave the collapse standing
+    on the enumeration path and let S3.8b land on top of it, so the row is the case rule
+    everywhere, not two lines. Ahead of S3.8b for that reason.
   - **SC.7** — `MemberResolver` has six near-identical hierarchy walks:
     `find{Method,Property,Constant}InHierarchy` and `collect{Methods,Properties,Constants}`,
     each a seen-check, a scan of the class's own members, and a recursion over
@@ -258,8 +266,9 @@ Notes:
     more copies. Outside Step 4's scope — that step decomposes `src/Resolution/`, this is
     `src/Repository/`.
   - **SC.8** — `Completion\PrefixMatcher::matches` and `SymbolIndex::findByPrefix` both
-    hand-roll `str_starts_with(strtolower(...))`. The smallest row here; listed because a
-    duplicated one-liner is worth folding in when it turns up next to work already open.
+    hand-roll `str_starts_with(strtolower(...))`. SC.6 owns the `strtolower` half (it is
+    the same per-kind case rule); what is left here is the duplicated *matching* helper, so
+    take SC.6 first or the two rows fight over the same line.
 - **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
   acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
   in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -76,9 +76,10 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
     S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    S3.8b  3b    lookupConstant project reach                       S3.7d             —
-    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a             —
-    S3.9a  3b    Generalize search to a kind parameter              S3.8a             —
+    S3.8d  3b    Collapse per-kind lookup to one kind-parameterized call  SC.5        —
+    S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.5,SC.6,S3.8d  —
+    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
+    S3.9a  3b    Generalize search to a kind parameter              S3.8a,S3.8d       —
     S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
     S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
     S3.11  3     Step 3 duplication audit                          all Step 3        —
@@ -90,10 +91,13 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
     S4.7   4     Step 4 duplication audit                          all Step 4        —
     SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
-    SC.2   —     Retire ScopeFinder's superseded import extraction   S4.4,S4.5         —
+    SC.2   —     Retire ScopeFinder's superseded import extraction   —                 —
     SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
     SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
-    SC.5   —     Merge the two class-like AST traversals             SC.3              —
+    SC.5   —     One declaration finder for the five hand-written    —                 —
+    SC.6   —     CompositeSymbolSource case rule -> NameKind         —                 —
+    SC.7   —     Six member-hierarchy walks -> one                   —                 —
+    SC.8   —     Prefix matching: SymbolIndex -> PrefixMatcher       —                 —
     SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
@@ -126,10 +130,23 @@ Notes:
     derived index knows every name each entry declares, so this is wiring enumeration
     onto it, not a second scan. Found while reviewing S3.7d, which delivered the lookup
     half only.
+- **S3.8d corrects the shape S3.8a landed.** S3.8a gave `SymbolBackend` a second per-kind
+  method, following the note below; 0002 §5.6's other half says backends take one
+  kind-parameterized lookup and that a new kind is "never a change to every backend". The
+  contradiction is resolved in 0002 in favour of the guardrail: the public `SymbolSource`
+  keeps a typed method per kind (§5.1 requires concrete return types), the backends behind
+  it take one. Today `FilesystemBackend` and `BuiltinBackend` each carry the same twenty
+  lines twice and `OpenDocumentBackend` two parallel array pairs; after SC.5 those differ
+  only in which factory builds the metadata. S3.8d also carries the §8.1 mechanism for §5.1
+  (see 0002), per the rule that a seam ships with its enforcement.
+  - **S3.8b is the proof.** Its acceptance carries one criterion that cannot be met by
+    appearance: **its diff must touch no `SymbolBackend` implementation.** If it does,
+    S3.8d did not work.
 - **S3.8 and S3.9 are cut by symbol namespace, not by layer.** A layer cut (interface,
   then backends, then consumers) would land `SymbolBackend` methods no backend
   implements, so each slice is instead one vertical: a kind's name type, its
-  `SymbolSource`/`SymbolBackend` method across all four backends, and its tests. S3.8c
+  `SymbolSource` method, its extraction, and its tests — **not** a `SymbolBackend` method
+  per kind, which is what S3.8a built and S3.8d undoes. S3.8c
   then migrates the consumers (`SymbolResolver`, `BasicTypeResolver`) off
   `FunctionRepository::get(string, array $ast)` — it is the Step 3b slice that edits
   `SymbolResolver`, so it, not S3.8a, is what S4.2 serializes against (§6).
@@ -164,12 +181,25 @@ Notes:
   them — which is exactly how they went unowned until an audit found them. They are in
   the table so `/do-next` can select them and SZ.1 can require them, not because a step
   produced them. A removal with no owning slice is a defect; put it here.
+  - **SC.1 and SC.3 are still undone**, and both predate the rows added since. Neither is
+    blocked by anything. SC.3 narrows once SC.5 lands, which removes its
+    `FilesystemBackend::findClassInAst` half and leaves `SymbolExtractor` — where the FQN
+    is rebuilt by string concatenation in three places, against a `namespacedName` the
+    parser already computed and four other sites already read.
+  - **Duplication that Step 4 will touch anyway is not filed here.** It is recorded as
+    acceptance criteria on the S4.2 / S4.4 / S4.5 rows in 0002 instead, so the
+    decomposition cannot be declared done while it survives. Filing it twice would put a
+    slice and a step in competition for the same edit.
   - **SC.1** — `Index/WorkspaceIndexer` has zero references in `src/` or `tests/`. It was
     previously a ledger row whose remover was a *§3 note*, which no slice could discharge.
   - **SC.2** — `ScopeFinder::extractImports` / `resolveFromUseStatements` were superseded
     by `NameContextFactory` and their own docblock says they go away once #331 moves the
     callers. #331 landed (#337); three callers did not move (`SymbolResolver` ×2,
-    `TextFallbackHelper` ×1). Gated on S4.4/S4.5, which rewrite exactly those sites.
+    `TextFallbackHelper` ×1). **Ungated, and ahead of S3.8b: this is a live defect, not a
+    tidy-up.** `extractImports` folds `use function` and `use const` into the class import
+    map, so a class and a function sharing a short name collide — and the constant table it
+    also folds in is exactly what constant resolution will read. `NameContext::importsFor()`
+    already keeps the three tables apart, so no caller needs Step 4 to move.
   - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
     `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
     `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
@@ -182,16 +212,41 @@ Notes:
     encoding. One `FileUri` replaces them. Found while splitting S3.7, whose locator
     wanted a fifth copy; the duplication predates that slice and belongs to no step,
     so S3.7c is gated on it rather than carrying it.
-  - **SC.5** — `FilesystemBackend::findClassInAst` and `Index\DeclarationScanner` both
-    walk an AST to find the class-likes a file declares. They differ in what they
-    return (one matched *node* versus every declared *name*) and in stopping early, so
-    this is scoped as **evaluate and merge if warranted** — concluding "two genuinely
-    different queries, one walk" is an acceptable outcome, but it must be concluded and
-    recorded, not left unexamined. Gated only on SC.3, which rewrites `findClassInAst`'s
-    namespace handling; it is deliberately *not* gated on S3.11, because an audit files
-    slices and a slice already filed must not wait on the audit that would have found
-    it. Found while reviewing S3.7d, which put the two traversals side by side without
-    merging them.
+  - **SC.5** — **Five** sites ask "which node declares this name", against
+    `Index\DeclarationScanner`, which already answers the general form:
+    `DefaultFunctionRepository::findFunctionInAst`, `FilesystemBackend::parseFunctionFrom`,
+    `FilesystemBackend::findClassInAst`, `DocumentSymbolSink::functionsIn`, and
+    `SymbolResolver::getFileFunctions`. What the backends need beyond the scanner is the
+    declaring *node*, so metadata can be built; that is the one thing to add.
+
+    Originally scoped to two class-like traversals and framed as "evaluate and merge if
+    warranted". A later audit found the other three and, with them, the reason this is not
+    optional: **the five disagree.** `getFileFunctions` feeds completion and iterates
+    top-level statements only, while `parseFunctionFrom` and `functionsIn` walk all depths,
+    so a `function_exists`-guarded polyfill resolves on hover and never appears in
+    completion. That is a §4.2 violation in the code today, which is why this now precedes
+    S3.8b and S3.8c rather than trailing them.
+
+    Ungated. It no longer depends on SC.3 — it *removes* the `findClassInAst` half of SC.3,
+    narrowing that slice to `SymbolExtractor` alone. Deliberately not gated on S3.11: an
+    audit files slices, and a slice already filed must not wait on the audit that would
+    have found it.
+  - **SC.6** — `CompositeSymbolSource` lowercases a whole FQN in two places (the
+    `searchClassLikes` merge, and the subtype walk's visited set). `NameKind::normalize()`
+    owns PHP's per-kind case rule, and `OpenDocumentBackend` already routes through it,
+    with a comment noting that whole-FQN lowercasing is right for class-likes and functions
+    and wrong for a constant. Constants are case-sensitive, so `FOO` and `foo` would
+    collapse. Ahead of S3.8b for that reason.
+  - **SC.7** — `MemberResolver` has six near-identical hierarchy walks:
+    `find{Method,Property,Constant}InHierarchy` and `collect{Methods,Properties,Constants}`,
+    each a seen-check, a scan of the class's own members, and a recursion over
+    `supertypes()`. #334 centralised the type-graph *edges*, and `supertypes()` is correct
+    and stays; the *walk* over them was never centralised, so a new member kind adds two
+    more copies. Outside Step 4's scope — that step decomposes `src/Resolution/`, this is
+    `src/Repository/`.
+  - **SC.8** — `Completion\PrefixMatcher::matches` and `SymbolIndex::findByPrefix` both
+    hand-roll `str_starts_with(strtolower(...))`. The smallest row here; listed because a
+    duplicated one-liner is worth folding in when it turns up next to work already open.
 - **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
   acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
   in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —


### PR DESCRIPTION
An audit of the knowledge and resolution tiers found duplicated mechanisms with no owning slice, several of them returning wrong answers today rather than merely being redundant. This schedules the fixes that must precede constant support, and closes the enforcement gaps that let them survive.

## Plan and manifest

- §5.6's per-kind / kind-agnostic contradiction is resolved: `SymbolSource` keeps a typed method per kind (§5.1 requires a concrete return type), `SymbolBackend` takes one kind-parameterized lookup. The backend's signature and its `SymbolInfo` return are specified so S3.8d does not have to invent them.
- §5.1 gains its missing §8.1 mechanism: a backend × kind × query grid whose axes derive from `NameKind::cases()` and the backend registry, with an unregistered cell failing. A hand-listed grid would reproduce the failure it exists to close. Step Z reads its not-applicable registrations against the named-deferrals list, so the escape hatch cannot outlive its blocker.
- Step 4 gains named acceptance criteria for the duplication its decomposition rewrites, since "the class is thin now" says nothing about where its contents went.
- The duplication audits gain an enumeration floor and two questions — "do these agree?" and "which surface reaches each?" — drawn from what the audits actually caught.
- New rows: SC.6 (symbol-name keys route through `NameKind::normalize`), SC.7 (six member-hierarchy walks), SC.8 (prefix matching). SC.2, SC.5 and SC.6 move above the Step 4 rows: each is a live defect, and row order is what `/do-next` uses to break ties.
- SC.5 is rescoped from two class-like traversals to five declaration finders that disagree — a `function_exists`-guarded polyfill resolves on hover and never appears in completion, which is a §4.2 violation standing in the code.

## Review corrections

The last commits address a review of the earlier ones:

- `CLAUDE.md` still taught the backend shape §5.6 discards, in the one file every session loads.
- SC.6 was scoped to two lines in `CompositeSymbolSource`; the same collapse is live on the enumeration path (`NamespaceContents`, `SymbolIndex`), where `CatalogSymbol` already carries the `NameKind` those sites discard.
- `/review-slice` did not check the plan's owed items, which 0002 claimed it did. It does now, and the skill is tracked rather than machine-local.

No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
