### PR TITLE
Index an open document's global constants

### DIFF
--- a/src/Index/SymbolExtractor.php
+++ b/src/Index/SymbolExtractor.php
@@ -54,6 +54,15 @@ final class SymbolExtractor
             );
         }
 
+        foreach ($declarations->constants as $declaration) {
+            $symbols[] = new Symbol(
+                name: $declaration->name->shortName,
+                fullyQualifiedName: $declaration->name->fullyQualifiedName(),
+                kind: SymbolKind::Constant,
+                location: self::locate($document, $declaration->node),
+            );
+        }
+
         // Callers index `$symbols[0]` as the file's first declaration, which the two
         // separate scanner lists would otherwise interleave by kind rather than by
         // where each is written.

--- a/tests/Index/SymbolExtractorTest.php
+++ b/tests/Index/SymbolExtractorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Tests\Index;
 
 use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Index\SymbolExtractor;
 use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Parser\ParserService;
@@ -133,5 +134,80 @@ class SymbolExtractorTest extends TestCase
         self::assertGreaterThanOrEqual(1, count($symbols));
         self::assertSame('Status', $symbols[0]->name);
         self::assertSame(SymbolKind::Enum_, $symbols[0]->kind);
+    }
+
+    public function testExtractNamespacedConstant(): void
+    {
+        $code = $this->loadFixture('AutoloadFiles/helpers.php');
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $constants = $this->constantsIn($this->extractor->extract($doc, $ast));
+
+        self::assertArrayHasKey(
+            'Fixtures\\Helpers\\HELPER_LIMIT',
+            $constants,
+            'a namespaced const must be indexed under the namespace it is written in',
+        );
+        $constant = $constants['Fixtures\\Helpers\\HELPER_LIMIT'];
+        self::assertSame('HELPER_LIMIT', $constant->name, 'the short name is what a prefix search matches on');
+        self::assertSame(
+            self::lineContaining($code, 'const HELPER_LIMIT'),
+            $constant->location->startLine,
+            'the location must come from the declaring node, so go-to-definition lands on it',
+        );
+    }
+
+    /**
+     * The extractor must not grow its own opinion of what declares a constant: the
+     * `define()` spellings, the multi-declarator statement and the computed name that
+     * {@see DeclarationScanner} already rules on are the same set here. A second rule
+     * is how a name came to resolve on hover while being invisible to completion.
+     */
+    public function testConstantsAgreeWithTheDeclarationScanner(): void
+    {
+        $code = $this->loadFixture('AutoloadFiles/globals.php');
+        $doc = new TextDocument('file:///test.php', 'php', 1, $code);
+        $ast = $this->parser->parse($doc);
+        self::assertNotNull($ast);
+
+        $extracted = array_keys($this->constantsIn($this->extractor->extract($doc, $ast)));
+        $scanned = array_map(
+            fn($declaration) => $declaration->name->fullyQualifiedName(),
+            (new DeclarationScanner())->scan($ast)->constants,
+        );
+
+        sort($extracted);
+        sort($scanned);
+        self::assertNotEmpty($scanned, 'the fixture must declare constants, or this asserts nothing');
+        self::assertSame($scanned, $extracted, 'the index must report exactly the declarations the scanner finds');
+    }
+
+    /**
+     * @param list<\Firehed\PhpLsp\Index\Symbol> $symbols
+     * @return array<string, \Firehed\PhpLsp\Index\Symbol> FQN -> symbol
+     */
+    private function constantsIn(array $symbols): array
+    {
+        $constants = [];
+        foreach ($symbols as $symbol) {
+            if ($symbol->kind === SymbolKind::Constant) {
+                $constants[$symbol->fullyQualifiedName] = $symbol;
+            }
+        }
+
+        return $constants;
+    }
+
+    private static function lineContaining(string $code, string $needle): int
+    {
+        foreach (explode("\n", $code) as $number => $line) {
+            if (str_contains($line, $needle)) {
+                return $number;
+            }
+        }
+
+        self::fail("the fixture no longer contains {$needle}");
     }
 }

--- a/tests/Knowledge/SymbolCoverageGridTest.php
+++ b/tests/Knowledge/SymbolCoverageGridTest.php
@@ -60,10 +60,6 @@ final class SymbolCoverageGridTest extends TestCase
         // import with it.
         'FilesystemBackend|ClassLike|search' => 'RFC 1 §3',
         'BuiltinBackend|ClassLike|search' => '#23',
-
-        // `SymbolExtractor` emits no `SymbolKind::Constant`, so an open document's
-        // constants never reach the index this reads. Found by this grid.
-        'OpenDocumentBackend|Constant|childrenOf' => 'SC.16',
     ];
 
     /**


### PR DESCRIPTION
Three of the four symbol backends can enumerate the constants in a namespace; the open-document one could not, because nothing ever put a constant into the index it reads. That is the same lookup-versus-enumeration split that made a `function_exists`-guarded polyfill resolve on hover while being invisible to completion (SC.5) and dropped a `class_exists`-guarded class out of open-document lookup (SC.9), on the one symbol namespace where it was still standing. S3.8b adds constant lookup next, so closing it now is what stops that landing on an enumeration with a hole in it.

Slice SC.16. Plan step: 0002 Step 3b. RFC 1 §4.2, §5.1.

## What changed

`SymbolExtractor` emits `SymbolKind::Constant` for the constants `DeclarationScanner` reports. Nine lines, because SC.3 already moved this class onto the scanner — the constants were being scanned and discarded.

Reading them from the scanner rather than matching `Stmt\Const_` here is what makes the set agree with the on-disk backends: `define()` with a literal name, several declarators in one `const` statement, and a declaration nested in a function body all count, while a computed name does not.

## Behaviour

No user-visible change. `NamespaceCandidates` still drops every catalog symbol that is not a class-like, so nothing surfaces these yet — S3.8b owns that, along with lookup.

## Tests

- `SymbolExtractorTest` gains a namespaced-constant case pinning name, FQN and location, and a case asserting the constants extracted equal the ones `DeclarationScanner` reports for the same AST, so this class cannot grow a second opinion about what declares a constant.
- `SymbolCoverageGridTest` loses its `OpenDocumentBackend|Constant|childrenOf` not-applicable entry. The grid fails a registration on a cell that answers, so the removal is the proof the cell now answers rather than a claim about it.
- Reuses the existing `AutoloadFiles/helpers.php` and `AutoloadFiles/globals.php` fixtures; no new ones.

## Checklist

- [x] An open document's `const` and literal `define()` declarations reach the symbol index
- [x] The extracted set equals `DeclarationScanner`'s for the same AST
- [x] The grid's not-applicable entry is removed, not re-pointed at another blocker
- [x] Baseline unchanged (39 -> 39): no new confined usage
- [x] No new fixtures

Candidate closes (pending review verification): none.
