### PR TITLE
Register class-likes at any depth in the open-document write path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,17 +141,16 @@ not a cost measurement; the set is explicit and usually tiny.
 
 **"Which node declares this name" is answered by `Index\DeclarationScanner`**, which
 reports every class-like, function and constant an AST declares — at any depth, paired
-with its declaring node (`Declaration`). Every function-namespace consumer reads it:
-on-disk and open-document lookup, the write path, the `autoload.files` index, and
-completion's file-function query, so none can disagree about what a file declares. Five
-hand-written traversals is how a `function_exists`-guarded polyfill came to resolve on
-hover while being invisible to completion. Do NOT write a new one; a rule about what
-counts as a declaration is a change to the scanner.
+with its declaring node (`Declaration`). Every consumer reads it: on-disk and
+open-document lookup, the write path, the `autoload.files` index, and completion's
+file-function query, so none can disagree about what a file declares. Hand-written
+traversals are how a `function_exists`-guarded polyfill came to resolve on hover while
+being invisible to completion, and how its `class_exists` twin dropped out of
+open-document lookup. Do NOT write a new one; a rule about what counts as a declaration
+is a change to the scanner.
 
-Two class-like traversals survive it, both tracked: `DocumentSymbolSink::classesIn`
-(top-level only, so a `class_exists`-guarded class drops out of open-document lookup
-while the on-disk backends resolve it) and `Index\SymbolExtractor`, which rebuilds FQNs
-by hand rather than reading `namespacedName`. Neither is licence for a third.
+One traversal survives it, tracked: `Index\SymbolExtractor` rebuilds FQNs by hand rather
+than reading `namespacedName`. That is not licence for a second.
 
 The same derived index also answers the backend's `childrenOf`, merged with the
 directory listing by `CompositeNamespaceCatalog`. Enumeration is not optional: §4.2
@@ -159,11 +158,10 @@ requires lookup and enumeration to draw on the same backends, so a name that res
 on hover while being invisible to completion is the split this tier exists to prevent.
 
 The write path is **`SymbolSink`** (`DocumentSymbolSink`), which registers class and
-function metadata and indexes symbols from one document. A *function* declared at any
-depth is registered, not just a top-level one — a polyfill guarded by `function_exists`
-is a name the file validly declares, and the on-disk backends resolve one, so opening
-the file must not make it disappear. Class-like registration is still top-level only
-(see `classesIn` above), which is the same defect awaiting its own slice.
+function metadata and indexes symbols from one document. A declaration at any depth is
+registered, not just a top-level one — a class or function guarded by
+`class_exists`/`function_exists` is a name the file validly declares, and the on-disk
+backends resolve one, so opening the file must not make it disappear.
 **`KnowledgeStack::forProject`** assembles the read composite and the write sink,
 sharing one open-document backend and symbol index.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,9 +160,10 @@ not a cost measurement; the set is explicit and usually tiny.
 
 **"Which node declares this name" is answered by `Index\DeclarationScanner`**, which
 reports every class-like, function and constant an AST declares — at any depth, paired
-with its declaring node (`Declaration`). Every consumer reads it: on-disk and
-open-document lookup, the write path, the `autoload.files` index, and completion's
-file-function query, so none can disagree about what a file declares. Hand-written
+with its declaring node (`Declaration`). Every consumer but one (tracked below) reads
+it: on-disk and open-document lookup, the write path's lookup half, the
+`autoload.files` index, and completion's file-function query, so none can disagree
+about what a file declares. Hand-written
 traversals are how a `function_exists`-guarded polyfill came to resolve on hover while
 being invisible to completion, and how its `class_exists` twin dropped out of
 open-document lookup. Do NOT write a new one; a rule about what counts as a declaration

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -110,7 +110,6 @@ deptrac:
       - Index
       - Parser
       - Repository
-      - Utility
     Repository:
       - Document # FileUri, the path/URI conversion authority
       - Domain

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -92,9 +92,9 @@ final class DocumentSymbolSink implements SymbolSink
      * The lookup store and the symbol index are separate structures, so the Step P
      * parity harness — which compares only observable outputs — could stay green
      * while they diverged internally (Plan 0002 §5.5, Step 3a(iv)). This guards the
-     * invariant directly: every name registered for lookup MUST also be indexed, so
-     * one is never resolvable through one surface yet invisible to the other
-     * (RFC 1 §4.3).
+     * invariant directly: every name registered for lookup MUST also be indexed
+     * (RFC 1 §4.3). The check is one-directional because the index is a superset —
+     * it also records members, which are not registered for lookup.
      *
      * It earns its place because the two stores qualify a name by different routes —
      * the parser's `namespacedName` here, a hand-tracked enclosing namespace in

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -138,7 +138,9 @@ final class DocumentSymbolSink implements SymbolSink
     /**
      * A declaration at any depth counts, matching what the on-disk backends resolve
      * (a polyfill guarded by `function_exists` is the common shape). Opening a file
-     * must not make a name that already resolved disappear (RFC 1 §4.2).
+     * must not make a name that already resolved disappear (RFC 1 §4.2). Of duplicate
+     * declarations, the first wins — the one PHP would define, and the one the
+     * on-disk backends return.
      *
      * @return array<string, FunctionInfo> Fully-qualified name -> metadata
      */
@@ -154,9 +156,9 @@ final class DocumentSymbolSink implements SymbolSink
     }
 
     /**
-     * Class-likes follow the same depth rule as functions above, for the same
-     * reason: a `class_exists`-guarded declaration is one the on-disk backends
-     * resolve.
+     * Class-likes follow the same depth and duplicate rules as functions above, for
+     * the same reasons: a `class_exists`-guarded declaration is one the on-disk
+     * backends resolve, and of duplicates they return the first.
      *
      * @return list<ClassInfo>
      */
@@ -164,9 +166,10 @@ final class DocumentSymbolSink implements SymbolSink
     {
         $classes = [];
         foreach ($declarations->classLikes as $declaration) {
-            $classes[] = $this->classInfoFactory->fromAstNode($declaration->node, $uri);
+            $fqn = $declaration->name->fullyQualifiedName();
+            $classes[$fqn] ??= $this->classInfoFactory->fromAstNode($declaration->node, $uri);
         }
 
-        return $classes;
+        return array_values($classes);
     }
 }

--- a/src/Knowledge/DocumentSymbolSink.php
+++ b/src/Knowledge/DocumentSymbolSink.php
@@ -10,11 +10,10 @@ use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\DocumentIndexer;
+use Firehed\PhpLsp\Index\FileDeclarations;
 use Firehed\PhpLsp\Index\SymbolIndex;
 use Firehed\PhpLsp\Repository\ClassInfoFactory;
 use Firehed\PhpLsp\Parser\ParserService;
-use Firehed\PhpLsp\Utility\ScopeFinder;
-use PhpParser\Node\Stmt;
 
 /**
  * The single write path for open-document symbol state (RFC 1 §4.3, §5.2): document
@@ -80,8 +79,9 @@ final class DocumentSymbolSink implements SymbolSink
         // failure yields no statements, so both are cleared together.
         $ast = $this->parser->parse($document) ?? [];
 
-        $classes = $this->classesIn($ast, $document->uri);
-        $functions = $this->functionsIn($ast, $document->uri);
+        $declarations = $this->scanner->scan($ast);
+        $classes = $this->classesIn($declarations, $document->uri);
+        $functions = $this->functionsIn($declarations, $document->uri);
         $this->backend->updateDocument($document->uri, $classes, $functions);
         $this->indexer->indexParsed($document, $ast);
 
@@ -92,16 +92,14 @@ final class DocumentSymbolSink implements SymbolSink
      * The lookup store and the symbol index are separate structures, so the Step P
      * parity harness — which compares only observable outputs — could stay green
      * while they diverged internally (Plan 0002 §5.5, Step 3a(iv)). This guards the
-     * invariant directly: every class-like registered for lookup MUST also be
-     * indexed, so a name is never resolvable through one surface yet invisible to the
-     * other (RFC 1 §4.3). The check is one-directional because the index is a
-     * superset — it also records class-likes declared inside conditional or nested
-     * statements, which the top-level lookup registration does not.
+     * invariant directly: every name registered for lookup MUST also be indexed, so
+     * one is never resolvable through one surface yet invisible to the other
+     * (RFC 1 §4.3).
      *
-     * Functions are checked on the same terms, and need it more: the two stores
-     * qualify a function name by different routes — the parser's `namespacedName`
-     * here, a hand-tracked enclosing namespace in {@see \Firehed\PhpLsp\Index\SymbolExtractor} —
-     * so agreement is a property of two implementations rather than of one.
+     * It earns its place because the two stores qualify a name by different routes —
+     * the parser's `namespacedName` here, a hand-tracked enclosing namespace in
+     * {@see \Firehed\PhpLsp\Index\SymbolExtractor} — so agreement is a property of two
+     * implementations rather than of one.
      *
      * @param list<ClassInfo> $classes
      * @param array<string, FunctionInfo> $functions
@@ -142,13 +140,12 @@ final class DocumentSymbolSink implements SymbolSink
      * (a polyfill guarded by `function_exists` is the common shape). Opening a file
      * must not make a name that already resolved disappear (RFC 1 §4.2).
      *
-     * @param array<Stmt> $ast
      * @return array<string, FunctionInfo> Fully-qualified name -> metadata
      */
-    private function functionsIn(array $ast, string $uri): array
+    private function functionsIn(FileDeclarations $declarations, string $uri): array
     {
         $functions = [];
-        foreach ($this->scanner->scan($ast)->functions as $declaration) {
+        foreach ($declarations->functions as $declaration) {
             $fqn = $declaration->name->fullyQualifiedName();
             $functions[$fqn] ??= FunctionInfo::fromNode($declaration->node, $uri);
         }
@@ -157,16 +154,17 @@ final class DocumentSymbolSink implements SymbolSink
     }
 
     /**
-     * @param array<Stmt> $ast
+     * Class-likes follow the same depth rule as functions above, for the same
+     * reason: a `class_exists`-guarded declaration is one the on-disk backends
+     * resolve.
+     *
      * @return list<ClassInfo>
      */
-    private function classesIn(array $ast, string $uri): array
+    private function classesIn(FileDeclarations $declarations, string $uri): array
     {
         $classes = [];
-        foreach (ScopeFinder::iterateTopLevelStatements($ast) as $stmt) {
-            if ($stmt instanceof Stmt\ClassLike && $stmt->name !== null) {
-                $classes[] = $this->classInfoFactory->fromAstNode($stmt, $uri);
-            }
+        foreach ($declarations->classLikes as $declaration) {
+            $classes[] = $this->classInfoFactory->fromAstNode($declaration->node, $uri);
         }
 
         return $classes;

--- a/src/Utility/ScopeFinder.php
+++ b/src/Utility/ScopeFinder.php
@@ -223,23 +223,6 @@ final class ScopeFinder
     }
 
     /**
-     * Iterate top-level statements, flattening namespace contents.
-     *
-     * @param array<Stmt> $ast
-     * @return \Generator<Stmt>
-     */
-    public static function iterateTopLevelStatements(array $ast): \Generator
-    {
-        foreach ($ast as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                yield from $stmt->stmts;
-            } else {
-                yield $stmt;
-            }
-        }
-    }
-
-    /**
      * Find the namespace declaration containing a given zero-based line.
      *
      * Returns null when the line is outside any namespace block or the enclosing

--- a/tests/Fixtures/MultiClass/DuplicateDeclarations.php
+++ b/tests/Fixtures/MultiClass/DuplicateDeclarations.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\MultiClass;
+
+// A name declared twice in one file: the unguarded declaration runs first, so it is
+// the one PHP defines. The guarded twin differs in every discriminating detail
+// (final-ness, members, return type) so a lookup reveals which declaration won.
+final class Duplicated
+{
+    public function fromFirstDeclaration(): void
+    {
+    }
+}
+
+function duplicated(): string
+{
+    return '';
+}
+
+if (!class_exists(Duplicated::class)) {
+    class Duplicated
+    {
+        public function fromSecondDeclaration(): void
+        {
+        }
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\duplicated')) {
+    function duplicated(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Knowledge/DocumentSymbolSinkTest.php
+++ b/tests/Knowledge/DocumentSymbolSinkTest.php
@@ -98,6 +98,19 @@ final class DocumentSymbolSinkTest extends TestCase
         );
     }
 
+    public function testOpenDocumentRegistersAClassLikeBelowTheTopLevel(): void
+    {
+        // The class-like half of the same rule: the on-disk backends resolve a
+        // `class_exists`-guarded declaration, so an open document must too.
+        $uri = 'file:///MultiClass.php';
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $this->loadFixture('MultiClass/MultiClass.php')));
+
+        self::assertNotNull(
+            $this->backend->lookupClassLike(self::className('Fixtures\Completion\ConditionalInMultiFile')),
+            'a conditionally declared class must be registered like any other declaration',
+        );
+    }
+
     public function testUpdatingAwayFromAFunctionDropsItsRegistration(): void
     {
         $uri = 'file:///helpers.php';

--- a/tests/Knowledge/DocumentSymbolSinkTest.php
+++ b/tests/Knowledge/DocumentSymbolSinkTest.php
@@ -111,6 +111,39 @@ final class DocumentSymbolSinkTest extends TestCase
         );
     }
 
+    public function testTheFirstOfDuplicateClassLikeDeclarationsWins(): void
+    {
+        // A file may declare one name twice (an unguarded declaration plus a guarded
+        // twin). PHP defines the first one executed, and the on-disk backends return
+        // the first declaration found — the open document must agree (RFC 1 §4.2).
+        $uri = 'file:///DuplicateDeclarations.php';
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $this->loadFixture('MultiClass/DuplicateDeclarations.php')));
+
+        $classInfo = $this->backend->lookupClassLike(self::className('Fixtures\MultiClass\Duplicated'));
+        self::assertNotNull($classInfo, 'the duplicated class must still resolve');
+        self::assertTrue(
+            $classInfo->isFinal,
+            'the first declaration (final) must win, matching runtime and the on-disk backends',
+        );
+    }
+
+    public function testTheFirstOfDuplicateFunctionDeclarationsWins(): void
+    {
+        // The function half of the same rule.
+        $uri = 'file:///DuplicateDeclarations.php';
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $this->loadFixture('MultiClass/DuplicateDeclarations.php')));
+
+        $functionInfo = $this->backend->lookupFunction(
+            FunctionName::fromFullyQualified('Fixtures\MultiClass\duplicated'),
+        );
+        self::assertNotNull($functionInfo, 'the duplicated function must still resolve');
+        self::assertSame(
+            'string',
+            $functionInfo->returnType?->format(),
+            'the first declaration (returning string) must win, matching runtime and the on-disk backends',
+        );
+    }
+
     public function testUpdatingAwayFromAFunctionDropsItsRegistration(): void
     {
         $uri = 'file:///helpers.php';

--- a/tests/Knowledge/DocumentSymbolSinkTest.php
+++ b/tests/Knowledge/DocumentSymbolSinkTest.php
@@ -117,7 +117,8 @@ final class DocumentSymbolSinkTest extends TestCase
         // twin). PHP defines the first one executed, and the on-disk backends return
         // the first declaration found — the open document must agree (RFC 1 §4.2).
         $uri = 'file:///DuplicateDeclarations.php';
-        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $this->loadFixture('MultiClass/DuplicateDeclarations.php')));
+        $content = $this->loadFixture('MultiClass/DuplicateDeclarations.php');
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $content));
 
         $classInfo = $this->backend->lookupClassLike(self::className('Fixtures\MultiClass\Duplicated'));
         self::assertNotNull($classInfo, 'the duplicated class must still resolve');
@@ -131,7 +132,8 @@ final class DocumentSymbolSinkTest extends TestCase
     {
         // The function half of the same rule.
         $uri = 'file:///DuplicateDeclarations.php';
-        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $this->loadFixture('MultiClass/DuplicateDeclarations.php')));
+        $content = $this->loadFixture('MultiClass/DuplicateDeclarations.php');
+        $this->sink->openDocument(new TextDocument($uri, 'php', 1, $content));
 
         $functionInfo = $this->backend->lookupFunction(
             FunctionName::fromFullyQualified('Fixtures\MultiClass\duplicated'),

--- a/tests/Utility/ScopeFinderTest.php
+++ b/tests/Utility/ScopeFinderTest.php
@@ -325,36 +325,6 @@ class ScopeFinderTest extends TestCase
         self::assertSame('Fixtures\Inheritance\ParentClass', ScopeFinder::resolveName($class->extends));
     }
 
-    public function testIterateTopLevelStatementsYieldsStatementsDirectly(): void
-    {
-        $code = $this->loadFixture('TypeInference/GlobalFunction.php');
-        $ast = self::parseWithParents($code);
-
-        $statements = iterator_to_array(ScopeFinder::iterateTopLevelStatements($ast));
-        $classLikes = array_filter($statements, fn($s) => $s instanceof Stmt\ClassLike);
-        $functions = array_filter($statements, fn($s) => $s instanceof Stmt\Function_);
-
-        self::assertCount(1, $classLikes);
-        self::assertCount(2, $functions);
-        $class = reset($classLikes);
-        self::assertInstanceOf(Stmt\Class_::class, $class);
-        self::assertSame('GlobalConfig', $class->name?->toString());
-    }
-
-    public function testIterateTopLevelStatementsFlattensNamespace(): void
-    {
-        $code = $this->loadFixture('src/Mixed/MultipleClasses.php');
-        $ast = self::parseWithParents($code);
-
-        $statements = iterator_to_array(ScopeFinder::iterateTopLevelStatements($ast));
-
-        self::assertGreaterThanOrEqual(2, count($statements));
-        self::assertInstanceOf(Stmt\Class_::class, $statements[0]);
-        self::assertSame('First', $statements[0]->name?->toString());
-        self::assertInstanceOf(Stmt\Class_::class, $statements[1]);
-        self::assertSame('Second', $statements[1]->name?->toString());
-    }
-
     public function testResolveClassNameDelegatesToResolveName(): void
     {
         $code = $this->loadFixture('src/Utility/ImportedExtends.php');


### PR DESCRIPTION
Slice **SC.9** (build-manifest.md). No plan step owns it — `SC.*` rows are audit-found defects that predate Plan 0002. RFC 1 §4.2 (lookup and enumeration draw on the same backends), §4.3 (the double write moves together).

`DocumentSymbolSink` asked "what does this file declare?" two different ways: `functionsIn` read `DeclarationScanner` at any depth, while `classesIn` hand-walked `ScopeFinder::iterateTopLevelStatements` and registered top-level class-likes only. So a `class_exists`-guarded class in an open buffer was returned by that backend's `searchClassLikes` (which reads `SymbolExtractor`, all depths) but not by its `lookupClassLike` — the same §4.2 split as the `function_exists` polyfill defect SC.5 closed, on the other symbol namespace. The on-disk `FilesystemBackend` already resolves one, so opening the file made the name disappear.

`classesIn` now reads the scanner, and `write()` scans once and hands the result to both extractors.

### Acceptance criteria

- [x] A `class_exists`-guarded class in an open document resolves through `lookupClassLike` (regression test; nothing pinned the depth behaviour in either direction before).
- [x] `classesIn` reads `DeclarationScanner`, not a hand-written traversal.
- [x] `ScopeFinder::iterateTopLevelStatements` retires with its last `src/` consumer.
- [x] `assertStoresAgree`'s concession that the index is a superset of the lookup registration is removed — it no longer holds.
- [x] CLAUDE.md's class-like traversal count drops to one (`SymbolExtractor`, SC.3's).

### Notes

- `SymbolExtractor` walks all depths, so the write-path agreement check still holds for a nested declaration.
- SC.10 (the PHPStan rule confining AST traversal) is gated on this slice and SC.3; one of its two known violators is now gone.

Candidate closes (pending review verification): none — the manifest row lists no issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
