### PR TITLE
Layer-dependency contract via deptrac

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,3 +24,20 @@ jobs:
 
       - name: PHPStan
         run: composer phpstan -- --error-format=github
+
+  deptrac:
+    runs-on: ubuntu-latest
+    name: Deptrac
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Deptrac
+        run: composer deptrac -- -f github-actions

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/cache": "^7 || ^8"
     },
     "require-dev": {
+        "deptrac/deptrac": "^4.7",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^12.5.22",
@@ -40,8 +41,11 @@
         "unit": "phpunit",
         "parity-coverage": "phpunit tests/Parity --coverage-text",
         "phpstan": "phpstan analyze",
+        "deptrac": "deptrac analyse --no-progress",
+        "deptrac-baseline": "deptrac analyse --no-progress -f baseline -o deptrac.baseline.yaml",
         "test": [
             "@phpstan",
+            "@deptrac",
             "@unit",
             "@phpcs"
         ]

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -1,0 +1,38 @@
+deptrac:
+  skip_violations:
+    Firehed\PhpLsp\Domain\FunctionInfo:
+      - Firehed\PhpLsp\Utility\TypeFactory
+    Firehed\PhpLsp\Domain\FunctionName:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Domain\ParameterInfo:
+      - Firehed\PhpLsp\Utility\TypeFactory
+    Firehed\PhpLsp\Domain\QualifiedName:
+      - Firehed\PhpLsp\Utility\NamespacePath
+    Firehed\PhpLsp\Index\AutoloadFilesLocator:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Index\CatalogSymbol:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Index\ComposerNamespaceSource:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Index\ComposerSymbolLocator:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Index\ReflectionNamespaceSource:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Index\WorkspaceNamespaceSource:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Knowledge\BuiltinBackend:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Knowledge\CompositeSymbolLocator:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Knowledge\FilesystemBackend:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Knowledge\OpenDocumentBackend:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Knowledge\SymbolCacheKey:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Knowledge\SymbolLocator:
+      - Firehed\PhpLsp\Resolution\NameKind
+    Firehed\PhpLsp\Repository\DefaultFunctionRepository:
+      - Firehed\PhpLsp\Index\DeclarationScanner
+    Firehed\PhpLsp\Repository\MemberResolver:
+      - Firehed\PhpLsp\Resolution\MemberFilter

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,144 @@
+imports:
+  - deptrac.baseline.yaml
+
+deptrac:
+  paths:
+    - src
+  # Layer-dependency contract (default-deny): an edge not listed in the ruleset
+  # fails analysis. Existing violations are frozen in deptrac.baseline.yaml
+  # (regenerate with `composer deptrac-baseline`) and must only shrink.
+  # ServerInfo is deliberately unlayered: it is a value Protocol/Capability carry.
+  layers:
+    - name: Root
+      collectors:
+        - type: classLike
+          value: ^Firehed\\PhpLsp\\Server$
+    - name: Cache
+      collectors:
+        - { type: directory, value: src/Cache/.* }
+    - name: Capability
+      collectors:
+        - { type: directory, value: src/Capability/.* }
+    - name: Client
+      collectors:
+        - { type: directory, value: src/Client/.* }
+    - name: Completion
+      collectors:
+        - { type: directory, value: src/Completion/.* }
+    - name: Document
+      collectors:
+        - { type: directory, value: src/Document/.* }
+    - name: Domain
+      collectors:
+        - { type: directory, value: src/Domain/.* }
+    - name: Handler
+      collectors:
+        - { type: directory, value: src/Handler/.* }
+    - name: Index
+      collectors:
+        - { type: directory, value: src/Index/.* }
+    - name: Knowledge
+      collectors:
+        - { type: directory, value: src/Knowledge/.* }
+    - name: Parser
+      collectors:
+        - { type: directory, value: src/Parser/.* }
+    - name: Protocol
+      collectors:
+        - { type: directory, value: src/Protocol/.* }
+    - name: Repository
+      collectors:
+        - { type: directory, value: src/Repository/.* }
+    - name: Resolution
+      collectors:
+        - { type: directory, value: src/Resolution/.* }
+    - name: Transport
+      collectors:
+        - { type: directory, value: src/Transport/.* }
+    - name: TypeInference
+      collectors:
+        - { type: directory, value: src/TypeInference/.* }
+    - name: Utility
+      collectors:
+        - { type: directory, value: src/Utility/.* }
+  ruleset:
+    Root:
+      - Cache
+      - Capability
+      - Client
+      - Completion
+      - Document
+      - Handler
+      - Index
+      - Knowledge
+      - Parser
+      - Protocol
+      - Repository
+      - Resolution
+      - Transport
+      - TypeInference
+    Handler:
+      - Capability
+      - Completion
+      - Document
+      - Domain
+      - Knowledge # write path only (SymbolSink); the SymbolSource read-side ban is held by the PHPStan rules
+      - Protocol
+      - Resolution
+    Completion:
+      - Capability
+      - Document
+      - Domain
+      - Index
+      - Knowledge
+      - Protocol
+      - Resolution
+      - Utility
+    Resolution:
+      - Document
+      - Domain
+      - Index
+      - Knowledge
+      - Parser
+      - Repository
+      - TypeInference
+      - Utility
+    Knowledge:
+      - Cache
+      - Document
+      - Domain
+      - Index
+      - Parser
+      - Repository
+      - Utility
+    Repository:
+      - Document # FileUri, the path/URI conversion authority
+      - Domain
+      - Knowledge
+      - Utility
+    Index:
+      - Cache
+      - Document
+      - Domain
+      - Knowledge
+      - Parser
+      - Utility
+    TypeInference:
+      - Domain
+      - Repository
+      - Utility
+    Utility:
+      - Domain
+      - TypeInference # ExpressionTypeResolver, the documented TypeResolverInterface wrapper
+    Parser:
+      - Document
+    Document:
+      - Protocol
+    Capability:
+      - Client
+      - Protocol
+    Client:
+      - Protocol
+      - Transport
+    Transport:
+      - Protocol


### PR DESCRIPTION
Adds deptrac/deptrac with a default-deny ruleset over the src namespaces: an inter-layer dependency not in the ruleset fails analysis. Runs as its own CI job and in `composer test`; regenerate the baseline with `composer deptrac-baseline`.

The 51 baselined violations are dominated by type placement, not illegal coupling: NameKind (~32 edges) and MemberFilter (10) live in Resolution while Knowledge/Index/Repository consume them, and Domain factories reach into Utility for TypeFactory/NamespacePath (7) — so the baseline drains in about three file moves plus the S3.10 teardown, with each move adjudicated (relocate vs. consciously allowlist) rather than bulk-accepted.

Judgment calls, for review:
- Handler → Knowledge is allowed: the sync handlers' SymbolSink dependency is the designed write path (S2.5). Namespace granularity can't split SymbolSink from SymbolSource, so the read-side ban stays with the PHPStan rules.
- Repository → Document is allowed for FileUri (the SC.4 conversion authority).
- ServerInfo is deliberately unlayered — it's a value Protocol/Capability carry; only Server is the composition root.
- 546 uncovered (vendor) dependencies are unchecked; layering php-parser nodes is a possible later tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)