### PR TITLE
Route symbol-name keys through the per-kind case rule

### DIFF
--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -289,6 +289,7 @@ Notes:
   - **SC.12** — `MemberResolver`'s deptrac-frozen edges on `Resolution\MemberFilter`: the same placement defect as SC.11, kept as its own row so each move drains reviewably.
   - **SC.13** — Domain factories reach into Utility (`TypeFactory`, `NamespacePath`); decide the direction in-slice (move the utility into Domain, or the factory methods out) and drain the frozen edges.
     Related: `ClassName::shortName`/`getNamespace` hand-roll the split `NamespacePath` owns, so the direction chosen also settles that duplicate.
+    Likewise `NameKind::normalize` re-implements the path fold `NamespacePath::normalize` owns — layer-blocked from routing through it until this move — so the direction also collapses the two folds into one, and the case-folding allowlist follows the file.
   - **SC.14** — `BuiltinBackend::lookupClassLike` lacks the `isInternal()` guard its function sibling has, so hover resolves any class the *server's own* autoloader can load while completion never offers it — the §4.2 lookup/enumeration split, live on the class namespace.
     A live defect; owes a regression test against a class the server vendors but the project does not.
   - **SC.15** — `TypeGraphParityTest`'s corpus has no trait `insteadof`/`as` shapes and no enums, so the reflection oracle cannot see #73's defect class (nor enum-interface members).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,13 +57,13 @@ parameters:
 		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
-			count: 4
+			count: 3
 			path: src/Index/ComposerNamespaceSource.php
 
 		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
-			count: 5
+			count: 4
 			path: src/Index/NamespaceContents.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,12 +115,6 @@ parameters:
 			path: src/Index/WorkspaceNamespaceSource.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 2
-			path: src/Knowledge/CompositeSymbolSource.php
-
-		-
 			message: '#^Class ReflectionFunction is forbidden, runtime reflection is confined\: BuiltinBackend, ReflectionNamespaceSource, and the fromReflection factories\. \[ReflectionFunction matches Reflection\*\]$#'
 			identifier: disallowed.class
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -215,9 +215,3 @@ parameters:
 			identifier: disallowed.namespace
 			count: 2
 			path: src/TypeInference/BasicTypeResolver.php
-
-		-
-			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Utility/NamespacePath.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,42 +37,6 @@ parameters:
 			path: src/Handler/CompletionHandler.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Index/AutoloadFilesLocator.php
-
-		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Index/CachedNamespaceCatalog.php
-
-		-
-			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Index/ComposerNamespaceSource.php
-
-		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 3
-			path: src/Index/ComposerNamespaceSource.php
-
-		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 4
-			path: src/Index/NamespaceContents.php
-
-		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Index/ReflectionNamespaceSource.php
-
-		-
 			message: '#^Class PhpParser\\NodeTraverser is forbidden, AST traversal is confined\: parser pipeline \(ParserService\), positional finders \(NodeAtPosition, Scope, ScopeFinder\), and DeclarationScanner\.$#'
 			identifier: disallowed.class
 			count: 1
@@ -93,7 +57,7 @@ parameters:
 		-
 			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
-			count: 5
+			count: 2
 			path: src/Index/SymbolIndex.php
 
 		-
@@ -107,12 +71,6 @@ parameters:
 			identifier: disallowed.function
 			count: 1
 			path: src/Index/WorkspaceIndexer.php
-
-		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Index/WorkspaceNamespaceSource.php
 
 		-
 			message: '#^Class ReflectionFunction is forbidden, runtime reflection is confined\: BuiltinBackend, ReflectionNamespaceSource, and the fromReflection factories\. \[ReflectionFunction matches Reflection\*\]$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -63,6 +63,7 @@ parameters:
             message: 'case rules for symbol names live in NameKind; non-symbol uses may be allowlisted here consciously'
             allowIn:
                 - src/Domain/NameKind.php
+                - src/Utility/NamespacePath.php # namespace paths are case-insensitive for every kind; not a symbol name
                 - src/Transport/MessageReader.php # HTTP header names
                 - src/Domain/Visibility.php # visibility keywords
                 - tests/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -59,6 +59,7 @@ parameters:
             function:
                 - 'strtolower()'
                 - 'strcasecmp()'
+                - 'strncasecmp()'
                 - 'mb_strtolower()'
             message: 'case rules for symbol names live in NameKind; non-symbol uses may be allowlisted here consciously'
             allowIn:

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -73,7 +73,7 @@ final class AutoloadFilesLocator implements SymbolLocator, NamespaceCatalog, Inv
     {
         $this->namespaces ??= NamespaceContents::indexByNamespace($this->declarations);
 
-        return $this->namespaces[NamespacePath::caseFold($namespace)] ?? new NamespaceContents();
+        return $this->namespaces[NamespacePath::normalize($namespace)] ?? new NamespaceContents();
     }
 
     /**

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -10,6 +10,7 @@ use Firehed\PhpLsp\Domain\NameKind;
 use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
 use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Utility\NamespacePath;
 use PhpParser\Node;
 
 /**
@@ -72,7 +73,7 @@ final class AutoloadFilesLocator implements SymbolLocator, NamespaceCatalog, Inv
     {
         $this->namespaces ??= NamespaceContents::indexByNamespace($this->declarations);
 
-        return $this->namespaces[strtolower($namespace)] ?? new NamespaceContents();
+        return $this->namespaces[NamespacePath::caseFold($namespace)] ?? new NamespaceContents();
     }
 
     /**

--- a/src/Index/CachedNamespaceCatalog.php
+++ b/src/Index/CachedNamespaceCatalog.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Cache\CacheKey;
 use Firehed\PhpLsp\Cache\Invalidatable;
+use Firehed\PhpLsp\Utility\NamespacePath;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -41,7 +42,7 @@ final class CachedNamespaceCatalog implements NamespaceCatalog, Invalidatable
     {
         // PHP namespaces are case-insensitive, so `Psr\Log` and `psr\log` are one
         // namespace and must not be two cache entries.
-        $key = CacheKey::from(strtolower($namespace));
+        $key = CacheKey::from(NamespacePath::caseFold($namespace));
 
         $cached = $this->cache->get($key);
         if ($cached !== null) {

--- a/src/Index/CachedNamespaceCatalog.php
+++ b/src/Index/CachedNamespaceCatalog.php
@@ -42,7 +42,7 @@ final class CachedNamespaceCatalog implements NamespaceCatalog, Invalidatable
     {
         // PHP namespaces are case-insensitive, so `Psr\Log` and `psr\log` are one
         // namespace and must not be two cache entries.
-        $key = CacheKey::from(NamespacePath::caseFold($namespace));
+        $key = CacheKey::from(NamespacePath::normalize($namespace));
 
         $cached = $this->cache->get($key);
         if ($cached !== null) {

--- a/src/Index/CatalogSymbol.php
+++ b/src/Index/CatalogSymbol.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
@@ -27,6 +28,19 @@ final readonly class CatalogSymbol
         public string $fullyQualifiedName,
         public NameKind $kind,
     ) {
+    }
+
+    /**
+     * The symbol's identity as an array key: the kind, and the name under that
+     * kind's case rule. The kind is part of the key because PHP's symbol
+     * namespaces are independent — a class and a function may share a spelling
+     * without being the same symbol.
+     */
+    public function key(): string
+    {
+        $normalized = $this->kind->normalize(QualifiedName::fromFullyQualified($this->fullyQualifiedName));
+
+        return $this->kind->name . '|' . $normalized;
     }
 
     public function shortName(): string

--- a/src/Index/ComposerNamespaceSource.php
+++ b/src/Index/ComposerNamespaceSource.php
@@ -62,7 +62,7 @@ final class ComposerNamespaceSource implements NamespaceCatalog
             $below = NamespacePath::relativeTo($prefixNamespace, $namespace);
             if ($below !== null) {
                 $child = NamespacePath::join($namespace, NamespacePath::firstSegment($below));
-                $childNamespaces[NamespacePath::caseFold($child)] = $child;
+                $childNamespaces[NamespacePath::normalize($child)] = $child;
                 continue;
             }
 
@@ -95,7 +95,7 @@ final class ComposerNamespaceSource implements NamespaceCatalog
 
                 $contents = self::readDirectory($path, $canonical);
                 foreach ($contents->childNamespaces as $child) {
-                    $childNamespaces[NamespacePath::caseFold($child)] = $child;
+                    $childNamespaces[NamespacePath::normalize($child)] = $child;
                 }
                 foreach ($contents->symbols as $symbol) {
                     $symbols[$symbol->key()] = $symbol;
@@ -198,6 +198,6 @@ final class ComposerNamespaceSource implements NamespaceCatalog
             array_keys($this->map->classMap()),
         ));
 
-        return $this->classMapIndex[NamespacePath::caseFold($namespace)] ?? new NamespaceContents();
+        return $this->classMapIndex[NamespacePath::normalize($namespace)] ?? new NamespaceContents();
     }
 }

--- a/src/Index/ComposerNamespaceSource.php
+++ b/src/Index/ComposerNamespaceSource.php
@@ -62,7 +62,7 @@ final class ComposerNamespaceSource implements NamespaceCatalog
             $below = NamespacePath::relativeTo($prefixNamespace, $namespace);
             if ($below !== null) {
                 $child = NamespacePath::join($namespace, NamespacePath::firstSegment($below));
-                $childNamespaces[strtolower($child)] = $child;
+                $childNamespaces[NamespacePath::caseFold($child)] = $child;
                 continue;
             }
 
@@ -95,7 +95,7 @@ final class ComposerNamespaceSource implements NamespaceCatalog
 
                 $contents = self::readDirectory($path, $canonical);
                 foreach ($contents->childNamespaces as $child) {
-                    $childNamespaces[strtolower($child)] = $child;
+                    $childNamespaces[NamespacePath::caseFold($child)] = $child;
                 }
                 foreach ($contents->symbols as $symbol) {
                     $symbols[$symbol->key()] = $symbol;
@@ -127,7 +127,7 @@ final class ComposerNamespaceSource implements NamespaceCatalog
 
             $match = null;
             foreach ($entries as $entry) {
-                if (strcasecmp($entry, $segment) === 0 && is_dir($path . '/' . $entry)) {
+                if (NamespacePath::equals($entry, $segment) && is_dir($path . '/' . $entry)) {
                     $match = $entry;
                     break;
                 }
@@ -198,6 +198,6 @@ final class ComposerNamespaceSource implements NamespaceCatalog
             array_keys($this->map->classMap()),
         ));
 
-        return $this->classMapIndex[strtolower($namespace)] ?? new NamespaceContents();
+        return $this->classMapIndex[NamespacePath::caseFold($namespace)] ?? new NamespaceContents();
     }
 }

--- a/src/Index/ComposerNamespaceSource.php
+++ b/src/Index/ComposerNamespaceSource.php
@@ -98,7 +98,7 @@ final class ComposerNamespaceSource implements NamespaceCatalog
                     $childNamespaces[strtolower($child)] = $child;
                 }
                 foreach ($contents->symbols as $symbol) {
-                    $symbols[strtolower($symbol->fullyQualifiedName)] = $symbol;
+                    $symbols[$symbol->key()] = $symbol;
                 }
             }
         }

--- a/src/Index/NamespaceContents.php
+++ b/src/Index/NamespaceContents.php
@@ -46,10 +46,10 @@ final readonly class NamespaceContents
 
         foreach ($symbols as $symbol) {
             $namespace = NamespacePath::namespaceOf($symbol->fullyQualifiedName);
-            $symbolsByNamespace[strtolower($namespace)][] = $symbol;
+            $symbolsByNamespace[NamespacePath::caseFold($namespace)][] = $symbol;
 
             foreach (NamespacePath::ancestors($namespace) as $parent => $child) {
-                $childNamespaces[strtolower($parent)][strtolower($child)] ??= $child;
+                $childNamespaces[NamespacePath::caseFold($parent)][NamespacePath::caseFold($child)] ??= $child;
             }
         }
 
@@ -83,7 +83,7 @@ final readonly class NamespaceContents
 
         foreach ($contents as $part) {
             foreach ($part->childNamespaces as $namespace) {
-                $namespaces[strtolower($namespace)] ??= $namespace;
+                $namespaces[NamespacePath::caseFold($namespace)] ??= $namespace;
             }
             foreach ($part->symbols as $symbol) {
                 $symbols[$symbol->key()] ??= $symbol;

--- a/src/Index/NamespaceContents.php
+++ b/src/Index/NamespaceContents.php
@@ -46,10 +46,10 @@ final readonly class NamespaceContents
 
         foreach ($symbols as $symbol) {
             $namespace = NamespacePath::namespaceOf($symbol->fullyQualifiedName);
-            $symbolsByNamespace[NamespacePath::caseFold($namespace)][] = $symbol;
+            $symbolsByNamespace[NamespacePath::normalize($namespace)][] = $symbol;
 
             foreach (NamespacePath::ancestors($namespace) as $parent => $child) {
-                $childNamespaces[NamespacePath::caseFold($parent)][NamespacePath::caseFold($child)] ??= $child;
+                $childNamespaces[NamespacePath::normalize($parent)][NamespacePath::normalize($child)] ??= $child;
             }
         }
 
@@ -83,7 +83,7 @@ final readonly class NamespaceContents
 
         foreach ($contents as $part) {
             foreach ($part->childNamespaces as $namespace) {
-                $namespaces[NamespacePath::caseFold($namespace)] ??= $namespace;
+                $namespaces[NamespacePath::normalize($namespace)] ??= $namespace;
             }
             foreach ($part->symbols as $symbol) {
                 $symbols[$symbol->key()] ??= $symbol;

--- a/src/Index/NamespaceContents.php
+++ b/src/Index/NamespaceContents.php
@@ -86,7 +86,7 @@ final readonly class NamespaceContents
                 $namespaces[strtolower($namespace)] ??= $namespace;
             }
             foreach ($part->symbols as $symbol) {
-                $symbols[strtolower($symbol->fullyQualifiedName)] ??= $symbol;
+                $symbols[$symbol->key()] ??= $symbol;
             }
         }
 

--- a/src/Index/ReflectionNamespaceSource.php
+++ b/src/Index/ReflectionNamespaceSource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Utility\NamespacePath;
 use ReflectionClass;
 
 /**
@@ -31,7 +32,7 @@ final class ReflectionNamespaceSource implements NamespaceCatalog
     {
         $this->byNamespace ??= NamespaceContents::indexByNamespace(self::internalSymbols());
 
-        return $this->byNamespace[strtolower($namespace)] ?? new NamespaceContents();
+        return $this->byNamespace[NamespacePath::caseFold($namespace)] ?? new NamespaceContents();
     }
 
     /**

--- a/src/Index/ReflectionNamespaceSource.php
+++ b/src/Index/ReflectionNamespaceSource.php
@@ -32,7 +32,7 @@ final class ReflectionNamespaceSource implements NamespaceCatalog
     {
         $this->byNamespace ??= NamespaceContents::indexByNamespace(self::internalSymbols());
 
-        return $this->byNamespace[NamespacePath::caseFold($namespace)] ?? new NamespaceContents();
+        return $this->byNamespace[NamespacePath::normalize($namespace)] ?? new NamespaceContents();
     }
 
     /**

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -30,7 +30,7 @@ final class SymbolIndex
         $this->byUri[$symbol->location->uri] ??= [];
         $this->byUri[$symbol->location->uri][] = $symbol->fullyQualifiedName;
 
-        $namespace = strtolower(NamespacePath::namespaceOf($symbol->fullyQualifiedName));
+        $namespace = NamespacePath::caseFold(NamespacePath::namespaceOf($symbol->fullyQualifiedName));
         $this->byNamespace[$namespace][$symbol->fullyQualifiedName] = $symbol;
     }
 
@@ -42,7 +42,7 @@ final class SymbolIndex
      */
     public function inNamespace(string $namespace): array
     {
-        return array_values($this->byNamespace[strtolower($namespace)] ?? []);
+        return array_values($this->byNamespace[NamespacePath::caseFold($namespace)] ?? []);
     }
 
     /**
@@ -120,7 +120,7 @@ final class SymbolIndex
                     unset($this->byName[$symbol->name]);
                 }
 
-                $namespace = strtolower(NamespacePath::namespaceOf($fqn));
+                $namespace = NamespacePath::caseFold(NamespacePath::namespaceOf($fqn));
                 unset($this->byNamespace[$namespace][$fqn]);
                 if (($this->byNamespace[$namespace] ?? []) === []) {
                     unset($this->byNamespace[$namespace]);

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -30,7 +30,7 @@ final class SymbolIndex
         $this->byUri[$symbol->location->uri] ??= [];
         $this->byUri[$symbol->location->uri][] = $symbol->fullyQualifiedName;
 
-        $namespace = NamespacePath::caseFold(NamespacePath::namespaceOf($symbol->fullyQualifiedName));
+        $namespace = NamespacePath::normalize(NamespacePath::namespaceOf($symbol->fullyQualifiedName));
         $this->byNamespace[$namespace][$symbol->fullyQualifiedName] = $symbol;
     }
 
@@ -42,7 +42,7 @@ final class SymbolIndex
      */
     public function inNamespace(string $namespace): array
     {
-        return array_values($this->byNamespace[NamespacePath::caseFold($namespace)] ?? []);
+        return array_values($this->byNamespace[NamespacePath::normalize($namespace)] ?? []);
     }
 
     /**
@@ -120,7 +120,7 @@ final class SymbolIndex
                     unset($this->byName[$symbol->name]);
                 }
 
-                $namespace = NamespacePath::caseFold(NamespacePath::namespaceOf($fqn));
+                $namespace = NamespacePath::normalize(NamespacePath::namespaceOf($fqn));
                 unset($this->byNamespace[$namespace][$fqn]);
                 if (($this->byNamespace[$namespace] ?? []) === []) {
                     unset($this->byNamespace[$namespace]);

--- a/src/Index/WorkspaceNamespaceSource.php
+++ b/src/Index/WorkspaceNamespaceSource.php
@@ -45,7 +45,7 @@ final class WorkspaceNamespaceSource implements NamespaceCatalog
             }
 
             $child = NamespacePath::join($namespace, NamespacePath::firstSegment($below));
-            $childNamespaces[strtolower($child)] = $child;
+            $childNamespaces[NamespacePath::caseFold($child)] = $child;
         }
 
         return new NamespaceContents(array_values($childNamespaces), $symbols);

--- a/src/Index/WorkspaceNamespaceSource.php
+++ b/src/Index/WorkspaceNamespaceSource.php
@@ -45,7 +45,7 @@ final class WorkspaceNamespaceSource implements NamespaceCatalog
             }
 
             $child = NamespacePath::join($namespace, NamespacePath::firstSegment($below));
-            $childNamespaces[NamespacePath::caseFold($child)] = $child;
+            $childNamespaces[NamespacePath::normalize($child)] = $child;
         }
 
         return new NamespaceContents(array_values($childNamespaces), $symbols);

--- a/src/Knowledge/CompositeSymbolSource.php
+++ b/src/Knowledge/CompositeSymbolSource.php
@@ -8,6 +8,8 @@ use Firehed\PhpLsp\Domain\ClassInfo;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\FunctionInfo;
 use Firehed\PhpLsp\Domain\FunctionName;
+use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Index\NamespaceContents;
 use Firehed\PhpLsp\Index\Symbol;
 
@@ -96,7 +98,7 @@ final class CompositeSymbolSource implements SymbolSource
             foreach ($backend->searchClassLikes($prefix) as $symbol) {
                 // The earlier (more authoritative) backend wins a name clash, so an
                 // open document's symbol is not shadowed by a cached copy of it.
-                $byFqn[strtolower($symbol->fullyQualifiedName)] ??= $symbol;
+                $byFqn[self::normalizeKey($symbol->fullyQualifiedName)] ??= $symbol;
             }
         }
 
@@ -139,8 +141,12 @@ final class CompositeSymbolSource implements SymbolSource
         return false;
     }
 
+    /**
+     * Class-like identity under the kind's case rule; every name this class keys
+     * or compares is a class-like. `fromFullyQualified` drops a leading `\`.
+     */
     private static function normalizeKey(string $fqn): string
     {
-        return strtolower(ltrim($fqn, '\\'));
+        return NameKind::ClassLike->normalize(QualifiedName::fromFullyQualified($fqn));
     }
 }

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -168,10 +168,11 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
 
     private function parseClassFrom(ClassName $name, string $filePath): ?ClassInfo
     {
-        $target = QualifiedName::fromClassName($name)->fullyQualifiedName();
+        $kind = NameKind::ClassLike;
+        $target = $kind->normalize(QualifiedName::fromClassName($name));
 
         foreach ($this->declarationsIn($filePath)->classLikes as $declaration) {
-            if ($declaration->name->fullyQualifiedName() === $target) {
+            if ($kind->normalize($declaration->name) === $target) {
                 return $this->factory->fromAstNode($declaration->node, FileUri::fromPath($filePath));
             }
         }

--- a/src/Utility/NamespacePath.php
+++ b/src/Utility/NamespacePath.php
@@ -37,6 +37,16 @@ final class NamespacePath
         return $ancestors;
     }
 
+    /**
+     * A namespace path as a lookup key. Paths are case-insensitive whatever kind
+     * of symbol they qualify, so the fold is kind-independent — the per-kind
+     * short-name rule lives in NameKind.
+     */
+    public static function caseFold(string $namespace): string
+    {
+        return strtolower($namespace);
+    }
+
     public static function equals(string $a, string $b): bool
     {
         return strcasecmp($a, $b) === 0;

--- a/src/Utility/NamespacePath.php
+++ b/src/Utility/NamespacePath.php
@@ -37,16 +37,6 @@ final class NamespacePath
         return $ancestors;
     }
 
-    /**
-     * A namespace path as a lookup key. Paths are case-insensitive whatever kind
-     * of symbol they qualify, so the fold is kind-independent — the per-kind
-     * short-name rule lives in NameKind.
-     */
-    public static function caseFold(string $namespace): string
-    {
-        return strtolower($namespace);
-    }
-
     public static function equals(string $a, string $b): bool
     {
         return strcasecmp($a, $b) === 0;
@@ -69,6 +59,16 @@ final class NamespacePath
         $separator = strrpos($fullyQualifiedName, '\\');
 
         return $separator === false ? '' : substr($fullyQualifiedName, 0, $separator);
+    }
+
+    /**
+     * A namespace path as a lookup key. Paths are case-insensitive whatever kind
+     * of symbol they qualify, so the rule is kind-independent — the per-kind
+     * short-name rule lives in NameKind.
+     */
+    public static function normalize(string $namespace): string
+    {
+        return strtolower($namespace);
     }
 
     /**

--- a/tests/Index/CompositeNamespaceCatalogTest.php
+++ b/tests/Index/CompositeNamespaceCatalogTest.php
@@ -44,8 +44,10 @@ final class CompositeNamespaceCatalogTest extends TestCase
 
     public function testTheEarlierCatalogWinsANameReportedByBoth(): void
     {
+        // The same class-like under its case rule, spelled differently: the
+        // spelling distinguishes which catalog's report survived the merge.
         $first = new CatalogSymbol('App\Shared', NameKind::ClassLike);
-        $second = new CatalogSymbol('App\Shared', NameKind::Function_);
+        $second = new CatalogSymbol('APP\SHARED', NameKind::ClassLike);
 
         $contents = (new CompositeNamespaceCatalog([
             self::catalogOfSymbols([$first]),

--- a/tests/Index/NamespaceContentsTest.php
+++ b/tests/Index/NamespaceContentsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Index;
+
+use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Index\CatalogSymbol;
+use Firehed\PhpLsp\Index\NamespaceContents;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Merge deduplicates the same symbol reported by several sources, so its key must
+ * be the symbol's identity: the kind, plus the name under that kind's case rule
+ * (NameKind::normalize). A whole-FQN lowercase key collapses distinct constants
+ * and collapses symbols from different namespaces of the language that share a
+ * spelling.
+ */
+#[CoversClass(NamespaceContents::class)]
+#[CoversClass(CatalogSymbol::class)]
+final class NamespaceContentsTest extends TestCase
+{
+    public function testMergeKeepsConstantsDifferingOnlyInShortNameCase(): void
+    {
+        $merged = NamespaceContents::merge([
+            new NamespaceContents([], [new CatalogSymbol('Fixtures\Helpers\STATUS', NameKind::Constant)]),
+            new NamespaceContents([], [new CatalogSymbol('Fixtures\Helpers\status', NameKind::Constant)]),
+        ]);
+
+        self::assertCount(
+            2,
+            $merged->symbols,
+            'constant names are case-sensitive, so these are two distinct symbols',
+        );
+    }
+
+    public function testMergeKeepsAClassAndAFunctionSharingASpelling(): void
+    {
+        $merged = NamespaceContents::merge([
+            new NamespaceContents([], [new CatalogSymbol('Fixtures\Helpers\Format', NameKind::ClassLike)]),
+            new NamespaceContents([], [new CatalogSymbol('Fixtures\Helpers\format', NameKind::Function_)]),
+        ]);
+
+        self::assertCount(
+            2,
+            $merged->symbols,
+            'PHP\'s symbol namespaces are independent: a class and a function may share a name',
+        );
+    }
+
+    public function testMergeDeduplicatesTheSameClassUnderItsCaseRule(): void
+    {
+        $merged = NamespaceContents::merge([
+            new NamespaceContents([], [new CatalogSymbol('Fixtures\Domain\User', NameKind::ClassLike)]),
+            new NamespaceContents([], [new CatalogSymbol('FIXTURES\DOMAIN\USER', NameKind::ClassLike)]),
+        ]);
+
+        self::assertCount(1, $merged->symbols, 'class names are case-insensitive, so this is one symbol');
+        self::assertSame(
+            'Fixtures\Domain\User',
+            $merged->symbols[0]->fullyQualifiedName,
+            'the earlier (more authoritative) source wins the spelling',
+        );
+    }
+
+    public function testMergeDeduplicatesConstantsDifferingOnlyInNamespaceCase(): void
+    {
+        $merged = NamespaceContents::merge([
+            new NamespaceContents([], [new CatalogSymbol('Fixtures\Helpers\STATUS', NameKind::Constant)]),
+            new NamespaceContents([], [new CatalogSymbol('FIXTURES\HELPERS\STATUS', NameKind::Constant)]),
+        ]);
+
+        self::assertCount(
+            1,
+            $merged->symbols,
+            'only the short name of a constant is case-sensitive; the namespace path is not',
+        );
+    }
+}

--- a/tests/Knowledge/CompositeSymbolSourceTest.php
+++ b/tests/Knowledge/CompositeSymbolSourceTest.php
@@ -191,6 +191,21 @@ final class CompositeSymbolSourceTest extends TestCase
         yield 'unrelated type' => ['App\Unrelated', false];
     }
 
+    public function testIsSubclassOfMatchesEdgesUnderTheClassCaseRule(): void
+    {
+        // The declared parent spelling differs in case from the queried target.
+        $backend = new FakeSymbolBackend([
+            'app\child' => self::classInfo('App\Child', parent: 'APP\PARENTCLASS'),
+            'app\parentclass' => self::classInfo('App\ParentClass'),
+        ]);
+        $source = new CompositeSymbolSource([$backend]);
+
+        self::assertTrue(
+            $source->isSubclassOf(self::className('App\Child'), self::className('App\ParentClass')),
+            'class-like names are case-insensitive, so a case-divergent parent spelling must still match',
+        );
+    }
+
     public function testIsSubclassOfReturnsFalseForAnUnknownClass(): void
     {
         $source = new CompositeSymbolSource([self::openWithChild(), self::vendorGraph()]);

--- a/tests/Knowledge/CompositeSymbolSourceTest.php
+++ b/tests/Knowledge/CompositeSymbolSourceTest.php
@@ -115,9 +115,9 @@ final class CompositeSymbolSourceTest extends TestCase
         $vendor = new FakeSymbolBackend(namespaces: [
             'App' => new NamespaceContents(
                 ['App\Other'],
-                // Same FQN as the open document's, but a different kind: the open
-                // document's spelling must win the merge.
-                [new CatalogSymbol('App\Shared', NameKind::Function_)],
+                // The same class-like under its case rule, spelled differently:
+                // the open document's spelling must win the merge.
+                [new CatalogSymbol('APP\SHARED', NameKind::ClassLike)],
             ),
         ]);
         $source = new CompositeSymbolSource([$open, $vendor]);
@@ -131,8 +131,8 @@ final class CompositeSymbolSourceTest extends TestCase
         );
         self::assertCount(1, $contents->symbols, 'the clashing symbol must be deduplicated to one');
         self::assertSame(
-            NameKind::ClassLike,
-            $contents->symbols[0]->kind,
+            'App\Shared',
+            $contents->symbols[0]->fullyQualifiedName,
             'the earlier backend must win the clash: the open document overrides the vendored listing',
         );
     }

--- a/tests/Knowledge/CompositeSymbolSourceTest.php
+++ b/tests/Knowledge/CompositeSymbolSourceTest.php
@@ -141,7 +141,9 @@ final class CompositeSymbolSourceTest extends TestCase
     {
         $open = new FakeSymbolBackend(searchResults: [self::symbol('App\Log', 'open.php')]);
         $vendor = new FakeSymbolBackend(searchResults: [
-            self::symbol('App\Log', 'vendor.php'),
+            // The same class-like under its case rule, spelled differently: it
+            // must still clash, and the open document's spelling must win.
+            self::symbol('APP\LOG', 'vendor.php'),
             self::symbol('App\Logger', 'vendor.php'),
         ]);
         $source = new CompositeSymbolSource([$open, $vendor]);

--- a/tests/Knowledge/FilesystemBackendTest.php
+++ b/tests/Knowledge/FilesystemBackendTest.php
@@ -114,6 +114,18 @@ final class FilesystemBackendTest extends TestCase
         );
     }
 
+    public function testLookupClassLikeIsCaseInsensitive(): void
+    {
+        $backend = $this->backendWithLocator(
+            $this->locatorReturning($this->fixturesRoot . '/src/Domain/User.php'),
+        );
+
+        self::assertNotNull(
+            $backend->lookupClassLike(self::className('fixtures\domain\user')),
+            'PHP matches class names case-insensitively, as the function path already does',
+        );
+    }
+
     public function testLookupFunctionResolvesAFunctionDeclaredInAnAutoloadFilesEntry(): void
     {
         $info = $this->backend()->lookupFunction(

--- a/tests/Utility/NamespacePathTest.php
+++ b/tests/Utility/NamespacePathTest.php
@@ -101,6 +101,15 @@ class NamespacePathTest extends TestCase
         yield 'unqualified' => ['User', 'User'];
     }
 
+    public function testCaseFoldIsTheLookupKeyForAPath(): void
+    {
+        self::assertSame(
+            'app\model',
+            NamespacePath::caseFold('App\Model'),
+            'namespace paths are case-insensitive whatever kind of symbol they qualify',
+        );
+    }
+
     public function testJoinSkipsEmptySegments(): void
     {
         self::assertSame(

--- a/tests/Utility/NamespacePathTest.php
+++ b/tests/Utility/NamespacePathTest.php
@@ -101,11 +101,11 @@ class NamespacePathTest extends TestCase
         yield 'unqualified' => ['User', 'User'];
     }
 
-    public function testCaseFoldIsTheLookupKeyForAPath(): void
+    public function testNormalizeIsTheLookupKeyForAPath(): void
     {
         self::assertSame(
             'app\model',
-            NamespacePath::caseFold('App\Model'),
+            NamespacePath::normalize('App\Model'),
             'namespace paths are case-insensitive whatever kind of symbol they qualify',
         );
     }


### PR DESCRIPTION
## Slice

SC.6 (no owning plan step — a live defect filed by the manifest's SC.* block, sequenced ahead of S3.8b so constant enumeration lands on a correct substrate).

Every key derived from a symbol name now routes through `NameKind::normalize()`, and every namespace-path fold through a new `NamespacePath::normalize()`. Whole-FQN `strtolower` keys collapsed `Foo\BAR`/`Foo\bar` constants and collapsed a class with a function sharing a spelling — the kind the `CatalogSymbol` already carried was being discarded.

## Acceptance (from the manifest note)

- [x] `CompositeSymbolSource` search-merge and subtype-walk keys route through `NameKind::normalize()`
- [x] `NamespaceContents::merge` keys symbols by kind-qualified identity (`CatalogSymbol::key()`): constants differing only in short-name case survive; a class and a function sharing a spelling survive; same-kind cross-source dedupe still collapses, earlier source winning (regression-tested)
- [x] `FilesystemBackend::parseClassFrom` matches declarations under the case rule, as its function sibling already did — a wrong-case class lookup on a cold cache now resolves (regression-tested)
- [x] Namespace-path keys (`NamespaceContents`, `SymbolIndex`, the namespace sources, `CachedNamespaceCatalog`) route through `NamespacePath::normalize()`; the segment `strcasecmp` routes through `NamespacePath::equals()`
- [x] PHPStan baseline drains 63 → 20 case-rule errors removed (63 → 43 total); deptrac unchanged

## Notes

- `NamespacePath` joins the case-folding allowlist in `phpstan.neon`: namespace paths are case-insensitive for every symbol kind, so the fold is deliberately kind-independent and not `NameKind`'s per-kind rule. Its own docblock already claimed namespace case semantics (it held `equals`).
- Two existing merge tests used *different kinds* as the marker for which source won a clash — the exact cross-kind collapse this slice removes. Their intent (earlier source wins the same symbol) is preserved; the marker is now FQN casing.
- Deliberately left for their owning slices: `SymbolIndex::findByPrefix` / `PrefixMatcher` prefix-match folds (SC.8, the shared matcher), and member-name case rules in `MemberResolver`/`MethodName` (SC.7).

Candidate closes: none listed in the manifest for this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
