### PR TITLE
Report the startable set; leave the pick to the human

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: do-next
-description: Implement the next build slice for the RFC-1 / Plan-0002 execution. Reads docs/architecture/build-manifest.md, computes the correct next slice from git/PR merge state (never a status field), enforces preconditions, and implements it under TDD on a slice/<id> branch. Invoke with /do-next.
+description: Report which build slices are startable for the RFC-1 / Plan-0002 execution, then implement the one chosen. Reads docs/architecture/build-manifest.md, derives status from git/PR merge state (never a status field), enforces preconditions, and implements under TDD on a slice/<id> branch. Invoke with /do-next.
 ---
 
-# do-next — implement the next build slice
+# do-next — report what is startable, then build the chosen slice
 
 Execute "Mode A" of `docs/architecture/build-procedure.md`. **Do not guess; halt and
-ask on any ambiguity.** The whole point is that a cold session picks the correct next
-slice from durable state, not from memory.
+ask on any ambiguity.** The point is that a cold session establishes what is *legal to
+start* from durable state rather than from memory — and then the human picks.
+
+**This skill does not choose the slice.** Manifest row order records when a row was
+filed, not what matters next, so picking the first startable row is an arbitrary choice
+dressed as a computed one. Report the set; let the human choose from it.
 
 ## 0. Read the goal first
 
@@ -26,7 +30,7 @@ noticed in passing, or easy.
 - Verify the base is green: run `composer test`. If red, **stop** — do not build on
   a red base.
 
-## 2. Compute the next slice X
+## 2. Compute the startable set
 
 - Read `docs/architecture/build-manifest.md`; parse the slice table (ID, Step,
   Depends on, Closes).
@@ -36,7 +40,7 @@ noticed in passing, or easy.
     `gh pr list --state merged --head slice/<ID> --json number` returns one.
   - `in-flight` — an open PR exists: `gh pr list --state open --head slice/<ID>`.
   - `todo` — neither.
-- `X` = the first `todo` slice whose every dependency is `done`.
+- The **startable set** = every `todo` slice whose every dependency is `done`.
 
 Dependencies are normally slice ids. The audit and Definition-of-Done gates use a
 collective form instead, which must be expanded before the check:
@@ -50,26 +54,49 @@ project's **Squash and Merge**: a squash rewrites the branch into one new commit
 `main`, so an ancestry check would report squashed slices as `todo` forever. Check
 `done` before `in-flight` so a squash-deleted branch is read as done, not unstarted.
 
-## 3. Safeguards (halt and report; do NOT proceed) if
+## 3. Check the set for phantoms
 
-- No slice is unblocked — report done / blocked / in-flight counts and stop.
-- Any slice is `in-flight` and not `done` — one slice in flight at a time; finish or
-  review it first.
+A row states work in prose, and prose goes stale: a row can claim a mechanism that
+already exists, or a removal already made. Selecting one costs a whole session before
+anyone notices, which has happened.
+
+Most cleanup rows are baseline drains, and the baseline is machine-readable, so check
+before offering: for each startable row that names files or entries it drains, confirm
+those entries are still in `phpstan-baseline.neon` / `deptrac.baseline.yaml`. A row
+whose claimed entries are gone is a **phantom** — report it as such rather than
+offering it, and say what appears to have discharged it.
+
+For a row that drains no baseline entry, spot-check its central claim against the code
+before offering it. One `grep` is enough; the failure mode is a row asserting that
+something is absent when it is present.
+
+## 4. Safeguards (halt and report; do NOT proceed) if
+
+- Nothing is startable — report done / blocked / in-flight counts and stop.
 - A slice's branch is merged while a dependency is not — surface the state drift.
 
-## 4. Explain X
+Slices already in flight do **not** block a report. Name them so the human can see what
+is open, and let them decide whether to start another.
 
-Read X's plan step in `docs/architecture/0002-execution-plan.md` for its acceptance
-criteria, and the RFC sections it cites in `0001-foundational-architecture.md`. Then
-describe the work in plain english and **wait** for approval, clarification, or
-modification before writing anything.
+## 5. Report the set and wait
+
+Report every startable slice as one line: id, what it does in plain english, and what
+it discharges — baseline entries drained, or the scheduled slice it unblocks. Mark any
+phantom found in step 3. Then **stop and wait** for the human to pick. Do not
+recommend one unless asked.
+
+Once a slice X is chosen, read its plan step in
+`docs/architecture/0002-execution-plan.md` for the acceptance criteria and the RFC
+sections it cites in `0001-foundational-architecture.md`. Describe the work in plain
+english and **wait** for approval, clarification, or modification before writing
+anything.
 
 Lead that description with X's answer to the goal test: what two features could
 disagree about without X, or which scheduled feature X unblocks. If you cannot write
 that sentence from the plan, **stop and ask** — a slice whose purpose you cannot state
 is one you will over- or under-build.
 
-## 5. Implement X
+## 6. Implement X
 
 - Create `slice/<X>` off `main`.
 - TDD:
@@ -88,7 +115,7 @@ is one you will over- or under-build.
 - If you hit a fundamental design question the plan does not answer, **STOP and ask**
   — do not invent an interpretation.
 
-## 6. Open the PR and report
+## 7. Open the PR and report
 
 - PR title carries no issue number; the body opens with what two features could have
   disagreed about without this change (or what it unblocks), then cites the slice id,
@@ -96,5 +123,5 @@ is one you will over- or under-build.
 - List manifest `Closes` candidates as "Candidate closes (pending review
   verification): #n" — do **not** wire `Closes #n` here; that is the reviewer's job
   after reading the issue body.
-- Report the PR URL and the **next** computed slice, so a follow-up `/do-next` is
-  predictable.
+- Report the PR URL, and the startable set as it now stands, so the human can pick the
+  next one without re-deriving it.

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -134,7 +134,7 @@ burn 75k+ tokens re-deriving the whole measurement.
 - `gh pr ready` if the PR was a draft.
 - Report: **"Pass clean. Verified closes: #n. Ready to land — merge when ready."**
   Do **not** auto-merge — merging is irreversible and outward-facing; the user lands.
-- Report the next computed slice for after landing.
+- Report the slices that become startable once this lands; do not pick one.
 
 ## 5. Close every pass against the goal
 

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -9,14 +9,17 @@
 Execute the plan across many short sessions without holding state in your head.
 Two commands:
 
-- **"do the next step"** — implement the correct next slice.
+- **"do the next step"** — report which slices are startable, then build the one
+  chosen.
 - **"review this step's branch"** — cleanroom-review and fix a slice, in a fresh
   session.
 
-The safeguard that makes this usable when you are juggling other work: **the next
-step is computed, never remembered.** A session determines what to do from durable,
-checkable state and *halts and asks* when that state is ambiguous. This is one or
-two notches below hands-off autonomy by design.
+The safeguard that makes this usable when you are juggling other work: **what is
+startable is computed, never remembered.** A session determines that from durable,
+checkable state and *halts and asks* when the state is ambiguous. Which of them to
+build is yours to say — the manifest records dependencies, which are checkable, and
+not priority, which is not. This is one or two notches below hands-off autonomy by
+design.
 
 ## The goal every slice serves
 
@@ -82,12 +85,17 @@ happens outside the tool.
     (`gh pr list --state merged --head slice/<id>`).
   - `in-flight` — an **open PR** exists for `slice/<id>`.
   - `todo` — neither.
-- The **next slice** = the first `todo` in the manifest whose dependencies are all
-  `done`. A dependency is normally a slice id; the audit/DoD gates instead use a
-  collective form, resolved before the check: **`all Step N`** expands to every other
-  slice whose Step column is `N` (sub-steps included), and **`all prior`** to every
-  other slice in the table. A gate depends on its whole section, so it cannot run
-  while any slice of that section is unbuilt — which an id chain does not guarantee.
+- The **startable set** = every `todo` whose dependencies are all `done`. A dependency
+  is normally a slice id; the audit/DoD gates instead use a collective form, resolved
+  before the check: **`all Step N`** expands to every other slice whose Step column is
+  `N` (sub-steps included), and **`all prior`** to every other slice in the table. A
+  gate depends on its whole section, so it cannot run while any slice of that section
+  is unbuilt — which an id chain does not guarantee.
+- **Which startable slice to build is a human choice, not a computed one.** Row order
+  records when a row was filed; it is not a priority. Once sections are worked out of
+  sequence — which the `SC.*` cleanup rows invite — the first startable row is an
+  arbitrary pick, and ordering intent written into a note rather than into `Depends on`
+  is invisible to the tool that reads the table.
 
 Because status is computed from merge reality, a cold session cannot be misled by a
 stale field, and nothing needs updating by hand.
@@ -119,25 +127,33 @@ squash-deleted branch is never misread as unstarted.
 
 1. **Preconditions (halt if unmet).** Working tree clean; on `main`; `main` synced
    with origin; `composer test` green on `main`. If any fails, report and stop.
-2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
-   state; `X` = first `todo` whose dependencies are all `done`.
-3. **Safeguards (halt and ask, do not guess) if:**
-   - nothing is unblocked (report how many are `done` / blocked / in-flight);
-   - a slice is already `in-flight` that is not yet `done` (finish or review it
-     first — one slice in flight at a time);
+2. **Compute the startable set.** Parse the manifest; compute each slice's status from
+   merged-PR state; the set is every `todo` whose dependencies are all `done`.
+3. **Screen for phantoms.** A row states its work in prose, which goes stale — it can
+   claim a mechanism that already exists or a removal already made, and selecting one
+   costs a session before anyone notices. For a row that names baseline entries it
+   drains, confirm they are still there; for one that does not, spot-check its central
+   claim against the code. Report a phantom instead of offering it.
+4. **Safeguards (halt and ask, do not guess) if:**
+   - nothing is startable (report how many are `done` / blocked / in-flight);
    - the manifest references a merged branch for a slice whose dependencies are not
      merged (state drift — surface it).
-4. **Explain X.** Describe in plain english the work to be done, lead with X's answer
-   to the goal test, then wait for approval, clarification, or modification.
-5. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
+
+   An open slice does not block the report: name what is in flight and let the human
+   decide whether to start another.
+5. **Report the set, then explain the chosen slice.** One line per startable slice —
+   id, what it does, what it discharges. Wait for a pick. Then describe that slice's
+   work in plain english, leading with its answer to the goal test, and wait for
+   approval, clarification, or modification.
+6. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
    (for a behavior-preserving step: parity fixtures first; for a step that
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
    `composer test`; open a PR citing X. Build what X's acceptance requires and
    nothing beyond it — a problem noticed in passing is reported, not solved (an
    `SC.*` row for duplication, a GitHub issue plus a can-the-next-slice-proceed
    call for a defect, a line in the PR body for tidiness).
-6. Stop. Report the PR and the *next* computed slice, so the human knows what a
-   follow-up "do the next step" would pick up.
+7. Stop. Report the PR and the startable set as it now stands, so the human can pick
+   the next one without re-deriving it.
 
 ## Mode B — "review this step's branch"
 
@@ -173,18 +189,22 @@ squash-deleted branch is never misread as unstarted.
    the change unblocks, if it is groundwork — or what corrections remain before it
    gets there. A pass that cannot write that paragraph has not understood the change
    well enough to approve it, and says so instead.
-7. Stop. Report what merged and the next computed slice.
+7. Stop. Report what merged and the startable set as it now stands.
 
-## The "X is always correct" guarantee, in one place
+## What the driver guarantees, in one place
 
-- Next step is **computed from git truth**, so a cold session cannot pick the wrong
-  one from a stale note.
+- The startable set is **derived from git truth**, so a cold session cannot be misled
+  by a stale note about what is already built.
+- **Selection is the human's.** The tool establishes what is legal to start and never
+  ranks it, because the manifest holds no priority to read — row order is filing
+  order. A tool that picked anyway would be presenting an arbitrary choice as a
+  derived one.
+- **Phantom rows are screened, not discovered mid-build** — a row's claim is checked
+  against the baseline or the code before it is offered.
 - The driver **halts and asks** at every fork it cannot resolve safely (unmet
-  precondition, nothing unblocked, a slice already in flight, state drift, a review
-  it cannot make clean).
+  precondition, nothing startable, state drift, a review it cannot make clean).
 - **Deterministic branch names** mean the review session always finds the right
   branch from the id.
-- **One slice in flight at a time** keeps "the next step" unambiguous.
 
 ## Relationship to GitHub issues
 


### PR DESCRIPTION
`/do-next` picked a slice by taking the first startable row in the manifest table. Row order records when a row was filed, not what matters next, so once sections started being worked out of sequence that pick became arbitrary — and ordering intent written into a note instead of into `Depends on` was invisible to the code reading the table. It computed S3.8b while a note two hundred lines below said SC.16 had to come first.

Thirteen slices are startable right now. "First row wins" among thirteen is not a decision, and presenting it as a computed one is worse than not computing it.

## What changed

**The tool reports; the human picks.** `/do-next` now derives the startable set and lists it — id, what each does, what each discharges — then stops. Deriving status from merged-PR state is untouched; that half worked all session, through a squash merge, a deleted remote branch, and slices taken out of order.

**Phantom screening, new step.** A row states its work in prose and prose goes stale. SC.10 was filed as "this invariant has no mechanism" when `phpstan.neon` had been enforcing it all along; selecting it would have cost a session to discover nothing was there. Most cleanup rows are baseline drains and the baseline is machine-readable, so a row whose claimed entries are gone is now detectable before it is offered rather than after it is started.

**The one-slice-in-flight halt is gone.** It existed to keep "the next step" unambiguous. With selection human-driven there is no ambiguity for it to resolve, and it actively blocks parking a slice under review to pick up an unrelated cleanup row.

`build-procedure.md` Mode A and the guarantees section are updated in the same commit, and `review-slice` no longer reports a "next computed slice" either. The two describing the same mechanism differently is the failure this repo keeps paying for.

## Checklist

- [x] Status derivation (merged-PR state, squash-safe, deterministic branch names) unchanged
- [x] Skill and `build-procedure.md` say the same thing
- [x] `review-slice`'s closing report no longer names a computed next slice
- [x] Genuine safeguards kept: nothing startable, state drift, unmet preconditions
- [x] Suite green

Candidate closes (pending review verification): none.
