### PR TITLE
Center the build procedure on the goal it serves

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -78,9 +78,9 @@ is one you will over- or under-build.
   - Write failing tests, then implement to green.
 - Keep commits small and logical (project rule). Run `composer test` to green.
 - Build what X's acceptance requires and nothing beyond it. A defect, duplication, or
-  rough edge noticed in passing is **reported, not solved** — if it is duplication or
-  divergence it earns an `SC.*` row, and if it is generic tidiness it earns neither a
-  row nor a diff.
+  rough edge noticed in passing is **reported, not solved** — duplication or
+  divergence earns an `SC.*` row; generic tidiness gets one line in the PR body and
+  neither a row nor a diff.
 - Comments earn their place. Name the non-obvious fact each one carries that the code
   does not, or leave it out; length tracks the subtlety of the code, not its size.
   Reviewers raise violations as findings, so writing them costs a round.

--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -81,6 +81,9 @@ is one you will over- or under-build.
   rough edge noticed in passing is **reported, not solved** — if it is duplication or
   divergence it earns an `SC.*` row, and if it is generic tidiness it earns neither a
   row nor a diff.
+- Comments earn their place. Name the non-obvious fact each one carries that the code
+  does not, or leave it out; length tracks the subtlety of the code, not its size.
+  Reviewers raise violations as findings, so writing them costs a round.
 - If you hit a fundamental design question the plan does not answer, **STOP and ask**
   — do not invent an interpretation.
 

--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -79,8 +79,9 @@ is one you will over- or under-build.
 - Keep commits small and logical (project rule). Run `composer test` to green.
 - Build what X's acceptance requires and nothing beyond it. A defect, duplication, or
   rough edge noticed in passing is **reported, not solved** — duplication or
-  divergence earns an `SC.*` row; generic tidiness gets one line in the PR body and
-  neither a row nor a diff.
+  divergence earns an `SC.*` row; a defect gets a GitHub issue plus a line in the
+  final report saying whether the next slice can proceed while it stays open;
+  generic tidiness gets one line in the PR body and neither a row nor a diff.
 - Comments earn their place. Name the non-obvious fact each one carries that the code
   does not, or leave it out; length tracks the subtlety of the code, not its size.
   Reviewers raise violations as findings, so writing them costs a round.

--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -9,6 +9,14 @@ Execute "Mode A" of `docs/architecture/build-procedure.md`. **Do not guess; halt
 ask on any ambiguity.** The whole point is that a cold session picks the correct next
 slice from durable state, not from memory.
 
+## 0. Read the goal first
+
+Read **"The goal every slice serves"** in `build-procedure.md` before anything else.
+Slices exist to make it impossible for two features to disagree about the same
+symbol. A slice's acceptance criteria are how it serves that goal, not a substitute
+for it — and work the goal does not call for is not made in-scope by being nearby,
+noticed in passing, or easy.
+
 ## 1. Preconditions (halt and report if any fail)
 
 - `git status`: the **tracked** working tree must be clean. Untracked scratch files
@@ -56,6 +64,11 @@ criteria, and the RFC sections it cites in `0001-foundational-architecture.md`. 
 describe the work in plain english and **wait** for approval, clarification, or
 modification before writing anything.
 
+Lead that description with X's answer to the goal test: what two features could
+disagree about without X, or which scheduled feature X unblocks. If you cannot write
+that sentence from the plan, **stop and ask** — a slice whose purpose you cannot state
+is one you will over- or under-build.
+
 ## 5. Implement X
 
 - Create `slice/<X>` off `main`.
@@ -64,13 +77,18 @@ modification before writing anything.
   - Seam-introducing slice → add its §8.1 enforcement rule in this slice.
   - Write failing tests, then implement to green.
 - Keep commits small and logical (project rule). Run `composer test` to green.
+- Build what X's acceptance requires and nothing beyond it. A defect, duplication, or
+  rough edge noticed in passing is **reported, not solved** — if it is duplication or
+  divergence it earns an `SC.*` row, and if it is generic tidiness it earns neither a
+  row nor a diff.
 - If you hit a fundamental design question the plan does not answer, **STOP and ask**
   — do not invent an interpretation.
 
 ## 6. Open the PR and report
 
-- PR title carries no issue number; the body cites the slice id, plan step, and RFC
-  section(s), and lists the acceptance criteria as a checklist.
+- PR title carries no issue number; the body opens with what two features could have
+  disagreed about without this change (or what it unblocks), then cites the slice id,
+  plan step, and RFC section(s), and lists the acceptance criteria as a checklist.
 - List manifest `Closes` candidates as "Candidate closes (pending review
   verification): #n" — do **not** wire `Closes #n` here; that is the reviewer's job
   after reading the issue body.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -63,6 +63,12 @@ Run a small diverse panel in parallel:
   goldens assert the right values, not just that they diffed clean.
   Note: instruct the reviewer to revert mutations through the edit tool, not git.
 
+Every reviewer also checks the comments and docblocks the diff adds or grows: each
+must name a fact the code does not convey, with length tracking the subtlety of the
+code rather than its size (`CLAUDE.md`). Raise these as findings, not nits — the rule
+is long-standing and routinely missed, and prose that restates code is the copy that
+goes stale.
+
 Each returns structured findings; then have them adversarially try to break the
 change.
 

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -61,6 +61,7 @@ Run a small diverse panel in parallel:
   mutation of the implementation (move a statement out of a `finally`, shorten a timed
   span, return a constant) and check whether anything fails. Spot-check that captured
   goldens assert the right values, not just that they diffed clean.
+  Note: instruct the reviewer to revert mutations through the edit tool, not git.
 
 Each returns structured findings; then have them adversarially try to break the
 change.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -9,6 +9,17 @@ Execute "Mode B" of `docs/architecture/build-procedure.md`. **One invocation = o
 pass.** If this pass fixes anything, the change needs another fresh pass — the user
 runs `/clear` then `/review-slice` again. Only a pass that finds nothing is "clean".
 
+## 0. Read the goal first
+
+Read **"The goal every slice serves"** in `build-procedure.md` before anything else.
+The review exists to protect one thing: that two features cannot disagree about the
+same symbol. Acceptance criteria are how a slice serves that goal, not a substitute
+for it — a pass that checks every box while the change drifts from the goal has
+failed, and so has a pass that generates work the goal does not call for.
+
+Every finding you keep, and every fix you write, carries its one-sentence answer to
+the goal test. No answer, no work.
+
 ## 1. Identify the slice
 
 - If a slice id / branch is given, use `slice/<id>`. Otherwise find the single
@@ -26,11 +37,18 @@ runs `/clear` then `/review-slice` again. Only a pass that finds nothing is "cle
 
 ## 2. Cleanroom review (this is the safeguard — keep it clean)
 
-Spawn independent reviewer subagents (the Agent tool) that see **only**: (a) the
-slice's acceptance criteria from `0002`, (b) the RFC sections it touches from `0001`,
-and (c) the diff. They **must not** be given this conversation, the commit messages'
-reasoning, or any implementer rationale — that is what makes it cleanroom. Run a small
-diverse panel in parallel:
+Spawn independent reviewer subagents (the Agent tool) that see **only**: (a) the goal
+section of `build-procedure.md`, (b) the slice's acceptance criteria from `0002`,
+(c) the RFC sections it touches from `0001`, and (d) the diff. They **must not** be
+given this conversation, the commit messages' reasoning, or any implementer rationale
+— that is what makes it cleanroom. The goal is a published document, not rationale;
+withholding it is what produces box-checking reviews.
+
+Require every finding to carry its one-sentence goal-test answer, and tell the panel
+that a finding without one is to be dropped rather than reported. That filter belongs
+in the reviewer, which has the code in context, not in your post-processing.
+
+Run a small diverse panel in parallel:
 
 - **Acceptance** — is every acceptance criterion actually met, not just plausibly?
   Including each owed item from step 1: the named test exists, and it fails against the
@@ -90,6 +108,11 @@ burn 75k+ tokens re-deriving the whole measurement.
 ## 3. Verify and fix
 
 - Keep only findings you can **confirm against the code**; discard speculation.
+- Apply the goal test yourself to what survives the panel. A finding that cannot
+  answer it is reported in one line as noted-not-fixed; nothing gets built for it.
+- Weigh each fix against the defect it prevents. When the change needed is wider than
+  the defect — a production API change, a new fixture dependency, a reshaped seam —
+  **state the cost and ask** rather than building it. That call is the user's.
 - If any survive: fix them on the branch in small commits; run `composer test` to
   green. Report: **"Pass found N issues, fixed and committed: [...]. Run /clear then
   /review-slice again to verify."** STOP — do not land. A fix needs a fresh pass.
@@ -103,3 +126,19 @@ burn 75k+ tokens re-deriving the whole measurement.
 - Report: **"Pass clean. Verified closes: #n. Ready to land — merge when ready."**
   Do **not** auto-merge — merging is irreversible and outward-facing; the user lands.
 - Report the next computed slice for after landing.
+
+## 5. Close every pass against the goal
+
+The last thing the report says, whether the pass was clean or not, is how this change
+serves the goal — in plain english, not slice ids:
+
+- **What two features could have disagreed about**, and what now makes that
+  impossible rather than merely unlikely. Name the mechanism that would fail.
+- **What the change unblocks**, if it is groundwork rather than a fix — which
+  scheduled feature could not be built until this shape existed.
+- **What corrections remain** before the change actually gets there, if it does not
+  yet. A slice that meets every criterion and still leaves a way for two features to
+  disagree is not finished, and this is where that gets said.
+
+A pass that cannot write this paragraph has not understood the change well enough to
+approve it. Say so instead of approving it.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -65,9 +65,9 @@ Run a small diverse panel in parallel:
 
 Every reviewer also checks the comments and docblocks the diff adds or grows: each
 must name a fact the code does not convey, with length tracking the subtlety of the
-code rather than its size (`CLAUDE.md`). Raise these as findings, not nits — the rule
-is long-standing and routinely missed, and prose that restates code is the copy that
-goes stale.
+code rather than its size (`CLAUDE.md`). Raise these as findings, not nits — they
+carry the standing goal-test answer from the goal section (two copies of one fact
+drifting apart), so the drop rule above does not apply to them.
 
 Each returns structured findings; then have them adversarially try to break the
 change.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -45,8 +45,8 @@ given this conversation, the commit messages' reasoning, or any implementer rati
 withholding it is what produces box-checking reviews.
 
 Require every finding to carry its one-sentence goal-test answer, and tell the panel
-that a finding without one is to be dropped rather than reported. That filter belongs
-in the reviewer, which has the code in context, not in your post-processing.
+that a finding without one is to be dropped rather than reported. The reviewer applies
+that filter — it has the code in context; step 3 only backstops it.
 
 Run a small diverse panel in parallel:
 
@@ -115,8 +115,9 @@ burn 75k+ tokens re-deriving the whole measurement.
 ## 3. Verify and fix
 
 - Keep only findings you can **confirm against the code**; discard speculation.
-- Apply the goal test yourself to what survives the panel. A finding that cannot
-  answer it is reported in one line as noted-not-fixed; nothing gets built for it.
+- Backstop the goal test on what survives the panel. A finding that cannot answer it
+  (comment discipline carries its standing answer) is reported in one line as
+  noted-not-fixed; nothing gets built for it.
 - Weigh each fix against the defect it prevents. When the change needed is wider than
   the defect — a production API change, a new fixture dependency, a reshaped seam —
   **state the cost and ask** rather than building it. That call is the user's.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -7,7 +7,7 @@ description: One cleanroom adversarial review pass (plus fixes) of a build slice
 
 Execute "Mode B" of `docs/architecture/build-procedure.md`. **One invocation = one
 pass.** If this pass fixes anything, the change needs another fresh pass — the user
-runs `/clear` then `/review-slice` again. Only a pass that finds nothing is "clean".
+runs `/clear` then `/review-slice` again. Only a pass that fixes nothing is "clean".
 
 ## 0. Read the goal first
 
@@ -117,7 +117,8 @@ burn 75k+ tokens re-deriving the whole measurement.
 - Keep only findings you can **confirm against the code**; discard speculation.
 - Backstop the goal test on what survives the panel. A finding that cannot answer it
   (comment discipline carries its standing answer) is reported in one line as
-  noted-not-fixed; nothing gets built for it.
+  noted-not-fixed; nothing gets built for it. Noted lines do not make the pass dirty
+  — only an applied fix forces a fresh pass. This is what lets the loop terminate.
 - Weigh each fix against the defect it prevents. When the change needed is wider than
   the defect — a production API change, a new fixture dependency, a reshaped seam —
   **state the cost and ask** rather than building it. That call is the user's.
@@ -125,7 +126,7 @@ burn 75k+ tokens re-deriving the whole measurement.
   green. Report: **"Pass found N issues, fixed and committed: [...]. Run /clear then
   /review-slice again to verify."** STOP — do not land. A fix needs a fresh pass.
 
-## 4. If the pass is clean (no surviving findings)
+## 4. If the pass is clean (nothing needed a fix)
 
 - For each `Closes` candidate in the manifest for this slice: `gh issue view <n>`,
   confirm its acceptance criteria are met **by this change**; if so, add `Closes #<n>`

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -38,6 +38,7 @@ Before writing a change or raising a finding, answer in one sentence:
 
 No answer means out of scope.
 Duplication or divergence earns an `SC.*` row — that is the goal's own subject matter.
+A defect gets a GitHub issue, and the session's stop report says whether the next slice can proceed while it stays open — never leave the human to derive that.
 Generic tidiness gets at most one line in the PR body or pass report, and neither a row nor a diff.
 
 These are the ways the test gets failed in practice, each observed:
@@ -133,7 +134,8 @@ squash-deleted branch is never misread as unstarted.
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
    `composer test`; open a PR citing X. Build what X's acceptance requires and
    nothing beyond it — a problem noticed in passing is reported, not solved (an
-   `SC.*` row for duplication, a line in the PR body for anything else).
+   `SC.*` row for duplication, a GitHub issue plus a can-the-next-slice-proceed
+   call for a defect, a line in the PR body for tidiness).
 6. Stop. Report the PR and the *next* computed slice, so the human knows what a
    follow-up "do the next step" would pick up.
 

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -21,7 +21,7 @@ two notches below hands-off autonomy by design.
 ## The goal every slice serves
 
 The rework exists to eliminate one bug class: two features disagreeing about the same symbol.
-Hover resolves a name completion never offers; definition works on a node type type-inference does not.
+Hover resolves a name completion never offers; definition works on a node type that type-inference does not.
 That is #190, #253 and #256, and the cause is M×N hand-written pairs — M consumers × N node types or symbol kinds — that drift apart.
 
 The method is one authority per question, so consistency holds by construction rather than by discipline.

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -163,7 +163,8 @@ squash-deleted branch is never misread as unstarted.
    A finding without one is reported as noted-not-fixed, in a line, and nothing is
    built for it. Noted lines do not make a pass dirty — only an applied fix forces a
    fresh pass, which is what lets the review loop terminate.
-4. **Fix.** Apply fixes on the branch; re-run the cleanroom pass until clean.
+4. **Fix.** Apply fixes on the branch; the change then needs a fresh pass (a new
+   session) before landing. Land only from a pass that fixed nothing.
 5. **Land.** Mark ready / merge. For each existing issue the manifest says this slice
    closes, **read the issue body, confirm its criteria are met, then** wire
    `Closes #<n>` (or close with a verification note).

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -140,9 +140,9 @@ squash-deleted branch is never misread as unstarted.
 
 1. **Identify the slice.** The `in-flight` one, or the id given. Check out its
    branch.
-2. **Cleanroom review.** A fresh reviewer (subagent) sees **only** the slice's
-   acceptance criteria, the relevant RFC sections, and the diff — **not** the
-   implementer's reasoning or this conversation. It adversarially verifies:
+2. **Cleanroom review.** A fresh reviewer (subagent) sees **only** the goal section
+   of this document, the slice's acceptance criteria, the relevant RFC sections, and
+   the diff — **not** the implementer's reasoning or this conversation. It adversarially verifies:
    - every acceptance criterion is actually met (not just plausibly);
    - §8.1 conformance for the invariants the slice touches;
    - the parity harness / enforcement rule would **actually catch a regression in**

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -18,6 +18,40 @@ step is computed, never remembered.** A session determines what to do from durab
 checkable state and *halts and asks* when that state is ambiguous. This is one or
 two notches below hands-off autonomy by design.
 
+## The goal every slice serves
+
+The rework exists to eliminate one bug class: two features disagreeing about the same symbol.
+Hover resolves a name completion never offers; definition works on a node type type-inference does not.
+That is #190, #253 and #256, and the cause is M×N hand-written pairs — M consumers × N node types or symbol kinds — that drift apart.
+
+The method is one authority per question, so consistency holds by construction rather than by discipline.
+Every seam ships with the enforcement that makes drift fail loudly; a rule without a mechanism is not done (§8.1).
+
+Everything else — fewer lines, tidier layering, better names — is a means.
+It counts when it serves that end or unblocks a feature the plan schedules, and not otherwise.
+
+### The goal test
+
+Before writing a change or raising a finding, answer in one sentence:
+
+> What can two features disagree about if this is not done — or which scheduled feature does it unblock?
+
+No answer means out of scope.
+Note it and move on.
+
+Filing an `SC.*` row is the right disposition when the thing is duplication or divergence, which is the goal's own subject matter.
+It is the wrong disposition for generic tidiness, which belongs in neither the manifest nor the diff.
+
+These are the ways the test gets failed in practice, each observed:
+
+- Enforcement built for a defect nobody can produce.
+- A mechanism widened to catch a risk belonging to a different class of bug.
+- Production API changed to improve the shape of a test.
+- Tidiness fixed or filed on the way past because it was noticed.
+
+A fix whose blast radius exceeds the defect it prevents is a decision for the human, not a reflex.
+State what it would cost and ask.
+
 ## Source of truth: git, not a status field
 
 Progress is **derived from git / PR merge state**, keyed by deterministic branch
@@ -76,12 +110,13 @@ squash-deleted branch is never misread as unstarted.
      first — one slice in flight at a time);
    - the manifest references a merged branch for a slice whose dependencies are not
      merged (state drift — surface it).
-4. **Explain X.** Describe in plain english the work to be done, then wait for
-   approval, clarification, or modification.
+4. **Explain X.** Describe in plain english the work to be done, lead with X's answer
+   to the goal test, then wait for approval, clarification, or modification.
 5. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
    (for a behavior-preserving step: parity fixtures first; for a step that
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
-   `composer test`; open a PR citing X.
+   `composer test`; open a PR citing X. Build what X's acceptance requires and
+   nothing beyond it — a problem noticed in passing is reported, not solved.
 6. Stop. Report the PR and the *next* computed slice, so the human knows what a
    follow-up "do the next step" would pick up.
 
@@ -105,11 +140,19 @@ squash-deleted branch is never misread as unstarted.
    PHPStan, PHPCS, coverage percentages. Those run on every push. Review effort goes
    where CI is blind — unverified claims, assertions that survive mutation,
    acceptance criteria met only in appearance.
-3. **Fix.** Apply fixes on the branch; re-run the cleanroom pass until clean.
-4. **Land.** Mark ready / merge. For each existing issue the manifest says this slice
+3. **Apply the goal test.** Every surviving finding carries its one-sentence answer.
+   A finding without one is reported as noted-not-fixed, in a line, and nothing is
+   built for it.
+4. **Fix.** Apply fixes on the branch; re-run the cleanroom pass until clean.
+5. **Land.** Mark ready / merge. For each existing issue the manifest says this slice
    closes, **read the issue body, confirm its criteria are met, then** wire
    `Closes #<n>` (or close with a verification note).
-5. Stop. Report what merged and the next computed slice.
+6. **Close against the goal.** Every pass ends by saying, in plain english, what two
+   features could have disagreed about and what now makes that impossible — or what
+   the change unblocks, if it is groundwork — or what corrections remain before it
+   gets there. A pass that cannot write that paragraph has not understood the change
+   well enough to approve it, and says so instead.
+7. Stop. Report what merged and the next computed slice.
 
 ## The "X is always correct" guarantee, in one place
 

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -65,6 +65,8 @@ A comment that restates its code is a second copy of it, and the copy is the one
 The project rule already says this (`CLAUDE.md`): name the non-obvious fact a comment carries that the code does not, or delete it, and let length track how subtle the code is rather than how much of it there is.
 It is stated here because it is the rule this project ignores most often.
 
+Comment discipline carries a standing goal-test answer — two copies of one fact drifting apart is this rework's bug class in miniature — so these findings pass the filter without a per-finding sentence.
+
 ## Source of truth: git, not a status field
 
 Progress is **derived from git / PR merge state**, keyed by deterministic branch

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -38,7 +38,7 @@ Before writing a change or raising a finding, answer in one sentence:
 
 No answer means out of scope.
 Duplication or divergence earns an `SC.*` row — that is the goal's own subject matter.
-Generic tidiness gets one line in the PR body or pass report, and neither a row nor a diff.
+Generic tidiness gets at most one line in the PR body or pass report, and neither a row nor a diff.
 
 These are the ways the test gets failed in practice, each observed:
 
@@ -159,7 +159,8 @@ squash-deleted branch is never misread as unstarted.
    acceptance criteria met only in appearance.
 3. **Apply the goal test.** Every surviving finding carries its one-sentence answer.
    A finding without one is reported as noted-not-fixed, in a line, and nothing is
-   built for it.
+   built for it. Noted lines do not make a pass dirty — only an applied fix forces a
+   fresh pass, which is what lets the review loop terminate.
 4. **Fix.** Apply fixes on the branch; re-run the cleanroom pass until clean.
 5. **Land.** Mark ready / merge. For each existing issue the manifest says this slice
    closes, **read the issue body, confirm its criteria are met, then** wire

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -61,6 +61,12 @@ Those cost as much to maintain as the real ones and buy nothing.
 Before settling on an implementation, check whether a smaller one makes the same disagreement impossible.
 It usually does.
 
+### Comments earn their place
+
+A comment that restates its code is a second copy of it, and the copy is the one that goes stale.
+The project rule already says this (`CLAUDE.md`): name the non-obvious fact a comment carries that the code does not, or delete it, and let length track how subtle the code is rather than how much of it there is.
+It is stated here because it is the rule this project ignores most often.
+
 ## Source of truth: git, not a status field
 
 Progress is **derived from git / PR merge state**, keyed by deterministic branch

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -37,10 +37,8 @@ Before writing a change or raising a finding, answer in one sentence:
 > What can two features disagree about if this is not done — or which scheduled feature does it unblock?
 
 No answer means out of scope.
-Note it and move on.
-
-Filing an `SC.*` row is the right disposition when the thing is duplication or divergence, which is the goal's own subject matter.
-It is the wrong disposition for generic tidiness, which belongs in neither the manifest nor the diff.
+Duplication or divergence earns an `SC.*` row — that is the goal's own subject matter.
+Generic tidiness gets one line in the PR body or pass report, and neither a row nor a diff.
 
 These are the ways the test gets failed in practice, each observed:
 
@@ -131,7 +129,8 @@ squash-deleted branch is never misread as unstarted.
    (for a behavior-preserving step: parity fixtures first; for a step that
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
    `composer test`; open a PR citing X. Build what X's acceptance requires and
-   nothing beyond it — a problem noticed in passing is reported, not solved.
+   nothing beyond it — a problem noticed in passing is reported, not solved (an
+   `SC.*` row for duplication, a line in the PR body for anything else).
 6. Stop. Report the PR and the *next* computed slice, so the human knows what a
    follow-up "do the next step" would pick up.
 

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -106,7 +106,8 @@ squash-deleted branch is never misread as unstarted.
 - **One slice = one branch = one PR.** Branch name is fixed by the manifest:
   `slice/<id>` (e.g. `slice/S2.1`). This is what lets a *review* session find "this
   step's branch" unambiguously from the id alone.
-- **PR body** cites the slice id, its plan step, and the RFC section(s) it satisfies.
+- **PR body** opens with the slice's goal-test answer, then cites the slice id, its
+  plan step, and the RFC section(s) it satisfies.
 - **`Closes #<n>`** is added to a PR **only after the reviewer has read that issue's
   body and confirmed its acceptance criteria are met** — never inferred from a title
   (per the project's review rules).

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -52,6 +52,15 @@ These are the ways the test gets failed in practice, each observed:
 A fix whose blast radius exceeds the defect it prevents is a decision for the human, not a reflex.
 State what it would cost and ask.
 
+### Prefer the simpler version
+
+Abstractions are how the M×N goes away, so this is not an argument against them.
+It is an argument against generality nobody asked for: a parameter no caller varies, an extension point with one implementation, a seam for a case that is not on the plan.
+Those cost as much to maintain as the real ones and buy nothing.
+
+Before settling on an implementation, check whether a smaller one makes the same disagreement impossible.
+It usually does.
+
 ## Source of truth: git, not a status field
 
 Progress is **derived from git / PR merge state**, keyed by deterministic branch


### PR DESCRIPTION
Process change, not a slice. `/do-next` and `/review-slice` both drive from `build-procedure.md`, which described the mechanics of picking and reviewing a slice but never stated what the slices are for. Without that, a review can check every acceptance box while the change drifts, and — the failure mode actually observed — it can generate work the goal does not call for.

## What this adds

`build-procedure.md` gains a section, placed ahead of the mechanics so it is read first: the bug class the rework exists to eliminate (two features disagreeing about the same symbol — #190, #253, #256), the method (one authority per question, with the enforcement shipped alongside each seam), and the fact that everything else is a means rather than an end.

From that, a test both modes apply:

> What can two features disagree about if this is not done — or which scheduled feature does it unblock?

No answer means out of scope. The section also names four ways the test gets failed; all four were observed during a single review pass, so they are recorded as observations rather than hypotheticals.

## Review path

- Reviewers now receive the goal document alongside the acceptance criteria and the diff. It is published guidance, not implementer rationale, so the cleanroom property is unaffected — and withholding it is what produces box-checking.
- Findings carry their goal-test answer, and the filter runs inside the reviewer, which has the code in context, rather than in post-processing.
- A fix wider than the defect it prevents — a production API change, a new fixture dependency, a reshaped seam — is costed and raised, not built.
- Every pass now closes by explaining in plain english how the change serves the goal, or which corrections remain before it does. A slice meeting every criterion while still leaving room for two features to disagree is not finished, and this is where that gets said. A pass unable to write that paragraph reports as much instead of approving.

## Implementation path

- The explain step leads with the slice's purpose and halts if that cannot be stated from the plan.
- Implementation is bounded to the acceptance criteria; something noticed in passing is reported rather than solved — an `SC.*` row when it is duplication or divergence, nothing at all when it is generic tidiness.
- PR bodies open with the disagreement the change prevents.

## Notes

Both skill files predate the `.gitignore` rule covering `.claude/`, so they are tracked and were staged with `-f`.

Docs and skill prompts only; no source, tests, or configuration touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
