### PR TITLE
Settle NamespacePath and TypeFactory in Domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ This section overrides the global "avoid adding to the baseline" guidance in the
 - `src/Index/` — Symbol indexing and workspace scanning
 - `src/Document/` — Open document management
 - `src/Parser/` — `ParserService` (the only place an AST is produced; memoizes by content for the duration of one handled LSP message, discarded by `Server`'s message loop) and `ParseMetrics` (parse count/time, which every parse is metered through)
-- `src/Utility/` — AST helpers (ScopeFinder, Scope, TypeFactory, DocblockParser)
+- `src/Utility/` — AST helpers (ScopeFinder, Scope, DocblockParser)
 - `src/Completion/` — Completion context detection (`ContextDetector`, `CompletionClassifier`) and per-kind sources (`*Candidates`, `CompletionItemFactory`)
 - `src/Capability/` — Protocol capability negotiation (see Capability Negotiation below)
 - `docs/features/` — Feature status documentation
@@ -225,6 +225,8 @@ Typed representations of code constructs in `src/Domain/`:
 - `ParameterInfo`, `FunctionInfo` — Function/method parameter details
 - `Visibility` enum — Public/protected/private with comparison logic
 - `ClassName`, `MethodName`, `PropertyName` — Typed identifiers
+- `TypeFactory` — Creates Type domain objects from AST nodes and reflection
+- `NamespacePath` — Segment operations on namespace and fully-qualified-name strings; the one place a name is split into namespace and short name, and the one place a namespace path is case-folded
 
 Domain objects implement `Formattable` for consistent signature formatting across handlers.
 
@@ -405,7 +407,6 @@ instead. `RawInitializeCapabilitiesRule` enforces this in PHPStan (RFC 1 §4.8, 
 - `Scope` — Value object modelling a lexical scope (params, statements, self/parent context, `$this`, closure captures). Function-like nodes and file-level/global code both map onto it via `Scope::atOffset()`/`forNode()`/`global()`, so type/variable resolution never branches on node type or handles a "no enclosing function" case.
 - `DocblockParser` — Extracts description from docblocks
 - `ExpressionTypeResolver` — Resolves expression types (wraps TypeResolverInterface, handles `$this`)
-- `TypeFactory` — Creates Type domain objects from AST nodes and reflection
 
 Note: `MemberAccessResolver` was removed in #262 — instance/static member access now flows through `SymbolResolver`.
 

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -1,9 +1,5 @@
 deptrac:
   skip_violations:
-    Firehed\PhpLsp\Domain\FunctionInfo:
-      - Firehed\PhpLsp\Utility\TypeFactory
-    Firehed\PhpLsp\Domain\ParameterInfo:
-      - Firehed\PhpLsp\Utility\TypeFactory
     Firehed\PhpLsp\Repository\DefaultFunctionRepository:
       - Firehed\PhpLsp\Index\DeclarationScanner
     Firehed\PhpLsp\Repository\MemberResolver:

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -4,8 +4,6 @@ deptrac:
       - Firehed\PhpLsp\Utility\TypeFactory
     Firehed\PhpLsp\Domain\ParameterInfo:
       - Firehed\PhpLsp\Utility\TypeFactory
-    Firehed\PhpLsp\Domain\QualifiedName:
-      - Firehed\PhpLsp\Utility\NamespacePath
     Firehed\PhpLsp\Repository\DefaultFunctionRepository:
       - Firehed\PhpLsp\Index\DeclarationScanner
     Firehed\PhpLsp\Repository\MemberResolver:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,7 +39,7 @@ parameters:
                 - src/Index/ReflectionNamespaceSource.php
                 - src/Repository/ClassInfoFactory.php
                 - src/Repository/DefaultClassInfoFactory.php
-                - src/Utility/TypeFactory.php
+                - src/Domain/TypeFactory.php
                 - src/Domain/FunctionInfo.php
                 - src/Domain/ParameterInfo.php
                 - tests/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -64,7 +64,7 @@ parameters:
             message: 'which case rule a name follows is NameKind (symbols) or MemberKind (class-like members); applying one is NameCase; other uses may be allowlisted here consciously'
             allowIn:
                 - src/Domain/NameCase.php
-                - src/Utility/NamespacePath.php # namespace paths are case-insensitive for every kind; not a symbol name
+                - src/Domain/NamespacePath.php # namespace paths are case-insensitive for every kind; not a symbol name
                 - src/Transport/MessageReader.php # HTTP header names
                 - src/Domain/Visibility.php # visibility keywords
                 - tests/*

--- a/src/Completion/CompletionItemFactory.php
+++ b/src/Completion/CompletionItemFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Completion;
 
 use Firehed\PhpLsp\Domain\FunctionInfo;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Firehed\PhpLsp\Domain\ParameterInfo;
 use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\ResolvedConstant;
@@ -13,7 +14,6 @@ use Firehed\PhpLsp\Resolution\ResolvedMember;
 use Firehed\PhpLsp\Resolution\ResolvedMethod;
 use Firehed\PhpLsp\Resolution\ResolvedProperty;
 use Firehed\PhpLsp\Utility\DocblockParser;
-use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * Builds LSP completion items. Centralizing construction here keeps item shape,

--- a/src/Completion/NamespaceCandidates.php
+++ b/src/Completion/NamespaceCandidates.php
@@ -7,6 +7,7 @@ namespace Firehed\PhpLsp\Completion;
 use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Firehed\PhpLsp\Domain\PrefixMatcher;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
@@ -14,7 +15,6 @@ use Firehed\PhpLsp\Knowledge\SymbolSource;
 use Firehed\PhpLsp\Protocol\Range;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 use Firehed\PhpLsp\Resolution\NameContext;
-use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * Produces namespace-navigation items through the {@see SymbolSource} knowledge seam

--- a/src/Domain/ClassName.php
+++ b/src/Domain/ClassName.php
@@ -40,20 +40,14 @@ final readonly class ClassName implements Type
 
     public function shortName(): string
     {
-        $lastSeparator = strrpos($this->fqn, '\\');
-        if ($lastSeparator === false) {
-            return $this->fqn;
-        }
-        return substr($this->fqn, $lastSeparator + 1);
+        return NamespacePath::shortNameOf($this->fqn);
     }
 
     public function namespace(): ?string
     {
-        $lastSeparator = strrpos($this->fqn, '\\');
-        if ($lastSeparator === false) {
-            return null;
-        }
-        return substr($this->fqn, 0, $lastSeparator);
+        $namespace = NamespacePath::namespaceOf($this->fqn);
+
+        return $namespace === '' ? null : $namespace;
     }
 
     public function equals(self $other): bool

--- a/src/Domain/FunctionInfo.php
+++ b/src/Domain/FunctionInfo.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
-use Firehed\PhpLsp\Utility\TypeFactory;
 use PhpParser\Node\Stmt;
 use ReflectionFunction;
 

--- a/src/Domain/NameKind.php
+++ b/src/Domain/NameKind.php
@@ -53,7 +53,7 @@ enum NameKind
     public function normalize(QualifiedName $name): string
     {
         $shortName = $this->caseRule()->normalize($name->shortName);
-        $namespace = NameCase::Insensitive->normalize($name->namespace);
+        $namespace = NamespacePath::normalize($name->namespace);
 
         return (new QualifiedName($namespace, $shortName))->fullyQualifiedName();
     }

--- a/src/Domain/NamespacePath.php
+++ b/src/Domain/NamespacePath.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Firehed\PhpLsp\Utility;
+namespace Firehed\PhpLsp\Domain;
 
 /**
  * Operations on namespace and fully-qualified-name strings.

--- a/src/Domain/ParameterInfo.php
+++ b/src/Domain/ParameterInfo.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
-use Firehed\PhpLsp\Utility\TypeFactory;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;

--- a/src/Domain/QualifiedName.php
+++ b/src/Domain/QualifiedName.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
-
 /**
  * A fully-qualified name split into namespace path and short name, carrying no
  * notion of what it names (Plan 0002 §5.3: the kind-neutral base FQN value type).

--- a/src/Domain/QualifiedName.php
+++ b/src/Domain/QualifiedName.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Domain;
 
-use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * A fully-qualified name split into namespace path and short name, carrying no

--- a/src/Domain/TypeFactory.php
+++ b/src/Domain/TypeFactory.php
@@ -2,15 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Firehed\PhpLsp\Utility;
+namespace Firehed\PhpLsp\Domain;
 
-use Firehed\PhpLsp\Domain\ClassName;
-use Firehed\PhpLsp\Domain\IntersectionType;
-use Firehed\PhpLsp\Domain\LateBindingKeyword;
-use Firehed\PhpLsp\Domain\LateStaticType;
-use Firehed\PhpLsp\Domain\PrimitiveType;
-use Firehed\PhpLsp\Domain\Type;
-use Firehed\PhpLsp\Domain\UnionType;
 use LogicException;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;

--- a/src/Index/AutoloadFilesLocator.php
+++ b/src/Index/AutoloadFilesLocator.php
@@ -7,10 +7,10 @@ namespace Firehed\PhpLsp\Index;
 use Firehed\PhpLsp\Cache\Invalidatable;
 use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Firehed\PhpLsp\Domain\QualifiedName;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
 use Firehed\PhpLsp\Parser\ParserService;
-use Firehed\PhpLsp\Utility\NamespacePath;
 use PhpParser\Node;
 
 /**

--- a/src/Index/CachedNamespaceCatalog.php
+++ b/src/Index/CachedNamespaceCatalog.php
@@ -6,7 +6,7 @@ namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Cache\CacheKey;
 use Firehed\PhpLsp\Cache\Invalidatable;
-use Firehed\PhpLsp\Utility\NamespacePath;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Psr\SimpleCache\CacheInterface;
 
 /**

--- a/src/Index/CatalogSymbol.php
+++ b/src/Index/CatalogSymbol.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Firehed\PhpLsp\Domain\QualifiedName;
-use Firehed\PhpLsp\Utility\NamespacePath;
 
 /**
  * A symbol discovered in a namespace.

--- a/src/Index/ComposerNamespaceSource.php
+++ b/src/Index/ComposerNamespaceSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Domain\NameKind;
-use Firehed\PhpLsp\Utility\NamespacePath;
+use Firehed\PhpLsp\Domain\NamespacePath;
 
 /**
  * Discovers symbols through Composer's autoload maps, without parsing or

--- a/src/Index/NamespaceContents.php
+++ b/src/Index/NamespaceContents.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
-use Firehed\PhpLsp\Utility\NamespacePath;
+use Firehed\PhpLsp\Domain\NamespacePath;
 
 /**
  * The immediate children of a namespace: the namespaces directly beneath it and

--- a/src/Index/ReflectionNamespaceSource.php
+++ b/src/Index/ReflectionNamespaceSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Domain\NameKind;
-use Firehed\PhpLsp\Utility\NamespacePath;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use ReflectionClass;
 
 /**

--- a/src/Index/SymbolIndex.php
+++ b/src/Index/SymbolIndex.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Index;
 
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Firehed\PhpLsp\Domain\PrefixMatcher;
-use Firehed\PhpLsp\Utility\NamespacePath;
 
 final class SymbolIndex
 {

--- a/src/Index/WorkspaceNamespaceSource.php
+++ b/src/Index/WorkspaceNamespaceSource.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Index;
 
 use Firehed\PhpLsp\Domain\NameKind;
-use Firehed\PhpLsp\Utility\NamespacePath;
+use Firehed\PhpLsp\Domain\NamespacePath;
 
 /**
  * Discovers the symbols declared in the workspace, from the symbol index.

--- a/src/Repository/DefaultClassInfoFactory.php
+++ b/src/Repository/DefaultClassInfoFactory.php
@@ -20,7 +20,7 @@ use Firehed\PhpLsp\Domain\PropertyInfo;
 use Firehed\PhpLsp\Domain\PropertyName;
 use Firehed\PhpLsp\Domain\UnionType;
 use Firehed\PhpLsp\Domain\Visibility;
-use Firehed\PhpLsp\Utility\TypeFactory;
+use Firehed\PhpLsp\Domain\TypeFactory;
 use PhpParser\Modifiers;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;

--- a/src/Resolution/ReferenceResolver.php
+++ b/src/Resolution/ReferenceResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\NameKind;
-use Firehed\PhpLsp\Utility\NamespacePath;
+use Firehed\PhpLsp\Domain\NamespacePath;
 
 /**
  * Computes how a symbol must be written at a given cursor: the shortest

--- a/src/TypeInference/BasicTypeResolver.php
+++ b/src/TypeInference/BasicTypeResolver.php
@@ -13,7 +13,7 @@ use Firehed\PhpLsp\Repository\FunctionRepository;
 use Firehed\PhpLsp\Repository\MemberResolver;
 use Firehed\PhpLsp\Utility\Scope;
 use Firehed\PhpLsp\Utility\ScopeFinder;
-use Firehed\PhpLsp\Utility\TypeFactory;
+use Firehed\PhpLsp\Domain\TypeFactory;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;

--- a/tests/Domain/NamespacePathTest.php
+++ b/tests/Domain/NamespacePathTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Utility;
 
-use Firehed\PhpLsp\Utility\NamespacePath;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/tests/Domain/TypeFactoryTest.php
+++ b/tests/Domain/TypeFactoryTest.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Firehed\PhpLsp\Utility;
+namespace Firehed\PhpLsp\Tests\Domain;
 
 use Firehed\PhpLsp\Domain\ClassName;
 use Firehed\PhpLsp\Domain\IntersectionType;
 use Firehed\PhpLsp\Domain\LateBindingKeyword;
 use Firehed\PhpLsp\Domain\LateStaticType;
 use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\TypeFactory;
 use Firehed\PhpLsp\Domain\UnionType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\IntersectionType as AstIntersectionType;

--- a/tests/Knowledge/KnowledgeStackTest.php
+++ b/tests/Knowledge/KnowledgeStackTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Knowledge;
 
 use Firehed\PhpLsp\Document\TextDocument;
 use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
 use Firehed\PhpLsp\Index\Location;
@@ -15,7 +16,6 @@ use Firehed\PhpLsp\Index\SymbolKind;
 use Firehed\PhpLsp\Knowledge\KnowledgeStack;
 use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Parser\ParserService;
-use Firehed\PhpLsp\Utility\NamespacePath;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Parity/BuiltinFunctionParityTest.php
+++ b/tests/Parity/BuiltinFunctionParityTest.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Tests\Parity;
 
 use Firehed\PhpLsp\Cache\CacheFactory;
 use Firehed\PhpLsp\Domain\NameKind;
+use Firehed\PhpLsp\Domain\NamespacePath;
 use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
 use Firehed\PhpLsp\Index\CatalogSymbol;
 use Firehed\PhpLsp\Index\ReflectionNamespaceSource;
@@ -14,7 +15,6 @@ use Firehed\PhpLsp\Knowledge\NamespaceName;
 use Firehed\PhpLsp\Knowledge\ReflectionSymbolInfoFactory;
 use Firehed\PhpLsp\Knowledge\SymbolCache;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Utility\NamespacePath;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
Splitting a fully-qualified name into namespace and short name had three implementations, and folding a namespace path to a lookup key had two. `NamespacePath` owned both, but it sat in `Utility`, which `Domain` may not depend on — so `ClassName` and `NameKind` each wrote their own instead, and the layer contract froze the edges rather than fixing them. Two names that disagree about where the namespace ends are two features that disagree about what symbol was asked for. There is now one split and one fold.

Slice: **SC.13** (`cleanup`, no owning step — pre-existing placement debt)
Plan: `build-manifest.md` SC.13; unblocks SC.18
RFC: `0001-foundational-architecture.md` §8.1 (a rule ships with the mechanism that enforces it — here, the layer contract)

## Direction

Both utilities move **into** `Domain`, rather than moving the factory methods out.

`FunctionInfo` and `ParameterInfo` already import PhpParser and Reflection directly — those are their `fromNode` / `fromReflection` parameter types. So the parser coupling is inside `Domain` either way, and `TypeFactory`'s home in `Utility` was what forced the violation, not the coupling. `NamespacePath` has no dependencies at all and belongs beside `NameKind`, `NameCase`, and `QualifiedName`, which are the other things that answer questions about names.

Moving the factory methods out instead would have touched about forty-five call sites to fix what the move fixes in four, and would have contradicted the project's own "add factory methods to domain objects" guideline.

## Acceptance

- [x] All three frozen `deptrac.baseline.yaml` edges drained (`FunctionInfo`→`TypeFactory`, `ParameterInfo`→`TypeFactory`, `QualifiedName`→`NamespacePath`); 5 → 2, nothing added
- [x] `ClassName::shortName()` / `namespace()` route through `NamespacePath`; the hand-rolled `strrpos`/`substr` split is gone
- [x] `NameKind::normalize` routes its path half through `NamespacePath::normalize`, which it was layer-blocked from reaching before
- [x] The case-folding allowlist entry follows the file to `src/Domain/NamespacePath.php`; the reflection allowlist follows `TypeFactory`
- [x] `composer test` green

Behaviour-preserving throughout, proven by the existing `ClassNameTest`, `NameKindTest`, `NamespacePathTest` and `TypeFactoryTest` assertions, which move with their subjects and are otherwise unchanged.

## Notes

`TypeFactoryTest` declared itself in the production namespace `Firehed\PhpLsp\Utility` rather than a `Tests\` one. The namespace had to change with the move, so it now reads `Firehed\PhpLsp\Tests\Domain` like every other test.

One line, neither filed nor fixed: `ClassName::namespace()` returns `?string` and has no callers outside its own test. Its shape is preserved here.

Candidate closes (pending review verification): none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
