### PR TITLE
Install every M×N enforcement rule

### DIFF
--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -32,7 +32,7 @@ That is why **enforcement-rules** comes first: until those rules exist, no slice
 
 Ordered. Each row starts when the one above it merges.
 
-- [ ] **enforcement-rules** — Install every M×N enforcement rule
+- [x] **enforcement-rules** — Install every M×N enforcement rule
 
   One slice, every unbuilt mechanism RFC 1 §8.1 designates. They were specified together and lapsed together; splitting them just recreates the window in which some axes are guarded and others are not.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,10 +1,46 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 2
+			path: src/Completion/ClassCandidates.php
+
+		-
 			message: '#^Calling get_defined_functions\(\) is forbidden, runtime symbol enumeration is confined to ReflectionNamespaceSource\.$#'
 			identifier: disallowed.function
 			count: 1
 			path: src/Completion/FunctionCandidates.php
+
+		-
+			message: '#^instanceof ResolvedMethod branches on concrete ResolvedSymbol; use predicates \(RFC 1 §4\.5\)\.$#'
+			identifier: phpLsp.kindInspection
+			count: 1
+			path: src/Completion/MemberCandidates.php
+
+		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 1
+			path: src/Completion/NamespaceCandidates.php
+
+		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 6
+			path: src/Repository/DefaultClassInfoFactory.php
+
+		-
+			message: '#^new PrimitiveType is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 3
+			path: src/Repository/DefaultClassInfoFactory.php
+
+		-
+			message: '#^new UnionType is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 1
+			path: src/Repository/DefaultClassInfoFactory.php
 
 		-
 			message: '#^Class ReflectionFunction is forbidden, runtime reflection is confined\: ReflectionNamespaceSource and the fromReflection factories\. \[ReflectionFunction matches Reflection\*\]$#'
@@ -67,9 +103,27 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 15
+			path: src/Resolution/SymbolResolver.php
+
+		-
 			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
 			identifier: disallowed.function
 			count: 2
+			path: src/Resolution/TextFallbackHelper.php
+
+		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 7
+			path: src/Resolution/TextFallbackHelper.php
+
+		-
+			message: '#^new UnionType is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 1
 			path: src/Resolution/TextFallbackHelper.php
 
 		-
@@ -89,3 +143,21 @@ parameters:
 			identifier: disallowed.namespace
 			count: 2
 			path: src/TypeInference/BasicTypeResolver.php
+
+		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 4
+			path: src/TypeInference/BasicTypeResolver.php
+
+		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 1
+			path: src/Utility/ExpressionTypeResolver.php
+
+		-
+			message: '#^new ClassName is confined to TypeFactory; use TypeFactory methods instead \(RFC 1 §4\.6\)\.$#'
+			identifier: phpLsp.typeConstruction
+			count: 1
+			path: src/Utility/Scope.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -151,6 +151,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Firehed\PhpLsp\Tests\Architecture\KindEnumMatchRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Firehed\PhpLsp\Tests\Architecture\SymbolDiscoveryAuthorityExtension
         tags:
             - phpstan.restrictedClassNameUsageExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -127,6 +127,33 @@ parameters:
                 - src/Transport/*
                 - tests/*
 
+    disallowedMethodCalls:
+        -
+            method: 'Firehed\PhpLsp\Knowledge\OpenDocumentBackend::updateDocument()'
+            message: 'single write path (RFC 1 §4.3/§5.2): document symbol registration goes through DocumentSymbolSink'
+            allowIn:
+                - src/Knowledge/DocumentSymbolSink.php
+                - tests/*
+        -
+            method: 'Firehed\PhpLsp\Knowledge\OpenDocumentBackend::removeDocument()'
+            message: 'single write path (RFC 1 §4.3/§5.2): document symbol registration goes through DocumentSymbolSink'
+            allowIn:
+                - src/Knowledge/DocumentSymbolSink.php
+                - src/Knowledge/OpenDocumentBackend.php
+                - tests/*
+        -
+            method: 'Firehed\PhpLsp\Index\SymbolIndex::add()'
+            message: 'single write path (RFC 1 §4.3/§5.2): symbol indexing goes through DocumentIndexer'
+            allowIn:
+                - src/Index/DocumentIndexer.php
+                - tests/*
+        -
+            method: 'Firehed\PhpLsp\Index\SymbolIndex::clearByUri()'
+            message: 'single write path (RFC 1 §4.3/§5.2): symbol indexing goes through DocumentIndexer'
+            allowIn:
+                - src/Index/DocumentIndexer.php
+                - tests/*
+
     level: max
     paths:
         - src

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -147,6 +147,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Firehed\PhpLsp\Tests\Architecture\KindInspectionRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Firehed\PhpLsp\Tests\Architecture\SymbolDiscoveryAuthorityExtension
         tags:
             - phpstan.restrictedClassNameUsageExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -143,6 +143,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Firehed\PhpLsp\Tests\Architecture\TypeConstructionRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Firehed\PhpLsp\Tests\Architecture\SymbolDiscoveryAuthorityExtension
         tags:
             - phpstan.restrictedClassNameUsageExtension

--- a/tests/Architecture/KindEnumMatchRule.php
+++ b/tests/Architecture/KindEnumMatchRule.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Match_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * The RFC 1 §8.1 mechanism for §4.5: consumers MUST NOT use `match` on a
+ * symbol-kind enum to branch on resolved symbol kinds.
+ *
+ * Allowed locations:
+ * - The kind enum's own file (internal operations like `normalize()`)
+ * - Metadata factories (DefaultClassInfoFactory, ReflectionSymbolInfoFactory)
+ * - Classifiers (CompletionItemFactory)
+ * - Tests
+ *
+ * @implements Rule<Match_>
+ */
+final class KindEnumMatchRule implements Rule
+{
+    /** @var list<class-string> */
+    private const array CONFINED_KIND_ENUMS = [
+        \Firehed\PhpLsp\Domain\NameKind::class,
+        \Firehed\PhpLsp\Domain\MemberKind::class,
+        \Firehed\PhpLsp\Domain\ClassKind::class,
+    ];
+
+    private const array ALLOWED_FILES = [
+        'src/Domain/NameKind.php',
+        'src/Domain/MemberKind.php',
+        'src/Domain/ClassKind.php',
+        'src/Domain/ClassInfo.php',
+        'src/Resolution/NameContext.php',
+        'src/Repository/DefaultClassInfoFactory.php',
+        'src/Knowledge/ReflectionSymbolInfoFactory.php',
+        'src/Knowledge/DeclarationSymbolInfoFactory.php',
+        'src/Completion/CompletionItemFactory.php',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Match_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        if (str_contains($file, '/tests/') && !str_contains($file, '/tests/Architecture/data/')) {
+            return [];
+        }
+
+        foreach (self::ALLOWED_FILES as $allowed) {
+            if (str_ends_with($file, $allowed)) {
+                return [];
+            }
+        }
+
+        $condType = $scope->getType($node->cond);
+
+        foreach (self::CONFINED_KIND_ENUMS as $kindEnum) {
+            $kindType = new ObjectType($kindEnum);
+            if ($kindType->isSuperTypeOf($condType)->yes()) {
+                $shortName = $this->shortName($kindEnum);
+                $message = sprintf(
+                    'match on %s branches per symbol kind; use predicates (RFC 1 §4.5).',
+                    $shortName,
+                );
+                return [
+                    RuleErrorBuilder::message($message)
+                        ->identifier('phpLsp.kindInspection')
+                        ->build(),
+                ];
+            }
+        }
+
+        return [];
+    }
+
+    private function shortName(string $className): string
+    {
+        $parts = explode('\\', $className);
+        return end($parts);
+    }
+}

--- a/tests/Architecture/KindEnumMatchRuleTest.php
+++ b/tests/Architecture/KindEnumMatchRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<KindEnumMatchRule>
+ */
+class KindEnumMatchRuleTest extends RuleTestCase
+{
+    public function testMatchOnKindEnumIsReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/match-on-kind-enum.php'],
+            [
+                [
+                    'match on NameKind branches per symbol kind; use predicates (RFC 1 §4.5).',
+                    17,
+                ],
+            ],
+        );
+    }
+
+    public function testKindEnumOwnFileAllowed(): void
+    {
+        $this->analyse([__DIR__ . '/../../src/Domain/NameKind.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new KindEnumMatchRule();
+    }
+}

--- a/tests/Architecture/KindInspectionRule.php
+++ b/tests/Architecture/KindInspectionRule.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * The RFC 1 §8.1 mechanism for §4.5: consumers MUST NOT use `instanceof`
+ * against a concrete Type or ResolvedSymbol implementation to decide
+ * suitability.
+ *
+ * Allowed locations:
+ * - Type implementations (internal operations)
+ * - TypeFactory (construction)
+ * - Metadata factories (DefaultClassInfoFactory, ReflectionSymbolInfoFactory)
+ * - Classifiers (CompletionItemFactory - maps symbol to LSP kind)
+ * - Tests
+ *
+ * @implements Rule<Instanceof_>
+ */
+final class KindInspectionRule implements Rule
+{
+    /** @var list<class-string> */
+    private const array CONFINED_TYPE_IMPLS = [
+        \Firehed\PhpLsp\Domain\ClassName::class,
+        \Firehed\PhpLsp\Domain\UnionType::class,
+        \Firehed\PhpLsp\Domain\IntersectionType::class,
+        \Firehed\PhpLsp\Domain\PrimitiveType::class,
+        \Firehed\PhpLsp\Domain\LateStaticType::class,
+    ];
+
+    /** @var list<class-string> */
+    private const array CONFINED_RESOLVED_IMPLS = [
+        \Firehed\PhpLsp\Resolution\ResolvedClass::class,
+        \Firehed\PhpLsp\Resolution\ResolvedConstant::class,
+        \Firehed\PhpLsp\Resolution\ResolvedEnumCase::class,
+        \Firehed\PhpLsp\Resolution\ResolvedFunction::class,
+        \Firehed\PhpLsp\Resolution\ResolvedGlobalConstant::class,
+        \Firehed\PhpLsp\Resolution\ResolvedMethod::class,
+        \Firehed\PhpLsp\Resolution\ResolvedParameter::class,
+        \Firehed\PhpLsp\Resolution\ResolvedProperty::class,
+        \Firehed\PhpLsp\Resolution\ResolvedVariable::class,
+    ];
+
+    private const array ALLOWED_FILES = [
+        'src/Domain/TypeFactory.php',
+        'src/Domain/ClassName.php',
+        'src/Domain/UnionType.php',
+        'src/Domain/IntersectionType.php',
+        'src/Domain/PrimitiveType.php',
+        'src/Domain/LateStaticType.php',
+        'src/Repository/DefaultClassInfoFactory.php',
+        'src/Knowledge/ReflectionSymbolInfoFactory.php',
+        'src/Completion/CompletionItemFactory.php',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Instanceof_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        if (str_contains($file, '/tests/') && !str_contains($file, '/tests/Architecture/data/')) {
+            return [];
+        }
+
+        foreach (self::ALLOWED_FILES as $allowed) {
+            if (str_ends_with($file, $allowed)) {
+                return [];
+            }
+        }
+
+        $class = $node->class;
+        if (!$class instanceof Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($class);
+
+        if (in_array($className, self::CONFINED_TYPE_IMPLS, true)) {
+            $shortName = (new \ReflectionClass($className))->getShortName();
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'instanceof %s branches on concrete Type; use Type interface or capability predicates instead (RFC 1 §4.5).',
+                    $shortName,
+                ))
+                    ->identifier('phpLsp.kindInspection')
+                    ->build(),
+            ];
+        }
+
+        if (in_array($className, self::CONFINED_RESOLVED_IMPLS, true)) {
+            $shortName = (new \ReflectionClass($className))->getShortName();
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'instanceof %s branches on concrete ResolvedSymbol; use capability predicates instead (RFC 1 §4.5).',
+                    $shortName,
+                ))
+                    ->identifier('phpLsp.kindInspection')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/Architecture/KindInspectionRule.php
+++ b/tests/Architecture/KindInspectionRule.php
@@ -88,29 +88,37 @@ final class KindInspectionRule implements Rule
         $className = $scope->resolveName($class);
 
         if (in_array($className, self::CONFINED_TYPE_IMPLS, true)) {
-            $shortName = (new \ReflectionClass($className))->getShortName();
+            $shortName = $this->shortName($className);
+            $message = sprintf(
+                'instanceof %s branches on concrete Type; use predicates (RFC 1 §4.5).',
+                $shortName,
+            );
             return [
-                RuleErrorBuilder::message(sprintf(
-                    'instanceof %s branches on concrete Type; use Type interface or capability predicates instead (RFC 1 §4.5).',
-                    $shortName,
-                ))
+                RuleErrorBuilder::message($message)
                     ->identifier('phpLsp.kindInspection')
                     ->build(),
             ];
         }
 
         if (in_array($className, self::CONFINED_RESOLVED_IMPLS, true)) {
-            $shortName = (new \ReflectionClass($className))->getShortName();
+            $shortName = $this->shortName($className);
+            $message = sprintf(
+                'instanceof %s branches on concrete ResolvedSymbol; use predicates (RFC 1 §4.5).',
+                $shortName,
+            );
             return [
-                RuleErrorBuilder::message(sprintf(
-                    'instanceof %s branches on concrete ResolvedSymbol; use capability predicates instead (RFC 1 §4.5).',
-                    $shortName,
-                ))
+                RuleErrorBuilder::message($message)
                     ->identifier('phpLsp.kindInspection')
                     ->build(),
             ];
         }
 
         return [];
+    }
+
+    private function shortName(string $className): string
+    {
+        $parts = explode('\\', $className);
+        return end($parts);
     }
 }

--- a/tests/Architecture/KindInspectionRuleTest.php
+++ b/tests/Architecture/KindInspectionRuleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<KindInspectionRule>
+ */
+class KindInspectionRuleTest extends RuleTestCase
+{
+    public function testInstanceofResolvedSymbolImplIsReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/instanceof-resolved-symbol.php'],
+            [
+                [
+                    'instanceof ResolvedMethod branches on concrete ResolvedSymbol; '
+                        . 'use capability predicates instead (RFC 1 §4.5).',
+                    19,
+                ],
+                [
+                    'instanceof ResolvedMethod branches on concrete ResolvedSymbol; '
+                        . 'use capability predicates instead (RFC 1 §4.5).',
+                    25,
+                ],
+                [
+                    'instanceof ResolvedProperty branches on concrete ResolvedSymbol; '
+                        . 'use capability predicates instead (RFC 1 §4.5).',
+                    26,
+                ],
+            ],
+        );
+    }
+
+    public function testCompletionItemFactoryMayMapSymbolToKind(): void
+    {
+        $this->analyse([__DIR__ . '/../../src/Completion/CompletionItemFactory.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new KindInspectionRule();
+    }
+}

--- a/tests/Architecture/KindInspectionRuleTest.php
+++ b/tests/Architecture/KindInspectionRuleTest.php
@@ -36,6 +36,20 @@ class KindInspectionRuleTest extends RuleTestCase
         );
     }
 
+    public function testInstanceofTypeImplIsReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/instanceof-type.php'],
+            [
+                [
+                    'instanceof ClassName branches on concrete Type; '
+                        . 'use predicates (RFC 1 §4.5).',
+                    18,
+                ],
+            ],
+        );
+    }
+
     public function testCompletionItemFactoryMayMapSymbolToKind(): void
     {
         $this->analyse([__DIR__ . '/../../src/Completion/CompletionItemFactory.php'], []);

--- a/tests/Architecture/KindInspectionRuleTest.php
+++ b/tests/Architecture/KindInspectionRuleTest.php
@@ -19,17 +19,17 @@ class KindInspectionRuleTest extends RuleTestCase
             [
                 [
                     'instanceof ResolvedMethod branches on concrete ResolvedSymbol; '
-                        . 'use capability predicates instead (RFC 1 §4.5).',
+                        . 'use predicates (RFC 1 §4.5).',
                     19,
                 ],
                 [
                     'instanceof ResolvedMethod branches on concrete ResolvedSymbol; '
-                        . 'use capability predicates instead (RFC 1 §4.5).',
+                        . 'use predicates (RFC 1 §4.5).',
                     25,
                 ],
                 [
                     'instanceof ResolvedProperty branches on concrete ResolvedSymbol; '
-                        . 'use capability predicates instead (RFC 1 §4.5).',
+                        . 'use predicates (RFC 1 §4.5).',
                     26,
                 ],
             ],

--- a/tests/Architecture/TypeConstructionRule.php
+++ b/tests/Architecture/TypeConstructionRule.php
@@ -63,7 +63,7 @@ final class TypeConstructionRule implements Rule
             }
         }
 
-        $shortName = (new \ReflectionClass($className))->getShortName();
+        $shortName = $this->shortName($className);
         $message = sprintf(
             'new %s is confined to TypeFactory; use TypeFactory methods instead (RFC 1 §4.6).',
             $shortName,
@@ -74,5 +74,11 @@ final class TypeConstructionRule implements Rule
                 ->identifier('phpLsp.typeConstruction')
                 ->build(),
         ];
+    }
+
+    private function shortName(string $className): string
+    {
+        $parts = explode('\\', $className);
+        return end($parts);
     }
 }

--- a/tests/Architecture/TypeConstructionRule.php
+++ b/tests/Architecture/TypeConstructionRule.php
@@ -25,6 +25,7 @@ final class TypeConstructionRule implements Rule
         \Firehed\PhpLsp\Domain\UnionType::class,
         \Firehed\PhpLsp\Domain\IntersectionType::class,
         \Firehed\PhpLsp\Domain\PrimitiveType::class,
+        \Firehed\PhpLsp\Domain\LateStaticType::class,
     ];
 
     private const array ALLOWED_FILES = [

--- a/tests/Architecture/TypeConstructionRule.php
+++ b/tests/Architecture/TypeConstructionRule.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * The RFC 1 §8.1 mechanism for §4.6: Type objects MUST be constructed through
+ * the type factory.
+ *
+ * @implements Rule<New_>
+ */
+final class TypeConstructionRule implements Rule
+{
+    /** @var list<class-string> */
+    private const array CONFINED_TYPES = [
+        \Firehed\PhpLsp\Domain\ClassName::class,
+        \Firehed\PhpLsp\Domain\UnionType::class,
+        \Firehed\PhpLsp\Domain\IntersectionType::class,
+        \Firehed\PhpLsp\Domain\PrimitiveType::class,
+    ];
+
+    private const array ALLOWED_FILES = [
+        'src/Domain/TypeFactory.php',
+        'src/Domain/ClassName.php',
+        'src/Domain/UnionType.php',
+        'src/Domain/IntersectionType.php',
+        'src/Domain/PrimitiveType.php',
+        'src/Domain/LateStaticType.php',
+    ];
+
+    public function getNodeType(): string
+    {
+        return New_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $class = $node->class;
+        if (!$class instanceof Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($class);
+        if (!in_array($className, self::CONFINED_TYPES, true)) {
+            return [];
+        }
+
+        $file = $scope->getFile();
+        if (str_contains($file, '/tests/') && !str_contains($file, '/tests/Architecture/data/')) {
+            return [];
+        }
+        foreach (self::ALLOWED_FILES as $allowed) {
+            if (str_ends_with($file, $allowed)) {
+                return [];
+            }
+        }
+
+        $shortName = (new \ReflectionClass($className))->getShortName();
+        $message = sprintf(
+            'new %s is confined to TypeFactory; use TypeFactory methods instead (RFC 1 §4.6).',
+            $shortName,
+        );
+
+        return [
+            RuleErrorBuilder::message($message)
+                ->identifier('phpLsp.typeConstruction')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Architecture/TypeConstructionRuleTest.php
+++ b/tests/Architecture/TypeConstructionRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TypeConstructionRule>
+ */
+class TypeConstructionRuleTest extends RuleTestCase
+{
+    public function testConstructingTypeOutsideFactoryIsReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/constructs-type-outside-factory.php'],
+            [
+                ['new ClassName is confined to TypeFactory; use TypeFactory methods instead (RFC 1 §4.6).', 19],
+                ['new PrimitiveType is confined to TypeFactory; use TypeFactory methods instead (RFC 1 §4.6).', 24],
+                ['new ClassName is confined to TypeFactory; use TypeFactory methods instead (RFC 1 §4.6).', 29],
+                ['new PrimitiveType is confined to TypeFactory; use TypeFactory methods instead (RFC 1 §4.6).', 29],
+                ['new UnionType is confined to TypeFactory; use TypeFactory methods instead (RFC 1 §4.6).', 29],
+            ],
+        );
+    }
+
+    public function testTypeFactoryMayConstructTypes(): void
+    {
+        $this->analyse([__DIR__ . '/../../src/Domain/TypeFactory.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new TypeConstructionRule();
+    }
+}

--- a/tests/Architecture/data/constructs-type-outside-factory.php
+++ b/tests/Architecture/data/constructs-type-outside-factory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\PrimitiveType;
+use Firehed\PhpLsp\Domain\UnionType;
+
+/**
+ * A component constructing Type implementations directly instead of through
+ * TypeFactory, which RFC 1 §4.6 forbids.
+ */
+final class ConstructsTypeOutsideFactory
+{
+    public function makeClassName(): ClassName
+    {
+        return new ClassName('Foo\\Bar');
+    }
+
+    public function makePrimitive(): PrimitiveType
+    {
+        return new PrimitiveType('string');
+    }
+
+    public function makeUnion(): UnionType
+    {
+        return new UnionType([new ClassName('Foo'), new PrimitiveType('null')]);
+    }
+}

--- a/tests/Architecture/data/instanceof-resolved-symbol.php
+++ b/tests/Architecture/data/instanceof-resolved-symbol.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Resolution\ResolvedMethod;
+use Firehed\PhpLsp\Resolution\ResolvedProperty;
+use Firehed\PhpLsp\Resolution\ResolvedSymbol;
+
+/**
+ * A consumer deciding suitability by instanceof against concrete ResolvedSymbol
+ * implementations, which RFC 1 §4.5 forbids.
+ */
+final class InstanceofResolvedSymbol
+{
+    public function isSuitableForParentAccess(ResolvedSymbol $symbol): bool
+    {
+        return $symbol instanceof ResolvedMethod;
+    }
+
+    public function getKind(ResolvedSymbol $symbol): string
+    {
+        return match (true) {
+            $symbol instanceof ResolvedMethod => 'method',
+            $symbol instanceof ResolvedProperty => 'property',
+            default => 'unknown',
+        };
+    }
+}

--- a/tests/Architecture/data/instanceof-type.php
+++ b/tests/Architecture/data/instanceof-type.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Domain\ClassName;
+use Firehed\PhpLsp\Domain\Type;
+
+/**
+ * A consumer deciding suitability by instanceof against concrete Type
+ * implementations, which RFC 1 §4.5 forbids.
+ */
+final class InstanceofType
+{
+    public function isClassType(Type $type): bool
+    {
+        return $type instanceof ClassName;
+    }
+}

--- a/tests/Architecture/data/match-on-kind-enum.php
+++ b/tests/Architecture/data/match-on-kind-enum.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Domain\NameKind;
+
+/**
+ * A consumer deciding behavior by match on a symbol-kind enum,
+ * which RFC 1 §4.5 forbids.
+ */
+final class MatchOnKindEnum
+{
+    public function branchOnKind(NameKind $kind): string
+    {
+        return match ($kind) {
+            NameKind::ClassLike => 'class',
+            NameKind::Function => 'function',
+            NameKind::Constant => 'constant',
+        };
+    }
+}

--- a/tests/Capability/SessionCapabilitiesDefaultsTest.php
+++ b/tests/Capability/SessionCapabilitiesDefaultsTest.php
@@ -53,7 +53,11 @@ final class SessionCapabilitiesDefaultsTest extends TestCase
     {
         $capabilities = new SessionCapabilities();
 
-        self::assertNotNull($capabilities, 'SessionCapabilities must be constructable with no arguments');
+        self::assertInstanceOf(
+            SessionCapabilities::class,
+            $capabilities,
+            'SessionCapabilities must be constructable with no arguments',
+        );
     }
 
     public function testAllDefaultsAreExplicit(): void

--- a/tests/Capability/SessionCapabilitiesDefaultsTest.php
+++ b/tests/Capability/SessionCapabilitiesDefaultsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Capability;
+
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionParameter;
+
+/**
+ * RFC 1 §5.4: "The absence of a client capability MUST resolve to a safe default
+ * that is the value's own default state, not a special-cased branch at the point
+ * of use."
+ *
+ * This test verifies that every SessionCapabilities property has a default value
+ * in the constructor, so a minimal client (one that declares no capabilities) is
+ * served by the defaults without a branch.
+ *
+ * If you add a new capability property, you MUST also provide a default value
+ * in the constructor. This test will fail if you add a required parameter.
+ */
+#[CoversClass(SessionCapabilities::class)]
+final class SessionCapabilitiesDefaultsTest extends TestCase
+{
+    public function testEveryCapabilityHasADefaultValue(): void
+    {
+        $reflection = new ReflectionClass(SessionCapabilities::class);
+        $constructor = $reflection->getConstructor();
+
+        self::assertNotNull($constructor, 'SessionCapabilities must have a constructor');
+
+        $parameters = $constructor->getParameters();
+        $missingDefaults = [];
+
+        foreach ($parameters as $param) {
+            if (!$param->isDefaultValueAvailable()) {
+                $missingDefaults[] = $param->getName();
+            }
+        }
+
+        self::assertSame(
+            [],
+            $missingDefaults,
+            'Every SessionCapabilities property must have a default value (RFC 1 §5.4). '
+            . 'Missing defaults: ' . implode(', ', $missingDefaults),
+        );
+    }
+
+    public function testDefaultSessionCapabilitiesIsConstructable(): void
+    {
+        $capabilities = new SessionCapabilities();
+
+        self::assertNotNull($capabilities, 'SessionCapabilities must be constructable with no arguments');
+    }
+
+    public function testAllDefaultsAreExplicit(): void
+    {
+        $capabilities = new SessionCapabilities();
+        $reflection = new ReflectionClass($capabilities);
+
+        foreach ($reflection->getProperties() as $property) {
+            $value = $property->getValue($capabilities);
+
+            self::assertNotNull(
+                $value,
+                sprintf(
+                    'Property %s has a null default; RFC 1 §5.4 requires explicit safe defaults',
+                    $property->getName(),
+                ),
+            );
+        }
+    }
+}

--- a/tests/Resolution/AstTextAgreementTest.php
+++ b/tests/Resolution/AstTextAgreementTest.php
@@ -59,6 +59,7 @@ final class AstTextAgreementTest extends TestCase
         $content = $this->loadFixture($fixture);
         $document = new TextDocument('file:///' . $fixture, 'php', 1, $content);
         $ast = $this->parser->parse($document);
+        self::assertNotNull($ast, 'Fixture must be parseable for agreement test');
 
         $astResult = ScopeFinder::findClassAtLine($ast, $line);
         $textResult = $this->textFallback->findEnclosingClassFromContent($content, $line);
@@ -96,7 +97,7 @@ final class AstTextAgreementTest extends TestCase
     #[DataProvider('enclosingClassDivergenceFixtures')]
     public function testEnclosingClassDivergence(string $fixture, int $line, string $expected): void
     {
-        $this->markTestSkipped(
+        self::markTestSkipped(
             'Known divergence (node-locator): findClassAtLine handles only Class_, '
             . 'text fallback handles all class-likes. See RFC 1 §4.11, Plan 0002 S4.2/S4.4.',
         );

--- a/tests/Resolution/AstTextAgreementTest.php
+++ b/tests/Resolution/AstTextAgreementTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Resolution;
+
+use Firehed\PhpLsp\Document\TextDocument;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Knowledge\KnowledgeStack;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\TextFallbackHelper;
+use Firehed\PhpLsp\Tests\LoadsFixturesTrait;
+use Firehed\PhpLsp\Utility\ScopeFinder;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * RFC 1 §4.11: Text-derived fallback logic MUST agree with the syntax-tree path
+ * on input that parses; that agreement MUST be held by test, not review.
+ *
+ * These tests verify that on parseable code, the AST-based resolution and the
+ * text-based fallback produce identical results for every positional question
+ * both paths answer.
+ *
+ * Known divergences are marked skipped with their owning slice; each skip is
+ * removed when that slice lands and the paths agree.
+ */
+#[CoversNothing]
+final class AstTextAgreementTest extends TestCase
+{
+    use LoadsFixturesTrait;
+
+    private ParserService $parser;
+    private MemberResolver $memberResolver;
+    private TextFallbackHelper $textFallback;
+
+    protected function setUp(): void
+    {
+        $this->parser = new ParserService();
+
+        $knowledge = KnowledgeStack::forProject(
+            new ComposerAutoloadMap(),
+            __DIR__ . '/../Fixtures/vendor',
+            $this->parser,
+        );
+        $this->memberResolver = new MemberResolver($knowledge->source);
+        $this->textFallback = new TextFallbackHelper($this->memberResolver);
+    }
+
+    /**
+     * The enclosing class-like at a position: for classes, both paths agree.
+     * Traits, interfaces, and enums are a known divergence (node-locator slice).
+     */
+    #[DataProvider('enclosingClassAgreementFixtures')]
+    public function testEnclosingClassAgreement(string $fixture, int $line, ?string $expected): void
+    {
+        $content = $this->loadFixture($fixture);
+        $document = new TextDocument('file:///' . $fixture, 'php', 1, $content);
+        $ast = $this->parser->parse($document);
+
+        $astResult = ScopeFinder::findClassAtLine($ast, $line);
+        $textResult = $this->textFallback->findEnclosingClassFromContent($content, $line);
+
+        if ($expected === null) {
+            self::assertNull($astResult, 'AST path: no enclosing class expected');
+            self::assertNull($textResult, 'Text path must agree: no enclosing class');
+        } else {
+            self::assertNotNull($astResult, 'AST path: enclosing class expected');
+            self::assertNotNull($textResult, 'Text path must agree: enclosing class expected');
+            self::assertSame(
+                $astResult->namespacedName?->toString() ?? $astResult->name?->name,
+                $textResult,
+                'AST and text paths must agree on the enclosing class name',
+            );
+        }
+    }
+
+    /**
+     * @return array<string, array{string, int, ?string}>
+     */
+    public static function enclosingClassAgreementFixtures(): array
+    {
+        return [
+            'inside class method' => ['src/Domain/User.php', 50, 'Fixtures\Domain\User'],
+            'outside any class' => ['src/Domain/User.php', 3, null],
+        ];
+    }
+
+    /**
+     * Known divergence: ScopeFinder::findClassAtLine returns only Stmt\Class_,
+     * not traits/interfaces/enums. The text fallback handles all four.
+     * Owner: node-locator slice (Step 4).
+     */
+    #[DataProvider('enclosingClassDivergenceFixtures')]
+    public function testEnclosingClassDivergence(string $fixture, int $line, string $expected): void
+    {
+        $this->markTestSkipped(
+            'Known divergence (node-locator): findClassAtLine handles only Class_, '
+            . 'text fallback handles all class-likes. See RFC 1 §4.11, Plan 0002 S4.2/S4.4.',
+        );
+    }
+
+    /**
+     * @return array<string, array{string, int, string}>
+     */
+    public static function enclosingClassDivergenceFixtures(): array
+    {
+        return [
+            'inside trait method' => ['src/Traits/HasTimestamps.php', 15, 'Fixtures\Traits\HasTimestamps'],
+            'inside interface' => ['src/Domain/Entity.php', 10, 'Fixtures\Domain\Entity'],
+            'inside enum' => ['src/Enum/Status.php', 15, 'Fixtures\Enum\Status'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Without these rules, an M×N violation can be introduced and pass CI. This slice makes violation recurrence fail analysis.

- **Slice:** `enforcement-rules`
- **Plan step:** N/A (this slice predates the per-step numbering; it bundles all §8.1 mechanisms)
- **RFC sections:** §4.5, §4.6, §4.11, §5.4

## What this does

Installs every unbuilt RFC 1 §8.1 enforcement mechanism:

- **§4.6 TypeConstructionRule** — PHPStan rule: no `new ClassName/UnionType/IntersectionType/PrimitiveType` outside `TypeFactory` and Type implementations
- **§4.5 KindInspectionRule** — PHPStan rule: no `instanceof` against concrete Type or ResolvedSymbol implementations outside factories/classifiers
- **§4.11 AstTextAgreementTest** — Tests that AST path and text-fallback path agree on parseable input; known divergences marked skipped pending `node-locator`
- **§5.4 SessionCapabilitiesDefaultsTest** — Tests that every `SessionCapabilities` property has an explicit default

## Baseline growth

The PHPStan baseline grows from 15 to 69 entries. This is expected and correct: the rules reveal pre-existing violations they did not create. Per the manifest, `enforcement-rules` is the one slice where growth is allowed; every subsequent slice must shrink or hold flat.

## §4.3/§5.2 note

The manifest claims S3.4 landed the write-path consistency check as a runtime `assert()` disabled in production. The actual code uses `throw new LogicException(...)`, which IS active in production. No work needed.

## Acceptance criteria

- [x] §4.5 rule installed and registered
- [x] §4.6 rule installed and registered
- [x] §4.11 agreement tests installed (with known divergences marked skipped)
- [x] §5.4 capability defaults test installed
- [x] Baseline regenerated to freeze pre-existing violations
- [x] `composer test` green

## Candidate closes (pending review verification)

None — this slice has no issue.

---

Generated with [Claude Code](https://claude.ai/code)
