### PR TITLE
Stop writing two name rules down twice

### DIFF
--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -117,6 +117,7 @@ re-runs repo-wide as its completion gate.
     SC.17  —     cleanup   Collapse the hand-routed invalidation fan-out      —                 —
     SC.18  —     cleanup   One home for the kind-qualified symbol key         SC.13             —
     SC.19  —     cleanup   Own the four unowned baseline entries              —                 —
+    SC.20  —     cleanup   Own the last unowned layer-contract entry          —                 —
     SZ.1   Z     scaffold  Definition of Done gate + repo-wide dup audit      all prior         —
 
 Notes:
@@ -349,6 +350,19 @@ Notes:
     belong in `CompletionClassifier`, which is where the allowlist already puts
     text-pattern analysis. Filed because the baseline must reach zero and an entry with no
     owning slice is how it stalls — found by auditing the baseline against this table.
+    It covers `phpstan-baseline.neon` only; the other baseline is SC.20.
+  - **SC.20** — `deptrac.baseline.yaml` freezes `DefaultFunctionRepository` depending on
+    `Index\DeclarationScanner`, and no row removes it. `Repository` may not reach `Index`
+    under the layer contract, and SC.5 created the edge on purpose, so it is real rather
+    than an oversight: the repository has to ask what a file declares, and the scanner is
+    the one thing that answers.
+    S3.10 is not the remover, though it looks like it — S3.10 retires that class's AST-in
+    *signature*, which is a different thing from the dependency and leaves it standing.
+    The slice decides which way the edge goes: let `Repository` read `Index`, move the
+    scanner somewhere both may reach, or route the repository through a seam it already
+    has. Take it after S3.10, whose teardown may narrow the choice.
+    The only entry either baseline still holds with no owning row. Found while reviewing
+    the wording of SC.19, which had claimed all four of its own were the last.
   - **SC.8** — `Completion\PrefixMatcher::matches` and `SymbolIndex::findByPrefix` both
     hand-roll `str_starts_with(strtolower(...))`. SC.6 owns the `strtolower` half (it is
     the same per-kind case rule); what is left here is the duplicated *matching* helper, so

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,18 +7,6 @@ parameters:
 			path: src/Completion/FunctionCandidates.php
 
 		-
-			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Completion/NamedArgumentCandidates.php
-
-		-
-			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'
-			identifier: disallowed.function
-			count: 2
-			path: src/Handler/CompletionHandler.php
-
-		-
 			message: '#^Class ReflectionFunction is forbidden, runtime reflection is confined\: ReflectionNamespaceSource and the fromReflection factories\. \[ReflectionFunction matches Reflection\*\]$#'
 			identifier: disallowed.class
 			count: 1
@@ -35,12 +23,6 @@ parameters:
 			identifier: disallowed.namespace
 			count: 1
 			path: src/Repository/DefaultFunctionRepository.php
-
-		-
-			message: '#^Calling strcasecmp\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
-			identifier: disallowed.function
-			count: 1
-			path: src/Resolution/ReferenceResolver.php
 
 		-
 			message: '#^Calling preg_match\(\) is forbidden, text\-pattern analysis is the mid\-edit resilience rim\: CompletionClassifier, DocblockParser, TextFallbackHelper\.$#'

--- a/src/Completion/CompletionClassifier.php
+++ b/src/Completion/CompletionClassifier.php
@@ -66,10 +66,43 @@ final class CompletionClassifier
     // constants, which are out of this position's scope (#239, #317).
     private const USE_PATTERN = '/\buse\s+' . self::QUALIFIED_TAIL . '$/';
 
+    // The variable name typed after a `$`. Read both by classification and, inside
+    // a call, by the handler offering variables alongside argument names.
+    private const VARIABLE_PATTERN = '/\$(\w*)$/';
+
+    // An argument name typed after a call's `(` or an argument separator.
+    private const ARGUMENT_NAME_PATTERN = '/[(,]\s*(\w*)$/';
+
+    // The value typed after a named argument's `name:`.
+    private const ARGUMENT_VALUE_PATTERN = '/\w+:\s*(\w*)$/';
+
+    /**
+     * The argument name being typed, empty when the position admits one but nothing
+     * has been typed yet.
+     */
+    public static function argumentNamePrefix(string $textBeforeCursor): string
+    {
+        return preg_match(self::ARGUMENT_NAME_PATTERN, $textBeforeCursor, $matches) === 1
+            ? $matches[1]
+            : '';
+    }
+
+    /**
+     * The value being typed after a named argument's colon, or null where the cursor
+     * is not in a value position at all — which the caller must tell apart from a
+     * value position with nothing typed yet, since only the former offers no items.
+     */
+    public static function argumentValuePrefix(string $textBeforeCursor): ?string
+    {
+        return preg_match(self::ARGUMENT_VALUE_PATTERN, $textBeforeCursor, $matches) === 1
+            ? $matches[1]
+            : null;
+    }
+
     public static function classify(string $textBeforeCursor): CompletionClassification
     {
         // Variable completion
-        if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
+        if (preg_match(self::VARIABLE_PATTERN, $textBeforeCursor, $matches) === 1) {
             return new CompletionClassification(CompletionKind::Variable, $matches[1]);
         }
 
@@ -169,6 +202,16 @@ final class CompletionClassifier
         }
 
         return new CompletionClassification(CompletionKind::None, '');
+    }
+
+    /**
+     * The variable name being typed, empty where the cursor is not on one.
+     */
+    public static function variablePrefix(string $textBeforeCursor): string
+    {
+        return preg_match(self::VARIABLE_PATTERN, $textBeforeCursor, $matches) === 1
+            ? $matches[1]
+            : '';
     }
 
     /**

--- a/src/Completion/NamedArgumentCandidates.php
+++ b/src/Completion/NamedArgumentCandidates.php
@@ -51,9 +51,6 @@ final class NamedArgumentCandidates
 
     private function extractPrefix(string $textBeforeCursor): string
     {
-        if (preg_match('/[(,]\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
-            return $matches[1];
-        }
-        return '';
+        return CompletionClassifier::argumentNamePrefix($textBeforeCursor);
     }
 }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -158,18 +158,19 @@ final class CompletionHandler implements HandlerInterface
             $items = $this->namedArgumentCandidates->find($callContext, $textBeforeCursor);
 
             // Also offer variables - filter by prefix if cursor is on one
-            $varPrefix = '';
-            if (preg_match('/\$(\w*)$/', $textBeforeCursor, $matches) === 1) {
-                $varPrefix = $matches[1];
-            }
             $items = array_merge(
                 $items,
-                $this->variableCandidates->find($varPrefix, $document, $line, $character),
+                $this->variableCandidates->find(
+                    CompletionClassifier::variablePrefix($textBeforeCursor),
+                    $document,
+                    $line,
+                    $character,
+                ),
             );
 
             // After named arg colon (value position), also offer expression keywords and classes
-            if (preg_match('/\w+:\s*(\w*)$/', $textBeforeCursor, $matches) === 1) {
-                $prefix = $matches[1];
+            $prefix = CompletionClassifier::argumentValuePrefix($textBeforeCursor);
+            if ($prefix !== null) {
                 $items = array_merge($items, $this->keywordCandidates->find($prefix, KeywordGroup::Expression));
                 $items = array_merge(
                     $items,

--- a/src/Resolution/ReferenceResolver.php
+++ b/src/Resolution/ReferenceResolver.php
@@ -6,6 +6,7 @@ namespace Firehed\PhpLsp\Resolution;
 
 use Firehed\PhpLsp\Domain\NameKind;
 use Firehed\PhpLsp\Domain\NamespacePath;
+use Firehed\PhpLsp\Domain\QualifiedName;
 
 /**
  * Computes how a symbol must be written at a given cursor: the shortest
@@ -171,17 +172,9 @@ final class ReferenceResolver
         return NamespacePath::relativeTo($namespace, $ancestor);
     }
 
-    /**
-     * Namespaces are case-insensitive even for constants — only a constant's
-     * final segment is case-sensitive.
-     */
     private static function namesMatch(string $a, string $b, NameKind $kind): bool
     {
-        if (!$kind->isCaseSensitive()) {
-            return strcasecmp($a, $b) === 0;
-        }
-
-        return NamespacePath::equals(NamespacePath::namespaceOf($a), NamespacePath::namespaceOf($b))
-            && NamespacePath::shortNameOf($a) === NamespacePath::shortNameOf($b);
+        return $kind->normalize(QualifiedName::fromFullyQualified($a))
+            === $kind->normalize(QualifiedName::fromFullyQualified($b));
     }
 }

--- a/tests/Completion/CompletionClassifierTest.php
+++ b/tests/Completion/CompletionClassifierTest.php
@@ -234,4 +234,74 @@ class CompletionClassifierTest extends TestCase
         yield 'none after member arrow' => ['$foo->', CompletionKind::None, ''];
         yield 'none after operator no word' => ['1 + ', CompletionKind::None, ''];
     }
+
+    #[DataProvider('provideVariablePrefixes')]
+    public function testVariablePrefix(string $textBeforeCursor, string $expected): void
+    {
+        self::assertSame($expected, CompletionClassifier::variablePrefix($textBeforeCursor));
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideVariablePrefixes(): iterable
+    {
+        yield 'bare sigil' => ['$', ''];
+        yield 'partial name' => ['$us', 'us'];
+        yield 'inside a call' => ['foo($ba', 'ba'];
+        yield 'not on a variable' => ['foo(', ''];
+        yield 'sigil already closed' => ['$user->', ''];
+    }
+
+    /**
+     * The same extractor serves classification and the in-call variable offer, so
+     * a variable named one way in one position cannot be named another elsewhere.
+     */
+    public function testVariablePrefixAgreesWithClassification(): void
+    {
+        $classification = CompletionClassifier::classify('$us');
+
+        self::assertSame(CompletionKind::Variable, $classification->kind);
+        self::assertSame(
+            $classification->prefix,
+            CompletionClassifier::variablePrefix('$us'),
+            'Classification and direct extraction must read the same prefix',
+        );
+    }
+
+    #[DataProvider('provideArgumentNamePrefixes')]
+    public function testArgumentNamePrefix(string $textBeforeCursor, string $expected): void
+    {
+        self::assertSame($expected, CompletionClassifier::argumentNamePrefix($textBeforeCursor));
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideArgumentNamePrefixes(): iterable
+    {
+        yield 'first argument' => ['foo(', ''];
+        yield 'first argument partly typed' => ['foo(na', 'na'];
+        yield 'later argument' => ['foo($a, na', 'na'];
+        yield 'not in an argument list' => ['$x = na', ''];
+    }
+
+    #[DataProvider('provideArgumentValuePrefixes')]
+    public function testArgumentValuePrefix(string $textBeforeCursor, ?string $expected): void
+    {
+        self::assertSame($expected, CompletionClassifier::argumentValuePrefix($textBeforeCursor));
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function provideArgumentValuePrefixes(): iterable
+    {
+        yield 'nothing typed after the colon' => ['foo(name: ', ''];
+        yield 'value partly typed' => ['foo(name: Sta', 'Sta'];
+        yield 'no colon at all' => ['foo(na', null];
+    }
 }


### PR DESCRIPTION
Two rules were written down twice.

The first is which characters make up a variable name at the cursor. `CompletionClassifier` had it, and `CompletionHandler` had its own copy. So variable completion inside a function call and variable completion everywhere else could come to read the same cursor differently.

The second is whether two symbol names are the same name, given that PHP ignores case for classes and functions but not for constants. `NameKind` had it, and `ReferenceResolver` had its own copy. `ReferenceResolver` decides how a completion item must be spelled, so the two disagreeing means a name the lookup finds is one the spelling check treats as absent.

Each rule now has one copy.

These were also the four entries in `phpstan-baseline.neon` that no planned piece of work was going to remove. That file has to reach zero, and an entry nobody owns is how it stops shrinking.

Slice: **SC.19** (`cleanup`, no owning step)
Plan: `build-manifest.md` SC.19

## What moved

The three text patterns move into `CompletionClassifier`, the one class allowed to match text patterns, as `variablePrefix()`, `argumentNamePrefix()` and `argumentValuePrefix()`. The variable pattern is now a single constant that both the classifier and the handler read, so the copy is gone rather than moved.

`ReferenceResolver` now compares names by asking `NameKind`, which already knows to ignore case in the namespace and to follow the per-kind rule for the last segment. That is what the old code spelled out by hand, in three more lines.

## Acceptance

- [x] All four unowned `phpstan-baseline.neon` entries removed (`ReferenceResolver`, `CompletionHandler` twice, `NamedArgumentCandidates`); 30 down to 26, none added
- [x] No text-pattern matching left outside the classes allowed to do it, and no case comparison outside `NameCase` and its callers
- [x] New tests for each of the three extractors, including one that checks the handler and the classifier read the same text the same way
- [x] `composer test` passes

Everything still in `phpstan-baseline.neon` has a piece of work that will remove it: `FunctionCandidates` is S3.9b, `DefaultFunctionRepository` is S3.10, `SymbolResolver` and `TextFallbackHelper` are S4.2 and S4.5, `BasicTypeResolver` is S4.8.

## One thing found, filed not fixed

`deptrac.baseline.yaml` was outside what SC.19 was written to cover, and it has the same problem. Two entries are left. `MemberResolver` needing `MemberFilter` is SC.12's to remove. But nothing owned `DefaultFunctionRepository` needing `DeclarationScanner`. S3.10 removes that class's ability to take a syntax tree as an argument, which is a different thing from the dependency between the two areas of code — that dependency exists because SC.5 deliberately made the repository use `DeclarationScanner`.

It is now **SC.20** in the manifest, for the same reason this one has a row. Not fixed here: the fix is a choice between three directions, and S3.10 may narrow it.

With that filed, neither baseline holds an entry nobody owns.

Candidate closes (pending review verification): none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
