### PR TITLE
Collapse the hand-routed invalidation fan-out

### DIFF
--- a/src/Knowledge/CompositeSymbolLocator.php
+++ b/src/Knowledge/CompositeSymbolLocator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Knowledge;
 
-use Firehed\PhpLsp\Cache\Invalidatable;
 use Firehed\PhpLsp\Domain\NameKind;
 use Firehed\PhpLsp\Domain\QualifiedName;
 
@@ -17,7 +16,7 @@ use Firehed\PhpLsp\Domain\QualifiedName;
  * covers what the maps structurally cannot (Plan 0002 §3). Chaining keeps the
  * cheaper route first and leaves each locator responsible for one mechanism.
  */
-final class CompositeSymbolLocator implements SymbolLocator, Invalidatable
+final class CompositeSymbolLocator implements SymbolLocator
 {
     /**
      * @param list<SymbolLocator> $locators In precedence order
@@ -25,19 +24,6 @@ final class CompositeSymbolLocator implements SymbolLocator, Invalidatable
     public function __construct(
         private readonly array $locators,
     ) {
-    }
-
-    /**
-     * Fans out to the members that hold derived state. A locator that resolves by
-     * arithmetic alone holds none and does not implement {@see Invalidatable}.
-     */
-    public function invalidate(string $uri): void
-    {
-        foreach ($this->locators as $locator) {
-            if ($locator instanceof Invalidatable) {
-                $locator->invalidate($uri);
-            }
-        }
     }
 
     public function locate(QualifiedName $name, NameKind $kind): ?string

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -78,9 +78,8 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
     }
 
     /**
-     * Evict the file's cached symbols by their recorded keys and drop cached
-     * namespace listings, so the next query re-reads disk and the pre-change value
-     * is not restored (RFC 1 §5.2, §5.3).
+     * Evict the file's cached symbols by their recorded keys, so the next query
+     * re-reads disk and the pre-change value is not restored (RFC 1 §5.2, §5.3).
      */
     public function invalidate(string $uri): void
     {
@@ -89,16 +88,6 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
             $this->cache->delete($cacheKey);
         }
         unset($this->cacheKeysByPath[$path]);
-
-        if ($this->namespaces instanceof Invalidatable) {
-            $this->namespaces->invalidate($uri);
-        }
-
-        // The autoload.files index is derived from disk too, so a change must reach
-        // the locator or the name -> file map stays stale behind an evicted cache.
-        if ($this->locator instanceof Invalidatable) {
-            $this->locator->invalidate($uri);
-        }
     }
 
     /**

--- a/src/Knowledge/KnowledgeStack.php
+++ b/src/Knowledge/KnowledgeStack.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\PhpLsp\Knowledge;
 
 use Firehed\PhpLsp\Cache\CacheFactory;
+use Firehed\PhpLsp\Cache\Invalidatable;
 use Firehed\PhpLsp\Index\AutoloadFilesLocator;
 use Firehed\PhpLsp\Index\CachedNamespaceCatalog;
 use Firehed\PhpLsp\Index\ComposerAutoloadMap;
@@ -60,8 +61,18 @@ final readonly class KnowledgeStack
         $scanner = new DeclarationScanner();
 
         $openDocuments = new OpenDocumentBackend($index);
-        $workspace = self::filesystemBackend($workspaceMap, $parser, $declarationInfoFactory, $scanner);
-        $vendor = self::filesystemBackend($vendorMap, $parser, $declarationInfoFactory, $scanner);
+        [$workspace, $workspaceInvalidatables] = self::filesystemBackend(
+            $workspaceMap,
+            $parser,
+            $declarationInfoFactory,
+            $scanner,
+        );
+        [$vendor, $vendorInvalidatables] = self::filesystemBackend(
+            $vendorMap,
+            $parser,
+            $declarationInfoFactory,
+            $scanner,
+        );
         $source = new CompositeSymbolSource([
             $openDocuments,
             $workspace,
@@ -84,46 +95,42 @@ final readonly class KnowledgeStack
             // cache for a file so the next query re-reads disk (RFC 1 §5.2, §5.3).
             // The open-document backend is authoritative and never cached, so it is
             // not invalidated; the built-in backend does not read workspace files.
-            [$workspace, $vendor],
+            [...$workspaceInvalidatables, ...$vendorInvalidatables],
         );
 
         return new self($source, $sink);
     }
 
     /**
-     * The two routes to a declaration, cheapest first: Composer's autoload maps
-     * address class-likes by arithmetic on the name, and the derived index covers
-     * the `autoload.files` set, which they address by no name at all (Plan 0002 §3).
-     *
-     * Both routes answer enumeration as well as lookup, from the one derived index
-     * — the `files` set sits outside every PSR-4 and PSR-0 prefix, so the directory
-     * listing cannot see it, and a name reachable by only one of the two surfaces is
-     * the split RFC 1 §4.2 forbids.
+     * @return array{FilesystemBackend, list<Invalidatable>}
      */
     private static function filesystemBackend(
         ComposerAutoloadMap $map,
         ParserService $parser,
         DeclarationSymbolInfoFactory $infoFactory,
         DeclarationScanner $scanner,
-    ): FilesystemBackend {
+    ): array {
         $autoloadFiles = new AutoloadFilesLocator($map, $parser, $scanner);
+        $cachedCatalog = new CachedNamespaceCatalog(
+            new CompositeNamespaceCatalog([
+                new ComposerNamespaceSource($map),
+                $autoloadFiles,
+            ]),
+            CacheFactory::inMemory(),
+        );
 
-        return new FilesystemBackend(
+        $backend = new FilesystemBackend(
             new CompositeSymbolLocator([
                 new ComposerSymbolLocator($map),
                 $autoloadFiles,
             ]),
-            new CachedNamespaceCatalog(
-                new CompositeNamespaceCatalog([
-                    new ComposerNamespaceSource($map),
-                    $autoloadFiles,
-                ]),
-                CacheFactory::inMemory(),
-            ),
+            $cachedCatalog,
             $parser,
             $infoFactory,
             $scanner,
             new SymbolCache(CacheFactory::inMemory()),
         );
+
+        return [$backend, [$backend, $cachedCatalog, $autoloadFiles]];
     }
 }

--- a/tests/Knowledge/CompositeSymbolLocatorTest.php
+++ b/tests/Knowledge/CompositeSymbolLocatorTest.php
@@ -4,23 +4,18 @@ declare(strict_types=1);
 
 namespace Firehed\PhpLsp\Tests\Knowledge;
 
-use Firehed\PhpLsp\Document\FileUri;
 use Firehed\PhpLsp\Domain\NameKind;
 use Firehed\PhpLsp\Domain\QualifiedName;
-use Firehed\PhpLsp\Index\AutoloadFilesLocator;
-use Firehed\PhpLsp\Index\ComposerAutoloadMap;
-use Firehed\PhpLsp\Index\DeclarationScanner;
 use Firehed\PhpLsp\Knowledge\CompositeSymbolLocator;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
-use Firehed\PhpLsp\Parser\ParserService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * A name may be reachable by arithmetic on the autoload maps or only through the
  * derived `autoload.files` index, so the two routes are chained rather than merged.
- * These prove the chain takes the first answer, falls through, and fans invalidation
- * out to the members holding derived state.
+ * These prove the chain takes the first answer and falls through when a route
+ * cannot answer.
  */
 #[CoversClass(CompositeSymbolLocator::class)]
 final class CompositeSymbolLocatorTest extends TestCase
@@ -83,46 +78,6 @@ final class CompositeSymbolLocatorTest extends TestCase
             $locator->locate(self::someName(), NameKind::ClassLike),
             'the chain must stop at the first answer rather than costing every route a lookup',
         );
-    }
-
-    /**
-     * Driven through the real {@see AutoloadFilesLocator} rather than a mock: it is
-     * the member that actually holds derived state, so this proves the fan-out
-     * reaches the implementation that ships. The leading locator holds none and is
-     * not Invalidatable, which is also the production shape — the chain must skip it
-     * rather than require every member to implement the interface.
-     */
-    public function testInvalidateReachesAMemberHoldingDerivedState(): void
-    {
-        $path = tempnam(sys_get_temp_dir(), 'php-lsp-chain-');
-        self::assertNotFalse($path, 'a temp file must be creatable');
-
-        try {
-            self::assertNotFalse(
-                file_put_contents($path, '<?php function chainedBefore(): void {}'),
-                'the temp file must be writable',
-            );
-
-            $files = new AutoloadFilesLocator(
-                new ComposerAutoloadMap([], [], [], [$path]),
-                new ParserService(),
-                new DeclarationScanner(),
-            );
-            $locator = new CompositeSymbolLocator([self::locatorReturning(null), $files]);
-
-            self::assertNotFalse(
-                file_put_contents($path, '<?php function chainedAfter(): void {}'),
-                'the rewrite must succeed',
-            );
-            $locator->invalidate(FileUri::fromPath($path));
-
-            self::assertNotNull(
-                $locator->locate(QualifiedName::fromFullyQualified('chainedAfter'), NameKind::Function_),
-                'invalidation must reach the chained index so the external edit is reflected (RFC 1 §5.2)',
-            );
-        } finally {
-            unlink($path);
-        }
     }
 
     private static function locatorReturning(?string $path): SymbolLocator

--- a/tests/Knowledge/FilesystemBackendTest.php
+++ b/tests/Knowledge/FilesystemBackendTest.php
@@ -22,7 +22,6 @@ use Firehed\PhpLsp\Knowledge\SymbolCache;
 use Firehed\PhpLsp\Knowledge\SymbolLocator;
 use Firehed\PhpLsp\Parser\ParserService;
 use Firehed\PhpLsp\Repository\DefaultClassInfoFactory;
-use Firehed\PhpLsp\Tests\Index\CountingNamespaceCatalog;
 use Psr\SimpleCache\CacheInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -273,29 +272,6 @@ final class FilesystemBackendTest extends TestCase
         );
     }
 
-    public function testInvalidateAlsoDropsCachedNamespaceListings(): void
-    {
-        $counting = new CountingNamespaceCatalog();
-        $backend = new FilesystemBackend(
-            self::createStub(SymbolLocator::class),
-            new CachedNamespaceCatalog($counting, CacheFactory::inMemory()),
-            $this->parser,
-            $this->infoFactory,
-            new DeclarationScanner(),
-            new SymbolCache(CacheFactory::inMemory()),
-        );
-
-        $backend->childrenOf(new NamespaceName('Psr\Log'));
-        $backend->invalidate('file:///any/changed/File.php');
-        $backend->childrenOf(new NamespaceName('Psr\Log'));
-
-        self::assertSame(
-            2,
-            $counting->calls,
-            'invalidate must drop cached namespace listings so a create or delete is reflected (RFC 1 §5.3)',
-        );
-    }
-
     public function testInvalidateDecodesAPercentEncodedUriToMatchTheCachedPath(): void
     {
         // A client URI percent-encodes reserved characters (a space becomes %20),
@@ -329,52 +305,6 @@ final class FilesystemBackendTest extends TestCase
         } finally {
             unlink($path);
             rmdir($dir);
-        }
-    }
-
-    /**
-     * Driven end to end through the locator chain the stack actually wires, rather
-     * than a mock: the autoload.files index is derived from disk, so an external
-     * change must reach it too. Evicting only the ClassInfo cache would leave the
-     * name -> file map itself stale, and a class added by the edit would stay
-     * invisible however many times it was asked for (RFC 1 §5.2, §5.3).
-     */
-    public function testInvalidateReachesALocatorHoldingDerivedState(): void
-    {
-        $path = tempnam(sys_get_temp_dir(), 'php-lsp-fsb-files-');
-        self::assertNotFalse($path, 'a temp file must be creatable');
-
-        try {
-            self::assertNotFalse(
-                file_put_contents($path, '<?php class DerivedBefore {}'),
-                'the temp file must be writable',
-            );
-
-            $backend = $this->backendWithLocator(new CompositeSymbolLocator([
-                new AutoloadFilesLocator(
-                    new ComposerAutoloadMap([], [], [], [$path]),
-                    $this->parser,
-                    new DeclarationScanner(),
-                ),
-            ]));
-
-            self::assertNotNull(
-                self::classLikeIn($backend, 'DerivedBefore'),
-                'a class-like declared in a files entry must resolve through the derived index',
-            );
-
-            self::assertNotFalse(
-                file_put_contents($path, '<?php class DerivedAfter {}'),
-                'the rewrite must succeed',
-            );
-            $backend->invalidate(FileUri::fromPath($path));
-
-            self::assertNotNull(
-                self::classLikeIn($backend, 'DerivedAfter'),
-                'invalidate must re-derive the index so a class added on disk resolves',
-            );
-        } finally {
-            unlink($path);
         }
     }
 


### PR DESCRIPTION
Two features could disagree about whether an external file change is visible if one `Invalidatable` thing is reachable through the fan-out tree while another is not — adding a cached structure meant finding its parent in that tree by hand, and missing one silently served stale data.

**Slice:** SC.17
**Plan step:** none (cleanup, predates the plan)

## Acceptance criteria

- [x] One registration list at `KnowledgeStack::forProject()` replaces the three fan-out sites
- [x] Three `instanceof Invalidatable` type tests removed
- [x] `CompositeSymbolLocator` no longer implements `Invalidatable`
- [x] `FilesystemBackend::invalidate()` handles only its own cache eviction
- [x] End-to-end behavior unchanged (`ServerTest` still passes)