### PR TITLE
Oracle corpus: trait adaptations and enums

### DIFF
--- a/tests/Fixtures/src/Hierarchy/ConflictingTraitA.php
+++ b/tests/Fixtures/src/Hierarchy/ConflictingTraitA.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+trait ConflictingTraitA
+{
+    public function conflictMethod(): string
+    {
+        return 'A';
+    }
+
+    public function onlyInA(): string
+    {
+        return 'A';
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/ConflictingTraitB.php
+++ b/tests/Fixtures/src/Hierarchy/ConflictingTraitB.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+trait ConflictingTraitB
+{
+    public function conflictMethod(): string
+    {
+        return 'B';
+    }
+
+    public function onlyInB(): string
+    {
+        return 'B';
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/EnumWithInterface.php
+++ b/tests/Fixtures/src/Hierarchy/EnumWithInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+enum EnumWithInterface: string implements BaseInterface
+{
+    case First = 'first';
+    case Second = 'second';
+
+    public function baseMethod(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Fixtures/src/Hierarchy/TraitAdaptationUser.php
+++ b/tests/Fixtures/src/Hierarchy/TraitAdaptationUser.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Hierarchy;
+
+class TraitAdaptationUser
+{
+    use ConflictingTraitA, ConflictingTraitB {
+        ConflictingTraitA::conflictMethod insteadof ConflictingTraitB;
+        ConflictingTraitB::conflictMethod as conflictMethodFromB;
+        ConflictingTraitB::onlyInB as protected protectedOnlyInB;
+    }
+}

--- a/tests/Repository/TypeGraphParityTest.php
+++ b/tests/Repository/TypeGraphParityTest.php
@@ -55,6 +55,8 @@ final class TypeGraphParityTest extends TestCase
             'interface extending a built-in' => ['Fixtures\Repository\Repository'],
             'PSR-7 request' => ['Psr\Http\Message\RequestInterface'],
             'PSR-7 server request' => ['Psr\Http\Message\ServerRequestInterface'],
+            'trait insteadof and as adaptations' => ['Fixtures\Hierarchy\TraitAdaptationUser'],
+            'enum implementing interface' => ['Fixtures\Hierarchy\EnumWithInterface'],
         ];
     }
 
@@ -75,6 +77,7 @@ final class TypeGraphParityTest extends TestCase
     #[DataProvider('hierarchyTypes')]
     public function testPublicMethodsMatchRuntime(string $fqcn): void
     {
+        $this->skipKnownGaps($fqcn);
         $resolved = array_map(
             fn ($method) => $method->name->name,
             $this->resolver->getMethods(new ClassName($fqcn), Visibility::Public),
@@ -93,6 +96,7 @@ final class TypeGraphParityTest extends TestCase
     #[DataProvider('hierarchyTypes')]
     public function testPublicPropertiesMatchRuntime(string $fqcn): void
     {
+        $this->skipKnownGaps($fqcn);
         $expected = array_map(
             fn (ReflectionProperty $property) => $property->getName(),
             (new ReflectionClass($fqcn))->getProperties(ReflectionProperty::IS_PUBLIC),
@@ -116,6 +120,7 @@ final class TypeGraphParityTest extends TestCase
     #[DataProvider('hierarchyTypes')]
     public function testPublicConstantsMatchRuntime(string $fqcn): void
     {
+        $this->skipKnownGaps($fqcn);
         $expected = [];
         foreach ((new ReflectionClass($fqcn))->getReflectionConstants() as $constant) {
             if ($constant->isPublic()) {
@@ -133,6 +138,17 @@ final class TypeGraphParityTest extends TestCase
             self::normalize($resolved),
             'resolved public constants should match the constants available at runtime',
         );
+    }
+
+    private function skipKnownGaps(string $fqcn): void
+    {
+        $gaps = [
+            'Fixtures\Hierarchy\TraitAdaptationUser' => 'Trait adaptations (insteadof/as) not yet handled #73',
+            'Fixtures\Hierarchy\EnumWithInterface' => 'Enum interface inheritance not yet handled #73',
+        ];
+        if (array_key_exists($fqcn, $gaps)) {
+            self::markTestSkipped($gaps[$fqcn]);
+        }
     }
 
     /**


### PR DESCRIPTION
Without these fixtures, the parity oracle cannot see #73's defect class — MemberResolver reports wrong members for trait adaptations (insteadof/as), but no test catches it. Enums implementing interfaces are similarly untested.

**Slice:** SC.15  
**RFC sections:** §4.2 (lookup/enumeration agreement via the parity oracle)

## Acceptance

- [x] Trait fixtures with `insteadof` and `as` adaptations added to corpus
- [x] Enum implementing interface added to corpus
- [x] Tests skip with `#73` reference until that issue is fixed
- [x] Suite green

## Notes

The new fixtures are skipped via `markTestSkipped` per project convention. When #73 lands, it removes the skips and the tests begin asserting.

🤖 Generated with [Claude Code](https://claude.ai/code)
