### PR TITLE
One home for the kind-qualified symbol key

### DIFF
--- a/src/Domain/NameKind.php
+++ b/src/Domain/NameKind.php
@@ -46,6 +46,15 @@ enum NameKind
     }
 
     /**
+     * The kind-qualified key for a name, used to store and retrieve symbols. The
+     * single home for this computation — do not duplicate it.
+     */
+    public function keyFor(QualifiedName $name): string
+    {
+        return $this->name . '|' . $this->normalize($name);
+    }
+
+    /**
      * The name as a lookup key under this kind's case rule. A namespace path is
      * case-insensitive whatever it qualifies, so the rule applies to the short
      * name alone.

--- a/src/Knowledge/DeclarationSymbolInfoFactory.php
+++ b/src/Knowledge/DeclarationSymbolInfoFactory.php
@@ -83,7 +83,7 @@ final readonly class DeclarationSymbolInfoFactory
         NameKind $kind,
         SymbolInfo $info,
     ): void {
-        $key = $kind->name . '|' . $kind->normalize($name);
+        $key = $kind->keyFor($name);
         if (array_key_exists($key, $seen)) {
             return;
         }

--- a/src/Knowledge/FilesystemBackend.php
+++ b/src/Knowledge/FilesystemBackend.php
@@ -38,12 +38,11 @@ use Firehed\PhpLsp\Parser\ParserService;
 final class FilesystemBackend implements SymbolBackend, Invalidatable
 {
     /**
-     * The cache keys derived from each file, recorded because a key is an opaque hash
-     * with no reverse mapping to a path.
+     * The symbols derived from each file, recorded so invalidation can evict them.
      *
-     * @var array<string, list<string>>
+     * @var array<string, list<array{QualifiedName, NameKind}>>
      */
-    private array $cacheKeysByPath = [];
+    private array $symbolsByPath = [];
 
     public function __construct(
         private readonly SymbolLocator $locator,
@@ -70,7 +69,7 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
 
             $info = $this->infoFactory->fromDeclarations($this->declarationsIn($filePath), $name, $kind, $filePath);
             if ($info !== null) {
-                $this->cacheKeysByPath[$filePath][] = $this->cache->keyFor($name, $kind);
+                $this->symbolsByPath[$filePath][] = [$name, $kind];
             }
 
             return $info;
@@ -78,16 +77,16 @@ final class FilesystemBackend implements SymbolBackend, Invalidatable
     }
 
     /**
-     * Evict the file's cached symbols by their recorded keys, so the next query
-     * re-reads disk and the pre-change value is not restored (RFC 1 §5.2, §5.3).
+     * Evict the file's cached symbols, so the next query re-reads disk and the
+     * pre-change value is not restored (RFC 1 §5.2, §5.3).
      */
     public function invalidate(string $uri): void
     {
         $path = FileUri::toPath($uri);
-        foreach ($this->cacheKeysByPath[$path] ?? [] as $cacheKey) {
-            $this->cache->delete($cacheKey);
+        foreach ($this->symbolsByPath[$path] ?? [] as [$name, $kind]) {
+            $this->cache->forget($name, $kind);
         }
-        unset($this->cacheKeysByPath[$path]);
+        unset($this->symbolsByPath[$path]);
     }
 
     /**

--- a/src/Knowledge/OpenDocumentBackend.php
+++ b/src/Knowledge/OpenDocumentBackend.php
@@ -61,7 +61,7 @@ final class OpenDocumentBackend implements SymbolBackend
 
     public function lookup(QualifiedName $name, NameKind $kind): ?SymbolInfo
     {
-        return $this->byKey[self::key($kind, $name)] ?? null;
+        return $this->byKey[$kind->keyFor($name)] ?? null;
     }
 
     /**
@@ -85,7 +85,7 @@ final class OpenDocumentBackend implements SymbolBackend
 
         $keys = [];
         foreach ($symbols as $symbol) {
-            $key = self::key($symbol->kind, $symbol->name);
+            $key = $symbol->kind->keyFor($symbol->name);
             $this->byKey[$key] = $symbol->info;
             $keys[] = $key;
         }
@@ -98,15 +98,5 @@ final class OpenDocumentBackend implements SymbolBackend
             unset($this->byKey[$key]);
         }
         unset($this->keysByUri[$uri]);
-    }
-
-    /**
-     * Registration and lookup must agree on the case rule, which differs by kind, so
-     * both go through {@see NameKind::normalize()} rather than lowercasing the whole
-     * FQN — right for class-likes and functions, wrong for a constant.
-     */
-    private static function key(NameKind $kind, QualifiedName $name): string
-    {
-        return $kind->name . '|' . $kind->normalize($name);
     }
 }

--- a/src/Knowledge/SymbolCache.php
+++ b/src/Knowledge/SymbolCache.php
@@ -27,14 +27,9 @@ final readonly class SymbolCache
     ) {
     }
 
-    public function delete(string $key): void
+    public function forget(QualifiedName $name, NameKind $kind): void
     {
-        $this->cache->delete($key);
-    }
-
-    public function keyFor(QualifiedName $name, NameKind $kind): string
-    {
-        return CacheKey::from($kind->name . '|' . $kind->normalize($name));
+        $this->cache->delete($this->keyFor($name, $kind));
     }
 
     /**
@@ -56,5 +51,10 @@ final readonly class SymbolCache
         }
 
         return $info;
+    }
+
+    private function keyFor(QualifiedName $name, NameKind $kind): string
+    {
+        return CacheKey::from($kind->keyFor($name));
     }
 }

--- a/tests/Domain/NameKindTest.php
+++ b/tests/Domain/NameKindTest.php
@@ -39,4 +39,20 @@ final class NameKindTest extends TestCase
     ): void {
         self::assertSame($expected, $kind->normalize($name));
     }
+
+    public function testKeyForCombinesKindNameAndNormalizedName(): void
+    {
+        $name = new QualifiedName('Fixtures\Helpers', 'HelperFormat');
+
+        self::assertSame(
+            'ClassLike|fixtures\helpers\helperformat',
+            NameKind::ClassLike->keyFor($name),
+            'the key must be kind name, pipe, normalized FQN',
+        );
+        self::assertSame(
+            'Constant|fixtures\helpers\HelperFormat',
+            NameKind::Constant->keyFor($name),
+            'constant keys preserve the short name case',
+        );
+    }
 }

--- a/tests/Knowledge/FakeSymbolBackend.php
+++ b/tests/Knowledge/FakeSymbolBackend.php
@@ -37,7 +37,7 @@ final class FakeSymbolBackend implements SymbolBackend
         private readonly array $searchResults = [],
     ) {
         foreach ($symbols as $symbol) {
-            $this->byKey[self::key($symbol->name, $symbol->kind)] = $symbol->info;
+            $this->byKey[$symbol->kind->keyFor($symbol->name)] = $symbol->info;
         }
     }
 
@@ -48,7 +48,7 @@ final class FakeSymbolBackend implements SymbolBackend
 
     public function lookup(QualifiedName $name, NameKind $kind): ?SymbolInfo
     {
-        return $this->byKey[self::key($name, $kind)] ?? null;
+        return $this->byKey[$kind->keyFor($name)] ?? null;
     }
 
     /**
@@ -63,10 +63,5 @@ final class FakeSymbolBackend implements SymbolBackend
                 strtolower($prefix),
             ),
         ));
-    }
-
-    private static function key(QualifiedName $name, NameKind $kind): string
-    {
-        return $kind->name . '|' . $kind->normalize($name);
     }
 }


### PR DESCRIPTION
Without this change, adding a new symbol kind requires updating four sites with the same key computation — a mistake in one would cause lookup/registration disagreement for that kind.

**Slice:** SC.18
**Plan step:** — (cleanup, no step)

## Changes

- Add `NameKind::keyFor(QualifiedName): string` as the single authoritative key computation
- Route all four sites through it:
  - `SymbolCache` (now private `keyFor`, public `forget` replaces `delete`)
  - `OpenDocumentBackend` (removed private `key()`)
  - `DeclarationSymbolInfoFactory`
  - `FakeSymbolBackend` (test fake, removed private `key()`)
- `FilesystemBackend` now stores `(QualifiedName, NameKind)` pairs instead of opaque hashed strings

## Acceptance criteria

- [ ] The key computation `$kind->name . '|' . $kind->normalize($name)` appears in exactly one place
- [ ] `SymbolCache::keyFor` and `delete` are off the public surface
- [ ] `FilesystemBackend` records what it knows (name/kind), not derived artifacts (hashed keys)