### PR TITLE
Walk the type graph once for every member kind

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,7 +13,7 @@ parameters:
 			path: src/Completion/NamedArgumentCandidates.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
 			path: src/Completion/PrefixMatcher.php
@@ -25,7 +25,7 @@ parameters:
 			path: src/Handler/CompletionHandler.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
 			path: src/Index/SymbolIndex.php
@@ -61,7 +61,7 @@ parameters:
 			path: src/Repository/DefaultFunctionRepository.php
 
 		-
-			message: '#^Calling strcasecmp\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strcasecmp\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 1
 			path: src/Resolution/ReferenceResolver.php
@@ -73,7 +73,7 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 1
 			path: src/Resolution/SymbolResolver.php
@@ -109,7 +109,7 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
 			path: src/Resolution/TextFallbackHelper.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,22 +13,10 @@ parameters:
 			path: src/Completion/NamedArgumentCandidates.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
 			path: src/Completion/PrefixMatcher.php
-
-		-
-			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Domain/ClassName.php
-
-		-
-			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Domain/MethodName.php
 
 		-
 			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'
@@ -37,7 +25,7 @@ parameters:
 			path: src/Handler/CompletionHandler.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
 			path: src/Index/SymbolIndex.php
@@ -73,13 +61,7 @@ parameters:
 			path: src/Repository/DefaultFunctionRepository.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Repository/MemberResolver.php
-
-		-
-			message: '#^Calling strcasecmp\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strcasecmp\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 1
 			path: src/Resolution/ReferenceResolver.php
@@ -91,7 +73,7 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 1
 			path: src/Resolution/SymbolResolver.php
@@ -127,7 +109,7 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, case rules for symbol names live in NameKind; non\-symbol uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule applies to a name is NameKind \(symbols\) or MemberKind \(members\); applying it is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
 			path: src/Resolution/TextFallbackHelper.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -61,9 +61,9 @@ parameters:
                 - 'strcasecmp()'
                 - 'strncasecmp()'
                 - 'mb_strtolower()'
-            message: 'case rules for symbol names live in NameKind; non-symbol uses may be allowlisted here consciously'
+            message: 'which case rule applies to a name is NameKind (symbols) or MemberKind (members); applying it is NameCase; other uses may be allowlisted here consciously'
             allowIn:
-                - src/Domain/NameKind.php
+                - src/Domain/NameCase.php
                 - src/Utility/NamespacePath.php # namespace paths are case-insensitive for every kind; not a symbol name
                 - src/Transport/MessageReader.php # HTTP header names
                 - src/Domain/Visibility.php # visibility keywords

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -61,7 +61,7 @@ parameters:
                 - 'strcasecmp()'
                 - 'strncasecmp()'
                 - 'mb_strtolower()'
-            message: 'which case rule applies to a name is NameKind (symbols) or MemberKind (members); applying it is NameCase; other uses may be allowlisted here consciously'
+            message: 'which case rule a name follows is NameKind (symbols) or MemberKind (class-like members); applying one is NameCase; other uses may be allowlisted here consciously'
             allowIn:
                 - src/Domain/NameCase.php
                 - src/Utility/NamespacePath.php # namespace paths are case-insensitive for every kind; not a symbol name

--- a/src/Completion/CompletionItemFactory.php
+++ b/src/Completion/CompletionItemFactory.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Completion;
 
 use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Protocol\Range;
-use Firehed\PhpLsp\Resolution\ResolvedConstant;
-use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
-use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\NamespacePath;
 
@@ -40,14 +38,11 @@ final class CompletionItemFactory
      */
     public static function forResolvedMember(ResolvedMember $member, bool $snippetSupport = false): array
     {
-        $kind = match (true) {
-            $member instanceof ResolvedMethod => CompletionItemKind::Method,
-            $member instanceof ResolvedProperty => CompletionItemKind::Property,
-            $member instanceof ResolvedConstant => CompletionItemKind::Constant,
-            $member instanceof ResolvedEnumCase => CompletionItemKind::EnumMember,
-            // @codeCoverageIgnoreStart
-            default => throw new \LogicException('Unexpected member type: ' . $member::class),
-            // @codeCoverageIgnoreEnd
+        $kind = match ($member->getMemberKind()) {
+            MemberKind::Constant => CompletionItemKind::Constant,
+            MemberKind::EnumCase => CompletionItemKind::EnumMember,
+            MemberKind::Method => CompletionItemKind::Method,
+            MemberKind::Property => CompletionItemKind::Property,
         };
 
         $item = [

--- a/src/Completion/CompletionItemFactory.php
+++ b/src/Completion/CompletionItemFactory.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Completion;
 
 use Firehed\PhpLsp\Domain\FunctionInfo;
-use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Protocol\Range;
+use Firehed\PhpLsp\Resolution\ResolvedConstant;
+use Firehed\PhpLsp\Resolution\ResolvedEnumCase;
 use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
+use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Utility\DocblockParser;
 use Firehed\PhpLsp\Utility\NamespacePath;
 
@@ -38,11 +40,14 @@ final class CompletionItemFactory
      */
     public static function forResolvedMember(ResolvedMember $member, bool $snippetSupport = false): array
     {
-        $kind = match ($member->getMemberKind()) {
-            MemberKind::Constant => CompletionItemKind::Constant,
-            MemberKind::EnumCase => CompletionItemKind::EnumMember,
-            MemberKind::Method => CompletionItemKind::Method,
-            MemberKind::Property => CompletionItemKind::Property,
+        $kind = match (true) {
+            $member instanceof ResolvedMethod => CompletionItemKind::Method,
+            $member instanceof ResolvedProperty => CompletionItemKind::Property,
+            $member instanceof ResolvedConstant => CompletionItemKind::Constant,
+            $member instanceof ResolvedEnumCase => CompletionItemKind::EnumMember,
+            // @codeCoverageIgnoreStart
+            default => throw new \LogicException('Unexpected member type: ' . $member::class),
+            // @codeCoverageIgnoreEnd
         };
 
         $item = [

--- a/src/Domain/ClassName.php
+++ b/src/Domain/ClassName.php
@@ -58,7 +58,8 @@ final readonly class ClassName implements Type
 
     public function equals(self $other): bool
     {
-        return strcasecmp($this->fqn, $other->fqn) === 0;
+        return NameKind::ClassLike->normalize(QualifiedName::fromClassName($this))
+            === NameKind::ClassLike->normalize(QualifiedName::fromClassName($other));
     }
 
     public function resolveLateBound(string $callingClass, bool $declaringClassIsTrait = false): Type

--- a/src/Domain/ConstantInfo.php
+++ b/src/Domain/ConstantInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a class constant.
  */
-final readonly class ConstantInfo implements Formattable
+final readonly class ConstantInfo implements Formattable, MemberInfo
 {
     public function __construct(
         public ConstantName $name,
@@ -33,5 +33,18 @@ final readonly class ConstantInfo implements Formattable
         }
         $parts[] = $this->name->name;
         return implode(' ', $parts);
+    }
+
+    public function getVisibility(): Visibility
+    {
+        return $this->visibility;
+    }
+
+    /**
+     * A class constant is reached on the class, never on an instance.
+     */
+    public function isStatic(): bool
+    {
+        return true;
     }
 }

--- a/src/Domain/EnumCaseInfo.php
+++ b/src/Domain/EnumCaseInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about an enum case.
  */
-final readonly class EnumCaseInfo implements Formattable
+final readonly class EnumCaseInfo implements Formattable, MemberInfo
 {
     public function __construct(
         public EnumCaseName $name,
@@ -28,5 +28,21 @@ final readonly class EnumCaseInfo implements Formattable
                 : ' = ' . $this->backingValue;
         }
         return $str;
+    }
+
+    /**
+     * An enum case cannot be given a visibility; it is always public.
+     */
+    public function getVisibility(): Visibility
+    {
+        return Visibility::Public;
+    }
+
+    /**
+     * A case is reached on the enum, never on an instance.
+     */
+    public function isStatic(): bool
+    {
+        return true;
     }
 }

--- a/src/Domain/MemberInfo.php
+++ b/src/Domain/MemberInfo.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Metadata about a class-like member, in the terms the hierarchy walk needs:
+ * whether the caller may see it, and whether it is reached on the class or on an
+ * instance. Everything else about a member is specific to its {@see MemberKind}.
+ */
+interface MemberInfo
+{
+    public function getVisibility(): Visibility;
+
+    public function isStatic(): bool;
+}

--- a/src/Domain/MemberKind.php
+++ b/src/Domain/MemberKind.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * A category of class-like member.
+ *
+ * RFC 1 Appendix A lists member kind as an axis switched in exactly one place;
+ * this enum is that place. Everything the hierarchy walk in
+ * {@see \Firehed\PhpLsp\Repository\MemberResolver} needs that varies by kind is
+ * answered here, so a new kind is a case in this file rather than another pair
+ * of walks.
+ */
+enum MemberKind
+{
+    case Constant;
+
+    case EnumCase;
+
+    case Method;
+
+    case Property;
+
+    /**
+     * Where a class-like holds the members of this kind, keyed by declared name.
+     *
+     * @return array<string, MemberInfo>
+     */
+    public function membersOf(ClassInfo $classInfo): array
+    {
+        return match ($this) {
+            self::Constant => $classInfo->constants,
+            self::EnumCase => $classInfo->enumCases,
+            self::Method => $classInfo->methods,
+            self::Property => $classInfo->properties,
+        };
+    }
+
+    /**
+     * The name as a lookup key. PHP matches method names case-insensitively;
+     * every other member kind is matched letter-for-letter.
+     */
+    public function normalize(string $name): string
+    {
+        return ($this === self::Method ? NameCase::Insensitive : NameCase::Sensitive)->fold($name);
+    }
+}

--- a/src/Domain/MemberKind.php
+++ b/src/Domain/MemberKind.php
@@ -39,11 +39,22 @@ enum MemberKind
     }
 
     /**
+     * A member's identity within a class-like: its kind, plus its name under
+     * that kind's case rule. Two members collide only when both match.
+     */
+    public function keyFor(string $name): string
+    {
+        return $this->name . ':' . $this->normalize($name);
+    }
+
+    /**
      * The name as a lookup key. PHP matches method names case-insensitively;
      * every other member kind is matched letter-for-letter.
      */
     public function normalize(string $name): string
     {
-        return ($this === self::Method ? NameCase::Insensitive : NameCase::Sensitive)->fold($name);
+        $rule = $this === self::Method ? NameCase::Insensitive : NameCase::Sensitive;
+
+        return $rule->normalize($name);
     }
 }

--- a/src/Domain/MethodInfo.php
+++ b/src/Domain/MethodInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a class method.
  */
-final readonly class MethodInfo implements Formattable
+final readonly class MethodInfo implements Formattable, MemberInfo
 {
     /**
      * @param list<ParameterInfo> $parameters
@@ -49,5 +49,15 @@ final readonly class MethodInfo implements Formattable
             $sig .= ': ' . $this->returnType->format();
         }
         return $sig;
+    }
+
+    public function getVisibility(): Visibility
+    {
+        return $this->visibility;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->isStatic;
     }
 }

--- a/src/Domain/MethodName.php
+++ b/src/Domain/MethodName.php
@@ -16,6 +16,6 @@ final readonly class MethodName
 
     public function equals(self $other): bool
     {
-        return strcasecmp($this->name, $other->name) === 0;
+        return MemberKind::Method->normalize($this->name) === MemberKind::Method->normalize($other->name);
     }
 }

--- a/src/Domain/NameCase.php
+++ b/src/Domain/NameCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+/**
+ * Whether a name is matched letter-for-letter, and how to key it if not.
+ *
+ * Which rule applies is a question about a kind of name, and is answered by
+ * {@see NameKind} for symbols and {@see MemberKind} for class-like members.
+ * Applying it is the same operation either way, so it is written once here.
+ */
+enum NameCase
+{
+    case Insensitive;
+
+    case Sensitive;
+
+    public function fold(string $name): string
+    {
+        return $this === self::Insensitive ? strtolower($name) : $name;
+    }
+}

--- a/src/Domain/NameCase.php
+++ b/src/Domain/NameCase.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Domain;
 
 /**
- * Whether a name is matched letter-for-letter, and how to key it if not.
+ * Whether names are matched letter-for-letter, and how to key one if not.
  *
- * Which rule applies is a question about a kind of name, and is answered by
- * {@see NameKind} for symbols and {@see MemberKind} for class-like members.
- * Applying it is the same operation either way, so it is written once here.
+ * Which rule a name follows is {@see NameKind}'s question for symbols and
+ * {@see MemberKind}'s for class-like members. Applying it is the same operation
+ * either way, so it is implemented once, here.
  */
 enum NameCase
 {
@@ -17,7 +17,7 @@ enum NameCase
 
     case Sensitive;
 
-    public function fold(string $name): string
+    public function normalize(string $name): string
     {
         return $this === self::Insensitive ? strtolower($name) : $name;
     }

--- a/src/Domain/NameKind.php
+++ b/src/Domain/NameKind.php
@@ -52,8 +52,10 @@ enum NameKind
      */
     public function normalize(QualifiedName $name): string
     {
-        $shortName = $this->isCaseSensitive() ? $name->shortName : strtolower($name->shortName);
+        $shortName = ($this->isCaseSensitive() ? NameCase::Sensitive : NameCase::Insensitive)
+            ->fold($name->shortName);
 
-        return (new QualifiedName(strtolower($name->namespace), $shortName))->fullyQualifiedName();
+        return (new QualifiedName(NameCase::Insensitive->fold($name->namespace), $shortName))
+            ->fullyQualifiedName();
     }
 }

--- a/src/Domain/NameKind.php
+++ b/src/Domain/NameKind.php
@@ -52,10 +52,14 @@ enum NameKind
      */
     public function normalize(QualifiedName $name): string
     {
-        $shortName = ($this->isCaseSensitive() ? NameCase::Sensitive : NameCase::Insensitive)
-            ->fold($name->shortName);
+        $shortName = $this->caseRule()->normalize($name->shortName);
+        $namespace = NameCase::Insensitive->normalize($name->namespace);
 
-        return (new QualifiedName(NameCase::Insensitive->fold($name->namespace), $shortName))
-            ->fullyQualifiedName();
+        return (new QualifiedName($namespace, $shortName))->fullyQualifiedName();
+    }
+
+    private function caseRule(): NameCase
+    {
+        return $this->isCaseSensitive() ? NameCase::Sensitive : NameCase::Insensitive;
     }
 }

--- a/src/Domain/PropertyInfo.php
+++ b/src/Domain/PropertyInfo.php
@@ -7,7 +7,7 @@ namespace Firehed\PhpLsp\Domain;
 /**
  * Metadata about a class property.
  */
-final readonly class PropertyInfo implements Formattable
+final readonly class PropertyInfo implements Formattable, MemberInfo
 {
     public function __construct(
         public PropertyName $name,
@@ -37,5 +37,15 @@ final readonly class PropertyInfo implements Formattable
         }
         $parts[] = '$' . $this->name->name;
         return implode(' ', $parts);
+    }
+
+    public function getVisibility(): Visibility
+    {
+        return $this->visibility;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->isStatic;
     }
 }

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -11,10 +11,14 @@ use Firehed\PhpLsp\Domain\ConstantInfo;
 use Firehed\PhpLsp\Domain\ConstantName;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
 use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\MemberInfo;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
+use Firehed\PhpLsp\Domain\NameKind;
 use Firehed\PhpLsp\Domain\PropertyInfo;
 use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Domain\Visibility;
 use Firehed\PhpLsp\Knowledge\SymbolSource;
 use Firehed\PhpLsp\Resolution\MemberFilter;
@@ -25,6 +29,11 @@ use Firehed\PhpLsp\Resolution\MemberFilter;
  * Class-like metadata is read through the {@see SymbolSource} seam (RFC 1 §4.2), so
  * the member walk sees the same coverage — open documents overriding the workspace,
  * vendored code, and built-ins — as every other consumer of symbol knowledge.
+ *
+ * Every member kind is answered by the one walk below, over the one type graph
+ * {@see self::supertypes()} defines. What varies between kinds lives in
+ * {@see MemberKind}, so no two kinds can come to disagree about the hierarchy or
+ * about how a member name is matched.
  */
 final class MemberResolver
 {
@@ -33,18 +42,25 @@ final class MemberResolver
     ) {
     }
 
+    public function findConstant(
+        ClassName $class,
+        ConstantName $constant,
+        Visibility $minVisibility,
+    ): ?ConstantInfo {
+        return $this->findMember($class, MemberKind::Constant, ConstantInfo::class, $constant->name, $minVisibility);
+    }
+
+    public function findEnumCase(ClassName $class, EnumCaseName $case): ?EnumCaseInfo
+    {
+        return $this->findMember($class, MemberKind::EnumCase, EnumCaseInfo::class, $case->name, Visibility::Public);
+    }
+
     public function findMethod(
         ClassName $class,
         MethodName $method,
         Visibility $minVisibility,
     ): ?MethodInfo {
-        $classInfo = $this->source->lookupClassLike($class);
-        if ($classInfo === null) {
-            return null;
-        }
-
-        $seen = [];
-        return $this->findMethodInHierarchy($classInfo, $method, $minVisibility, $seen, true);
+        return $this->findMember($class, MemberKind::Method, MethodInfo::class, $method->name, $minVisibility);
     }
 
     public function findProperty(
@@ -52,38 +68,35 @@ final class MemberResolver
         PropertyName $property,
         Visibility $minVisibility,
     ): ?PropertyInfo {
-        $classInfo = $this->source->lookupClassLike($class);
-        if ($classInfo === null) {
-            return null;
-        }
-
-        $seen = [];
-        return $this->findPropertyInHierarchy($classInfo, $property, $minVisibility, $seen, true);
+        return $this->findMember($class, MemberKind::Property, PropertyInfo::class, $property->name, $minVisibility);
     }
 
-    public function findConstant(
-        ClassName $class,
-        ConstantName $constant,
-        Visibility $minVisibility,
-    ): ?ConstantInfo {
-        $classInfo = $this->source->lookupClassLike($class);
-        if ($classInfo === null) {
-            return null;
-        }
-
-        $seen = [];
-        return $this->findConstantInHierarchy($classInfo, $constant, $minVisibility, $seen, true);
-    }
-
-    public function findEnumCase(ClassName $class, EnumCaseName $case): ?EnumCaseInfo
+    /**
+     * @return list<ConstantInfo>
+     */
+    public function getConstants(ClassName $class, Visibility $minVisibility): array
     {
-        $classInfo = $this->source->lookupClassLike($class);
-        return $classInfo?->enumCases[$case->name] ?? null;
+        return $this->collectMembers(
+            $class,
+            MemberKind::Constant,
+            ConstantInfo::class,
+            $minVisibility,
+            MemberFilter::All,
+        );
     }
 
-    public function isTraitClass(ClassName $class): bool
+    /**
+     * @return list<EnumCaseInfo>
+     */
+    public function getEnumCases(ClassName $class): array
     {
-        return $this->source->lookupClassLike($class)?->kind === ClassKind::Trait_;
+        return $this->collectMembers(
+            $class,
+            MemberKind::EnumCase,
+            EnumCaseInfo::class,
+            Visibility::Public,
+            MemberFilter::All,
+        );
     }
 
     /**
@@ -94,16 +107,7 @@ final class MemberResolver
         Visibility $minVisibility,
         MemberFilter $filter = MemberFilter::All,
     ): array {
-        $classInfo = $this->source->lookupClassLike($class);
-        if ($classInfo === null) {
-            return [];
-        }
-
-        $methods = [];
-        $seen = [];
-        $this->collectMethods($classInfo, $minVisibility, $filter, $methods, $seen, true);
-
-        return array_values($methods);
+        return $this->collectMembers($class, MemberKind::Method, MethodInfo::class, $minVisibility, $filter);
     }
 
     /**
@@ -114,220 +118,130 @@ final class MemberResolver
         Visibility $minVisibility,
         MemberFilter $filter = MemberFilter::All,
     ): array {
-        $classInfo = $this->source->lookupClassLike($class);
-        if ($classInfo === null) {
-            return [];
-        }
+        return $this->collectMembers($class, MemberKind::Property, PropertyInfo::class, $minVisibility, $filter);
+    }
 
-        $properties = [];
-        $seen = [];
-        $this->collectProperties($classInfo, $minVisibility, $filter, $properties, $seen, true);
-
-        return array_values($properties);
+    public function isTraitClass(ClassName $class): bool
+    {
+        return $this->source->lookupClassLike($class)?->kind === ClassKind::Trait_;
     }
 
     /**
-     * @return list<ConstantInfo>
+     * Every member of $kind visible from $class, nearest declaration winning.
+     *
+     * @template T of MemberInfo
+     * @param class-string<T> $memberType The type $kind is stored as.
+     * @return list<T>
      */
-    public function getConstants(ClassName $class, Visibility $minVisibility): array
+    private function collectMembers(
+        ClassName $class,
+        MemberKind $kind,
+        string $memberType,
+        Visibility $minVisibility,
+        MemberFilter $filter,
+    ): array {
+        $collected = [];
+        foreach ($this->hierarchy($class) as [$classInfo, $isOriginClass]) {
+            foreach ($kind->membersOf($classInfo) as $name => $member) {
+                $key = $kind->normalize($name);
+                if (array_key_exists($key, $collected) || !$member instanceof $memberType) {
+                    continue;
+                }
+                if ($this->isVisible($member, $minVisibility, $filter, $isOriginClass)) {
+                    $collected[$key] = $member;
+                }
+            }
+        }
+
+        return array_values($collected);
+    }
+
+    /**
+     * @template T of MemberInfo
+     * @param class-string<T> $memberType The type $kind is stored as.
+     * @return ?T
+     */
+    private function findMember(
+        ClassName $class,
+        MemberKind $kind,
+        string $memberType,
+        string $name,
+        Visibility $minVisibility,
+    ): ?MemberInfo {
+        $wanted = $kind->normalize($name);
+        foreach ($this->hierarchy($class) as [$classInfo, $isOriginClass]) {
+            foreach ($kind->membersOf($classInfo) as $declared => $member) {
+                if ($kind->normalize($declared) !== $wanted || !$member instanceof $memberType) {
+                    continue;
+                }
+                if ($this->isVisible($member, $minVisibility, MemberFilter::All, $isOriginClass)) {
+                    return $member;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * $class and every type it inherits members from, in PHP's resolution order,
+     * each paired with its isOriginClass flag. A type reached by more than one
+     * edge is visited once; an unresolvable one is skipped.
+     *
+     * @return iterable<array{ClassInfo, bool}>
+     */
+    private function hierarchy(ClassName $class): iterable
     {
         $classInfo = $this->source->lookupClassLike($class);
         if ($classInfo === null) {
-            return [];
+            return;
         }
 
-        $constants = [];
         $seen = [];
-        $this->collectConstants($classInfo, $minVisibility, $constants, $seen, true);
-
-        return array_values($constants);
+        yield from $this->descend($classInfo, true, $seen);
     }
 
     /**
-     * @return list<EnumCaseInfo>
+     * @param array<string, true> $seen
+     * @return iterable<array{ClassInfo, bool}>
      */
-    public function getEnumCases(ClassName $class): array
+    private function descend(ClassInfo $classInfo, bool $isOriginClass, array &$seen): iterable
     {
-        $classInfo = $this->source->lookupClassLike($class);
-        if ($classInfo === null) {
-            return [];
-        }
-
-        return array_values($classInfo->enumCases);
-    }
-
-    /**
-     * @param array<string, true> $seen
-     */
-    private function findMethodInHierarchy(
-        ClassInfo $classInfo,
-        MethodName $method,
-        Visibility $minVisibility,
-        array &$seen,
-        bool $isOriginClass,
-    ): ?MethodInfo {
-        $fqn = $classInfo->name->fqn;
-        if (array_key_exists($fqn, $seen)) {
-            return null;
-        }
-        $seen[$fqn] = true;
-
-        foreach ($classInfo->methods as $methodInfo) {
-            if (!$methodInfo->name->equals($method)) {
-                continue;
-            }
-            if ($this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass)) {
-                return $methodInfo;
-            }
-        }
-
-        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
-            $result = $this->findMethodInHierarchy($superInfo, $method, $minVisibility, $seen, $superIsOrigin);
-            if ($result !== null) {
-                return $result;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, true> $seen
-     */
-    private function findPropertyInHierarchy(
-        ClassInfo $classInfo,
-        PropertyName $property,
-        Visibility $minVisibility,
-        array &$seen,
-        bool $isOriginClass,
-    ): ?PropertyInfo {
-        $fqn = $classInfo->name->fqn;
-        if (array_key_exists($fqn, $seen)) {
-            return null;
-        }
-        $seen[$fqn] = true;
-
-        if (array_key_exists($property->name, $classInfo->properties)) {
-            $propInfo = $classInfo->properties[$property->name];
-            if ($this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass)) {
-                return $propInfo;
-            }
-        }
-
-        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
-            $result = $this->findPropertyInHierarchy($superInfo, $property, $minVisibility, $seen, $superIsOrigin);
-            if ($result !== null) {
-                return $result;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, true> $seen
-     */
-    private function findConstantInHierarchy(
-        ClassInfo $classInfo,
-        ConstantName $constant,
-        Visibility $minVisibility,
-        array &$seen,
-        bool $isOriginClass,
-    ): ?ConstantInfo {
-        $fqn = $classInfo->name->fqn;
-        if (array_key_exists($fqn, $seen)) {
-            return null;
-        }
-        $seen[$fqn] = true;
-
-        if (array_key_exists($constant->name, $classInfo->constants)) {
-            $constInfo = $classInfo->constants[$constant->name];
-            if ($this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass)) {
-                return $constInfo;
-            }
-        }
-
-        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
-            $result = $this->findConstantInHierarchy($superInfo, $constant, $minVisibility, $seen, $superIsOrigin);
-            if ($result !== null) {
-                return $result;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, MethodInfo> $methods
-     * @param array<string, true> $seen
-     */
-    private function collectMethods(
-        ClassInfo $classInfo,
-        Visibility $minVisibility,
-        MemberFilter $filter,
-        array &$methods,
-        array &$seen,
-        bool $isOriginClass,
-    ): void {
-        $fqn = $classInfo->name->fqn;
-        if (array_key_exists($fqn, $seen)) {
+        $key = NameKind::ClassLike->normalize(QualifiedName::fromClassName($classInfo->name));
+        if (array_key_exists($key, $seen)) {
             return;
         }
-        $seen[$fqn] = true;
+        $seen[$key] = true;
 
-        foreach ($classInfo->methods as $methodInfo) {
-            $key = strtolower($methodInfo->name->name);
-            if (array_key_exists($key, $methods)) {
-                continue;
-            }
-            if (!$this->matchesFilter($methodInfo->isStatic, $filter)) {
-                continue;
-            }
-            if (!$this->isAccessible($methodInfo->visibility, $minVisibility, $isOriginClass)) {
-                continue;
-            }
-            $methods[$key] = $methodInfo;
-        }
+        yield [$classInfo, $isOriginClass];
 
         foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
-            $this->collectMethods($superInfo, $minVisibility, $filter, $methods, $seen, $superIsOrigin);
+            yield from $this->descend($superInfo, $superIsOrigin, $seen);
         }
     }
 
-    /**
-     * @param array<string, PropertyInfo> $properties
-     * @param array<string, true> $seen
-     */
-    private function collectProperties(
-        ClassInfo $classInfo,
+    private function isVisible(
+        MemberInfo $member,
         Visibility $minVisibility,
         MemberFilter $filter,
-        array &$properties,
-        array &$seen,
         bool $isOriginClass,
-    ): void {
-        $fqn = $classInfo->name->fqn;
-        if (array_key_exists($fqn, $seen)) {
-            return;
-        }
-        $seen[$fqn] = true;
-
-        foreach ($classInfo->properties as $key => $propInfo) {
-            if (array_key_exists($key, $properties)) {
-                continue;
-            }
-            if (!$this->matchesFilter($propInfo->isStatic, $filter)) {
-                continue;
-            }
-            if (!$this->isAccessible($propInfo->visibility, $minVisibility, $isOriginClass)) {
-                continue;
-            }
-            $properties[$key] = $propInfo;
+    ): bool {
+        $matchesFilter = match ($filter) {
+            MemberFilter::All => true,
+            MemberFilter::Static => $member->isStatic(),
+            MemberFilter::Instance => !$member->isStatic(),
+        };
+        if (!$matchesFilter) {
+            return false;
         }
 
-        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
-            $this->collectProperties($superInfo, $minVisibility, $filter, $properties, $seen, $superIsOrigin);
+        $visibility = $member->getVisibility();
+        if (!$visibility->isAccessibleFrom($minVisibility)) {
+            return false;
         }
+
+        // A private member is only reachable from the class that declares it.
+        return $visibility !== Visibility::Private || $isOriginClass;
     }
 
     /**
@@ -364,62 +278,5 @@ final class MemberResolver
         }
 
         return $supertypes;
-    }
-
-    private function matchesFilter(bool $isStatic, MemberFilter $filter): bool
-    {
-        return match ($filter) {
-            MemberFilter::All => true,
-            MemberFilter::Static => $isStatic,
-            MemberFilter::Instance => !$isStatic,
-        };
-    }
-
-    /**
-     * @param array<string, ConstantInfo> $constants
-     * @param array<string, true> $seen
-     */
-    private function collectConstants(
-        ClassInfo $classInfo,
-        Visibility $minVisibility,
-        array &$constants,
-        array &$seen,
-        bool $isOriginClass,
-    ): void {
-        $fqn = $classInfo->name->fqn;
-        if (array_key_exists($fqn, $seen)) {
-            return;
-        }
-        $seen[$fqn] = true;
-
-        foreach ($classInfo->constants as $key => $constInfo) {
-            if (array_key_exists($key, $constants)) {
-                continue;
-            }
-            if (!$this->isAccessible($constInfo->visibility, $minVisibility, $isOriginClass)) {
-                continue;
-            }
-            $constants[$key] = $constInfo;
-        }
-
-        foreach ($this->supertypes($classInfo) as [$superInfo, $superIsOrigin]) {
-            $this->collectConstants($superInfo, $minVisibility, $constants, $seen, $superIsOrigin);
-        }
-    }
-
-    private function isAccessible(
-        Visibility $memberVisibility,
-        Visibility $minVisibility,
-        bool $isOriginClass,
-    ): bool {
-        if (!$memberVisibility->isAccessibleFrom($minVisibility)) {
-            return false;
-        }
-
-        if ($memberVisibility === Visibility::Private) {
-            return $isOriginClass;
-        }
-
-        return true;
     }
 }

--- a/src/Repository/MemberResolver.php
+++ b/src/Repository/MemberResolver.php
@@ -143,7 +143,7 @@ final class MemberResolver
         $collected = [];
         foreach ($this->hierarchy($class) as [$classInfo, $isOriginClass]) {
             foreach ($kind->membersOf($classInfo) as $name => $member) {
-                $key = $kind->normalize($name);
+                $key = $kind->keyFor($name);
                 if (array_key_exists($key, $collected) || !$member instanceof $memberType) {
                     continue;
                 }
@@ -168,10 +168,10 @@ final class MemberResolver
         string $name,
         Visibility $minVisibility,
     ): ?MemberInfo {
-        $wanted = $kind->normalize($name);
+        $wanted = $kind->keyFor($name);
         foreach ($this->hierarchy($class) as [$classInfo, $isOriginClass]) {
             foreach ($kind->membersOf($classInfo) as $declared => $member) {
-                if ($kind->normalize($declared) !== $wanted || !$member instanceof $memberType) {
+                if ($kind->keyFor($declared) !== $wanted || !$member instanceof $memberType) {
                     continue;
                 }
                 if ($this->isVisible($member, $minVisibility, MemberFilter::All, $isOriginClass)) {

--- a/src/Resolution/ResolvedConstant.php
+++ b/src/Resolution/ResolvedConstant.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantInfo;
 use Firehed\PhpLsp\Domain\ConstantName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 
@@ -32,6 +33,11 @@ final readonly class ResolvedConstant implements ResolvedMember
         return $this->info->declaringClass;
     }
 
+    public function getMemberKind(): MemberKind
+    {
+        return MemberKind::Constant;
+    }
+
     public function getName(): ConstantName
     {
         return $this->info->name;
@@ -39,11 +45,11 @@ final readonly class ResolvedConstant implements ResolvedMember
 
     public function getVisibility(): Visibility
     {
-        return $this->info->visibility;
+        return $this->info->getVisibility();
     }
 
     public function isStatic(): bool
     {
-        return true;
+        return $this->info->isStatic();
     }
 }

--- a/src/Resolution/ResolvedEnumCase.php
+++ b/src/Resolution/ResolvedEnumCase.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
 use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\Type;
 use Firehed\PhpLsp\Domain\Visibility;
 
@@ -29,6 +30,11 @@ final readonly class ResolvedEnumCase implements ResolvedMember
         return $this->info->declaringClass;
     }
 
+    public function getMemberKind(): MemberKind
+    {
+        return MemberKind::EnumCase;
+    }
+
     public function getName(): EnumCaseName
     {
         return $this->info->name;
@@ -41,11 +47,11 @@ final readonly class ResolvedEnumCase implements ResolvedMember
 
     public function getVisibility(): Visibility
     {
-        return Visibility::Public;
+        return $this->info->getVisibility();
     }
 
     public function isStatic(): bool
     {
-        return true;
+        return $this->info->isStatic();
     }
 }

--- a/src/Resolution/ResolvedMember.php
+++ b/src/Resolution/ResolvedMember.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantName;
 use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Visibility;
@@ -20,6 +21,8 @@ interface ResolvedMember extends ResolvedSymbol
      * Returns the class that declares this member.
      */
     public function getDeclaringClass(): ClassName;
+
+    public function getMemberKind(): MemberKind;
 
     public function getName(): MethodName|PropertyName|ConstantName|EnumCaseName;
 

--- a/src/Resolution/ResolvedMember.php
+++ b/src/Resolution/ResolvedMember.php
@@ -7,15 +7,15 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantName;
 use Firehed\PhpLsp\Domain\EnumCaseName;
-use Firehed\PhpLsp\Domain\MemberInfo;
 use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
+use Firehed\PhpLsp\Domain\Visibility;
 
 /**
  * A resolved class member (method, property, constant, enum case).
  */
-interface ResolvedMember extends ResolvedSymbol, MemberInfo
+interface ResolvedMember extends ResolvedSymbol
 {
     /**
      * Returns the class that declares this member.
@@ -25,4 +25,8 @@ interface ResolvedMember extends ResolvedSymbol, MemberInfo
     public function getMemberKind(): MemberKind;
 
     public function getName(): MethodName|PropertyName|ConstantName|EnumCaseName;
+
+    public function getVisibility(): Visibility;
+
+    public function isStatic(): bool;
 }

--- a/src/Resolution/ResolvedMember.php
+++ b/src/Resolution/ResolvedMember.php
@@ -7,15 +7,15 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantName;
 use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\MemberInfo;
 use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\PropertyName;
-use Firehed\PhpLsp\Domain\Visibility;
 
 /**
  * A resolved class member (method, property, constant, enum case).
  */
-interface ResolvedMember extends ResolvedSymbol
+interface ResolvedMember extends ResolvedSymbol, MemberInfo
 {
     /**
      * Returns the class that declares this member.
@@ -25,8 +25,4 @@ interface ResolvedMember extends ResolvedSymbol
     public function getMemberKind(): MemberKind;
 
     public function getName(): MethodName|PropertyName|ConstantName|EnumCaseName;
-
-    public function getVisibility(): Visibility;
-
-    public function isStatic(): bool;
 }

--- a/src/Resolution/ResolvedMethod.php
+++ b/src/Resolution/ResolvedMethod.php
@@ -52,11 +52,11 @@ final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
 
     public function getVisibility(): Visibility
     {
-        return $this->info->getVisibility();
+        return $this->info->visibility;
     }
 
     public function isStatic(): bool
     {
-        return $this->info->isStatic();
+        return $this->info->isStatic;
     }
 }

--- a/src/Resolution/ResolvedMethod.php
+++ b/src/Resolution/ResolvedMethod.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\ParameterInfo;
@@ -37,6 +38,11 @@ final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
     public function getDeclaringClass(): ClassName
     {
         return $this->info->declaringClass;
+    }
+
+    public function getMemberKind(): MemberKind
+    {
+        return MemberKind::Method;
     }
 
     public function getName(): MethodName

--- a/src/Resolution/ResolvedMethod.php
+++ b/src/Resolution/ResolvedMethod.php
@@ -52,11 +52,11 @@ final readonly class ResolvedMethod implements ResolvedMember, ResolvedCallable
 
     public function getVisibility(): Visibility
     {
-        return $this->info->visibility;
+        return $this->info->getVisibility();
     }
 
     public function isStatic(): bool
     {
-        return $this->info->isStatic;
+        return $this->info->isStatic();
     }
 }

--- a/src/Resolution/ResolvedProperty.php
+++ b/src/Resolution/ResolvedProperty.php
@@ -45,11 +45,11 @@ final readonly class ResolvedProperty implements ResolvedMember
 
     public function getVisibility(): Visibility
     {
-        return $this->info->getVisibility();
+        return $this->info->visibility;
     }
 
     public function isStatic(): bool
     {
-        return $this->info->isStatic();
+        return $this->info->isStatic;
     }
 }

--- a/src/Resolution/ResolvedProperty.php
+++ b/src/Resolution/ResolvedProperty.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\PropertyInfo;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\Type;
@@ -30,6 +31,11 @@ final readonly class ResolvedProperty implements ResolvedMember
     public function getDeclaringClass(): ClassName
     {
         return $this->info->declaringClass;
+    }
+
+    public function getMemberKind(): MemberKind
+    {
+        return MemberKind::Property;
     }
 
     public function getName(): PropertyName

--- a/src/Resolution/ResolvedProperty.php
+++ b/src/Resolution/ResolvedProperty.php
@@ -45,11 +45,11 @@ final readonly class ResolvedProperty implements ResolvedMember
 
     public function getVisibility(): Visibility
     {
-        return $this->info->visibility;
+        return $this->info->getVisibility();
     }
 
     public function isStatic(): bool
     {
-        return $this->info->isStatic;
+        return $this->info->isStatic();
     }
 }

--- a/src/Resolution/TextFallbackHelper.php
+++ b/src/Resolution/TextFallbackHelper.php
@@ -595,16 +595,28 @@ final class TextFallbackHelper
     {
         $seen = [];
         foreach ($members as $member) {
-            $seen[$member::class . ':' . $member->getName()->name] = true;
+            $seen[self::memberKey($member)] = true;
         }
         foreach ($inherited as $member) {
-            $key = $member::class . ':' . $member->getName()->name;
-            if (!isset($seen[$key])) {
+            $key = self::memberKey($member);
+            if (!array_key_exists($key, $seen)) {
                 $seen[$key] = true;
                 $members[] = $member;
             }
         }
         return $members;
+    }
+
+    /**
+     * A member's identity within its class: its kind, plus its name under that
+     * kind's case rule, so an override spelled in another case is not a second
+     * member.
+     */
+    private static function memberKey(ResolvedMember $member): string
+    {
+        $kind = $member->getMemberKind();
+
+        return $kind->name . ':' . $kind->normalize($member->getName()->name);
     }
 
     /**

--- a/src/Resolution/TextFallbackHelper.php
+++ b/src/Resolution/TextFallbackHelper.php
@@ -607,16 +607,9 @@ final class TextFallbackHelper
         return $members;
     }
 
-    /**
-     * A member's identity within its class: its kind, plus its name under that
-     * kind's case rule, so an override spelled in another case is not a second
-     * member.
-     */
     private static function memberKey(ResolvedMember $member): string
     {
-        $kind = $member->getMemberKind();
-
-        return $kind->name . ':' . $kind->normalize($member->getName()->name);
+        return $member->getMemberKind()->keyFor($member->getName()->name);
     }
 
     /**

--- a/tests/Domain/ClassNameTest.php
+++ b/tests/Domain/ClassNameTest.php
@@ -58,6 +58,15 @@ class ClassNameTest extends TestCase
         self::assertTrue($a->equals($b));
     }
 
+    public function testEqualsIgnoresALeadingSeparator(): void
+    {
+        $a = new ClassName(ClassName::class);
+        /** @var class-string $leadingSeparator */
+        $leadingSeparator = '\\' . ClassName::class;
+        $b = new ClassName($leadingSeparator);
+        self::assertTrue($a->equals($b), 'A leading separator is spelling, not identity');
+    }
+
     public function testFormatReturnsFqn(): void
     {
         $cn = new ClassName(ClassName::class);

--- a/tests/Domain/MemberInfoTest.php
+++ b/tests/Domain/MemberInfoTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The two questions the hierarchy walk asks of every member kind. They are
+ * asserted together so no kind can answer them in its own terms.
+ */
+#[CoversClass(ConstantInfo::class)]
+#[CoversClass(EnumCaseInfo::class)]
+#[CoversClass(MethodInfo::class)]
+#[CoversClass(PropertyInfo::class)]
+class MemberInfoTest extends TestCase
+{
+    #[DataProvider('members')]
+    public function testAnswersTheWalk(MemberInfo $member, Visibility $visibility, bool $isStatic): void
+    {
+        self::assertSame($visibility, $member->getVisibility());
+        self::assertSame($isStatic, $member->isStatic());
+    }
+
+    /**
+     * @return iterable<string, array{MemberInfo, Visibility, bool}>
+     */
+    public static function members(): iterable
+    {
+        $declaringClass = new ClassName(self::class);
+
+        $constant = new ConstantInfo(
+            name: new ConstantName('MAX'),
+            visibility: Visibility::Protected,
+            isFinal: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+        // A constant is reached on the class, whatever its visibility says.
+        yield 'constant' => [$constant, Visibility::Protected, true];
+
+        $enumCase = new EnumCaseInfo(
+            name: new EnumCaseName('Draft'),
+            backingValue: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+        yield 'enum case' => [$enumCase, Visibility::Public, true];
+
+        $method = new MethodInfo(
+            name: new MethodName('run'),
+            visibility: Visibility::Private,
+            isStatic: true,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [],
+            returnType: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+        yield 'static method' => [$method, Visibility::Private, true];
+
+        $property = new PropertyInfo(
+            name: new PropertyName('value'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isReadonly: false,
+            isPromoted: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: $declaringClass,
+        );
+        yield 'instance property' => [$property, Visibility::Public, false];
+    }
+}

--- a/tests/Domain/MemberKindTest.php
+++ b/tests/Domain/MemberKindTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MemberKind::class)]
+#[CoversClass(NameCase::class)]
+class MemberKindTest extends TestCase
+{
+    public function testMembersOfReadsTheMapForItsKind(): void
+    {
+        $constant = self::createConstantInfo();
+        $enumCase = self::createEnumCaseInfo();
+        $method = self::createMethodInfo();
+        $property = self::createPropertyInfo();
+        $classInfo = self::createClassInfo($constant, $enumCase, $method, $property);
+
+        self::assertSame(['MAX' => $constant], MemberKind::Constant->membersOf($classInfo));
+        self::assertSame(['Draft' => $enumCase], MemberKind::EnumCase->membersOf($classInfo));
+        self::assertSame(['run' => $method], MemberKind::Method->membersOf($classInfo));
+        self::assertSame(['value' => $property], MemberKind::Property->membersOf($classInfo));
+    }
+
+    public function testMethodNamesAreMatchedCaseInsensitively(): void
+    {
+        self::assertSame(
+            MemberKind::Method->normalize('run'),
+            MemberKind::Method->normalize('RUN'),
+        );
+    }
+
+    #[DataProvider('caseSensitiveKinds')]
+    public function testEveryOtherKindIsMatchedLetterForLetter(MemberKind $kind): void
+    {
+        self::assertNotSame($kind->normalize('value'), $kind->normalize('VALUE'));
+        self::assertSame('value', $kind->normalize('value'));
+    }
+
+    public function testKeyForSeparatesTwoKindsSharingAName(): void
+    {
+        self::assertNotSame(
+            MemberKind::Method->keyFor('value'),
+            MemberKind::Property->keyFor('value'),
+        );
+    }
+
+    public function testKeyForCollapsesACaseVariedMethodOverride(): void
+    {
+        self::assertSame(
+            MemberKind::Method->keyFor('overriddenMethod'),
+            MemberKind::Method->keyFor('OVERRIDDENMETHOD'),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{MemberKind}>
+     */
+    public static function caseSensitiveKinds(): iterable
+    {
+        yield 'constant' => [MemberKind::Constant];
+        yield 'enum case' => [MemberKind::EnumCase];
+        yield 'property' => [MemberKind::Property];
+    }
+
+    private static function createClassInfo(
+        ConstantInfo $constant,
+        EnumCaseInfo $enumCase,
+        MethodInfo $method,
+        PropertyInfo $property,
+    ): ClassInfo {
+        return new ClassInfo(
+            name: new ClassName(self::class),
+            kind: ClassKind::Class_,
+            isAbstract: false,
+            isFinal: false,
+            isReadonly: false,
+            isAttribute: false,
+            parent: null,
+            interfaces: [],
+            traits: [],
+            methods: ['run' => $method],
+            properties: ['value' => $property],
+            constants: ['MAX' => $constant],
+            enumCases: ['Draft' => $enumCase],
+            docblock: null,
+            file: null,
+            line: null,
+        );
+    }
+
+    private static function createConstantInfo(): ConstantInfo
+    {
+        return new ConstantInfo(
+            name: new ConstantName('MAX'),
+            visibility: Visibility::Public,
+            isFinal: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+    }
+
+    private static function createEnumCaseInfo(): EnumCaseInfo
+    {
+        return new EnumCaseInfo(
+            name: new EnumCaseName('Draft'),
+            backingValue: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+    }
+
+    private static function createMethodInfo(): MethodInfo
+    {
+        return new MethodInfo(
+            name: new MethodName('run'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isAbstract: false,
+            isFinal: false,
+            parameters: [],
+            returnType: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+    }
+
+    private static function createPropertyInfo(): PropertyInfo
+    {
+        return new PropertyInfo(
+            name: new PropertyName('value'),
+            visibility: Visibility::Public,
+            isStatic: false,
+            isReadonly: false,
+            isPromoted: false,
+            type: null,
+            docblock: null,
+            file: null,
+            line: null,
+            declaringClass: new ClassName(self::class),
+        );
+    }
+}

--- a/tests/Fixtures/TopLevel/case_varied_override_child.php
+++ b/tests/Fixtures/TopLevel/case_varied_override_child.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Test;
+
+use Fixtures\Inheritance\ParentClass;
+
+// PHP matches method names case-insensitively, so this overrides the parent's
+// `overriddenMethod` despite the different spelling.
+class CaseVariedOverrideChild extends ParentClass
+{
+    public function OVERRIDDENMETHOD(): void
+    {
+    }
+}

--- a/tests/Fixtures/TopLevel/method_and_property_same_name.php
+++ b/tests/Fixtures/TopLevel/method_and_property_same_name.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Test;
+
+use Fixtures\Completion\MethodAccess;
+
+class MethodAndPropertySameName extends MethodAccess
+{
+    // Shares its name with the inherited property `$active`: a name identifies a
+    // member only together with its kind, and the two rules differ on case.
+    public function active(): void
+    {
+    }
+}

--- a/tests/Repository/MemberResolverTest.php
+++ b/tests/Repository/MemberResolverTest.php
@@ -1219,6 +1219,130 @@ final class MemberResolverTest extends TestCase
         self::assertContains($interfaceConst, $result);
     }
 
+    public function testFindMethodMatchesNameCaseInsensitively(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $methodInfo = $this->createMethodInfo('overriddenMethod', Visibility::Public, $className);
+        $classInfo = $this->createClassInfo($className, methods: ['overriddenMethod' => $methodInfo]);
+
+        $repo = self::createStub(SymbolSource::class);
+        $repo->method('lookupClassLike')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findMethod($className, new MethodName('OVERRIDDENMETHOD'), Visibility::Public);
+
+        self::assertSame($methodInfo, $result);
+    }
+
+    public function testGetMethodsTreatsCaseVariedOverrideAsOneMethod(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+        $parentMethod = $this->createMethodInfo('overriddenMethod', Visibility::Public, $parentName);
+        $childMethod = $this->createMethodInfo('OVERRIDDENMETHOD', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, methods: ['overriddenMethod' => $parentMethod]);
+        $childInfo = $this->createClassInfo(
+            $childName,
+            parent: $parentName,
+            methods: ['OVERRIDDENMETHOD' => $childMethod],
+        );
+
+        $repo = self::createStub(SymbolSource::class);
+        $repo->method('lookupClassLike')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getMethods($childName, Visibility::Public);
+
+        self::assertSame([$childMethod], $result);
+    }
+
+    public function testFindPropertyMatchesNameCaseSensitively(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $propertyInfo = $this->createPropertyInfo('value', Visibility::Public, $className);
+        $classInfo = $this->createClassInfo($className, properties: ['value' => $propertyInfo]);
+
+        $repo = self::createStub(SymbolSource::class);
+        $repo->method('lookupClassLike')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findProperty($className, new PropertyName('VALUE'), Visibility::Public);
+
+        self::assertNull($result);
+    }
+
+    public function testFindConstantMatchesNameCaseSensitively(): void
+    {
+        $className = new ClassName(self::fakeClass());
+        $constantInfo = $this->createConstantInfo('VALUE', Visibility::Public, $className);
+        $classInfo = $this->createClassInfo($className, constants: ['VALUE' => $constantInfo]);
+
+        $repo = self::createStub(SymbolSource::class);
+        $repo->method('lookupClassLike')->willReturn($classInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->findConstant($className, new ConstantName('Value'), Visibility::Public);
+
+        self::assertNull($result);
+    }
+
+    public function testFindEnumCaseMatchesNameCaseSensitively(): void
+    {
+        $enumName = new ClassName(self::fakeClass());
+        $caseInfo = $this->createEnumCaseInfo('Draft', $enumName);
+        $enumInfo = $this->createClassInfo($enumName, ClassKind::Enum_, enumCases: ['Draft' => $caseInfo]);
+
+        $repo = self::createStub(SymbolSource::class);
+        $repo->method('lookupClassLike')->willReturn($enumInfo);
+
+        $resolver = new MemberResolver($repo);
+
+        self::assertNull($resolver->findEnumCase($enumName, new EnumCaseName('DRAFT')));
+    }
+
+    public function testGetConstantsKeepsCaseVariedNamesApart(): void
+    {
+        $parentName = new ClassName(self::fakeClass());
+        $childName = new ClassName(self::fakeClass());
+        $parentConstant = $this->createConstantInfo('VALUE', Visibility::Public, $parentName);
+        $childConstant = $this->createConstantInfo('Value', Visibility::Public, $childName);
+
+        $parentInfo = $this->createClassInfo($parentName, constants: ['VALUE' => $parentConstant]);
+        $childInfo = $this->createClassInfo(
+            $childName,
+            parent: $parentName,
+            constants: ['Value' => $childConstant],
+        );
+
+        $repo = self::createStub(SymbolSource::class);
+        $repo->method('lookupClassLike')->willReturnCallback(
+            fn (ClassName $name) => match ($name->fqn) {
+                $parentName->fqn => $parentInfo,
+                $childName->fqn => $childInfo,
+                default => null,
+            },
+        );
+
+        $resolver = new MemberResolver($repo);
+
+        $result = $resolver->getConstants($childName, Visibility::Public);
+
+        self::assertCount(2, $result);
+        self::assertContains($parentConstant, $result);
+        self::assertContains($childConstant, $result);
+    }
+
     public function testIsTraitClassReturnsTrueForTrait(): void
     {
         $traitName = new ClassName(self::fakeClass());

--- a/tests/Resolution/ResolvedConstantTest.php
+++ b/tests/Resolution/ResolvedConstantTest.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Resolution;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ConstantInfo;
 use Firehed\PhpLsp\Domain\ConstantName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\Visibility;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -66,6 +67,11 @@ class ResolvedConstantTest extends TestCase
 
         self::assertInstanceOf(ConstantName::class, $name);
         self::assertSame('MAX_RETRIES', $name->name);
+    }
+
+    public function testGetMemberKind(): void
+    {
+        self::assertSame(MemberKind::Constant, $this->createResolvedConstant()->getMemberKind());
     }
 
     public function testGetVisibility(): void

--- a/tests/Resolution/ResolvedEnumCaseTest.php
+++ b/tests/Resolution/ResolvedEnumCaseTest.php
@@ -8,6 +8,7 @@ use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\ClassKind;
 use Firehed\PhpLsp\Domain\EnumCaseInfo;
 use Firehed\PhpLsp\Domain\EnumCaseName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\Visibility;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -69,6 +70,11 @@ class ResolvedEnumCaseTest extends TestCase
 
         self::assertInstanceOf(EnumCaseName::class, $name);
         self::assertSame('Active', $name->name);
+    }
+
+    public function testGetMemberKind(): void
+    {
+        self::assertSame(MemberKind::EnumCase, $this->createResolvedEnumCase()->getMemberKind());
     }
 
     public function testGetVisibilityAlwaysPublic(): void

--- a/tests/Resolution/ResolvedMethodTest.php
+++ b/tests/Resolution/ResolvedMethodTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\MethodInfo;
 use Firehed\PhpLsp\Domain\MethodName;
 use Firehed\PhpLsp\Domain\ParameterInfo;
@@ -75,6 +76,11 @@ class ResolvedMethodTest extends TestCase
 
         self::assertInstanceOf(MethodName::class, $name);
         self::assertSame('doSomething', $name->name);
+    }
+
+    public function testGetMemberKind(): void
+    {
+        self::assertSame(MemberKind::Method, $this->createResolvedMethod()->getMemberKind());
     }
 
     public function testGetVisibility(): void

--- a/tests/Resolution/ResolvedPropertyTest.php
+++ b/tests/Resolution/ResolvedPropertyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\MemberKind;
 use Firehed\PhpLsp\Domain\PrimitiveType;
 use Firehed\PhpLsp\Domain\PropertyInfo;
 use Firehed\PhpLsp\Domain\PropertyName;
@@ -66,6 +67,11 @@ class ResolvedPropertyTest extends TestCase
 
         self::assertInstanceOf(PropertyName::class, $name);
         self::assertSame('name', $name->name);
+    }
+
+    public function testGetMemberKind(): void
+    {
+        self::assertSame(MemberKind::Property, $this->createResolvedProperty()->getMemberKind());
     }
 
     public function testGetVisibility(): void

--- a/tests/Resolution/TextFallbackHelperTest.php
+++ b/tests/Resolution/TextFallbackHelperTest.php
@@ -536,6 +536,28 @@ class TextFallbackHelperTest extends TestCase
         );
     }
 
+    public function testExtractMembersKeepsAMethodAndAPropertyOfTheSameName(): void
+    {
+        $content = $this->loadFixture('TopLevel/method_and_property_same_name.php');
+        $document = new TextDocument('file:///test.php', 'php', 1, $content);
+
+        $members = $this->helperWithReflection->extractMembers(
+            $document,
+            // @phpstan-ignore argument.type (test uses fake child class name)
+            new ClassName('Test\\MethodAndPropertySameName'),
+            Visibility::Private,
+            MemberFilter::Instance,
+        );
+
+        $names = self::memberNames($members);
+        $occurrences = count(array_filter($names, static fn (string $name): bool => $name === 'active'));
+        self::assertSame(
+            2,
+            $occurrences,
+            'A method and an inherited property of the same name are two members, not one',
+        );
+    }
+
     public function testExtractMembersDeduplicatesCaseVariedOverride(): void
     {
         $content = $this->loadFixture('TopLevel/case_varied_override_child.php');

--- a/tests/Resolution/TextFallbackHelperTest.php
+++ b/tests/Resolution/TextFallbackHelperTest.php
@@ -536,6 +536,31 @@ class TextFallbackHelperTest extends TestCase
         );
     }
 
+    public function testExtractMembersDeduplicatesCaseVariedOverride(): void
+    {
+        $content = $this->loadFixture('TopLevel/case_varied_override_child.php');
+        $document = new TextDocument('file:///test.php', 'php', 1, $content);
+
+        $members = $this->helperWithReflection->extractMembers(
+            $document,
+            // @phpstan-ignore argument.type (test uses fake child class name)
+            new ClassName('Test\\CaseVariedOverrideChild'),
+            Visibility::Private,
+            MemberFilter::Instance,
+        );
+
+        $names = self::memberNames($members);
+        $occurrences = count(array_filter(
+            $names,
+            static fn (string $name): bool => strtolower($name) === 'overriddenmethod',
+        ));
+        self::assertSame(
+            1,
+            $occurrences,
+            'Method names are case-insensitive in PHP, so an override spelled differently is still one method',
+        );
+    }
+
     /**
      * @param list<ResolvedMember> $members
      * @return list<string>


### PR DESCRIPTION
Without this, features disagree about what a class has. `MemberResolver` answered "does this type have member X" and "what members does this type have" with six near-copies of the same hierarchy walk — one per member kind, per question. The copies had already drifted on how a member name is matched, so a method override spelled in a different case was one method to the main path and two to the mid-edit text fallback. Adding a member kind (property hooks are scheduled) meant writing the walk twice more.

Slice **SC.7** (build-manifest). No plan step owns it: it is duplication that predates the plan, so its acceptance is the manifest row. RFC 1 Appendix A lists **member kind** as an axis whose extension point is "one extraction + one walk + preds", and §747 lists it among the dimensions "switched in exactly one place". That single place did not exist. It does now.

## One implementation per question

| Question | Now answered by |
|---|---|
| What types does a member lookup search? | `MemberResolver::supertypes()` (unchanged — the #334 invariant) |
| In what order, and visiting each type once? | `MemberResolver::hierarchy()`, replacing six walks |
| Which of `ClassInfo`'s maps holds a kind? | `MemberKind::membersOf()` |
| What is a member's identity within a class? | `MemberKind::keyFor()` |
| Which case rule does a name follow? | `NameKind` (symbols), `MemberKind` (members) |
| How is that rule applied? | `NameCase` |
| What kind is this resolved member? | `ResolvedMember::getMemberKind()` |
| What does any member expose to the walk? | `MemberInfo` |

`NameCase` exists so that adding the member-name rule **extends** the confined authority rather than widening its allowlist — the allowlist entry moves off `NameKind` instead of gaining a sibling. `MemberKind` and `NameKind` state only *which* rule applies.

## Behaviour

- **Fixed:** a method override spelled in another case is one method on every path. The text fallback keyed members by `$member::class` plus the raw name; the class name was standing in for the kind but could not answer the case rule, which is why it was the third disagreeing copy.
- **Enum cases join the walk.** `findEnumCase` / `getEnumCases` previously read the origin class only. Enums have no supertype carrying cases, so this is behaviour-identical; it is what makes the switch complete rather than three-quarters of one.
- Everything else is behaviour-preserving.

## Acceptance

- [x] Six hierarchy walks reduced to one; `supertypes()` retained as the sole type-graph traversal
- [x] The member-name case rule has one owner; the three disagreeing copies are gone
- [x] Regression test first: a case-varied override is one method, not two (`TextFallbackHelperTest::testExtractMembersDeduplicatesCaseVariedOverride`, failing before the fix)
- [x] Behaviour preserved elsewhere — `TypeGraphParityTest` (reflection as oracle) and the Step P goldens unchanged
- [x] Guardrail baselines shrink only: `phpstan-baseline.neon` 39 → 36, draining `MemberResolver`, `MethodName`, and `ClassName`; deptrac unchanged at 5; no allowlist widened

`ClassName::equals` is in scope only because the guardrail ratchets: the `MemberKind` work changed the rule's message, which unfroze that entry, and a drained entry cannot be re-frozen.

## Notes

`src` is +46 lines net. The walk itself is −143; the remainder is `MemberInfo`'s two accessors on four domain types and `getMemberKind()` on four resolved types. On PHP 8.4 most of that would be interface property hooks and would not need writing — `composer.json` requires `^8.3`, and raising it is not this slice's call.

Noted, not fixed — each wants its own row rather than this branch:

- `CompletionItemFactory::forResolvedMember` picks its item kind with four `instanceof` tests against concrete resolved types, plus a `default => throw` marked coverage-ignore. That is a second per-kind switch on the axis this slice centralises, and an RFC §4.5 violation; `getMemberKind()` now makes it a four-line change.
- `MemberCandidates` decides "is this a method" with `instanceof ResolvedMethod` — same §4.5 shape, single predicate. Belongs to the Step 4 decomposition.
- `NameKind` and `NamespacePath` each still lowercase a name for keying. Both route policy correctly, but they remain two implementations. SC.13 owns collapsing them and can see all of it at once; this slice leaves it at two rather than making it three.
- `ReferenceResolver::namesMatch` hand-rolls what `NameKind::normalize` does. Already owned by SC.19.
