### PR TITLE
Amend RFC 1 and extend the manifest for the guardrails era

### DIFF
--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -549,7 +549,7 @@ it was held by *mechanism* — a single interface plus a parity test — not by 
 documented rule, and every invariant here is expected to be held the same way. An
 invariant added by amendment MUST specify its mechanism.
 
-Two default-deny mechanisms hold whole categories rather than per-axis rules, because per-axis rules can only guard axes already discovered.
+The default-deny mechanisms hold whole categories rather than per-axis rules, because per-axis rules can only guard axes already discovered.
 Capability confinement (PHPStan disallowed-calls) denies AST traversal, symbol-name case folding, regex, runtime reflection, and filesystem access everywhere except each capability's named homes.
 The layer-dependency contract (deptrac) denies any inter-layer dependency the ruleset does not allow.
 Their baselines freeze pre-existing violations only: the violation total MUST only shrink and MUST reach empty (0002 Step Z), and no violation may be introduced by new code.

--- a/docs/architecture/0001-foundational-architecture.md
+++ b/docs/architecture/0001-foundational-architecture.md
@@ -4,7 +4,7 @@
     Category:   Architecture Requirements (Best Current Practice)
     Status:     Draft
     Target:     Language Server Protocol 3.17
-    Date:       2026-07-19
+    Date:       2026-08-10
     Supersedes: none
     Relates-To: docs issues #264, #265, #266; architecture invariants in CLAUDE.md
 
@@ -49,6 +49,7 @@ a bumped date.
        4.8. Protocol Capability Negotiation
        4.9. Position Encoding
        4.10. Client Conformance Defects
+       4.11. Parse-Health Collapse
     5. Component Requirements
        5.1. Symbol Knowledge: Read Contract (SymbolSource)
        5.2. Symbol State: Write Contract (SymbolSink)
@@ -63,6 +64,7 @@ a bumped date.
     Appendix A. Axes of Variation Catalog
     Appendix B. Relationship to Existing Invariants and Issues
     Appendix C. LSP Feature and Version Reference
+    Appendix D. Dimension Catalog
 
 ## 1. Introduction
 
@@ -162,11 +164,14 @@ consumers of an axis. The catalog is in Appendix A. The axes are:
 
 - **Data source** — where symbol knowledge comes from.
 - **Symbol kind** — what categories of symbol exist.
+- **Member kind** — what categories of class-like member exist (method, property, constant, enum case; future hooks).
+- **Access context** — which members exist for a position: visibility per operation, static-ness, and vantage point.
 - **Type form** — what shapes a type can take.
 - **Target environment** — which language version/platform is assumed.
 - **Protocol capability** — what the client understands and how output is shaped.
 - **Position/intent** — where in the source a completion or resolution is
-  requested.
+  requested; this decomposes into cursor intent, node type, and parse health
+  (Section 4.11).
 
 Client-supplied configuration (initialization options, `workspace/configuration`)
 is deliberately not a separate axis: version- and platform-like settings fold into
@@ -234,8 +239,8 @@ target environment) alone.
 
 A consumer MUST determine a symbol's suitability for a position or operation by
 querying a capability predicate. A consumer MUST NOT branch on a concrete symbol
-kind enumeration, and MUST NOT use `instanceof` against a concrete type
-implementation, to make such a decision.
+kind enumeration, and MUST NOT use `instanceof` against a concrete implementation
+of the type or resolved-symbol interfaces, to make such a decision.
 
 Consequently, introducing a new symbol kind or a new type form MUST NOT require
 edits to consumers that operate through predicates and interfaces. A new
@@ -342,6 +347,13 @@ last resort, MUST be documented and isolated from feature logic, and MUST NOT le
 A running list of observed client defects and their accommodations SHOULD be
 maintained (Appendix B).
 
+### 4.11. Parse-Health Collapse
+
+A live server answers positional questions on documents that may not currently parse.
+Each positional question MUST be answered through one component regardless of parse state; whether the answer derived from a full syntax tree, a recovered tree, or raw text MUST NOT be observable above the positional layer.
+Text-derived fallback logic MUST be confined to that layer's resilience rim, and MUST agree with the syntax-tree path on input that parses; that agreement MUST be held by test, not review.
+This is the same collapse Section 4.9 requires for encoding, applied to parse state: a dimension without a collapse point silently multiplies every question it touches.
+
 ## 5. Component Requirements
 
 ### 5.1. Symbol Knowledge: Read Contract (SymbolSource)
@@ -360,6 +372,10 @@ Names MUST be represented by typed identifiers, not bare strings (for example,
 distinct identifier types for class, function, and constant names). Coverage MUST
 be uniform across kinds: a query answerable for one kind MUST be answerable for
 all kinds for which it is meaningful.
+
+The query verbs are not all primitive, and derived verbs MUST NOT fork.
+A definition-site query (`locate`) MUST be a projection of lookup, never an independent implementation.
+A search SHOULD be derived from enumeration plus filtering; where cost forces an independent implementation, agreement between search and enumeration MUST be held by test.
 
 ### 5.2. Symbol State: Write Contract (SymbolSink)
 
@@ -487,6 +503,9 @@ single extension point and MUST NOT edit consumers of the axis:
   handler remains a coordinator (retains the existing completion-source
   invariant).
 
+A language or protocol feature MUST be decomposed, before implementation, into the axis values it adds; each touched axis is then served by its extension point above.
+New features are new values on existing axes, not new axes: a feature that does not decompose is the signal that an axis is missing.
+
 A contribution that cannot be expressed as one of the above SHOULD be treated as
 a signal that an axis or extension point is missing, and SHOULD be raised as an
 amendment to this document before implementation.
@@ -503,9 +522,9 @@ exhaustive over the normative sections; each item names the section it checks.
    single write path (Section 4.3).
 4. No knowledge query takes a cursor position or a caller-supplied syntax tree
    (Section 4.4).
-5. No consumer branches on a *resolved* symbol's kind, or on a concrete type
-   implementation, to decide suitability; syntactic-position routing is exempt
-   (Section 4.5).
+5. No consumer branches on a *resolved* symbol's kind, or on a concrete type or
+   resolved-symbol implementation, to decide suitability; syntactic-position
+   routing is exempt (Section 4.5).
 6. Types are constructed only via the factory and consumed only via the interface;
    traversal occurs in one place (Section 4.6).
 7. Built-in knowledge is parameterized by target environment, not the server's
@@ -518,6 +537,8 @@ exhaustive over the normative sections; each item names the section it checks.
     bounded coverage is observable (Section 5.3).
 11. Correctness holds under synchronous execution (Section 6).
 12. Malformed input yields an error response, not process termination (Section 9).
+13. Positional answers do not expose parse health, and the text fallback agrees
+    with the syntax-tree path on parseable input (Section 4.11).
 
 ### 8.1. Enforcement
 
@@ -528,23 +549,36 @@ it was held by *mechanism* — a single interface plus a parity test — not by 
 documented rule, and every invariant here is expected to be held the same way. An
 invariant added by amendment MUST specify its mechanism.
 
+Two default-deny mechanisms hold whole categories rather than per-axis rules, because per-axis rules can only guard axes already discovered.
+Capability confinement (PHPStan disallowed-calls) denies AST traversal, symbol-name case folding, regex, runtime reflection, and filesystem access everywhere except each capability's named homes.
+The layer-dependency contract (deptrac) denies any inter-layer dependency the ruleset does not allow.
+Their baselines freeze pre-existing violations only: the violation total MUST only shrink and MUST reach empty (0002 Step Z), and no violation may be introduced by new code.
+An entry MAY be rewritten when a strangler step relocates the code it froze, so incremental migration is never blocked; a drained entry either routes through the authority or is consciously promoted to the allowlist.
+
     Invariant                         Mechanism
     --------------------------------  ------------------------------------------------
-    4.1 Handler responsibility        Architecture test: handler code MUST NOT depend
-                                      on parser, repository, or reflection.
+    4.1 Handler responsibility        Layer contract (deptrac): the Handler layer
+                                      cannot depend on parser, repository, index, or
+                                      type-inference tiers; reflection confined by
+                                      capability rule.
     4.2 SymbolSource authority        Static rule: no ReflectionClass, concrete index,
-                                      or autoload-map use outside a backend.
-    4.3 Read/write segregation        Static rule: consumers depend on SymbolSource or
-                                      SymbolSink, not a concrete impl; single write
-                                      path checked by architecture test.
+                                      or autoload-map use outside a backend; reflection
+                                      and filesystem capability confinement.
+    4.3 Read/write segregation        Layer contract (deptrac) for tier dependencies;
+                                      single write path checked by architecture test.
+                                      The SymbolSource/SymbolSink split within the
+                                      Knowledge layer is below deptrac granularity and
+                                      is held by the §4.2 static rule.
     4.4 Positional/knowledge split    Interface shape: knowledge signatures accept no
                                       position or syntax tree (checked by the type
                                       checker on the interface).
     4.5 Predicates over kind/type     Static rule: no `instanceof` against a concrete
-                                      Type impl, and no `match`/`switch` on the kind
-                                      enum, outside the factory and classifier.
+                                      Type or ResolvedSymbol impl, and no `match`/
+                                      `switch` on the kind enum, outside the factory
+                                      and classifier.
     4.6 Type factory + traversal      Static rule: no `new` of a Type impl outside the
-                                      factory; TypeGraphParityTest for the walk.
+                                      factory; traversal capability confinement;
+                                      TypeGraphParityTest for the walk.
     4.7 Env-parameterized built-ins   Test: built-ins resolve against a supplied
                                       environment, and re-key on its change; review.
     4.8 Capability negotiation        Static rule: raw `initialize` params reachable
@@ -552,6 +586,9 @@ invariant added by amendment MUST specify its mechanism.
     4.9 Position encoding             Test: multibyte round-trip at the boundary;
                                       review of interior offset use.
     4.10 Client conformance defects   Review only; defect list in Appendix B.
+    4.11 Parse-health collapse        Regex capability confinement (the text rim is
+                                      the allowlist) + AST/text agreement tests on
+                                      parseable fixtures.
     5.1 Uniform coverage across kinds Test: a backend x kind x query grid, its axes derived
                                       from the kind enum and the backend registry rather
                                       than listed, each cell either answering over the
@@ -618,10 +655,15 @@ work.
     -------------------  ----------------------------------  -----------------
     Data source          SymbolSource backend                4.2, 5.3
     Symbol kind          kind + lookup + extraction          4.5, 5.1
+    Member kind          one extraction + one walk + preds   4.5, 4.6 (target)
+    Access context       one access-context value + filter   4.5 (target)
     Type form            Type implementation + factory        4.6
     Target environment   environment parameter + backend      4.7
     Protocol capability  session capabilities + handler       4.8, 5.4
     Position/intent      completion source + intent mapping   7
+    Parse health         one positional facade + text rim     4.11
+
+Rows marked (target) name their intended single extension point ahead of it existing; the build manifest owns the work.
 
 Configuration/settings is intentionally not a separate axis (Section 3.1); it folds
 into target environment (4.7) and session capabilities (4.8, 5.4).
@@ -645,6 +687,7 @@ into target environment (4.7) and session capabilities (4.8, 5.4).
   offsets are handled as bytes (violates Section 4.9). These are to be migrated
   toward this document, not grandfathered; each SHOULD be tracked as an issue
   citing the section it violates.
+- **Divergences added by the 2026-08-10 amendment (informative).** The text fallback answers several positional questions per consumer and lacks the Section 4.11 agreement tests; suitability checks in completion use `instanceof` against resolved-symbol implementations (Section 4.5 as widened); class-like search is neither derived from enumeration nor bound to it by test (Section 5.1). Each is frozen in a guardrail baseline or owned by a build-manifest slice; none blocks incremental migration.
 - **Observed client defects (informative).** Per Section 4.10, accommodations for
   clients that advertise a capability but mishandle it are recorded here as they
   are found. Known: some clients ignore a completion item's `textEdit` range and
@@ -681,3 +724,25 @@ locations were checked against the live 3.17 specification.
 
 When the targeted [LSP] version is raised, this appendix and Section 1.4 MUST be
 updated, and any newly available negotiation MUST be reconciled with Section 4.8.
+
+## Appendix D. Dimension Catalog (Non-Normative)
+
+The axes in Appendix A are the load-bearing subset of a larger dimension space.
+The full catalog exists so a feature can be decomposed (Section 7) and so a new "axis" claim can be checked against a bounded list rather than discovered by defect.
+Dimensions derive from the language's semantic model and the protocol's I/O model, both of which change on the order of years; features add values to dimensions, almost never dimensions.
+
+    Group      Dimensions
+    ---------  ----------------------------------------------------------------
+    Verbs      protocol feature; knowledge query verb (lookup, enumerate,
+               search, locate, predicate); write verb (open, update, close,
+               invalidate)
+    Cursor     intent; node type; parse health; scope shape
+    Names      symbol namespace; class-like flavour; member kind; name form;
+               declaration shape
+    Sources    backend; locate route; freshness; target environment
+    Answers    type form; type provenance; inheritance edge (including its
+               payload, e.g. trait adaptations); access context
+    Emission   client capability; position encoding; kind taxonomy; rendering
+
+Every dimension is handled one of three ways: **collapsed** at a boundary into one canonical form (name form, encoding, parse health), **switched** in exactly one place (backend, node type, member kind), or **applied as a modifier** at the edge (client capability, rendering).
+A works-on-X-but-not-Y defect requires a dimension switched in more than one place crossing a dimension enumerated in more than one place; the mechanisms in Section 8.1 exist to make the first half of that conjunction fail CI.

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -334,19 +334,13 @@ target version or extension the server process lacks. This is **deferred** (Step
 and tracked as an open §4.7 gap, not scheduled; the interim behavior (reflection +
 optimistic availability) is intentional.
 
-### Step 4 — `SymbolResolver` decomposition
+### Step 4 — One implementation per positional question (reframed 2026-08-10)
 
-*Goal:* split the god class into positional layer + thin glue + `TypeClassifier`,
-and finish the interface split.
+*Goal:* drain the guardrail-baseline entries for `src/Resolution/` and `src/TypeInference/` — each drain moves a confined mechanism (a traversal, a regex, a case rule) into its single home — and finish the interface split.
+The original decomposition slices predate the default-deny guardrails; the duplication they targeted is now enumerated mechanically as baseline entries, so "done" is checkable (those entries are gone, each positional question has one implementation) rather than judged (the class looks thin).
+`SymbolResolver` becoming thin glue is the side effect, not the metric.
 
-*Acceptance:* the positional layer (node-at-offset, scope, member/call detection,
-text fallback, **plus the name-resolution context query `getNameContext`** — this is
-document-scoped name context, not FQN-knowledge, so it lives here) is its own unit; `TypeClassifier` owns the predicates; `SymbolResolver`
-is thin glue over the positional layer and `SymbolSource`; **`CodeResolver` is reduced
-to the positional-facing interface — its knowledge-facing responsibilities are served
-by `SymbolSource` (there is no second knowledge interface)**; the no-`instanceof`-on-
-concrete-`Type` and no-branch-on-resolved-kind rules pass, as does the §4.6
-"no `new` of a `Type` implementation outside the factory" rule; parity green.
+*Acceptance:* `phpstan-baseline.neon` and `deptrac.baseline.yaml` carry no entries for `src/Resolution/` or `src/TypeInference/`; each positional question is answered in exactly one place, with parse health collapsed behind the positional facade and the §4.11 AST/text agreement test in place; `TypeClassifier` owns the predicates; **`CodeResolver` is reduced to the positional-facing interface — its knowledge-facing responsibilities are served by `SymbolSource` (there is no second knowledge interface)**; the S4.1 rules pass, with the `instanceof` rule widened to resolved-symbol implementations (§4.5 as amended); parity green.
 
 *Handler dependency shape.* This does not give handlers a second resolver. Point-query
 handlers (Definition / Hover / …) depend on the positional-facing `CodeResolver`
@@ -393,6 +387,14 @@ sites; naming it is what stops the step being declared done with every one intac
   partial qualification) in ~65 lines of regex. That last one is legitimate where no AST
   exists, so the requirement is that it share the *shape* of the AST path, not that it be
   deleted.
+- **S4.8 — `TypeInference` comes inside the boundary.** Two walks answer "which variables
+  are bound before this line" and disagree: `SymbolResolver::collectVariablesFromStatements`
+  knows assign/foreach/catch, `BasicTypeResolver` knows params/assign only, so a foreach or
+  catch variable appears in `$`-completion but its members do not resolve.
+  `BasicTypeResolver`'s expression dispatch also parallels `SymbolResolver::resolveNode`
+  with narrower coverage. `src/TypeInference/` sits outside the original decomposition's
+  directory boundary, which is how both survived every named row above; its guardrail
+  baseline entries are part of this step's drain.
 
 ### Step 5 — Environment-parameterized built-ins (deferred; tracked §4.7 gap)
 
@@ -540,7 +542,7 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
 - **Enforcement is complete.** Every §8.1 enforcement rule is active **repo-wide with
   zero remaining exemptions or allowlists** (the Step 2 §4.2 exemption, and any other,
   are gone). A rule still carrying a scope is an open step, not done.
-- **Conformance is repo-wide.** RFC §8's 12-item checklist passes across the whole
+- **Conformance is repo-wide.** RFC §8's checklist passes across the whole
   codebase, not merely per change.
 - **Parity is trustworthy.** The Step P harness is green **and** its branch coverage of
   the migrated surfaces is adequate — no unexercised surface branch (Step P) — and
@@ -562,6 +564,9 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
   (byte offsets, functions-need-AST, constants-unresolved, capabilities-unread) is
   either **fixed** or **converted to an explicitly-tracked deferred gap with an open
   issue** — none silently persists.
+- **Guardrail baselines are empty.** `phpstan-baseline.neon` and `deptrac.baseline.yaml`
+  contain no entries and are deleted; every confinement and layer rule is active with
+  allowlists only, so regrowth is loud.
 - **Remaining gaps are named.** The only surviving non-conformances are the
   explicitly-deferred, tracked ones, each with an issue: §4.7 / built-ins (Step 5), the
   workspace scope (#264/#265), the diagnostics / scheduler tier (Step 6 / #266), and
@@ -571,7 +576,7 @@ verified repo-wide — that the invariants hold and no transitional cruft remain
   landed fails the gate. Otherwise the grid's own escape hatch outlives what it was
   granted for, and a hole is certified rather than exposed.
 
-Only when all seven hold is the foundation deemed complete.
+Only when every item above holds is the foundation deemed complete.
 
 ## 5. Step 2 in depth
 
@@ -822,6 +827,10 @@ once Step P is green.
   interim is reflection + optimistic availability, and §4.7 is a tracked gap.
 - The external-change invalidation fallback when the client does not support
   `didChangeWatchedFiles` (lazy re-read vs. no invalidation) (Step 3).
+- ~~A query-registry reshape of the resolution tier.~~ **Shelved (2026-08-10):**
+  duplication control is held by the default-deny guardrails instead; revisit only if
+  central invalidation or incrementality becomes a live need (a measured performance
+  wall, or the Step 6 scheduler tier).
 
 ## 8. Step 0 spike record (measured)
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -58,9 +58,10 @@ Step 3 is one plan step with two halves: **3a** is behavior-preserving (proven b
 Step P harness — parity fixtures first), **3b** both preserves and extends the function
 surface (existing behavior frozen to a golden; new project reach proven by new
 fixtures). The `Step` column carries the half, since 3a and 3b own distinct acceptance
-criteria in 0002. Step 4 decomposes `SymbolResolver`; Step Z is the terminal
-Definition-of-Done gate. Steps 3 and 4 each end with a duplication audit (S3.11,
-S4.7), which Step Z re-runs repo-wide as its completion gate.
+criteria in 0002. Step 4 drains the Resolution/TypeInference guardrail-baseline
+entries (0002, reframed 2026-08-10); Step Z is the terminal Definition-of-Done
+gate. Steps 3 and 4 each end with a duplication audit (S3.11, S4.7), which Step Z
+re-runs repo-wide as its completion gate.
 
     ID     Step  Title                                              Depends on        Closes
     -----  ----  -------------------------------------------------  ----------------  -------
@@ -79,7 +80,8 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     SC.2   —     Retire ScopeFinder's superseded import extraction  —                 —
     SC.5   —     One declaration finder, not five hand-written      —                 —
     SC.9   —     Class-like registration -> one declaration scan   —                 —
-    SC.6   —     Symbol-name keys -> NameKind::normalize           —                 —
+    SC.11  —     Move NameKind into Domain                          —                 —
+    SC.6   —     Symbol-name keys -> NameKind::normalize           SC.11             —
     S3.8d  3b    Collapse per-kind lookup to one call               SC.5              —
     S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.6,S3.8d  —
     S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
@@ -92,7 +94,8 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     S4.3   4     Extract member-access + call-context detectors     S4.2              —
     S4.4   4     Extract name-context resolver                      S4.2              —
     S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
-    S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5  —
+    S4.8   4     Bring TypeInference inside the boundary            S4.2              —
+    S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5,S4.8  —
     S4.7   4     Step 4 duplication audit                          all Step 4        —
     SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
     SC.3   —     Namespace tracking -> the parser's namespacedName   —                 —
@@ -100,6 +103,10 @@ S4.7), which Step Z re-runs repo-wide as its completion gate.
     SC.7   —     Six member-hierarchy walks -> one                   —                 —
     SC.8   —     Prefix matching: SymbolIndex -> PrefixMatcher       —                 —
     SC.10  —     Enforce the one-declaration-scanner rule            SC.3,SC.9         —
+    SC.12  —     Move MemberFilter out of Resolution                 —                 —
+    SC.13  —     Settle Domain->Utility type placement               —                 —
+    SC.14  —     Filter BuiltinBackend class-like lookup to internal —                 —
+    SC.15  —     Oracle corpus: trait adaptations and enums          —                 —
     SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
@@ -256,6 +263,8 @@ Notes:
     leaves the suite green, so the slice owes a regression test — a `class_exists`-guarded
     class resolves through `lookupClassLike` on an open document. It is the last consumer
     of `iterateTopLevelStatements` in `src/`, which retires with it.
+  - **SC.11** — deptrac froze the edges of Knowledge, Index, and Domain classes importing `Resolution\NameKind`; the type is cross-tier currency, so it moves to `Domain` and those baseline entries drain.
+    It sits ahead of SC.6 so the case-rule work lands in the type's real home; SC.6 depends on it.
   - **SC.6** — every key derived from a symbol name routes through
     `NameKind::normalize()`, which owns PHP's per-kind case rule. A whole-FQN `strtolower`
     is hand-rolled instead in `CompositeSymbolSource` (the `searchClassLikes` merge, and
@@ -277,6 +286,13 @@ Notes:
     same key, and `OpenDocumentBackend` answers a name this backend does not. Predates SC.5
     (the deleted `findClassInAst` compared raw strings too) and is unpinned in either
     direction, so the fix owes a test.
+  - **SC.12** — `MemberResolver`'s deptrac-frozen edges on `Resolution\MemberFilter`: the same placement defect as SC.11, kept as its own row so each move drains reviewably.
+  - **SC.13** — Domain factories reach into Utility (`TypeFactory`, `NamespacePath`); decide the direction in-slice (move the utility into Domain, or the factory methods out) and drain the frozen edges.
+    Related: `ClassName::shortName`/`getNamespace` hand-roll the split `NamespacePath` owns, so the direction chosen also settles that duplicate.
+  - **SC.14** — `BuiltinBackend::lookupClassLike` lacks the `isInternal()` guard its function sibling has, so hover resolves any class the *server's own* autoloader can load while completion never offers it — the §4.2 lookup/enumeration split, live on the class namespace.
+    A live defect; owes a regression test against a class the server vendors but the project does not.
+  - **SC.15** — `TypeGraphParityTest`'s corpus has no trait `insteadof`/`as` shapes and no enums, so the reflection oracle cannot see #73's defect class (nor enum-interface members).
+    Fixture-only slice; #73's fix lands on top of it and must fail before, pass after.
   - **SC.7** — `MemberResolver` has six near-identical hierarchy walks:
     `find{Method,Property,Constant}InHierarchy` and `collect{Methods,Properties,Constants}`,
     each a seen-check, a scan of the class's own members, and a recursion over
@@ -284,6 +300,7 @@ Notes:
     and stays; the *walk* over them was never centralised, so a new member kind adds two
     more copies. Outside Step 4's scope — that step decomposes `src/Resolution/`, this is
     `src/Repository/`.
+    The member-name case rule rides along: the collect keys (`strtolower`), `MethodName::equals` (`strcasecmp`), and the fallback's raw merge key disagree today, and the walks' seen-sets key raw FQNs where `ClassName::equals` is case-insensitive.
   - **SC.10** — SC.5 states a hard invariant ("Do NOT write a new one; a rule about what
     counts as a declaration is a change to the scanner") with no mechanism, which §8.1
     forbids where a static rule or test is feasible. One is: a PHPStan rule confining
@@ -297,6 +314,10 @@ Notes:
     hand-roll `str_starts_with(strtolower(...))`. SC.6 owns the `strtolower` half (it is
     the same per-kind case rule); what is left here is the duplicated *matching* helper, so
     take SC.6 first or the two rows fight over the same line.
+- **S4.8** — see 0002 Step 4: the variable-binding walks and expression dispatch are
+  duplicated across `src/Resolution/` and `src/TypeInference/`, and the latter sat outside
+  the original decomposition's directory boundary. Its guardrail-baseline entries are part
+  of the Step 4 drain; gated on S4.2 because both edit `SymbolResolver`.
 - **Each section ends with a duplication audit** (**S3.11**, **S4.7**), and Step Z's
   acceptance carries the repo-wide one. Method, scope and outcome rule are defined once
   in 0002 §Duplication audits and the terminal condition is a Step Z acceptance item —
@@ -342,3 +363,5 @@ when their phase is reached.
   interactive requests and is cancelable, feature-detecting `pcntl` / `ext-parallel`
   with a synchronous fallback. Appended as slices when a push feature (or #266) takes
   it up.
+- **Feature-matrix runner — deprioritized (2026-08-10).** A fixture-scenario × handler-registry grid (every cell asserts that handler's observable or registers not-applicable; an unregistered cell fails), intended as the cross-feature agreement net and the TDD vehicle for new language features. Revisit after the Step 4 drain and the Wave 3 axes.
+- **Wave 3 — member kind, access context, intent detection.** The axes the 2026-08-10 RFC amendment added (RFC 1 §3.1, Appendix A "target" rows). Sliced when reached, after Step 4; property hooks and asymmetric visibility are the features waiting on the first two.


### PR DESCRIPTION
Docs only. Records the decisions from the structural review now that both guardrail PRs (#407, #408) are on main.

RFC 1: adds the member-kind and access-context axes and a parse-health collapse invariant (§4.11); widens §4.5's instanceof ban to resolved-symbol implementations; adds verb-derivation rules to §5.1 (locate is a projection of lookup; search derives from enumeration or is bound to it by test); records the default-deny guardrails as §8.1 mechanisms with the baseline-shrink rules; adds the feature-decomposition procedure to §7 and a condensed dimension catalog as Appendix D. New MUSTs the current code violates are recorded as Appendix B divergences, so the strangler pattern is preserved — nothing requires a stop-the-world migration.

Plan 0002: Step 4 is reframed from "decompose the god class" to "drain the Resolution/TypeInference baseline entries" — checkable rather than judged — keeping the named-divergence acceptance and adding S4.8 (TypeInference inside the boundary). Step Z gains an empty-baselines gate. The query-registry reshape is recorded as shelved with its revisit condition.

Manifest: new rows SC.11–SC.15 (NameKind and MemberFilter placement moves, Domain→Utility direction, the BuiltinBackend isInternal guard, oracle-corpus fixtures) and S4.8; SC.6 now depends on SC.11; the matrix runner and Wave 3 axes are recorded in the deferred section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)