### PR TITLE
Enforce and document the baseline burn-down

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,6 +25,23 @@ jobs:
       - name: PHPStan
         run: composer phpstan -- --error-format=github
 
+  baseline-shrink:
+    runs-on: ubuntu-latest
+    name: Baselines only shrink
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fetch comparison base
+        run: git fetch origin main --depth=1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Check baselines
+        run: php bin/check-baseline-shrink origin/main
+
   deptrac:
     runs-on: ubuntu-latest
     name: Deptrac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,25 @@ composer phpstan -- --error-format=raw --no-progress path/to/analyze # run phpst
 composer phpcs -- -q --report=emacs # run code style checks (PSR-12)
 ```
 
+## Guardrails (default-deny)
+
+Two CI-enforced mechanisms confine where code may live; a rule firing on your change is design feedback, not an obstacle.
+
+- **Capability confinement** (`phpstan.neon`): AST traversal, symbol-name case folding, regex, runtime reflection, and filesystem reads are each usable only in their named homes (allowlists inline, each with its rationale).
+- **Layer contract** (`deptrac.yaml`): an inter-layer dependency not in the ruleset fails analysis.
+
+When a rule fires on your change, in order of preference:
+
+1. Move the logic into (or route it through) the confined authority — the usual fix.
+2. If the authority genuinely cannot serve the need, extend the authority.
+3. Widening an allowlist is a last-resort, conscious decision; justify it in the PR.
+
+NEVER regenerate a baseline to absorb a new violation.
+The baselines (`phpstan-baseline.neon`, `deptrac.baseline.yaml`) freeze pre-existing debt only and must shrink to zero; CI enforces shrink-only (`bin/check-baseline-shrink`).
+Regenerate (`composer phpstan-baseline` / `composer deptrac-baseline`) only when draining entries, or when a refactor relocates a violation the baseline already froze — totals may never grow.
+When changing a file that has baseline entries, prefer draining them in the same change.
+This section overrides the global "avoid adding to the baseline" guidance in the strict direction: here, additions are forbidden outright and shrink-churn is the goal.
+
 ## Project Structure
 
 - `src/Handler/` — LSP request handlers (completion, hover, definition, etc.)

--- a/bin/check-baseline-shrink
+++ b/bin/check-baseline-shrink
@@ -1,0 +1,50 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+// Fails when a guardrail baseline grows relative to a base ref (default
+// origin/main). RFC 1 §8.1: baseline totals only shrink; relocating a frozen
+// violation is allowed, absorbing a new one is not.
+
+$baseRef = $argv[1] ?? 'origin/main';
+
+$phpstanTotal = function (string $contents): int {
+    preg_match_all('/^\s*count:\s*(\d+)/m', $contents, $matches);
+    return (int) array_sum($matches[1]);
+};
+
+$deptracTotal = function (string $contents): int {
+    preg_match_all('/^\s+-\s+\S/m', $contents, $matches);
+    return count($matches[0]);
+};
+
+$contentsAt = function (string $ref, string $file): string {
+    $out = shell_exec('git show ' . escapeshellarg("$ref:$file") . ' 2>/dev/null');
+    return is_string($out) ? $out : '';
+};
+
+$files = [
+    'phpstan-baseline.neon' => $phpstanTotal,
+    'deptrac.baseline.yaml' => $deptracTotal,
+];
+
+$failed = false;
+foreach ($files as $file => $total) {
+    $base = $total($contentsAt($baseRef, $file));
+    $head = $total(is_file($file) ? (string) file_get_contents($file) : '');
+    printf("%s: %d -> %d\n", $file, $base, $head);
+    if ($head > $base) {
+        fwrite(STDERR, sprintf(
+            "%s grew (%d -> %d): baselines only shrink. Route the new" .
+            " violation through its authority, or consciously widen the" .
+            " allowlist in the rule config instead.\n",
+            $file,
+            $base,
+            $head,
+        ));
+        $failed = true;
+    }
+}
+
+exit($failed ? 1 : 0);


### PR DESCRIPTION
Closes the gap where nothing mechanically prevented regenerating a baseline to absorb a new violation.

- `bin/check-baseline-shrink`: compares per-file baseline totals (sum of PHPStan entry counts; deptrac skip pairs) against origin/main and fails on growth. Relocating a frozen violation keeps totals equal, so strangler steps aren't blocked. Runs as its own CI job; failure path verified with a synthetic entry.
- CLAUDE.md gains a Guardrails section: the fire-on-your-change decision tree (route through the authority → extend it → consciously widen the allowlist), the shrink-only baseline rule, and an explicit override of the global "use the baseline generator for updates" guidance in the strict direction — since that guidance otherwise points a session at exactly the absorb-by-regenerate move this forbids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)