### PR TITLE
Settle the constant type as one shape, not two

### DIFF
--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -602,7 +602,7 @@ interface SymbolSource
     // --- Added JIT, when the step that needs them lands (NOT built in Step 2) ---
     // Step 3b (functions/constants gain project reach; a second searchable kind exists):
     //   lookupFunction(FunctionName): ?FunctionInfo
-    //   lookupConstant(ConstantName): ?ConstantInfo
+    //   lookupConstant(GlobalConstantName): ?ConstantInfo
     //   searchClassLikes generalizes to search(string $prefix, NameKind $kind)
     // Future (workspace scope, #264):
     //   locate(QualifiedName, NameKind): ?SymbolDefinition   // kind-neutral def-site, only if a feature needs it

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -641,21 +641,27 @@ To stop the two typing models fighting before they are built:
 
 - `QualifiedName` is the base FQN value type — a namespace path plus a short name,
   **kind-neutral**.
-- `ClassLikeName`, `FunctionName`, `ConstantName`, `NamespaceName` extend / wrap it
-  and **carry their kind intrinsically** (each exposes `kind(): NameKind`). These are
+- `ClassLikeName`, `FunctionName`, `GlobalConstantName`, `NamespaceName` extend / wrap
+  it and **carry their kind intrinsically** (each exposes `kind(): NameKind`). These are
   the primary currency; the per-kind `lookup*` methods take the matching one, so the
   kind is implicit and `NameKind` is not passed. `ClassLikeName` is today's
   `ClassName` (which per CLAUDE.md also serves as the class `Type`); whether it is
   reused as-is, renamed, or wrapped is an open decision (§7). The other three are new.
-- **One constant type, class-declared or not.** `Domain\ConstantInfo` serves both:
-  `declaringClass` is `?ClassName`, and its absence is what makes a constant global. A
-  global constant is mechanically public and final, so `visibility` and `isFinal` carry
-  the true value rather than a placeholder, and `format()` branches on the declaring
-  class alone. `Domain\ConstantName` likewise holds either a member name or an FQN, so
-  the `ConstantName` above needs no second type. A global constant is **not** a
-  `ResolvedMember` — that interface means *reached through a class*, which is a path it
-  does not have — so `ConstantInfo` implements `ResolvedSymbol` itself rather than
-  gaining a fifth wrapper, which is also a down payment on the collapse in #416.
+- **`GlobalConstantName`, because `ConstantName` is the class constant member name**
+  beside `MethodName` and `PropertyName`. A bare member name is not an FQN, and one type
+  holding both would report `NameKind::Constant` for a member name. Unlike
+  `ClassLikeName` versus `ClassName` in §7, these are two concepts, not two names.
+- **One `ConstantInfo` serves both**, with `?ClassName` for `declaringClass`; its absence
+  is what makes a constant global, and `format()` branches on that alone. `visibility`
+  and `isFinal` carry true values — a redeclared `const` is fatal, a repeated `define()`
+  a no-op. The nullable is a conscious exception to the no-nullable rule: the
+  alternatives are a second metadata type differing in one field, or a sentinel
+  `ClassName` the type system cannot catch as a lie.
+- A global constant is **not** a `ResolvedMember` — that interface means *reached through
+  a class*, which is a path it does not have. Whether it instead gets a fifth wrapper or
+  `ConstantInfo` carries `ResolvedSymbol` itself is #416's, and turns on SC.13:
+  `ResolvedSymbol` is in `Resolution` and returns an `Index\Location`, so a `Domain`
+  object carrying it adds edges the layer contract denies.
 - `locate(QualifiedName, NameKind)` is the kind-agnostic entry, used when the caller
   has an FQN whose kind is known only from syntactic position and has not minted a
   typed subtype. `NameKind` is **not** redundant here precisely because the input is
@@ -665,7 +671,7 @@ To stop the two typing models fighting before they are built:
   is about identifiers, not search fragments. `kind` (once the parameter exists in
   Step 3b) selects which namespace to search.
 - **JIT:** Step 2 uses only `ClassLikeName` (today's `ClassName`) and `NamespaceName`.
-  `QualifiedName`, `NameKind`, `FunctionName`, and `ConstantName` land with the methods
+  `QualifiedName`, `NameKind`, `FunctionName`, and `GlobalConstantName` land with the methods
   that first use them (Step 3b, and `locate` in the workspace scope) — an unused type
   is not carried ahead of its method. This whole model is the *target*; it is
   introduced piecewise.
@@ -823,7 +829,7 @@ once Step P is green.
   **Resolved — see Section 8.**
 - Whether `ClassLikeName` is the existing `ClassName` reused as-is, renamed, or a
   wrapper — it must coexist with `ClassName`'s dual role as the class `Type` (§5.3).
-- Whether `FunctionName` / `ConstantName` / `NamespaceName` land in Step 2 as prep
+- Whether `FunctionName` / `GlobalConstantName` / `NamespaceName` land in Step 2 as prep
   or in Step 3 with their lookups (lean: Step 3, to avoid an unused-type commit;
   `NamespaceName` is needed by `childrenOf` in Step 2, so it lands then).
 - Whether completion detail after the `search` migration comes from a follow-up

--- a/docs/architecture/0002-execution-plan.md
+++ b/docs/architecture/0002-execution-plan.md
@@ -647,6 +647,15 @@ To stop the two typing models fighting before they are built:
   kind is implicit and `NameKind` is not passed. `ClassLikeName` is today's
   `ClassName` (which per CLAUDE.md also serves as the class `Type`); whether it is
   reused as-is, renamed, or wrapped is an open decision (§7). The other three are new.
+- **One constant type, class-declared or not.** `Domain\ConstantInfo` serves both:
+  `declaringClass` is `?ClassName`, and its absence is what makes a constant global. A
+  global constant is mechanically public and final, so `visibility` and `isFinal` carry
+  the true value rather than a placeholder, and `format()` branches on the declaring
+  class alone. `Domain\ConstantName` likewise holds either a member name or an FQN, so
+  the `ConstantName` above needs no second type. A global constant is **not** a
+  `ResolvedMember` — that interface means *reached through a class*, which is a path it
+  does not have — so `ConstantInfo` implements `ResolvedSymbol` itself rather than
+  gaining a fifth wrapper, which is also a down payment on the collapse in #416.
 - `locate(QualifiedName, NameKind)` is the kind-agnostic entry, used when the caller
   has an FQN whose kind is known only from syntactic position and has not minted a
   typed subtype. `NameKind` is **not** redundant here precisely because the input is

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -182,12 +182,11 @@ Notes:
   of it. `NameKind` already exists (it predates Wave 2, as the catalog's coarse kind);
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
   whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
-  `ConstantName` in **S3.8b**, with their lookups.
-  - **`ConstantName` is already taken, and stays one type.** `Domain\ConstantName` wraps
-    a *class* constant name; §5.3's `ConstantName` is a *global* constant FQN. One type
-    holds both, as does one `ConstantInfo`: a global constant is a constant whose
-    declaring class is absent (0002 §5.3). So S3.8b introduces no constant type at all —
-    unlike `ClassLikeName` versus `ClassName`, which §7 leaves open.
+  `GlobalConstantName` in **S3.8b**, with their lookups.
+  - **The `ConstantName` collision is settled (0002 §5.3):** the global FQN type is
+    `GlobalConstantName`, `Domain\ConstantName` stays the class member name, and one
+    `ConstantInfo` serves both kinds. The *resolved* shape stays open — it is #416's and
+    turns on SC.13, so take SC.13 first.
 - **Steps 3 and 4 both edit `SymbolResolver` (§6).** S4.2 (positional extraction) is
   gated on S3.8 (the 3b lookup migration) so the two never run concurrently; manifest
   order keeps Step 3 ahead of Step 4 regardless. S4.1 (`TypeClassifier` + the §4.5/§4.6

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -176,10 +176,11 @@ Notes:
   Step 2 carries `ClassLikeName` / `NamespaceName`; `QualifiedName` lands in **S3.7b**,
   whose `DeclarationScanner` is its first caller; `FunctionName` in **S3.8a** and
   `ConstantName` in **S3.8b**, with their lookups.
-  - **`ConstantName` is already taken.** `Domain\ConstantName` wraps a *class* constant
-    name; §5.3's `ConstantName` is a *global* constant FQN. Decide the naming before
-    S3.8b rather than inside it — this is the same coexistence question §7 leaves open
-    for `ClassLikeName` versus `ClassName`.
+  - **`ConstantName` is already taken, and stays one type.** `Domain\ConstantName` wraps
+    a *class* constant name; §5.3's `ConstantName` is a *global* constant FQN. One type
+    holds both, as does one `ConstantInfo`: a global constant is a constant whose
+    declaring class is absent (0002 §5.3). So S3.8b introduces no constant type at all —
+    unlike `ClassLikeName` versus `ClassName`, which §7 leaves open.
 - **Steps 3 and 4 both edit `SymbolResolver` (§6).** S4.2 (positional extraction) is
   gated on S3.8 (the 3b lookup migration) so the two never run concurrently; manifest
   order keeps Step 3 ahead of Step 4 regardless. S4.1 (`TypeClassifier` + the §4.5/§4.6


### PR DESCRIPTION
Without this, S3.8b would have had to decide in-flight whether a global constant gets its own metadata type, its own name type, and its own resolved wrapper. Three near-copies of types that already exist is the duplication this rework removes, so the decisions that can be made now are recorded now — and the one that cannot is named as such.

Docs only. No code changes.

## The decisions

**Name type: `GlobalConstantName`.** `ConstantName` is already the *class* constant member name, sitting beside `MethodName` and `PropertyName`. A bare member name is not an FQN, and one type holding both would report `NameKind::Constant` for a member name and send it through the global-constant case rule. Naming the new type for what it is renames nothing. Unlike `ClassLikeName` versus `ClassName` in §7, these are two concepts rather than two names for one.

**Metadata: one `ConstantInfo`.** `declaringClass` becomes `?ClassName` and its absence is what makes a constant global; `format()` branches on that alone. `visibility` and `isFinal` keep true values — a redeclared `const` is fatal and a repeated `define()` is a no-op. The nullable is a conscious exception to the no-nullable rule, and the doc says why: the alternatives are a second metadata type differing in one field, or a sentinel `ClassName` that the type system cannot catch as a lie.

**Not a `ResolvedMember`.** That interface means reached through a class, via `->` or `::`, which a global constant has no path for.

## What is deliberately left open

Whether `ConstantInfo` carries `ResolvedSymbol` itself or a fifth thin wrapper is #416's question, and it turns on SC.13. `ResolvedSymbol` lives in `Resolution` and returns an `Index\Location`, so a `Domain` object carrying it adds two edges the layer contract denies — the same ruling SC.13 owes for `TypeFactory` and `NamespacePath`. Deciding it here would schedule a slice that cannot pass deptrac, and would pre-empt a cleanup row that is startable now.

Net new types needed for global constants: one name type, no metadata type, no wrapper decision.

## Where it lands

- `0002-execution-plan.md` §5.3 carries the decisions; §7's open-decision list and the JIT bullet pick up the rename.
- `build-manifest.md`'s note under the JIT name-type bullet is rewritten from posing the question to recording the answer, and points S3.8b at SC.13 for the rest.

Plan step: 0002 §5.3, feeding S3.8b's acceptance. RFC section: RFC 1 §5.1 (concrete return types per kind), §5.3.

## Checklist

- [x] The `ConstantName` collision the manifest deferred is resolved, not restated
- [x] The nullable field is argued against the project's no-nullable rule, in the doc
- [x] Nothing is decided that the layer contract would reject at build time
- [x] Manifest note rewritten rather than appended to (docs rule)
- [x] Slice table untouched, so `SymbolCoverageGridTest`'s registry parse is unaffected

Candidate closes (pending review verification): none.
