### PR TITLE
Default-deny capability confinement rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "unit": "phpunit",
         "parity-coverage": "phpunit tests/Parity --coverage-text",
         "phpstan": "phpstan analyze",
+        "phpstan-baseline": "phpstan analyze --generate-baseline",
         "test": [
             "@phpstan",
             "@unit",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^12.5.22",
+        "spaze/phpstan-disallowed-calls": "^4.14",
         "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Completion/NamedArgumentCandidates.php
+
+		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
@@ -17,6 +23,12 @@ parameters:
 			identifier: disallowed.function
 			count: 1
 			path: src/Domain/MethodName.php
+
+		-
+			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'
+			identifier: disallowed.function
+			count: 2
+			path: src/Handler/CompletionHandler.php
 
 		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
@@ -101,6 +113,12 @@ parameters:
 			identifier: disallowed.function
 			count: 1
 			path: src/Resolution/ReferenceResolver.php
+
+		-
+			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'
+			identifier: disallowed.function
+			count: 8
+			path: src/Resolution/SymbolResolver.php
 
 		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -97,6 +97,18 @@ parameters:
 			path: src/Index/SymbolIndex.php
 
 		-
+			message: '#^Calling file_get_contents\(\) is forbidden, filesystem access is confined\: ParserService reads source, ComposerAutoloadMap/ComposerNamespaceSource read Composer metadata, transport owns its streams\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Index/WorkspaceIndexer.php
+
+		-
+			message: '#^Calling is_dir\(\) is forbidden, filesystem access is confined\: ParserService reads source, ComposerAutoloadMap/ComposerNamespaceSource read Composer metadata, transport owns its streams\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Index/WorkspaceIndexer.php
+
+		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,67 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Class PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.class
+			count: 1
+			path: src/Index/SymbolExtractor.php
+
+		-
+			message: '#^Namespace PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.namespace
+			count: 1
+			path: src/Index/SymbolExtractor.php
+
+		-
+			message: '#^Namespace PhpParser\\NodeVisitorAbstract is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\. \[PhpParser\\NodeVisitorAbstract matches PhpParser\\NodeVisitor\*\]$#'
+			identifier: disallowed.namespace
+			count: 2
+			path: src/Index/SymbolExtractor.php
+
+		-
+			message: '#^Class PhpParser\\NodeFinder is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.class
+			count: 1
+			path: src/Resolution/SymbolResolver.php
+
+		-
+			message: '#^Class PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.class
+			count: 1
+			path: src/Resolution/SymbolResolver.php
+
+		-
+			message: '#^Namespace PhpParser\\NodeFinder is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.namespace
+			count: 1
+			path: src/Resolution/SymbolResolver.php
+
+		-
+			message: '#^Namespace PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.namespace
+			count: 1
+			path: src/Resolution/SymbolResolver.php
+
+		-
+			message: '#^Namespace PhpParser\\NodeVisitorAbstract is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\. \[PhpParser\\NodeVisitorAbstract matches PhpParser\\NodeVisitor\*\]$#'
+			identifier: disallowed.namespace
+			count: 2
+			path: src/Resolution/SymbolResolver.php
+
+		-
+			message: '#^Class PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.class
+			count: 2
+			path: src/TypeInference/BasicTypeResolver.php
+
+		-
+			message: '#^Namespace PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
+			identifier: disallowed.namespace
+			count: 1
+			path: src/TypeInference/BasicTypeResolver.php
+
+		-
+			message: '#^Namespace PhpParser\\NodeVisitorAbstract is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\. \[PhpParser\\NodeVisitorAbstract matches PhpParser\\NodeVisitor\*\]$#'
+			identifier: disallowed.namespace
+			count: 2
+			path: src/TypeInference/BasicTypeResolver.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,60 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 2
+			path: src/Completion/PrefixMatcher.php
+
+		-
+			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Domain/ClassName.php
+
+		-
+			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Domain/MethodName.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Index/AutoloadFilesLocator.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Index/CachedNamespaceCatalog.php
+
+		-
+			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Index/ComposerNamespaceSource.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 4
+			path: src/Index/ComposerNamespaceSource.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 5
+			path: src/Index/NamespaceContents.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Index/ReflectionNamespaceSource.php
+
+		-
 			message: '#^Class PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
 			identifier: disallowed.class
 			count: 1
@@ -17,6 +71,42 @@ parameters:
 			identifier: disallowed.namespace
 			count: 2
 			path: src/Index/SymbolExtractor.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 5
+			path: src/Index/SymbolIndex.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Index/WorkspaceNamespaceSource.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 2
+			path: src/Knowledge/CompositeSymbolSource.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Repository/MemberResolver.php
+
+		-
+			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Resolution/ReferenceResolver.php
+
+		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Resolution/SymbolResolver.php
 
 		-
 			message: '#^Class PhpParser\\NodeFinder is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
@@ -49,6 +139,12 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
+			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 2
+			path: src/Resolution/TextFallbackHelper.php
+
+		-
 			message: '#^Class PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
 			identifier: disallowed.class
 			count: 2
@@ -65,3 +161,9 @@ parameters:
 			identifier: disallowed.namespace
 			count: 2
 			path: src/TypeInference/BasicTypeResolver.php
+
+		-
+			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Utility/NamespacePath.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Calling get_defined_functions\(\) is forbidden, runtime symbol enumeration is confined to BuiltinBackend and ReflectionNamespaceSource\.$#'
+			identifier: disallowed.function
+			count: 1
+			path: src/Completion/FunctionCandidates.php
+
+		-
 			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'
 			identifier: disallowed.function
 			count: 1
@@ -101,6 +107,24 @@ parameters:
 			identifier: disallowed.function
 			count: 2
 			path: src/Knowledge/CompositeSymbolSource.php
+
+		-
+			message: '#^Class ReflectionFunction is forbidden, runtime reflection is confined\: BuiltinBackend, ReflectionNamespaceSource, and the fromReflection factories\. \[ReflectionFunction matches Reflection\*\]$#'
+			identifier: disallowed.class
+			count: 1
+			path: src/Repository/DefaultFunctionRepository.php
+
+		-
+			message: '#^Namespace ReflectionException is forbidden, runtime reflection is confined\: BuiltinBackend, ReflectionNamespaceSource, and the fromReflection factories\. \[ReflectionException matches Reflection\*\]$#'
+			identifier: disallowed.namespace
+			count: 1
+			path: src/Repository/DefaultFunctionRepository.php
+
+		-
+			message: '#^Namespace ReflectionFunction is forbidden, runtime reflection is confined\: BuiltinBackend, ReflectionNamespaceSource, and the fromReflection factories\. \[ReflectionFunction matches Reflection\*\]$#'
+			identifier: disallowed.namespace
+			count: 1
+			path: src/Repository/DefaultFunctionRepository.php
 
 		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -54,6 +54,19 @@ parameters:
                 - src/Transport/MessageReader.php # HTTP header names
                 - src/Domain/Visibility.php # visibility keywords
                 - tests/*
+        -
+            function:
+                - 'preg_match()'
+                - 'preg_match_all()'
+                - 'preg_replace()'
+                - 'preg_split()'
+                - 'preg_quote()'
+            message: 'text-pattern analysis is the mid-edit resilience rim: CompletionClassifier, DocblockParser, TextFallbackHelper'
+            allowIn:
+                - src/Completion/CompletionClassifier.php
+                - src/Utility/DocblockParser.php
+                - src/Resolution/TextFallbackHelper.php
+                - tests/*
 
     level: max
     paths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,47 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/spaze/phpstan-disallowed-calls/extension.neon
+    - phpstan-baseline.neon
 
 parameters:
+    # Default-deny capability confinement: each mechanism below is usable only in
+    # its named home(s). A new use elsewhere is a duplicate implementation waiting
+    # to happen — extend the authority instead, or (rarely) widen the allowlist.
+    # Existing violations are frozen in phpstan-baseline.neon (regenerate with
+    # `composer phpstan-baseline`) and drain via their owning slices; the
+    # baseline must only shrink.
+    disallowedNamespaces:
+        -
+            namespace: 'PhpParser\NodeTraverser'
+            message: 'AST traversal is confined: parser pipeline (ParserService), positional finders (NodeAtPosition, Scope, ScopeFinder), and DeclarationScanner'
+            allowIn:
+                - src/Parser/ParserService.php
+                - src/Index/NodeAtPosition.php
+                - src/Index/DeclarationScanner.php
+                - src/Utility/Scope.php
+                - src/Utility/ScopeFinder.php
+                - tests/*
+        -
+            namespace: 'PhpParser\NodeFinder'
+            message: 'AST traversal is confined: parser pipeline (ParserService), positional finders (NodeAtPosition, Scope, ScopeFinder), and DeclarationScanner'
+            allowIn:
+                - src/Parser/ParserService.php
+                - src/Index/NodeAtPosition.php
+                - src/Index/DeclarationScanner.php
+                - src/Utility/Scope.php
+                - src/Utility/ScopeFinder.php
+                - tests/*
+        -
+            namespace: 'PhpParser\NodeVisitor*'
+            message: 'AST traversal is confined: parser pipeline (ParserService), positional finders (NodeAtPosition, Scope, ScopeFinder), and DeclarationScanner'
+            allowIn:
+                - src/Parser/ParserService.php
+                - src/Index/NodeAtPosition.php
+                - src/Index/DeclarationScanner.php
+                - src/Utility/Scope.php
+                - src/Utility/ScopeFinder.php
+                - tests/*
+
     level: max
     paths:
         - src

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -89,6 +89,23 @@ parameters:
                 - src/Knowledge/BuiltinBackend.php
                 - src/Index/ReflectionNamespaceSource.php
                 - tests/*
+        -
+            function:
+                - 'file_get_contents()'
+                - 'file_exists()'
+                - 'is_file()'
+                - 'is_dir()'
+                - 'scandir()'
+                - 'glob()'
+                - 'fopen()'
+                - 'realpath()'
+            message: 'filesystem access is confined: ParserService reads source, ComposerAutoloadMap/ComposerNamespaceSource read Composer metadata, transport owns its streams'
+            allowIn:
+                - src/Parser/ParserService.php
+                - src/Index/ComposerAutoloadMap.php
+                - src/Index/ComposerNamespaceSource.php
+                - src/Transport/*
+                - tests/*
 
     level: max
     paths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,6 +32,18 @@ parameters:
                 - src/Utility/ScopeFinder.php
                 - tests/*
         -
+            namespace: 'Reflection*'
+            message: 'runtime reflection is confined: BuiltinBackend, ReflectionNamespaceSource, and the fromReflection factories'
+            allowIn:
+                - src/Knowledge/BuiltinBackend.php
+                - src/Index/ReflectionNamespaceSource.php
+                - src/Repository/ClassInfoFactory.php
+                - src/Repository/DefaultClassInfoFactory.php
+                - src/Utility/TypeFactory.php
+                - src/Domain/FunctionInfo.php
+                - src/Domain/ParameterInfo.php
+                - tests/*
+        -
             namespace: 'PhpParser\NodeVisitor*'
             message: 'AST traversal is confined: parser pipeline (ParserService), positional finders (NodeAtPosition, Scope, ScopeFinder), and DeclarationScanner'
             allowIn:
@@ -66,6 +78,16 @@ parameters:
                 - src/Completion/CompletionClassifier.php
                 - src/Utility/DocblockParser.php
                 - src/Resolution/TextFallbackHelper.php
+                - tests/*
+        -
+            function:
+                - 'get_defined_functions()'
+                - 'get_declared_classes()'
+                - 'get_defined_constants()'
+            message: 'runtime symbol enumeration is confined to BuiltinBackend and ReflectionNamespaceSource'
+            allowIn:
+                - src/Knowledge/BuiltinBackend.php
+                - src/Index/ReflectionNamespaceSource.php
                 - tests/*
 
     level: max

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,6 +42,19 @@ parameters:
                 - src/Utility/ScopeFinder.php
                 - tests/*
 
+    disallowedFunctionCalls:
+        -
+            function:
+                - 'strtolower()'
+                - 'strcasecmp()'
+                - 'mb_strtolower()'
+            message: 'case rules for symbol names live in NameKind; non-symbol uses may be allowlisted here consciously'
+            allowIn:
+                - src/Resolution/NameKind.php
+                - src/Transport/MessageReader.php # HTTP header names
+                - src/Domain/Visibility.php # visibility keywords
+                - tests/*
+
     level: max
     paths:
         - src


### PR DESCRIPTION
Adds spaze/phpstan-disallowed-calls and confines five mechanisms to their named homes: AST traversal, symbol-name case folding, regex, runtime reflection, and filesystem reads. Anything outside an allowlist fails PHPStan at level max, so a duplicate implementation of a confined mechanism cannot merge regardless of which axis it lands on.

Existing violations (63) are frozen in phpstan-baseline.neon and map to already-owned work (SC.1, SC.3, SC.6, S3.9b, S3.10, Step 4); the baseline must only shrink. Regenerate with `composer phpstan-baseline`.

Allowlist judgment calls, for review:
- ScopeFinder/Scope are allowed traversal homes (positional layer) even though Step 4 consolidates them; their internal duplication stays owned by S4.4, not the baseline.
- Domain `fromReflection` factories (FunctionInfo, ParameterInfo) are allowed reflection users per the existing factory-method convention.
- ClassName/MethodName/NamespacePath case comparisons are baselined, not allowlisted — drain-time decides whether they route through NameKind or get consciously allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)