### PR TITLE
Rank the startable set by kind, not row order

### DIFF
--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -50,14 +50,29 @@ project's **Squash and Merge**: a squash rewrites the branch into one new commit
 `main`, so an ancestry check would report squashed slices as `todo` forever. Check
 `done` before `in-flight` so a squash-deleted branch is read as done, not unstarted.
 
-## 3. Safeguards (halt and report; do NOT proceed) if
+## 3. Check X for phantoms
+
+A row states its work in prose, and prose goes stale: a row can claim a mechanism that
+already exists, or a removal already made. Selecting one costs a whole session before
+anyone notices, which has happened.
+
+Most cleanup rows are baseline drains, and the baseline is machine-readable, so check
+before offering: if X names files or entries it drains, confirm those entries are still
+in `phpstan-baseline.neon` / `deptrac.baseline.yaml`. If X drains no baseline entry,
+spot-check its central claim against the code — one `grep` is enough; the failure mode
+is a row asserting that something is absent when it is present.
+
+A row whose claim no longer holds is a **phantom**. Report it as such, say what appears
+to have discharged it, and move to the next candidate rather than building it.
+
+## 4. Safeguards (halt and report; do NOT proceed) if
 
 - No slice is unblocked — report done / blocked / in-flight counts and stop.
 - Any slice is `in-flight` and not `done` — one slice in flight at a time; finish or
   review it first.
 - A slice's branch is merged while a dependency is not — surface the state drift.
 
-## 4. Explain X
+## 5. Explain X
 
 Read X's plan step in `docs/architecture/0002-execution-plan.md` for its acceptance
 criteria, and the RFC sections it cites in `0001-foundational-architecture.md`. Then
@@ -69,7 +84,7 @@ disagree about without X, or which scheduled feature X unblocks. If you cannot w
 that sentence from the plan, **stop and ask** — a slice whose purpose you cannot state
 is one you will over- or under-build.
 
-## 5. Implement X
+## 6. Implement X
 
 - Create `slice/<X>` off `main`.
 - TDD:
@@ -88,7 +103,7 @@ is one you will over- or under-build.
 - If you hit a fundamental design question the plan does not answer, **STOP and ask**
   — do not invent an interpretation.
 
-## 6. Open the PR and report
+## 7. Open the PR and report
 
 - PR title carries no issue number; the body opens with what two features could have
   disagreed about without this change (or what it unblocks), then cites the slice id,

--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -7,7 +7,8 @@ description: Implement the next build slice for the RFC-1 / Plan-0002 execution.
 
 Execute "Mode A" of `docs/architecture/build-procedure.md`. **Do not guess; halt and
 ask on any ambiguity.** The whole point is that a cold session picks the correct next
-slice from durable state, not from memory.
+slice from durable state, not from memory — what *may* start from git, what starts
+*first* from the manifest's `Kind` column.
 
 ## 0. Read the goal first
 
@@ -26,9 +27,9 @@ noticed in passing, or easy.
 - Verify the base is green: run `composer test`. If red, **stop** — do not build on
   a red base.
 
-## 2. Compute the next slice X
+## 2. Compute the startable set, then rank it
 
-- Read `docs/architecture/build-manifest.md`; parse the slice table (ID, Step,
+- Read `docs/architecture/build-manifest.md`; parse the slice table (ID, Step, Kind,
   Depends on, Closes).
 - Compute each slice's status from **GitHub PR merge state** (not git commit
   ancestry, and not any written status), checked in this order:
@@ -36,7 +37,11 @@ noticed in passing, or easy.
     `gh pr list --state merged --head slice/<ID> --json number` returns one.
   - `in-flight` — an open PR exists: `gh pr list --state open --head slice/<ID>`.
   - `todo` — neither.
-- `X` = the first `todo` slice whose every dependency is `done`.
+- The **startable set** = every `todo` slice whose every dependency is `done`.
+- `X` = its highest-ranked member by the `Kind` column: **`defect`** first, then
+  **`cleanup`**, then **`scaffold`**. Within a kind, prefer the row draining the most
+  `phpstan-baseline.neon` / `deptrac.baseline.yaml` entries; row order breaks what is
+  left. Row order carries no priority of its own — it records when a row was filed.
 
 Dependencies are normally slice ids. The audit and Definition-of-Done gates use a
 collective form instead, which must be expanded before the check:
@@ -78,8 +83,9 @@ open PR blocking every other row is a stall, not a safeguard.
 
 Read X's plan step in `docs/architecture/0002-execution-plan.md` for its acceptance
 criteria, and the RFC sections it cites in `0001-foundational-architecture.md`. Then
-describe the work in plain english and **wait** for approval, clarification, or
-modification before writing anything.
+describe the work in plain english, name the rest of the startable set in one line
+each so an override costs the human a single id, and **wait** for approval,
+clarification, or modification before writing anything.
 
 Lead that description with X's answer to the goal test: what two features could
 disagree about without X, or which scheduled feature X unblocks. If you cannot write
@@ -113,5 +119,5 @@ is one you will over- or under-build.
 - List manifest `Closes` candidates as "Candidate closes (pending review
   verification): #n" — do **not** wire `Closes #n` here; that is the reviewer's job
   after reading the issue body.
-- Report the PR URL and the **next** computed slice, so a follow-up `/do-next` is
-  predictable.
+- Report the PR URL and the **next** computed slice, plus the rest of the startable
+  set, so a follow-up `/do-next` is predictable and an override is cheap.

--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -68,9 +68,11 @@ to have discharged it, and move to the next candidate rather than building it.
 ## 4. Safeguards (halt and report; do NOT proceed) if
 
 - No slice is unblocked — report done / blocked / in-flight counts and stop.
-- Any slice is `in-flight` and not `done` — one slice in flight at a time; finish or
-  review it first.
 - A slice's branch is merged while a dependency is not — surface the state drift.
+
+An open slice does **not** halt this. Name what is in flight so the human can see it,
+and carry on — a slice waits on another only through `Depends on`, and an unrelated
+open PR blocking every other row is a stall, not a safeguard.
 
 ## 5. Explain X
 

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -134,7 +134,8 @@ burn 75k+ tokens re-deriving the whole measurement.
 - `gh pr ready` if the PR was a draft.
 - Report: **"Pass clean. Verified closes: #n. Ready to land — merge when ready."**
   Do **not** auto-merge — merging is irreversible and outward-facing; the user lands.
-- Report the next computed slice for after landing.
+- Report the next computed slice for after landing (highest `Kind` in the startable
+  set), and the rest of that set in one line each.
 
 ## 5. Close every pass against the goal
 

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -90,7 +90,7 @@ re-runs repo-wide as its completion gate.
     SC.11  —     cleanup   Move NameKind into Domain                          —                 —
     SC.6   —     defect    Symbol-name keys -> NameKind::normalize            SC.11             —
     S3.8d  3b    scaffold  Collapse per-kind lookup to one call               SC.5              —
-    S3.8b  3b    scaffold  lookupConstant project reach                       S3.7d,SC.2,SC.6,S3.8d  —
+    S3.8b  3b    scaffold  lookupConstant project reach                       S3.7d,SC.2,SC.6,SC.16,S3.8d  —
     S3.8c  3b    scaffold  Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
     S3.9a  3b    scaffold  Generalize search to a kind parameter              S3.8a,S3.8d       —
     S3.9b  3b    scaffold  Function search + FunctionCandidates migration     S3.9a             —
@@ -320,7 +320,8 @@ Notes:
   - **SC.16** — `SymbolExtractor` emits no `SymbolKind::Constant`, so a global constant in an open document is never indexed and `OpenDocumentBackend::childrenOf` cannot enumerate it, while the on-disk and built-in backends both do.
     `WorkspaceNamespaceSource` already maps the kind, so the gap is upstream in the extractor.
     Found by the S3.8d coverage grid on its first run.
-    Ungated, and ahead of S3.8b — constant lookup landing on an enumeration blind to open documents would rebuild the §4.2 split on the third symbol namespace.
+    Ungated itself, and a dependency of S3.8b — constant lookup landing on an enumeration blind to open documents would rebuild the §4.2 split on the third symbol namespace.
+    That is a real ordering requirement, so it is in `Depends on` rather than implied by where the row sits.
   - **SC.17** — telling the parts that hold file-derived state that a file changed is written out three times: `DocumentSymbolSink` over a list it is handed, `FilesystemBackend` over its catalog and locator, `CompositeSymbolLocator` over its routes.
     The latter two steer by an `instanceof` test, three in all; the sink instead takes a pre-filtered list, so the composition root already decides who holds state and the knowledge is split between the two styles.
     So adding a holder means finding its parent in that tree by hand, and missing one is silent — the stale value is still served and nothing fails.

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -13,10 +13,17 @@ Append later phases as they are reached; do not create the whole tree up front.
 ## Columns
 
 - **ID** — stable slice id; the branch is `slice/<ID>`. An id is assigned when the slice is
-  filed and never changes, because a merged slice is found by it. It therefore does **not**
-  imply execution order: order is this table's row order plus `Depends on`, so a row can be
-  inserted anywhere without renumbering merged work.
+  filed and never changes, because a merged slice is found by it. It carries **no** ordering
+  meaning, and neither does row order, which records when a row was filed: what may start is
+  `Depends on`, and what starts first is `Kind`. So a row can be inserted anywhere without
+  renumbering merged work.
 - **Step** — the plan step in 0002 that owns the acceptance criteria.
+- **Kind** — what the row is, which is what the driver ranks the startable rows by:
+  **`defect`** (behavior is wrong today — two features already disagree), **`cleanup`**
+  (duplication or dead code that predates the plan; no feature is wrong yet), **`scaffold`**
+  (the plan's own construction work — every row with a Step). Ranked `defect`, then
+  `cleanup`, then `scaffold`, so the unblocked cleanup is front-loaded and the guardrail
+  baselines drain before the rework's feature-adjacent reach lands on top of them.
 - **Depends on** — slice ids that must be `done` (merged) first. Two collective forms
   exist so a gate's dependencies cannot go stale as slices are added: **`all Step N`**
   means every *other* slice whose Step column is `N` (sub-steps included, so `all Step
@@ -26,22 +33,22 @@ Append later phases as they are reached; do not create the whole tree up front.
 
 ## Wave 1 — Steps 0, 1, P, 2
 
-    ID     Step  Title                                              Depends on        Closes
-    -----  ----  -------------------------------------------------  ----------------  -------
-    S0.1   0     Instrument parse count/time; run the spike         —                 —
-    S0.2   0     Request-scoped parse dedup (if spike warrants)     S0.1              —
-    S1.1   1     Read ClientCapabilities -> SessionCapabilities     —                 —
-    S1.2   1     Negotiate positionEncoding; convert at the edge    S1.1              #192
-    S1.3   1     Shape hover markup / snippets via capabilities     S1.1              #22
-    S1.4   1     Lifecycle state + malformed-frame robustness       S1.1              —
-    S1.5   1     Position round-trip corpus (regression net)        S1.2              —
-    SP.1   P     Per-surface parity harness + branch-coverage gate  —                 —
-    S2.1   2     Define SymbolSource/SymbolSink + delegating facade SP.1              —
-    S2.2   2     Migrate ClassCandidates -> search                  S2.1              —
-    S2.3   2     Migrate NamespaceCandidates -> childrenOf          S2.1              —
-    S2.4   2     Migrate SymbolResolver class lookups -> lookupClassLike  S2.1        —
-    S2.5   2     Migrate TextDocumentSyncHandler -> SymbolSink      S2.1              —
-    S2.6   2     §4.2 enforcement rule (scoped-exempt FunctionRepo) S2.2,S2.3,S2.4,S2.5  —
+    ID     Step  Kind      Title                                              Depends on        Closes
+    -----  ----  --------  -------------------------------------------------  ----------------  -------
+    S0.1   0     scaffold  Instrument parse count/time; run the spike         —                 —
+    S0.2   0     scaffold  Request-scoped parse dedup (if spike warrants)     S0.1              —
+    S1.1   1     scaffold  Read ClientCapabilities -> SessionCapabilities     —                 —
+    S1.2   1     scaffold  Negotiate positionEncoding; convert at the edge    S1.1              #192
+    S1.3   1     scaffold  Shape hover markup / snippets via capabilities     S1.1              #22
+    S1.4   1     scaffold  Lifecycle state + malformed-frame robustness       S1.1              —
+    S1.5   1     scaffold  Position round-trip corpus (regression net)        S1.2              —
+    SP.1   P     scaffold  Per-surface parity harness + branch-coverage gate  —                 —
+    S2.1   2     scaffold  Define SymbolSource/SymbolSink + delegating facade SP.1              —
+    S2.2   2     scaffold  Migrate ClassCandidates -> search                  S2.1              —
+    S2.3   2     scaffold  Migrate NamespaceCandidates -> childrenOf          S2.1              —
+    S2.4   2     scaffold  Migrate SymbolResolver class lookups -> lookupClassLike  S2.1        —
+    S2.5   2     scaffold  Migrate TextDocumentSyncHandler -> SymbolSink      S2.1              —
+    S2.6   2     scaffold  §4.2 enforcement rule (scoped-exempt FunctionRepo) S2.2,S2.3,S2.4,S2.5  —
 
 Notes:
 
@@ -63,54 +70,54 @@ entries (0002, reframed 2026-08-10); Step Z is the terminal Definition-of-Done
 gate. Steps 3 and 4 each end with a duplication audit (S3.11, S4.7), which Step Z
 re-runs repo-wide as its completion gate.
 
-    ID     Step  Title                                              Depends on        Closes
-    -----  ----  -------------------------------------------------  ----------------  -------
-    S3.1   3a    Existing caches -> replaceable §5.3 seam (verify)  S2.6              —
-    S3.2   3a    Dedupe the duplicate ComposerAutoloadMap           S2.6              —
-    S3.3   3a    Named backends + fixed-precedence composite        S3.1,S3.2         —
-    S3.4   3a    One parse / one write path + consistency check     S3.3              —
-    S3.5   3a    External-file-change invalidation                  S3.3,S3.4         —
-    S3.6   3b    Function-surface golden + Builtin enum oracle      S3.3              —
-    S3.7a  3b    Read autoload.files into ComposerAutoloadMap       S3.3              —
-    S3.7b  3b    Scan a file for the declarations it makes          S3.3              —
-    S3.7c  3b    ClassLocator -> kind-agnostic SymbolLocator        S3.3,SC.4         —
-    S3.7d  3b    Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
-    S3.7e  3b    Enumerate the derived index in childrenOf          S3.7d             —
-    S3.8a  3b    lookupFunction project reach                       S3.6,S3.7d        —
-    SC.2   —     Retire ScopeFinder's superseded import extraction  —                 —
-    SC.5   —     One declaration finder, not five hand-written      —                 —
-    SC.9   —     Class-like registration -> one declaration scan   —                 —
-    SC.11  —     Move NameKind into Domain                          —                 —
-    SC.6   —     Symbol-name keys -> NameKind::normalize           SC.11             —
-    S3.8d  3b    Collapse per-kind lookup to one call               SC.5              —
-    S3.8b  3b    lookupConstant project reach                       S3.7d,SC.2,SC.6,S3.8d  —
-    S3.8c  3b    Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
-    S3.9a  3b    Generalize search to a kind parameter              S3.8a,S3.8d       —
-    S3.9b  3b    Function search + FunctionCandidates migration     S3.9a             —
-    S3.10  3b    Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
-    S3.11  3     Step 3 duplication audit                          all Step 3        —
-    S4.1   4     TypeClassifier + §4.5/§4.6 static rules            S2.6              —
-    S4.2   4     Extract node locator + scope analyzer              S3.8c,S4.1        —
-    S4.3   4     Extract member-access + call-context detectors     S4.2              —
-    S4.4   4     Extract name-context resolver                      S4.2              —
-    S4.5   4     Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
-    S4.8   4     Bring TypeInference inside the boundary            S4.2              —
-    S4.6   4     SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5,S4.8  —
-    S4.7   4     Step 4 duplication audit                          all Step 4        —
-    SC.1   —     Delete the dead WorkspaceIndexer                    —                 —
-    SC.3   —     SymbolExtractor reads DeclarationScanner            —                 —
-    SC.4   —     Dedupe the hand-rolled file:// conversion           —                 —
-    SC.7   —     Six member-hierarchy walks -> one                   —                 —
-    SC.8   —     Prefix matching: SymbolIndex -> PrefixMatcher       —                 —
-    SC.12  —     Move MemberFilter out of Resolution                 —                 —
-    SC.13  —     Settle Domain->Utility type placement               —                 —
-    SC.14  —     Filter BuiltinBackend class-like lookup to internal —                 —
-    SC.15  —     Oracle corpus: trait adaptations and enums          —                 —
-    SC.16  —     Index an open document's global constants          —                 —
-    SC.17  —     Collapse the hand-routed invalidation fan-out      —                 —
-    SC.18  —     One home for the kind-qualified symbol key         SC.13             —
-    SC.19  —     Own the four unowned baseline entries               —                 —
-    SZ.1   Z     Definition of Done gate + repo-wide dup audit      all prior         —
+    ID     Step  Kind      Title                                              Depends on        Closes
+    -----  ----  --------  -------------------------------------------------  ----------------  -------
+    S3.1   3a    scaffold  Existing caches -> replaceable §5.3 seam (verify)  S2.6              —
+    S3.2   3a    scaffold  Dedupe the duplicate ComposerAutoloadMap           S2.6              —
+    S3.3   3a    scaffold  Named backends + fixed-precedence composite        S3.1,S3.2         —
+    S3.4   3a    scaffold  One parse / one write path + consistency check     S3.3              —
+    S3.5   3a    scaffold  External-file-change invalidation                  S3.3,S3.4         —
+    S3.6   3b    scaffold  Function-surface golden + Builtin enum oracle      S3.3              —
+    S3.7a  3b    scaffold  Read autoload.files into ComposerAutoloadMap       S3.3              —
+    S3.7b  3b    scaffold  Scan a file for the declarations it makes          S3.3              —
+    S3.7c  3b    scaffold  ClassLocator -> kind-agnostic SymbolLocator        S3.3,SC.4         —
+    S3.7d  3b    scaffold  Derived autoload.files index, for all three kinds  S3.7a,S3.7b,S3.7c —
+    S3.7e  3b    scaffold  Enumerate the derived index in childrenOf          S3.7d             —
+    S3.8a  3b    scaffold  lookupFunction project reach                       S3.6,S3.7d        —
+    SC.2   —     defect    Retire ScopeFinder's superseded import extraction  —                 —
+    SC.5   —     defect    One declaration finder, not five hand-written      —                 —
+    SC.9   —     defect    Class-like registration -> one declaration scan    —                 —
+    SC.11  —     cleanup   Move NameKind into Domain                          —                 —
+    SC.6   —     defect    Symbol-name keys -> NameKind::normalize            SC.11             —
+    S3.8d  3b    scaffold  Collapse per-kind lookup to one call               SC.5              —
+    S3.8b  3b    scaffold  lookupConstant project reach                       S3.7d,SC.2,SC.6,S3.8d  —
+    S3.8c  3b    scaffold  Retire the AST-in function lookup from consumers   S3.8a,SC.5        —
+    S3.9a  3b    scaffold  Generalize search to a kind parameter              S3.8a,S3.8d       —
+    S3.9b  3b    scaffold  Function search + FunctionCandidates migration     S3.9a             —
+    S3.10  3b    scaffold  Remove §4.2 fn-path exemption; retire scaffolding  S3.8b,S3.8c,S3.9b —
+    S3.11  3     scaffold  Step 3 duplication audit                           all Step 3        —
+    S4.1   4     scaffold  TypeClassifier + §4.5/§4.6 static rules            S2.6              —
+    S4.2   4     scaffold  Extract node locator + scope analyzer              S3.8c,S4.1        —
+    S4.3   4     scaffold  Extract member-access + call-context detectors     S4.2              —
+    S4.4   4     scaffold  Extract name-context resolver                      S4.2              —
+    S4.5   4     scaffold  Narrow TextFallbackHelper to FQN recovery          S4.3,S4.4         —
+    S4.8   4     scaffold  Bring TypeInference inside the boundary            S4.2              —
+    S4.6   4     scaffold  SymbolResolver -> glue; CodeResolver positional    S4.2,S4.3,S4.4,S4.5,S4.8  —
+    S4.7   4     scaffold  Step 4 duplication audit                           all Step 4        —
+    SC.1   —     cleanup   Delete the dead WorkspaceIndexer                   —                 —
+    SC.3   —     cleanup   SymbolExtractor reads DeclarationScanner           —                 —
+    SC.4   —     cleanup   Dedupe the hand-rolled file:// conversion          —                 —
+    SC.7   —     defect    Six member-hierarchy walks -> one                  —                 —
+    SC.8   —     cleanup   Prefix matching: SymbolIndex -> PrefixMatcher      —                 —
+    SC.12  —     cleanup   Move MemberFilter out of Resolution                —                 —
+    SC.13  —     cleanup   Settle Domain->Utility type placement              —                 —
+    SC.14  —     defect    Filter BuiltinBackend class-like lookup to internal —                —
+    SC.15  —     cleanup   Oracle corpus: trait adaptations and enums         —                 —
+    SC.16  —     defect    Index an open document's global constants          —                 —
+    SC.17  —     cleanup   Collapse the hand-routed invalidation fan-out      —                 —
+    SC.18  —     cleanup   One home for the kind-qualified symbol key         SC.13             —
+    SC.19  —     cleanup   Own the four unowned baseline entries              —                 —
+    SZ.1   Z     scaffold  Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
 
@@ -194,11 +201,12 @@ Notes:
   predate the plan rather than scaffolding it introduced, so no step's acceptance covers
   them — which is exactly how they went unowned until an audit found them. They are in
   the table so `/do-next` can select them and SZ.1 can require them, not because a step
-  produced them. A removal with no owning slice is a defect; put it here.
-  - **SC.2, SC.5 and SC.6 sit up in the Step 3b rows, not here.** Each is a live defect
-    rather than a redundancy, and row order is what `/do-next` uses to break ties between
-    unblocked slices — in this block they would be picked after S4.1, leaving wrong
-    completion results standing for another slice or two. Keep them ahead of S3.8b; their
+  produced them. A removal with no owning slice is how debt stays unowned; put it here.
+  Their `Kind` splits them: `defect` where behavior is wrong today, `cleanup` where it is
+  redundancy no feature can yet disagree over.
+  - **SC.2, SC.5 and SC.6 sit up in the Step 3b rows, not here** — as a reading aid only.
+    Each is `defect`, so the `Kind` ranking is what puts it ahead of the Step 3b scaffold
+    it must precede; row position carries none of that weight and never should have. Their
     notes stay below with the rest of the `SC.*` explanations.
 
     Their Step column stays `—`, so `all Step 3` does not expand to include them and S3.11

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -121,22 +121,27 @@ squash-deleted branch is never misread as unstarted.
    with origin; `composer test` green on `main`. If any fails, report and stop.
 2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
    state; `X` = first `todo` whose dependencies are all `done`.
-3. **Safeguards (halt and ask, do not guess) if:**
+3. **Screen X for phantoms.** A row states its work in prose, which goes stale — it can
+   claim a mechanism that already exists or a removal already made, and selecting one
+   costs a session before anyone notices. If X names baseline entries it drains, confirm
+   they are still there; if it drains none, spot-check its central claim against the
+   code. Report a phantom and move to the next candidate instead of building it.
+4. **Safeguards (halt and ask, do not guess) if:**
    - nothing is unblocked (report how many are `done` / blocked / in-flight);
    - a slice is already `in-flight` that is not yet `done` (finish or review it
      first — one slice in flight at a time);
    - the manifest references a merged branch for a slice whose dependencies are not
      merged (state drift — surface it).
-4. **Explain X.** Describe in plain english the work to be done, lead with X's answer
+5. **Explain X.** Describe in plain english the work to be done, lead with X's answer
    to the goal test, then wait for approval, clarification, or modification.
-5. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
+6. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
    (for a behavior-preserving step: parity fixtures first; for a step that
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
    `composer test`; open a PR citing X. Build what X's acceptance requires and
    nothing beyond it — a problem noticed in passing is reported, not solved (an
    `SC.*` row for duplication, a GitHub issue plus a can-the-next-slice-proceed
    call for a defect, a line in the PR body for tidiness).
-6. Stop. Report the PR and the *next* computed slice, so the human knows what a
+7. Stop. Report the PR and the *next* computed slice, so the human knows what a
    follow-up "do the next step" would pick up.
 
 ## Mode B — "review this step's branch"
@@ -179,6 +184,8 @@ squash-deleted branch is never misread as unstarted.
 
 - Next step is **computed from git truth**, so a cold session cannot pick the wrong
   one from a stale note.
+- **A row's claim is screened before it is built**, so a phantom — work already
+  discharged by something else — is reported rather than discovered mid-slice.
 - The driver **halts and asks** at every fork it cannot resolve safely (unmet
   precondition, nothing unblocked, a slice already in flight, state drift, a review
   it cannot make clean).

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -82,15 +82,30 @@ happens outside the tool.
     (`gh pr list --state merged --head slice/<id>`).
   - `in-flight` — an **open PR** exists for `slice/<id>`.
   - `todo` — neither.
-- The **next slice** = the first `todo` in the manifest whose dependencies are all
-  `done`. A dependency is normally a slice id; the audit/DoD gates instead use a
-  collective form, resolved before the check: **`all Step N`** expands to every other
-  slice whose Step column is `N` (sub-steps included), and **`all prior`** to every
-  other slice in the table. A gate depends on its whole section, so it cannot run
-  while any slice of that section is unbuilt — which an id chain does not guarantee.
+- The **startable set** = every `todo` whose dependencies are all `done`. A dependency
+  is normally a slice id; the audit/DoD gates instead use a collective form, resolved
+  before the check: **`all Step N`** expands to every other slice whose Step column is
+  `N` (sub-steps included), and **`all prior`** to every other slice in the table. A
+  gate depends on its whole section, so it cannot run while any slice of that section
+  is unbuilt — which an id chain does not guarantee.
+- The **next slice** = the highest-ranked member of that set, by the manifest's `Kind`
+  column: **`defect`** first, then **`cleanup`**, then **`scaffold`**; within a kind,
+  the row draining the most guardrail-baseline entries, and row order last. Report the
+  rest of the set alongside it — an override is a slice id said out loud, not a reason
+  to leave the pick unmade.
 
 Because status is computed from merge reality, a cold session cannot be misled by a
 stale field, and nothing needs updating by hand.
+
+**Why `Kind` outranks row order.** Row order records when a row was filed, so once
+sections run out of sequence — which the `SC.*` rows invite — picking the first
+startable row is an arbitrary choice presented as a derived one. `Kind` is the
+priority, stated once: fix what is already wrong, then front-load the unblocked
+cleanup, then build. The guardrail baselines are the reason. Most of what they still
+freeze is the M×N traversal and text-pattern debt this rework exists to remove, so
+draining every entry that is reachable *now* keeps the feature-adjacent reach still
+scheduled from landing on top of it. The rest of the drain is gated on that reach and
+comes with it.
 
 **Squash-merge safety.** Status is derived from GitHub's **PR merge state**, which is
 set identically for squash, rebase, and merge-commit — not from git commit ancestry.
@@ -120,7 +135,8 @@ squash-deleted branch is never misread as unstarted.
 1. **Preconditions (halt if unmet).** Working tree clean; on `main`; `main` synced
    with origin; `composer test` green on `main`. If any fails, report and stop.
 2. **Compute X.** Parse the manifest; compute each slice's status from merged-PR
-   state; `X` = first `todo` whose dependencies are all `done`.
+   state; the startable set is every `todo` whose dependencies are all `done`; `X` is
+   its highest-ranked member by `Kind` (`defect`, then `cleanup`, then `scaffold`).
 3. **Screen X for phantoms.** A row states its work in prose, which goes stale — it can
    claim a mechanism that already exists or a removal already made, and selecting one
    costs a session before anyone notices. If X names baseline entries it drains, confirm
@@ -135,7 +151,8 @@ squash-deleted branch is never misread as unstarted.
    on another only through `Depends on`, so an unrelated open PR blocking every other
    row is a stall rather than a safeguard.
 5. **Explain X.** Describe in plain english the work to be done, lead with X's answer
-   to the goal test, then wait for approval, clarification, or modification.
+   to the goal test, and name the rest of the startable set in one line each so an
+   override is cheap. Then wait for approval, clarification, or modification.
 6. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
    (for a behavior-preserving step: parity fixtures first; for a step that
    introduces an invariant seam: its §8.1 enforcement rule in the same slice); run
@@ -184,8 +201,9 @@ squash-deleted branch is never misread as unstarted.
 
 ## The "X is always correct" guarantee, in one place
 
-- Next step is **computed from git truth**, so a cold session cannot pick the wrong
-  one from a stale note.
+- What may start is **computed from git truth**, so a cold session cannot pick the
+  wrong one from a stale note; what starts first is **read from `Kind`**, so the
+  priority is stated in the manifest rather than implied by row order.
 - **A row's claim is screened before it is built**, so a phantom — work already
   discharged by something else — is reported rather than discovered mid-slice.
 - The driver **halts and asks** at every fork it cannot resolve safely (unmet

--- a/docs/architecture/build-procedure.md
+++ b/docs/architecture/build-procedure.md
@@ -128,10 +128,12 @@ squash-deleted branch is never misread as unstarted.
    code. Report a phantom and move to the next candidate instead of building it.
 4. **Safeguards (halt and ask, do not guess) if:**
    - nothing is unblocked (report how many are `done` / blocked / in-flight);
-   - a slice is already `in-flight` that is not yet `done` (finish or review it
-     first — one slice in flight at a time);
    - the manifest references a merged branch for a slice whose dependencies are not
      merged (state drift — surface it).
+
+   An open slice does not halt this: name what is in flight and carry on. A slice waits
+   on another only through `Depends on`, so an unrelated open PR blocking every other
+   row is a stall rather than a safeguard.
 5. **Explain X.** Describe in plain english the work to be done, lead with X's answer
    to the goal test, then wait for approval, clarification, or modification.
 6. **Implement X.** Create `slice/<X>`; work the plan-step's acceptance under TDD
@@ -146,8 +148,8 @@ squash-deleted branch is never misread as unstarted.
 
 ## Mode B — "review this step's branch"
 
-1. **Identify the slice.** The `in-flight` one, or the id given. Check out its
-   branch.
+1. **Identify the slice.** The id given, or the single `in-flight` one. If more than
+   one is in flight and no id was given, stop and ask which. Check out its branch.
 2. **Cleanroom review.** A fresh reviewer (subagent) sees **only** the goal section
    of this document, the slice's acceptance criteria, the relevant RFC sections, and
    the diff — **not** the implementer's reasoning or this conversation. It adversarially verifies:
@@ -187,11 +189,9 @@ squash-deleted branch is never misread as unstarted.
 - **A row's claim is screened before it is built**, so a phantom — work already
   discharged by something else — is reported rather than discovered mid-slice.
 - The driver **halts and asks** at every fork it cannot resolve safely (unmet
-  precondition, nothing unblocked, a slice already in flight, state drift, a review
-  it cannot make clean).
+  precondition, nothing unblocked, state drift, a review it cannot make clean).
 - **Deterministic branch names** mean the review session always finds the right
   branch from the id.
-- **One slice in flight at a time** keeps "the next step" unambiguous.
 
 ## Relationship to GitHub issues
 


### PR DESCRIPTION
Two features could disagree because the driver kept picking work by where a row happened to sit in the table. Row order records when a row was filed, so once the `SC.*` cleanup rows started running out of sequence, "the first startable row" was an arbitrary choice presented as a derived one — and the fix in use was to hand-hoist rows up the table, which nothing enforces and nothing checks.

Replaces #420, which reached the same diagnosis and concluded the driver should stop picking. It should keep picking; the manifest just had no priority to read.

## What changes

- **`Kind` column** on the manifest: `defect` (behavior is wrong today), `cleanup` (duplication or dead code, nothing disagrees yet), `scaffold` (the plan's own construction work). The classification was already in the row notes, as prose the tool cannot read.
- **Pick rule** reads it: `defect`, then `cleanup`, then `scaffold`; within a kind, the row draining the most guardrail-baseline entries. The whole startable set is reported alongside the pick, so an override costs one slice id.
- **Phantom screening** before building: a row that claims a mechanism already built, or a removal already made, is reported rather than discovered a session later. Baseline drains are checkable against the baseline files; other rows get one `grep`.
- **An open slice no longer stalls the next one.** A slice waits on another through `Depends on`; an unrelated open PR blocking every other row is a stall, not a safeguard. `review-slice` already asks which branch when more than one is open.
- **`S3.8b` now depends on `SC.16`.** That ordering was real and was being carried by row position. It belongs in `Depends on`.

## Why this ranking

Most of what the guardrail baselines still freeze is the M×N traversal and text-pattern debt this rework exists to remove. Front-loading the unblocked cleanup drains every entry reachable now, so the feature-adjacent reach still scheduled lands on the reworked shape rather than on top of the debt. The rest of the drain is gated on that reach and comes with it.

Documentation only.
