### PR TITLE
Answer 'which node declares this name' in one place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ All symbol resolution flows through the `CodeResolver` interface (implemented by
 
 **File queries** (parser-agnostic; keep completion sources off the raw AST):
 - `getNameContext(doc, line): NameContext` — the namespace and the three import tables in effect
-- `getFileFunctions(doc): list<FunctionInfo>` — user-defined functions declared in the document
+- `getFileFunctions(doc): list<FunctionInfo>` — user-defined functions declared in the document, at any depth
 
 **Type checks:**
 - `isInstantiable(ClassName): bool` — valid after `new`
@@ -138,6 +138,14 @@ derive the map; it is built eagerly, covers all three symbol namespaces (a name-
 route cannot know which kind a file declares), and applies PHP's per-kind case rules via
 `NameKind::normalize()`. A test pins the parse *count* at construction, which is
 not a cost measurement; the set is explicit and usually tiny.
+
+**"Which node declares this name" is answered in exactly one place**, `Index\DeclarationScanner`,
+which reports every class-like, function and constant an AST declares — at any depth,
+paired with its declaring node (`Declaration`). Lookup, the write path, and completion's
+file-function query all read it, so none can disagree about what a file declares. Five
+hand-written traversals is how a `function_exists`-guarded polyfill came to resolve on
+hover while being invisible to completion. Do NOT write a new one; a rule about what
+counts as a declaration is a change to the scanner.
 
 The same derived index also answers the backend's `childrenOf`, merged with the
 directory listing by `CompositeNamespaceCatalog`. Enumeration is not optional: §4.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,13 +139,19 @@ route cannot know which kind a file declares), and applies PHP's per-kind case r
 `NameKind::normalize()`. A test pins the parse *count* at construction, which is
 not a cost measurement; the set is explicit and usually tiny.
 
-**"Which node declares this name" is answered in exactly one place**, `Index\DeclarationScanner`,
-which reports every class-like, function and constant an AST declares — at any depth,
-paired with its declaring node (`Declaration`). Lookup, the write path, and completion's
-file-function query all read it, so none can disagree about what a file declares. Five
+**"Which node declares this name" is answered by `Index\DeclarationScanner`**, which
+reports every class-like, function and constant an AST declares — at any depth, paired
+with its declaring node (`Declaration`). Every function-namespace consumer reads it:
+on-disk and open-document lookup, the write path, the `autoload.files` index, and
+completion's file-function query, so none can disagree about what a file declares. Five
 hand-written traversals is how a `function_exists`-guarded polyfill came to resolve on
 hover while being invisible to completion. Do NOT write a new one; a rule about what
 counts as a declaration is a change to the scanner.
+
+Two class-like traversals survive it, both tracked: `DocumentSymbolSink::classesIn`
+(top-level only, so a `class_exists`-guarded class drops out of open-document lookup
+while the on-disk backends resolve it) and `Index\SymbolExtractor`, which rebuilds FQNs
+by hand rather than reading `namespacedName`. Neither is licence for a third.
 
 The same derived index also answers the backend's `childrenOf`, merged with the
 directory listing by `CompositeNamespaceCatalog`. Enumeration is not optional: §4.2
@@ -153,10 +159,11 @@ requires lookup and enumeration to draw on the same backends, so a name that res
 on hover while being invisible to completion is the split this tier exists to prevent.
 
 The write path is **`SymbolSink`** (`DocumentSymbolSink`), which registers class and
-function metadata and indexes symbols from one document. A declaration at any depth is
-registered, not just a top-level one — a polyfill guarded by `function_exists` is a name
-the file validly declares, and the on-disk backends resolve one, so opening the file must
-not make it disappear.
+function metadata and indexes symbols from one document. A *function* declared at any
+depth is registered, not just a top-level one — a polyfill guarded by `function_exists`
+is a name the file validly declares, and the on-disk backends resolve one, so opening
+the file must not make it disappear. Class-like registration is still top-level only
+(see `classesIn` above), which is the same defect awaiting its own slice.
 **`KnowledgeStack::forProject`** assembles the read composite and the write sink,
 sharing one open-document backend and symbol index.
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -78,6 +78,7 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
     SC.2   —     Retire ScopeFinder's superseded import extraction  —                 —
     SC.5   —     One declaration finder, not five hand-written      —                 —
+    SC.9   —     Class-like registration -> one declaration scan   —                 —
     SC.6   —     Symbol-name keys -> NameKind::normalize           —                 —
     S3.8d  3b    Collapse per-kind lookup to one call               SC.5              —
     S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.6,S3.8d  —
@@ -238,6 +239,22 @@ Notes:
     Ungated. It *removes* the `findClassInAst` half of SC.3, narrowing that slice to
     `SymbolExtractor` alone. Deliberately not gated on S3.11: an audit files slices, and a
     slice already filed must not wait on the audit that would have found it.
+  - **SC.9** — the class-like half of SC.5, left standing because SC.5's row names five
+    sites and this is a sixth. `DocumentSymbolSink::classesIn` hand-walks
+    `ScopeFinder::iterateTopLevelStatements` and registers **top-level class-likes only**,
+    while its sibling `functionsIn` reads `DeclarationScanner` at any depth. So a
+    `class_exists`-guarded class in an open buffer is returned by that backend's
+    `searchClassLikes` (which reads `SymbolExtractor`, and does walk all depths) but not by
+    its `lookupClassLike` — the §4.2 lookup/enumeration split, exactly as the polyfill
+    defect was, on the other symbol namespace. `assertStoresAgree`'s own docblock already
+    concedes it ("the index is a superset ... which the top-level lookup registration does
+    not").
+
+    A live defect, so it sits with SC.5 rather than in the redundancy block below. Nothing
+    pins the depth behaviour in either direction: switching `classesIn` to the scanner
+    leaves the suite green, so the slice owes a regression test — a `class_exists`-guarded
+    class resolves through `lookupClassLike` on an open document. It is the last consumer
+    of `iterateTopLevelStatements` in `src/`, which retires with it.
   - **SC.6** — every key derived from a symbol name routes through
     `NameKind::normalize()`, which owns PHP's per-kind case rule. A whole-FQN `strtolower`
     is hand-rolled instead in `CompositeSymbolSource` (the `searchClassLikes` merge, and

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -210,7 +210,7 @@ Notes:
     map, so a class and a function sharing a short name collide — and the constant table it
     also folds in is exactly what constant resolution will read. `NameContext::importsFor()`
     already keeps the three tables apart, so no caller needs Step 4 to move.
-  - **SC.3** — `SymbolExtractor` and `FilesystemBackend::findClassInAst` each hand-track
+  - **SC.3** — `SymbolExtractor` hand-tracks
     `Stmt\Namespace_` to build FQNs that `NameResolver` already computed into
     `namespacedName` (which `DefaultClassInfoFactory`, `DefaultFunctionRepository`,
     `ScopeFinder`, and `DeclarationScanner` all read). Behavior-preserving, so the Step P

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -99,6 +99,7 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
     SC.7   —     Six member-hierarchy walks -> one                   —                 —
     SC.8   —     Prefix matching: SymbolIndex -> PrefixMatcher       —                 —
+    SC.10  —     Enforce the one-declaration-scanner rule            SC.3,SC.9         —
     SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
@@ -283,6 +284,15 @@ Notes:
     and stays; the *walk* over them was never centralised, so a new member kind adds two
     more copies. Outside Step 4's scope — that step decomposes `src/Resolution/`, this is
     `src/Repository/`.
+  - **SC.10** — SC.5 states a hard invariant ("Do NOT write a new one; a rule about what
+    counts as a declaration is a change to the scanner") with no mechanism, which §8.1
+    forbids where a static rule or test is feasible. One is: a PHPStan rule confining
+    `NodeVisitorAbstract` / `NodeFinder` / `NodeTraverser` to the parser, the positional
+    finders, and `DeclarationScanner`, in the shape of the existing
+    `SymbolDiscoveryAuthorityExtension`. Gated on its two known violators (SC.3's
+    `SymbolExtractor`, SC.9's `classesIn`) because a rule that must ship with two
+    exemptions enforces nothing. The analogue to follow is `TypeGraphParityTest`, which is
+    how the sibling single-traversal invariant on `supertypes()` is held.
   - **SC.8** — `Completion\PrefixMatcher::matches` and `SymbolIndex::findByPrefix` both
     hand-roll `str_starts_with(strtolower(...))`. SC.6 owns the `strtolower` half (it is
     the same per-kind case rule); what is left here is the duplicated *matching* helper, so

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -268,6 +268,14 @@ Notes:
     S3.7e enumerates constants from the derived `autoload.files` index. The row is the case
     rule everywhere rather than one class, so the collapse cannot survive on the
     enumeration path for S3.8b to land on top of. Ahead of S3.8b for that reason.
+
+    Also here: `FilesystemBackend::parseClassFrom` compares raw fully-qualified names,
+    while `lookupClassLike` keys its cache through `SymbolCacheKey` — which *does*
+    normalize — and the sibling `parseFunctionFrom` normalizes both sides. So a wrong-case
+    class lookup misses on a cold cache and hits once a correct-case lookup has warmed the
+    same key, and `OpenDocumentBackend` answers a name this backend does not. Predates SC.5
+    (the deleted `findClassInAst` compared raw strings too) and is unpinned in either
+    direction, so the fix owes a test.
   - **SC.7** — `MemberResolver` has six near-identical hierarchy walks:
     `find{Method,Property,Constant}InHierarchy` and `collect{Methods,Properties,Constants}`,
     each a seen-check, a scan of the class's own members, and a recursion over

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Resolution\NameKind;
+use PhpParser\Node;
 
 /**
  * Locates a declaration in Composer's `autoload.files` set, by deriving the
@@ -118,11 +119,12 @@ final class AutoloadFilesLocator implements SymbolLocator, NamespaceCatalog, Inv
     }
 
     /**
-     * @param list<QualifiedName> $names
+     * @param list<Declaration<Node>> $declarations
      */
-    private function record(NameKind $kind, array $names, string $path): void
+    private function record(NameKind $kind, array $declarations, string $path): void
     {
-        foreach ($names as $name) {
+        foreach ($declarations as $declaration) {
+            $name = $declaration->name;
             $key = $kind->normalize($name);
 
             // Composer requires the entries in order, so the first declaration of a

--- a/src/Index/Declaration.php
+++ b/src/Index/Declaration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Index;
+
+use Firehed\PhpLsp\Domain\QualifiedName;
+use PhpParser\Node;
+
+/**
+ * One name a file declares, paired with the node that declares it.
+ *
+ * The name alone answers what a name -> file map needs. A backend building metadata
+ * needs the node too, and re-finding it means a second walk that can disagree with
+ * the first about which declarations count.
+ *
+ * @template-covariant TNode of Node
+ */
+final readonly class Declaration
+{
+    /**
+     * @param TNode $node
+     */
+    public function __construct(
+        public QualifiedName $name,
+        public Node $node,
+    ) {
+    }
+}

--- a/src/Index/DeclarationScanner.php
+++ b/src/Index/DeclarationScanner.php
@@ -36,31 +36,34 @@ final class DeclarationScanner
     public function scan(array $ast): FileDeclarations
     {
         $visitor = new class () extends NodeVisitorAbstract {
-            /** @var list<QualifiedName> */
+            /** @var list<Declaration<Stmt\ClassLike>> */
             public array $classLikes = [];
 
-            /** @var list<QualifiedName> */
+            /** @var list<Declaration<Stmt\Function_>> */
             public array $functions = [];
 
-            /** @var list<QualifiedName> */
+            /** @var list<Declaration<Node\Const_|Expr\FuncCall>> */
             public array $constants = [];
 
             public function enterNode(Node $node): null
             {
                 // An anonymous class has no name, so there is nothing to index.
                 if ($node instanceof Stmt\ClassLike && $node->name !== null) {
-                    $this->classLikes[] = self::qualify($node->namespacedName ?? $node->name);
+                    $this->classLikes[] = new Declaration(self::qualify($node->namespacedName ?? $node->name), $node);
                     return null;
                 }
 
                 if ($node instanceof Stmt\Function_) {
-                    $this->functions[] = self::qualify($node->namespacedName ?? $node->name);
+                    $this->functions[] = new Declaration(self::qualify($node->namespacedName ?? $node->name), $node);
                     return null;
                 }
 
                 if ($node instanceof Stmt\Const_) {
                     foreach ($node->consts as $const) {
-                        $this->constants[] = self::qualify($const->namespacedName ?? $const->name);
+                        $this->constants[] = new Declaration(
+                            self::qualify($const->namespacedName ?? $const->name),
+                            $const,
+                        );
                     }
                     return null;
                 }
@@ -87,7 +90,7 @@ final class DeclarationScanner
                     return;
                 }
 
-                $this->constants[] = QualifiedName::fromFullyQualified($name->value);
+                $this->constants[] = new Declaration(QualifiedName::fromFullyQualified($name->value), $node);
             }
 
             /**

--- a/src/Index/FileDeclarations.php
+++ b/src/Index/FileDeclarations.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
-use Firehed\PhpLsp\Domain\QualifiedName;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
 
 /**
  * The names one file declares, across all three of PHP's symbol namespaces.
@@ -17,9 +19,10 @@ use Firehed\PhpLsp\Domain\QualifiedName;
 final readonly class FileDeclarations
 {
     /**
-     * @param list<QualifiedName> $classLikes
-     * @param list<QualifiedName> $functions
-     * @param list<QualifiedName> $constants
+     * @param list<Declaration<Stmt\ClassLike>> $classLikes
+     * @param list<Declaration<Stmt\Function_>> $functions
+     * @param list<Declaration<Node\Const_|Expr\FuncCall>> $constants a `const`
+     *        declarator, or the `define()` call that names the constant
      */
     public function __construct(
         public array $classLikes,

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -8,13 +8,13 @@ use Firehed\PhpLsp\Cache\Invalidatable;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Utility\ScopeFinder;
 use PhpParser\Node\Stmt;
-use PhpParser\NodeFinder;
 
 /**
  * The single write path for open-document symbol state (RFC 1 §4.3, §5.2): document
@@ -40,6 +40,7 @@ final class DocumentSymbolSink implements SymbolSink
         private readonly SymbolIndex $index,
         private readonly ClassInfoFactory $classInfoFactory,
         private readonly ParserService $parser,
+        private readonly DeclarationScanner $scanner,
         private readonly array $onDiskBackends = [],
     ) {
     }
@@ -147,9 +148,9 @@ final class DocumentSymbolSink implements SymbolSink
     private function functionsIn(array $ast, string $uri): array
     {
         $functions = [];
-        foreach ((new NodeFinder())->findInstanceOf($ast, Stmt\Function_::class) as $node) {
-            $fqn = ($node->namespacedName ?? $node->name)->toString();
-            $functions[$fqn] ??= FunctionInfo::fromNode($node, $uri);
+        foreach ($this->scanner->scan($ast)->functions as $declaration) {
+            $fqn = $declaration->name->fullyQualifiedName();
+            $functions[$fqn] ??= FunctionInfo::fromNode($declaration->node, $uri);
         }
 
         return $functions;

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -11,16 +11,13 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Index\DeclarationScanner;
+use Firehed\PhpLsp\Index\FileDeclarations;
 use Firehed\PhpLsp\Index\NamespaceCatalog;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Resolution\NameKind;
-use PhpParser\Node;
-use PhpParser\Node\Stmt;
-use PhpParser\NodeFinder;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -60,6 +57,7 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
         private readonly NamespaceCatalog $namespaces,
         private readonly ParserService $parser,
         private readonly ClassInfoFactory $factory,
+        private readonly DeclarationScanner $scanner,
         private readonly CacheInterface $cache,
     ) {
     }
@@ -154,100 +152,44 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
         return [];
     }
 
-    /**
-     * A declaration at any depth counts, not just a top-level one: the shape most
-     * `autoload.files` entries take is a polyfill declared inside an
-     * `if (!function_exists(...))`, and that is a name the file validly declares
-     * (matching {@see \Firehed\PhpLsp\Index\DeclarationScanner}, which derived the
-     * name -> file map this lookup arrived through).
-     */
     private function parseFunctionFrom(FunctionName $name, string $filePath): ?FunctionInfo
     {
-        $ast = $this->parser->parseFile($filePath);
-        if ($ast === null) {
-            return null;
-        }
-
         $kind = $name->kind();
         $target = $kind->normalize($name->qualifiedName);
 
-        $node = (new NodeFinder())->findFirst(
-            $ast,
-            static fn(Node $node): bool => $node instanceof Stmt\Function_
-                && $kind->normalize(
-                    QualifiedName::fromFullyQualified(($node->namespacedName ?? $node->name)->toString()),
-                ) === $target,
-        );
-        if (!$node instanceof Stmt\Function_) {
-            return null;
+        foreach ($this->declarationsIn($filePath)->functions as $declaration) {
+            if ($kind->normalize($declaration->name) === $target) {
+                return FunctionInfo::fromNode($declaration->node, $filePath);
+            }
         }
 
-        return FunctionInfo::fromNode($node, $filePath);
+        return null;
     }
 
     private function parseClassFrom(ClassName $name, string $filePath): ?ClassInfo
     {
-        $ast = $this->parser->parseFile($filePath);
-        if ($ast === null) {
-            return null;
+        $target = QualifiedName::fromClassName($name)->fullyQualifiedName();
+
+        foreach ($this->declarationsIn($filePath)->classLikes as $declaration) {
+            if ($declaration->name->fullyQualifiedName() === $target) {
+                return $this->factory->fromAstNode($declaration->node, FileUri::fromPath($filePath));
+            }
         }
 
-        $node = $this->findClassInAst($name->fqn, $ast);
-        if ($node === null) {
-            return null;
-        }
-
-        return $this->factory->fromAstNode($node, FileUri::fromPath($filePath));
+        return null;
     }
 
     /**
-     * @param array<Stmt> $ast
+     * A declaration at any depth counts, not just a top-level one: the shape most
+     * `autoload.files` entries take is a polyfill declared inside an
+     * `if (!function_exists(...))`, and that is a name the file validly declares.
+     * This is the scan that derived the name -> file map the lookup arrived through,
+     * so the two cannot disagree about what the file declares.
      */
-    private function findClassInAst(
-        string $className,
-        array $ast,
-    ): Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null {
-        $finder = new class ($className) extends NodeVisitorAbstract {
-            public Stmt\Class_|Stmt\Interface_|Stmt\Trait_|Stmt\Enum_|null $found = null;
-            private string $namespace = '';
+    private function declarationsIn(string $filePath): FileDeclarations
+    {
+        $ast = $this->parser->parseFile($filePath);
 
-            public function __construct(private readonly string $className)
-            {
-            }
-
-            public function enterNode(Node $node): ?int
-            {
-                if ($node instanceof Stmt\Namespace_) {
-                    $this->namespace = $node->name?->toString() ?? '';
-                    return null;
-                }
-
-                if (
-                    $node instanceof Stmt\Class_
-                    || $node instanceof Stmt\Interface_
-                    || $node instanceof Stmt\Trait_
-                    || $node instanceof Stmt\Enum_
-                ) {
-                    $name = $node->name?->toString();
-                    if ($name === null) {
-                        return null;
-                    }
-                    $fqn = $this->namespace !== '' ? $this->namespace . '\\' . $name : $name;
-
-                    if ($fqn === $this->className || $name === $this->className) {
-                        $this->found = $node;
-                        return NodeTraverser::STOP_TRAVERSAL;
-                    }
-                }
-
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        return $finder->found;
+        return $ast === null ? new FileDeclarations([], [], []) : $this->scanner->scan($ast);
     }
 }

--- a/src/Knowledge/KnowledgeStack.php
+++ b/src/Knowledge/KnowledgeStack.php
@@ -122,6 +122,7 @@ final readonly class KnowledgeStack
             ),
             $parser,
             $classInfoFactory,
+            $scanner,
             CacheFactory::inMemory(),
         );
     }

--- a/src/Knowledge/KnowledgeStack.php
+++ b/src/Knowledge/KnowledgeStack.php
@@ -79,6 +79,7 @@ final readonly class KnowledgeStack
             $index,
             $classInfoFactory,
             $parser,
+            $scanner,
             // External-change and close-after-edit invalidation drops the on-disk
             // cache for a file so the next query re-reads disk (RFC 1 §5.2, §5.3).
             // The open-document backend is authoritative and never cached, so it is

--- a/src/Repository/DefaultFunctionRepository.php
+++ b/src/Repository/DefaultFunctionRepository.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Repository;
 
 use Firehed\PhpLsp\Domain\FunctionInfo;
-use PhpParser\Node;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitorAbstract;
 use ReflectionException;
 use ReflectionFunction;
 
 final class DefaultFunctionRepository implements FunctionRepository
 {
+    public function __construct(private readonly DeclarationScanner $scanner)
+    {
+    }
+
     public function get(string $functionName, array $ast): ?FunctionInfo
     {
         $node = $this->findFunctionInAst($functionName, $ast);
@@ -36,34 +38,13 @@ final class DefaultFunctionRepository implements FunctionRepository
      */
     private function findFunctionInAst(string $functionName, array $ast): ?Stmt\Function_
     {
-        $finder = new class ($functionName) extends NodeVisitorAbstract {
-            public ?Stmt\Function_ $found = null;
-
-            public function __construct(private readonly string $functionName)
-            {
+        foreach ($this->scanner->scan($ast)->functions as $declaration) {
+            $name = $declaration->name;
+            if ($name->shortName === $functionName || $name->fullyQualifiedName() === $functionName) {
+                return $declaration->node;
             }
+        }
 
-            public function enterNode(Node $node): ?int
-            {
-                if (!$node instanceof Stmt\Function_) {
-                    return null;
-                }
-
-                $shortName = $node->name->toString();
-                $fqn = $node->namespacedName?->toString();
-                if ($shortName === $this->functionName || $fqn === $this->functionName) {
-                    $this->found = $node;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-
-                return null;
-            }
-        };
-
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor($finder);
-        $traverser->traverse($ast);
-
-        return $finder->found;
+        return null;
     }
 }

--- a/src/Resolution/CodeResolver.php
+++ b/src/Resolution/CodeResolver.php
@@ -129,7 +129,9 @@ interface CodeResolver
     public function getNameContext(TextDocument $document, int $line): NameContext;
 
     /**
-     * Get the user-defined functions declared in a document.
+     * Get the user-defined functions declared in a document, at any depth: a
+     * `function_exists`-guarded polyfill is a name the file declares, and the
+     * backends resolve one, so enumeration must not narrow to top level.
      * Used by: Completion
      *
      * @return list<FunctionInfo>

--- a/src/Resolution/SymbolResolver.php
+++ b/src/Resolution/SymbolResolver.php
@@ -7,6 +7,8 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\Visibility;
+use Firehed\PhpLsp\Index\Declaration;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\NodeAtPosition;
 use Firehed\PhpLsp\Knowledge\SymbolSource;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -79,6 +81,7 @@ final class SymbolResolver implements CodeResolver
         private readonly MemberResolver $memberResolver,
         private readonly TypeResolverInterface $typeResolver,
         private readonly FunctionRepository $functionRepository,
+        private readonly DeclarationScanner $declarationScanner,
     ) {
         $this->textFallback = new TextFallbackHelper($memberResolver);
     }
@@ -661,14 +664,10 @@ final class SymbolResolver implements CodeResolver
             // @codeCoverageIgnoreEnd
         }
 
-        $functions = [];
-        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
-            if ($stmt instanceof Stmt\Function_) {
-                $functions[] = FunctionInfo::fromNode($stmt);
-            }
-        }
-
-        return $functions;
+        return array_map(
+            static fn(Declaration $declaration): FunctionInfo => FunctionInfo::fromNode($declaration->node),
+            $this->declarationScanner->scan($ast)->functions,
+        );
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -25,6 +25,7 @@ use Firehed\PhpLsp\Handler\LifecycleHandler;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
@@ -109,6 +110,7 @@ final class Server
             $memberResolver,
             $typeResolver,
             $functionRepository,
+            new DeclarationScanner(),
         );
 
         $negotiator = new CapabilityNegotiator($serverInfo);

--- a/src/Server.php
+++ b/src/Server.php
@@ -100,7 +100,7 @@ final class Server
         $symbolSource = $knowledge->source;
         $symbolSink = $knowledge->sink;
 
-        $functionRepository = new DefaultFunctionRepository();
+        $functionRepository = new DefaultFunctionRepository(new DeclarationScanner());
         $memberResolver = new MemberResolver($symbolSource);
         $typeResolver = new BasicTypeResolver($memberResolver, $functionRepository);
 

--- a/tests/Fixtures/FunctionCompletion.php
+++ b/tests/Fixtures/FunctionCompletion.php
@@ -8,6 +8,18 @@ function calculateSum(int $a, int $b): int
     return $a + $b;
 }
 
+// The shape a polyfill takes: declared only where the runtime lacks it, so the
+// declaration is nested rather than top-level. It is still a name this file declares.
+if (!function_exists('calculateProduct')) {
+    /**
+     * Multiplies two numbers.
+     */
+    function calculateProduct(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+}
+
 $result = calc/*|user_defined_function*/
 
 class FunctionReturnConfig

--- a/tests/Fixtures/MultiClass/MultiClass.php
+++ b/tests/Fixtures/MultiClass/MultiClass.php
@@ -27,6 +27,15 @@ class ChildInMultiFile extends ParentInMultiFile
     }
 }
 
+// The class-like analogue of a polyfill: declared only where the runtime lacks it,
+// so the declaration is nested rather than top-level. It is still a name this file
+// declares.
+if (!class_exists(ConditionalInMultiFile::class)) {
+    class ConditionalInMultiFile
+    {
+    }
+}
+
 class FirstUnrelated
 {
     public const FIRST_CONST = 1;

--- a/tests/Fixtures/src/Completion/FunctionCompletion.php
+++ b/tests/Fixtures/src/Completion/FunctionCompletion.php
@@ -17,6 +17,19 @@ function getConfig(): Config
     return new Config();
 }
 
+// A polyfill declares itself only where the runtime lacks it, so the declaration is
+// nested rather than top-level. It is still a name this file declares, and the
+// completion surface must offer it (RFC 1 §4.2).
+if (!function_exists(__NAMESPACE__ . '\calculateProduct')) {
+    /**
+     * Multiplies two numbers.
+     */
+    function calculateProduct(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+}
+
 class FunctionCompletionTriggers
 {
     public function triggerBuiltinFunction(): void

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -2825,6 +2825,22 @@ class CompletionHandlerTest extends TestCase
         self::assertStringContainsString('Adds two numbers', $functionItem['documentation'] ?? '');
     }
 
+    public function testConditionallyDeclaredFunctionCompletion(): void
+    {
+        $cursor = $this->openFixtureAtCursor('FunctionCompletion.php', 'user_defined_function');
+
+        $result = $this->handler->handle($this->completionRequestAt($cursor));
+
+        self::assertIsArray($result);
+        self::assertContains(
+            'calculateProduct',
+            array_column($result['items'], 'label'),
+            'a function_exists-guarded polyfill is a name the file declares, so completion must offer it '
+            . '— hover already resolves one, and a name visible to lookup but not to enumeration is the '
+            . 'split RFC 1 §4.2 forbids',
+        );
+    }
+
     public function testThisCompletionTargetsEnclosingClassNotFirstClass(): void
     {
         // Issue #173: When multiple classes in file, $this-> should complete

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -85,13 +85,13 @@ class CompletionHandlerTest extends TestCase
         $this->symbolSource = $knowledge->source;
 
         $memberResolver = new MemberResolver($knowledge->source);
-        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository(new DeclarationScanner()));
         $this->symbolResolver = new SymbolResolver(
             $this->parser,
             $knowledge->source,
             $memberResolver,
             $typeResolver,
-            new DefaultFunctionRepository(),
+            new DefaultFunctionRepository(new DeclarationScanner()),
             new DeclarationScanner(),
         );
         $this->handler = $this->makeHandler($this->symbolSource);

--- a/tests/Handler/CompletionHandlerTest.php
+++ b/tests/Handler/CompletionHandlerTest.php
@@ -25,6 +25,7 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\FunctionName;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\Location;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
@@ -91,6 +92,7 @@ class CompletionHandlerTest extends TestCase
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
+            new DeclarationScanner(),
         );
         $this->handler = $this->makeHandler($this->symbolSource);
         $this->syncHandler = new TextDocumentSyncHandler($this->documents, $knowledge->sink);

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -48,6 +49,7 @@ class DefinitionHandlerTest extends TestCase
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
+            new DeclarationScanner(),
         );
         $this->handler = new DefinitionHandler(
             $this->documents,

--- a/tests/Handler/DefinitionHandlerTest.php
+++ b/tests/Handler/DefinitionHandlerTest.php
@@ -42,13 +42,13 @@ class DefinitionHandlerTest extends TestCase
             $this->parser,
         );
         $memberResolver = new MemberResolver($knowledge->source);
-        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository(new DeclarationScanner()));
         $symbolResolver = new SymbolResolver(
             $this->parser,
             $knowledge->source,
             $memberResolver,
             $typeResolver,
-            new DefaultFunctionRepository(),
+            new DefaultFunctionRepository(new DeclarationScanner()),
             new DeclarationScanner(),
         );
         $this->handler = new DefinitionHandler(

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -14,6 +14,7 @@ use Firehed\PhpLsp\Protocol\MarkupKind;
 use Firehed\PhpLsp\Protocol\NotificationMessage;
 use Firehed\PhpLsp\Protocol\RequestMessage;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
@@ -53,6 +54,7 @@ class HoverHandlerTest extends TestCase
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
+            new DeclarationScanner(),
         );
         // The default markup kind is plaintext (the pre-initialize default a
         // minimal client is served); the fenced-markdown path is exercised

--- a/tests/Handler/HoverHandlerTest.php
+++ b/tests/Handler/HoverHandlerTest.php
@@ -47,13 +47,13 @@ class HoverHandlerTest extends TestCase
             $this->parser,
         );
         $memberResolver = new MemberResolver($knowledge->source);
-        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository(new DeclarationScanner()));
         $this->symbolResolver = new SymbolResolver(
             $this->parser,
             $knowledge->source,
             $memberResolver,
             $typeResolver,
-            new DefaultFunctionRepository(),
+            new DefaultFunctionRepository(new DeclarationScanner()),
             new DeclarationScanner(),
         );
         // The default markup kind is plaintext (the pre-initialize default a

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -40,13 +40,13 @@ class SignatureHelpHandlerTest extends TestCase
             $this->parser,
         );
         $memberResolver = new MemberResolver($knowledge->source);
-        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository(new DeclarationScanner()));
         $symbolResolver = new SymbolResolver(
             $this->parser,
             $knowledge->source,
             $memberResolver,
             $typeResolver,
-            new DefaultFunctionRepository(),
+            new DefaultFunctionRepository(new DeclarationScanner()),
             new DeclarationScanner(),
         );
         $this->handler = new SignatureHelpHandler(

--- a/tests/Handler/SignatureHelpHandlerTest.php
+++ b/tests/Handler/SignatureHelpHandlerTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\SignatureHelpHandler;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
@@ -46,6 +47,7 @@ class SignatureHelpHandlerTest extends TestCase
             $memberResolver,
             $typeResolver,
             new DefaultFunctionRepository(),
+            new DeclarationScanner(),
         );
         $this->handler = new SignatureHelpHandler(
             $this->documents,

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -315,6 +315,11 @@ final class DeclarationScannerTest extends TestCase
         $beta = $declarations->constants[2];
         self::assertSame('FIXTURE_GLOBAL_BETA', $beta->name->shortName, 'the third constant is the second declarator');
         self::assertInstanceOf(Node\Const_::class, $beta->node, 'the declarator is the node, not its statement');
+        self::assertSame(
+            'FIXTURE_GLOBAL_BETA',
+            $beta->node->name->toString(),
+            'the node is this name\'s own declarator, not the first one its statement holds',
+        );
 
         self::assertInstanceOf(
             Expr\FuncCall::class,

--- a/tests/Index/DeclarationScannerTest.php
+++ b/tests/Index/DeclarationScannerTest.php
@@ -6,15 +6,19 @@ namespace Firehed\PhpLsp\Tests\Index;
 
 use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Document\TextDocument;
-use Firehed\PhpLsp\Domain\QualifiedName;
+use Firehed\PhpLsp\Index\Declaration;
 use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\FileDeclarations;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
 use ReflectionFunction;
 
+#[CoversClass(Declaration::class)]
 #[CoversClass(DeclarationScanner::class)]
 #[CoversClass(FileDeclarations::class)]
 final class DeclarationScannerTest extends TestCase
@@ -91,12 +95,12 @@ final class DeclarationScannerTest extends TestCase
 
         $qualified = array_values(array_filter(
             $declarations->constants,
-            static fn(QualifiedName $name): bool => $name->namespace !== '',
+            static fn(Declaration $declaration): bool => $declaration->name->namespace !== '',
         ));
 
         self::assertSame(
             ['Fixtures\Helpers', 'Fixtures\Helpers'],
-            array_map(static fn(QualifiedName $name): string => $name->namespace, $qualified),
+            array_map(static fn(Declaration $declaration): string => $declaration->name->namespace, $qualified),
             'a define() literal carrying a namespace is split like any other qualified name',
         );
     }
@@ -283,6 +287,42 @@ final class DeclarationScannerTest extends TestCase
         self::assertSame([], $declarations->constants, 'a class constant is not a namespaced constant');
     }
 
+    public function testEachDeclarationCarriesTheNodeThatDeclaresIt(): void
+    {
+        $declarations = $this->scanFixture('AutoloadFiles/globals.php');
+
+        // Pairing, not merely presence: a backend builds its metadata from this
+        // node, so a name paired with a neighbouring declaration would describe the
+        // wrong symbol entirely.
+        foreach ($declarations->functions as $declaration) {
+            $node = $declaration->node;
+            self::assertInstanceOf(Stmt\Function_::class, $node, 'a function is declared by a function node');
+            self::assertSame(
+                $declaration->name->shortName,
+                $node->name->toString(),
+                'a declaration carries the node declaring its own name',
+            );
+        }
+
+        self::assertInstanceOf(
+            Stmt\Class_::class,
+            $declarations->classLikes[0]->node,
+            'a class is declared by a class node',
+        );
+
+        // `const A = 1, B = 2;` is one statement holding two declarators, so the
+        // statement cannot be the node: both names would carry the first's value.
+        $beta = $declarations->constants[2];
+        self::assertSame('FIXTURE_GLOBAL_BETA', $beta->name->shortName, 'the third constant is the second declarator');
+        self::assertInstanceOf(Node\Const_::class, $beta->node, 'the declarator is the node, not its statement');
+
+        self::assertInstanceOf(
+            Expr\FuncCall::class,
+            $declarations->constants[3]->node,
+            'a define() constant is declared by the call that names it',
+        );
+    }
+
     public function testAnEmptyAstYieldsNothing(): void
     {
         $declarations = $this->scanner->scan([]);
@@ -304,11 +344,14 @@ final class DeclarationScannerTest extends TestCase
     }
 
     /**
-     * @param list<QualifiedName> $names
+     * @param list<Declaration<Node>> $declarations
      * @return list<string>
      */
-    private static function fqns(array $names): array
+    private static function fqns(array $declarations): array
     {
-        return array_map(static fn(QualifiedName $name): string => $name->fullyQualifiedName(), $names);
+        return array_map(
+            static fn(Declaration $declaration): string => $declaration->name->fullyQualifiedName(),
+            $declarations,
+        );
     }
 }

--- a/tests/Knowledge/DocumentSymbolSinkTest.php
+++ b/tests/Knowledge/DocumentSymbolSinkTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionName;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\DocumentIndexer;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolIndex;
@@ -45,6 +46,7 @@ final class DocumentSymbolSinkTest extends TestCase
             $this->index,
             new DefaultClassInfoFactory(),
             $parser,
+            new DeclarationScanner(),
         );
     }
 
@@ -282,6 +284,7 @@ final class DocumentSymbolSinkTest extends TestCase
             $this->index,
             new DefaultClassInfoFactory(),
             $parser,
+            new DeclarationScanner(),
             array_values($onDiskBackends),
         );
     }

--- a/tests/Knowledge/FilesystemBackendTest.php
+++ b/tests/Knowledge/FilesystemBackendTest.php
@@ -99,6 +99,21 @@ final class FilesystemBackendTest extends TestCase
         );
     }
 
+    public function testLookupClassLikeResolvesADeclarationBelowTheTopLevel(): void
+    {
+        // The class-like half of the same rule the function path follows: a
+        // `class_exists`-guarded declaration is a name the file declares, so a scan
+        // narrowed to top-level statements would lose it.
+        $backend = $this->backendWithLocator(
+            $this->locatorReturning($this->fixturesRoot . '/MultiClass/MultiClass.php'),
+        );
+
+        self::assertNotNull(
+            $backend->lookupClassLike(self::className('Fixtures\Completion\ConditionalInMultiFile')),
+            'a conditionally declared class must resolve like any other declaration',
+        );
+    }
+
     public function testLookupFunctionResolvesAFunctionDeclaredInAnAutoloadFilesEntry(): void
     {
         $info = $this->backend()->lookupFunction(

--- a/tests/Knowledge/FilesystemBackendTest.php
+++ b/tests/Knowledge/FilesystemBackendTest.php
@@ -263,6 +263,7 @@ final class FilesystemBackendTest extends TestCase
             new CachedNamespaceCatalog($counting, CacheFactory::inMemory()),
             $this->parser,
             $this->factory,
+            new DeclarationScanner(),
             CacheFactory::inMemory(),
         );
 
@@ -409,6 +410,7 @@ final class FilesystemBackendTest extends TestCase
             $catalog,
             $this->parser,
             $this->factory,
+            new DeclarationScanner(),
             CacheFactory::inMemory(),
         );
 
@@ -448,6 +450,7 @@ final class FilesystemBackendTest extends TestCase
             new ComposerNamespaceSource($map),
             $this->parser,
             $this->factory,
+            new DeclarationScanner(),
             CacheFactory::inMemory(),
         );
     }
@@ -459,6 +462,7 @@ final class FilesystemBackendTest extends TestCase
             self::createStub(NamespaceCatalog::class),
             $this->parser,
             $this->factory,
+            new DeclarationScanner(),
             CacheFactory::inMemory(),
         );
     }

--- a/tests/Parity/FunctionSurfaceParityTest.php
+++ b/tests/Parity/FunctionSurfaceParityTest.php
@@ -86,8 +86,8 @@ final class FunctionSurfaceParityTest extends TestCase
             $parser,
             $knowledge->source,
             $memberResolver,
-            new BasicTypeResolver($memberResolver, new DefaultFunctionRepository()),
-            new DefaultFunctionRepository(),
+            new BasicTypeResolver($memberResolver, new DefaultFunctionRepository(new DeclarationScanner())),
+            new DefaultFunctionRepository(new DeclarationScanner()),
             new DeclarationScanner(),
         );
     }

--- a/tests/Parity/FunctionSurfaceParityTest.php
+++ b/tests/Parity/FunctionSurfaceParityTest.php
@@ -9,6 +9,7 @@ use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Completion\FunctionCandidates;
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -87,6 +88,7 @@ final class FunctionSurfaceParityTest extends TestCase
             $memberResolver,
             new BasicTypeResolver($memberResolver, new DefaultFunctionRepository()),
             new DefaultFunctionRepository(),
+            new DeclarationScanner(),
         );
     }
 

--- a/tests/Parity/goldens/function-surface.json
+++ b/tests/Parity/goldens/function-surface.json
@@ -5,6 +5,12 @@
             "kind": 3,
             "detail": "function calculateSum(int $a, int $b): int",
             "documentation": "Adds two numbers."
+        },
+        {
+            "label": "calculateProduct",
+            "kind": 3,
+            "detail": "function calculateProduct(int $a, int $b): int",
+            "documentation": "Multiplies two numbers."
         }
     ],
     "document|calc+snippet": [
@@ -15,6 +21,14 @@
             "documentation": "Adds two numbers.",
             "insertText": "calculateSum($0)",
             "insertTextFormat": 2
+        },
+        {
+            "label": "calculateProduct",
+            "kind": 3,
+            "detail": "function calculateProduct(int $a, int $b): int",
+            "documentation": "Multiplies two numbers.",
+            "insertText": "calculateProduct($0)",
+            "insertTextFormat": 2
         }
     ],
     "document|CALCULATE": [
@@ -23,6 +37,12 @@
             "kind": 3,
             "detail": "function calculateSum(int $a, int $b): int",
             "documentation": "Adds two numbers."
+        },
+        {
+            "label": "calculateProduct",
+            "kind": 3,
+            "detail": "function calculateProduct(int $a, int $b): int",
+            "documentation": "Multiplies two numbers."
         }
     ],
     "document|getConfig": [

--- a/tests/Repository/DefaultFunctionRepositoryTest.php
+++ b/tests/Repository/DefaultFunctionRepositoryTest.php
@@ -65,6 +65,14 @@ class DefaultFunctionRepositoryTest extends TestCase
             'calculateSum',
             'calculateSum',
         ];
+        // A polyfill declares itself only where the runtime lacks it, so the
+        // declaration is nested; the on-disk backends resolve one, and a walk
+        // narrowed to top-level statements here would disagree with them.
+        yield 'namespaced user function declared below the top level' => [
+            'src/Completion/FunctionCompletion.php',
+            'calculateProduct',
+            'calculateProduct',
+        ];
         yield 'built-in function via reflection' => [
             'TypeInference/GlobalFunction.php',
             'strlen',

--- a/tests/Repository/DefaultFunctionRepositoryTest.php
+++ b/tests/Repository/DefaultFunctionRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Repository;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
 use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
@@ -23,7 +24,7 @@ class DefaultFunctionRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->repository = new DefaultFunctionRepository();
+        $this->repository = new DefaultFunctionRepository(new DeclarationScanner());
     }
 
     /**

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -2624,4 +2624,25 @@ final class SymbolResolverTest extends TestCase
         self::assertContains('calculateSum', $names, 'Functions inside a namespace should be found');
         self::assertContains('getConfig', $names, 'Functions inside a namespace should be found');
     }
+
+    public function testGetFileFunctionsFindsDeclarationsAtAnyDepth(): void
+    {
+        $uri = $this->openFixture('FunctionCompletion.php');
+        $document = $this->documents->get($uri);
+        assert($document !== null);
+
+        $names = array_map(
+            static fn(FunctionInfo $fn): string => $fn->name,
+            $this->resolver->getFileFunctions($document),
+        );
+
+        // The on-disk backends and the open-document write path both resolve a
+        // declaration at any depth, so a top-level-only walk here made a polyfill
+        // resolve on hover while being invisible to completion (RFC 1 §4.2).
+        self::assertContains(
+            'calculateProduct',
+            $names,
+            'a function declared inside a function_exists guard is still declared by the file',
+        );
+    }
 }

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -66,14 +66,14 @@ final class SymbolResolverTest extends TestCase
             $this->parser,
         );
         $memberResolver = new MemberResolver($knowledge->source);
-        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $typeResolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository(new DeclarationScanner()));
 
         $this->resolver = new SymbolResolver(
             parser: $this->parser,
             symbolSource: $knowledge->source,
             memberResolver: $memberResolver,
             typeResolver: $typeResolver,
-            functionRepository: new DefaultFunctionRepository(),
+            functionRepository: new DefaultFunctionRepository(new DeclarationScanner()),
             declarationScanner: new DeclarationScanner(),
         );
 

--- a/tests/Resolution/SymbolResolverTest.php
+++ b/tests/Resolution/SymbolResolverTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Tests\Resolution;
 use Firehed\PhpLsp\Document\DocumentManager;
 use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
@@ -73,6 +74,7 @@ final class SymbolResolverTest extends TestCase
             memberResolver: $memberResolver,
             typeResolver: $typeResolver,
             functionRepository: new DefaultFunctionRepository(),
+            declarationScanner: new DeclarationScanner(),
         );
 
         $this->syncHandler = new TextDocumentSyncHandler($this->documents, $knowledge->sink);

--- a/tests/TypeInference/BasicTypeResolverTest.php
+++ b/tests/TypeInference/BasicTypeResolverTest.php
@@ -13,6 +13,7 @@ use Firehed\PhpLsp\Domain\IntersectionType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\UnionType;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Parser\ParserService;
 use Throwable;
@@ -45,7 +46,10 @@ class BasicTypeResolverTest extends TestCase
         );
         $memberResolver = new MemberResolver($knowledge->source);
 
-        $this->resolver = new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        $this->resolver = new BasicTypeResolver(
+            $memberResolver,
+            new DefaultFunctionRepository(new DeclarationScanner()),
+        );
     }
 
     public function testResolveNewExpression(): void
@@ -941,6 +945,6 @@ class BasicTypeResolverTest extends TestCase
         );
         $memberResolver = new MemberResolver($knowledge->source);
 
-        return new BasicTypeResolver($memberResolver, new DefaultFunctionRepository());
+        return new BasicTypeResolver($memberResolver, new DefaultFunctionRepository(new DeclarationScanner()));
     }
 }


### PR DESCRIPTION
Slice **SC.5** — "One declaration finder, not five hand-written"
(`docs/architecture/build-manifest.md`; Plan 0002 §3b corrections; RFC 1 §4.2, §4.3, §5.3).

Five sites independently answered "which node in this AST declares this name", and
they disagreed about depth: `SymbolResolver::getFileFunctions` walked top-level
statements only, while `DocumentSymbolSink::functionsIn`,
`FilesystemBackend::parseFunctionFrom`/`findClassInAst` and
`DefaultFunctionRepository::findFunctionInAst` walked all depths. A polyfill declared
inside `if (!function_exists(...))` therefore resolved on hover and never appeared in
completion — the lookup/enumeration split RFC 1 §4.2 forbids.

`Index\DeclarationScanner` already answered the general question correctly. What the
backends needed beyond it was the declaring *node*, so `FileDeclarations` now carries
`Declaration<TNode>` — a name paired with the node that declares it — for all three
symbol namespaces. All five sites read it; five hand-written traversals are gone.

## Behaviour change

The function-completion surface now offers a declaration at any depth, so the Step P
golden `function-surface.json` is deliberately rewritten (the one golden SC.5 is
expected to move). The diff is three additions of the same new fixture polyfill, in
the three prefix queries that match it; no query reordered or lost an item.

## Dropped as vestigial

`findClassInAst` also matched a class by bare short name. That dates to the original
`ClassFinder` (#3), which searched an AST in hand for whatever string the user typed.
Today the method is reachable only from `lookupClassLike(ClassName)` after a locator
mapped that FQN to a file; the classmap and `autoload.files` routes are keyed by FQN,
so the FQN branch always wins first. The short-name branch could only fire when a
root-prefix (`""`) PSR-4/PSR-0 map pointed at a namespace-mismatched file, where
matching is a false positive rather than a fallback. Nothing exercised it.

Class-like matching stays case-**sensitive** and function matching stays on
`NameKind::normalize`, exactly as before — unifying the two case rules is SC.6's row,
not this one.

## Acceptance criteria

- [x] The five hand-written declaration finders are replaced by `DeclarationScanner`
- [x] `FileDeclarations` carries the declaring node, for all three symbol namespaces
- [x] Regression test (written failing first): a `function_exists`-guarded function
      appears in completion, not only on hover —
      `CompletionHandlerTest::testConditionallyDeclaredFunctionCompletion` and
      `SymbolResolverTest::testGetFileFunctionsFindsDeclarationsAtAnyDepth`
- [x] The function-surface golden recaptured deliberately, diff reviewed
- [x] Every other golden stays frozen
- [x] No new coverage gaps on any file changed here

Candidate closes (pending review verification): none listed in the manifest.

## Noted, not fixed (out of this slice's scope)

`DocumentSymbolSink::classesIn` is a sixth hand-written declaration scan, top-level
only, with the same depth defect for class-likes: a `class_exists`-guarded class is
resolved by the on-disk backends but drops out of open-document lookup. The manifest
enumerates exactly five sites for SC.5 and assigns the remaining `SymbolExtractor`
work to SC.3, so this is left for a new row rather than folded in here. CLAUDE.md's
write-path paragraph currently overstates the sink as registering "a declaration at
any depth", which holds for functions but not for class-likes.
