### PR TITLE
Name every enforcement edit as tighten, loosen or lateral

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "ask": [
+      "Edit(phpstan.neon)",
+      "Write(phpstan.neon)",
+      "Edit(deptrac.yaml)",
+      "Write(deptrac.yaml)",
+      "Edit(phpstan-baseline.neon)",
+      "Write(phpstan-baseline.neon)",
+      "Edit(deptrac.baseline.yaml)",
+      "Write(deptrac.baseline.yaml)",
+      "Edit(tests/Architecture/**)",
+      "Write(tests/Architecture/**)",
+      "Edit(bin/**)",
+      "Write(bin/**)",
+      "Edit(.github/**)",
+      "Write(.github/**)",
+      "Edit(.claude/**)",
+      "Write(.claude/**)",
+      "Edit(docs/architecture/enforcement-edits.md)",
+      "Write(docs/architecture/enforcement-edits.md)"
+    ]
+  }
+}

--- a/.claude/skills/do-next/SKILL.md
+++ b/.claude/skills/do-next/SKILL.md
@@ -57,9 +57,12 @@ in `phpstan-baseline.neon` / `deptrac.baseline.yaml`. If the row drains no basel
 entry, spot-check its central claim against the code — one `grep` is enough; the
 failure mode is a row asserting that something is absent when it is present.
 
-**Baseline rule:** `enforcement-rules` is the only slice that may grow a baseline (the
-human overrides CI). Every other slice must leave baselines flat or shrink them —
-widening an enforcement rule's allowlist to avoid growth is the same failure.
+**Baseline rule:** every slice leaves the baselines flat or shrinks them. A slice
+never makes a **Loosen** edit (`docs/architecture/enforcement-edits.md`): no allowlist
+addition, no layer edge, no baseline growth for an existing check, no skipped test, no
+change to `bin/`, `.github/`, `.claude/`, or a policy paragraph in this manifest or the
+build procedure. If the slice cannot land without one, **stop and report** — the human
+makes that edit, or strikes the slice.
 
 A row whose claim no longer holds is a **phantom**. Report it as such, say what appears
 to have discharged it, and ask whether to remove it from the list and continue to the

--- a/.claude/skills/review-slice/SKILL.md
+++ b/.claude/skills/review-slice/SKILL.md
@@ -50,6 +50,15 @@ that filter — it has the code in context; step 3 only backstops it.
 
 Run a small diverse panel in parallel:
 
+- **Policy surface** — classify every hunk touching `phpstan.neon`, `deptrac.yaml`,
+  `tests/Architecture/`, either baseline, `bin/`, `.github/`, `.claude/`, or the
+  policy paragraphs of the manifest and build procedure, using the table in
+  `docs/architecture/enforcement-edits.md`. A **Loosen** edit is a finding, always;
+  a **Lateral** edit is a finding unless the same diff contains the file move it
+  depends on; baseline growth is a finding unless every new entry is reported by a
+  check the same diff adds. This reviewer carries the standing goal-test answer
+  (a loosened rule removes a violation from the record instead of freezing it), so
+  the drop rule does not apply to it.
 - **Acceptance** — is every acceptance criterion actually met, not just plausibly?
   Including each owed item from step 1: the named test exists, and it fails against the
   code it replaces (check that by reverting the fix locally, not by reading the test).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,18 @@ Two CI-enforced mechanisms confine where code may live; a rule firing on your ch
 - **Capability confinement** (`phpstan.neon`): AST traversal, symbol-name case folding, regex, runtime reflection, runtime symbol existence/enumeration, and filesystem reads are each usable only in their named homes (allowlists inline, each with its rationale).
 - **Layer contract** (`deptrac.yaml`): an inter-layer dependency not in the ruleset fails analysis.
 
-When a rule fires on your change, in order of preference:
+When a rule fires on your change:
 
 1. Move the logic into (or route it through) the confined authority — the usual fix.
 2. If the authority genuinely cannot serve the need, extend the authority.
-3. Widening an allowlist is a last-resort, conscious decision; justify it in the PR.
+
+There is no third option. Widening an allowlist, adding a layer edge, or growing a baseline for an existing check is a **Loosen** edit, and only the human makes one.
+`docs/architecture/enforcement-edits.md` classifies every edit to a rule, allowlist, baseline, or policy file as Tighten, Lateral, or Loosen; read it before touching any of them.
+A PR body cannot justify a Loosen edit.
 
 NEVER regenerate a baseline to absorb a new violation.
 The baselines (`phpstan-baseline.neon`, `deptrac.baseline.yaml`) freeze pre-existing debt only and must shrink to zero; CI enforces shrink-only (`bin/check-baseline-shrink`).
-Regenerate (`composer phpstan-baseline` / `composer deptrac-baseline`) only when draining entries, or when a refactor relocates a violation the baseline already froze — totals may never grow.
+Regenerate (`composer phpstan-baseline` / `composer deptrac-baseline`) only when draining entries, when a refactor moves a file whose violations the baseline already froze (a Lateral edit), or when a newly added check reports pre-existing violations (a Tighten edit).
 When changing a file that has baseline entries, prefer draining them in the same change.
 This section overrides the global "avoid adding to the baseline" guidance in the strict direction: here, additions are forbidden outright and shrink-churn is the goal.
 

--- a/bin/check-baseline-shrink
+++ b/bin/check-baseline-shrink
@@ -37,8 +37,8 @@ foreach ($files as $file => $total) {
     if ($head > $base) {
         fwrite(STDERR, sprintf(
             "%s grew (%d -> %d): baselines only shrink. Route the new" .
-            " violation through its authority, or consciously widen the" .
-            " allowlist in the rule config instead.\n",
+            " violation through its authority. Growth is permitted only" .
+            " for a newly added check; see docs/architecture/enforcement-edits.md.\n",
             $file,
             $base,
             $head,

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -5,8 +5,8 @@ deptrac:
   paths:
     - src
   # Layer-dependency contract (default-deny): an edge not listed in the ruleset
-  # fails analysis. Existing violations are frozen in deptrac.baseline.yaml
-  # (regenerate with `composer deptrac-baseline`) and must only shrink.
+  # fails analysis. Adding a layer tightens; adding a ruleset edge loosens and is
+  # the human's edit only. See docs/architecture/enforcement-edits.md.
   # ServerInfo is deliberately unlayered: it is a value Protocol/Capability carry.
   layers:
     - name: Root

--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -42,9 +42,9 @@ Ordered. Each row starts when the one above it merges.
   - **§4.11** — the AST/text agreement tests: the AST path and the text-fallback path must answer the same question the same way on parseable fixtures. Writable against the code as it stands, and landing it first constrains the Step 4 refactor instead of trailing it.
   - **§5.4** — a safe default for every capability the client did not declare. §5.4 has no §8.1 row at all; §4.8's rule enforces *where* raw parameters may be read, not this. Add a capability with no default and nothing fails today. Same shape as the §5.1 coverage grid.
 
-  **The baselines grow, once.** That is expected and correct: a rule reveals pre-existing violations, it does not introduce them (RFC 1 §8.1). `bin/check-baseline-shrink` will fail on the growth — the human overrides CI and merges anyway. That gate exists to stop unconscious growth, and this is the one conscious event. From that commit the totals shrink again and must reach zero.
+  **The baselines grew once, here, at the human's direction.** A rule reveals pre-existing violations, it does not introduce them (RFC 1 §8.1).
 
-  **Every other slice must leave the baselines flat or shrink them.** No exceptions, no judgment calls. If a slice is not `enforcement-rules` and CI fails on baseline growth, the slice is wrong — and widening an enforcement rule's allowlist to avoid the growth is the same failure with extra steps.
+  **Every slice must leave the baselines flat or shrink them.** No exceptions, no judgment calls. If CI fails on baseline growth, the slice is wrong. Widening an allowlist, adding a layer edge, or rewriting this paragraph to permit the growth is the same failure with extra steps; `docs/architecture/enforcement-edits.md` names every such edit as the human's alone.
 
 - [ ] **search-kind-param** — Generalize search to a kind parameter
 

--- a/docs/architecture/enforcement-edits.md
+++ b/docs/architecture/enforcement-edits.md
@@ -16,6 +16,7 @@ A reviewer classifies every edit to the files above with this table before readi
 | Remove an edge from the layer ruleset | Tighten | Anyone. |
 | Remove a path from an allowlist | Tighten | Anyone. |
 | Add a check, rule, test, or layer | Tighten | Anyone. |
+| Add a deny entry or rule together with its allowlist | Tighten, when every allowlist path is one file that uses the denied thing today (`tests/*` is the one directory glob). A directory glob, or a file with no use, is a Loosen hidden inside a Tighten. | Anyone, under that condition. The reviewer greps each denied name in `src/`: the hits and the allowlist must be the same set, with the rest in the baseline. |
 | Rename a path in an allowlist or a baseline entry | Lateral | Anyone, only when the same PR moves that file (git reports a rename) and the entry count does not change. |
 | Rename a rule identifier or message, with the baseline rewritten to match | Lateral | Anyone, only when the total for that rule does not change. |
 | Add a path to an allowlist | Loosen | The human only. |

--- a/docs/architecture/enforcement-edits.md
+++ b/docs/architecture/enforcement-edits.md
@@ -1,0 +1,43 @@
+# Enforcement edits: tighten, loosen, lateral
+
+    Status:   Policy
+    Applies:  phpstan.neon, deptrac.yaml, tests/Architecture/*, the two baselines, bin/, .github/, .claude/
+
+The M×N rules (RFC 1 §8.1) are lists.
+A list edit has one of three meanings, and only the first is open to an implementer.
+A reviewer classifies every edit to the files above with this table before reading anything else in the diff.
+
+## The table
+
+| Edit | Meaning | Who may make it |
+|---|---|---|
+| Add a function, class, enum, or implementation to a deny set or confined set | Tighten | Anyone. The baseline may grow in the same PR, by the entries the new check reports and no others. |
+| Remove a baseline entry | Tighten | Anyone. |
+| Remove an edge from the layer ruleset | Tighten | Anyone. |
+| Remove a path from an allowlist | Tighten | Anyone. |
+| Add a check, rule, test, or layer | Tighten | Anyone. |
+| Rename a path in an allowlist or a baseline entry | Lateral | Anyone, only when the same PR moves that file (git reports a rename) and the entry count does not change. |
+| Rename a rule identifier or message, with the baseline rewritten to match | Lateral | Anyone, only when the total for that rule does not change. |
+| Add a path to an allowlist | Loosen | The human only. |
+| Remove a function, class, enum, or implementation from a deny set or confined set | Loosen | The human only. |
+| Add an edge to the layer ruleset | Loosen | The human only. |
+| Add an `excludePaths` or `ignoreErrors` entry, or an inline `@phpstan-ignore` for a `phpLsp.*` or `disallowed.*` identifier | Loosen | The human only. |
+| Add a baseline entry for a check that existed before the PR | Loosen | The human only. |
+| Skip or delete a test | Loosen | The human only. |
+| Edit `bin/check-baseline-shrink`, a workflow under `.github/`, a skill under `.claude/`, or this document | Loosen | The human only. |
+
+"The human only" means the human writes the edit, or names it in the slice row before the slice starts.
+A PR body that explains why a Loosen edit was necessary does not make it allowed.
+
+## Why a Loosen edit is never the implementer's call
+
+A rule that is narrowed to keep CI green reports nothing, and a check that reports nothing reads the same as a check that is satisfied.
+The baseline only records what a rule reports, so a loosened rule removes the violation from the record instead of freezing it.
+That is the one failure the rules exist to prevent, one tier up.
+
+## What a reviewer does with the table
+
+- A Loosen row in the diff is a finding, always.
+- A Lateral row is a finding unless the diff also contains the rename it depends on.
+- A Tighten row that grows a baseline is correct when every new entry is reported by the added check; any other growth is a Loosen row in disguise.
+- A prose change to a policy paragraph (build manifest, build procedure, a skill) is a Loosen row.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,7 +67,7 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase\.$#'
 			identifier: disallowed.function
 			count: 1
 			path: src/Resolution/SymbolResolver.php
@@ -109,7 +109,7 @@ parameters:
 			path: src/Resolution/SymbolResolver.php
 
 		-
-			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase; other uses may be allowlisted here consciously\.$#'
+			message: '#^Calling strtolower\(\) is forbidden, which case rule a name follows is NameKind \(symbols\) or MemberKind \(class\-like members\); applying one is NameCase\.$#'
 			identifier: disallowed.function
 			count: 2
 			path: src/Resolution/TextFallbackHelper.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,8 +7,15 @@ parameters:
     # Default-deny capability confinement: each mechanism below is usable only in
     # its named home(s). A new use elsewhere is a duplicate implementation waiting
     # to happen — extend the authority instead.
-    # Adding to a deny list tightens; adding to an allowIn list loosens and is the
-    # human's edit only. See docs/architecture/enforcement-edits.md.
+    #
+    # Every entry in the three disallowed* blocks has the same shape, and each
+    # part has one edit meaning (docs/architecture/enforcement-edits.md):
+    #   namespace / function / method  — the deny list. Adding tightens.
+    #   allowIn                        — the allowlist. Adding loosens (human only).
+    #                                    On a new entry, each path must be one file
+    #                                    that calls the denied thing today.
+    #   message                        — text only. Changing it is lateral, and the
+    #                                    baseline must be regenerated at the same total.
     disallowedNamespaces:
         -
             namespace: 'PhpParser\NodeTraverser'
@@ -157,13 +164,16 @@ parameters:
     paths:
         - src
         - tests
+    # Adding a path here removes it from every check: loosen (human only).
     excludePaths:
         - tests/Fixtures
         # Deliberate rule violations, analysed only by RuleTestCase.
         - tests/Architecture/data
 
 services:
-    # RFC 1 §8.1 enforcement mechanisms.
+    # RFC 1 §8.1 enforcement mechanisms. Registering a rule tightens; removing
+    # one loosens (human only). Each rule's own lists are documented on its
+    # constants.
     -
         class: Firehed\PhpLsp\Tests\Architecture\RawInitializeCapabilitiesRule
         tags:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,10 +6,9 @@ includes:
 parameters:
     # Default-deny capability confinement: each mechanism below is usable only in
     # its named home(s). A new use elsewhere is a duplicate implementation waiting
-    # to happen — extend the authority instead, or (rarely) widen the allowlist.
-    # Existing violations are frozen in phpstan-baseline.neon (regenerate with
-    # `composer phpstan-baseline`) and drain via their owning slices; the
-    # baseline must only shrink.
+    # to happen — extend the authority instead.
+    # Adding to a deny list tightens; adding to an allowIn list loosens and is the
+    # human's edit only. See docs/architecture/enforcement-edits.md.
     disallowedNamespaces:
         -
             namespace: 'PhpParser\NodeTraverser'
@@ -61,7 +60,7 @@ parameters:
                 - 'strcasecmp()'
                 - 'strncasecmp()'
                 - 'mb_strtolower()'
-            message: 'which case rule a name follows is NameKind (symbols) or MemberKind (class-like members); applying one is NameCase; other uses may be allowlisted here consciously'
+            message: 'which case rule a name follows is NameKind (symbols) or MemberKind (class-like members); applying one is NameCase'
             allowIn:
                 - src/Domain/NameCase.php
                 - src/Domain/NamespacePath.php # namespace paths are case-insensitive for every kind; not a symbol name

--- a/tests/Architecture/KindEnumMatchRule.php
+++ b/tests/Architecture/KindEnumMatchRule.php
@@ -25,13 +25,23 @@ use PHPStan\Type\ObjectType;
  */
 final class KindEnumMatchRule implements Rule
 {
-    /** @var list<class-string> */
+    /**
+     * Adding an entry tightens. Removing one loosens (human only). See
+     * docs/architecture/enforcement-edits.md.
+     *
+     * @var list<class-string>
+     */
     private const array CONFINED_KIND_ENUMS = [
         \Firehed\PhpLsp\Domain\NameKind::class,
         \Firehed\PhpLsp\Domain\MemberKind::class,
         \Firehed\PhpLsp\Domain\ClassKind::class,
     ];
 
+    /**
+     * Adding an entry loosens (human only). Removing one tightens. Renaming one
+     * is lateral only when the same PR moves the file. See
+     * docs/architecture/enforcement-edits.md.
+     */
     private const array ALLOWED_FILES = [
         'src/Domain/NameKind.php',
         'src/Domain/MemberKind.php',

--- a/tests/Architecture/KindInspectionRule.php
+++ b/tests/Architecture/KindInspectionRule.php
@@ -27,7 +27,12 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 final class KindInspectionRule implements Rule
 {
-    /** @var list<class-string> */
+    /**
+     * Adding an entry tightens. Removing one loosens (human only). See
+     * docs/architecture/enforcement-edits.md.
+     *
+     * @var list<class-string>
+     */
     private const array CONFINED_TYPE_IMPLS = [
         \Firehed\PhpLsp\Domain\ClassName::class,
         \Firehed\PhpLsp\Domain\UnionType::class,
@@ -36,7 +41,11 @@ final class KindInspectionRule implements Rule
         \Firehed\PhpLsp\Domain\LateStaticType::class,
     ];
 
-    /** @var list<class-string> */
+    /**
+     * Adding an entry tightens. Removing one loosens (human only).
+     *
+     * @var list<class-string>
+     */
     private const array CONFINED_RESOLVED_IMPLS = [
         \Firehed\PhpLsp\Resolution\ResolvedClass::class,
         \Firehed\PhpLsp\Resolution\ResolvedConstant::class,
@@ -49,6 +58,11 @@ final class KindInspectionRule implements Rule
         \Firehed\PhpLsp\Resolution\ResolvedVariable::class,
     ];
 
+    /**
+     * Adding an entry loosens (human only). Removing one tightens. Renaming one
+     * is lateral only when the same PR moves the file. See
+     * docs/architecture/enforcement-edits.md.
+     */
     private const array ALLOWED_FILES = [
         'src/Domain/TypeFactory.php',
         'src/Domain/ClassName.php',

--- a/tests/Architecture/RawInitializeCapabilitiesRule.php
+++ b/tests/Architecture/RawInitializeCapabilitiesRule.php
@@ -26,8 +26,15 @@ use PHPStan\Type\MixedType;
  */
 final class RawInitializeCapabilitiesRule implements Rule
 {
-    /** @var list<string> */
+    /**
+     * Adding an entry tightens. Removing one loosens (human only). See
+     * docs/architecture/enforcement-edits.md.
+     *
+     * @var list<string>
+     */
     private const array CONFINED_FIELDS = ['capabilities', 'general'];
+
+    /** Changing this loosens (human only). */
     private const string NEGOTIATION_NAMESPACE = 'Firehed\PhpLsp\Capability';
 
     public function getNodeType(): string

--- a/tests/Architecture/SymbolDiscoveryAuthorityExtension.php
+++ b/tests/Architecture/SymbolDiscoveryAuthorityExtension.php
@@ -44,6 +44,9 @@ final class SymbolDiscoveryAuthorityExtension implements RestrictedClassNameUsag
      * has no namespace prefix). Class-like lookup is now served entirely by the
      * {@see \Firehed\PhpLsp\Knowledge\SymbolBackend}s, so `ClassRepository` is gone.
      *
+     * Adding an entry tightens. Removing one loosens (human only). See
+     * docs/architecture/enforcement-edits.md.
+     *
      * @var list<class-string>
      */
     private const array CONFINED_COLLABORATORS = [
@@ -62,6 +65,8 @@ final class SymbolDiscoveryAuthorityExtension implements RestrictedClassNameUsag
      * carve-out — so the two names sit in the confined set above and are exempted here
      * rather than simply omitted.
      *
+     * Adding an entry loosens (human only). Removing one tightens.
+     *
      * @var list<class-string>
      */
     private const array FUNCTION_PATH_EXEMPTION = [
@@ -72,6 +77,8 @@ final class SymbolDiscoveryAuthorityExtension implements RestrictedClassNameUsag
     /**
      * The composition root (Server) wires the concrete collaborators into the backend,
      * so the root namespace names them directly.
+     *
+     * Changing this loosens (human only).
      */
     private const string COMPOSITION_ROOT_NAMESPACE = 'Firehed\PhpLsp';
 
@@ -80,6 +87,8 @@ final class SymbolDiscoveryAuthorityExtension implements RestrictedClassNameUsag
      * compose, and tests are not production consumers — the parity suites use
      * reflection as the §4.7 oracle by design. A namespace equal to or nested under one
      * of these is exempt.
+     *
+     * Adding an entry loosens (human only). Removing one tightens.
      *
      * @var list<string>
      */

--- a/tests/Architecture/TypeConstructionRule.php
+++ b/tests/Architecture/TypeConstructionRule.php
@@ -19,7 +19,12 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 final class TypeConstructionRule implements Rule
 {
-    /** @var list<class-string> */
+    /**
+     * Adding an entry tightens. Removing one loosens (human only). See
+     * docs/architecture/enforcement-edits.md.
+     *
+     * @var list<class-string>
+     */
     private const array CONFINED_TYPES = [
         \Firehed\PhpLsp\Domain\ClassName::class,
         \Firehed\PhpLsp\Domain\UnionType::class,
@@ -28,6 +33,11 @@ final class TypeConstructionRule implements Rule
         \Firehed\PhpLsp\Domain\LateStaticType::class,
     ];
 
+    /**
+     * Adding an entry loosens (human only). Removing one tightens. Renaming one
+     * is lateral only when the same PR moves the file. See
+     * docs/architecture/enforcement-edits.md.
+     */
     private const array ALLOWED_FILES = [
         'src/Domain/TypeFactory.php',
         'src/Domain/ClassName.php',


### PR DESCRIPTION
## What two features could disagree about without this

Nothing directly. This change protects the rules that protect them: a rule narrowed to keep CI green reports nothing, and a check that reports nothing reads the same as a satisfied one. The last slice attempt rewrote the manifest's growth paragraph so its own baseline growth became permitted, and no text anywhere said that edit was out of bounds.

## What this does

- Adds `docs/architecture/enforcement-edits.md`: a table that classifies every edit to a rule, allowlist, layer ruleset, baseline, or policy file as **Tighten** (anyone), **Lateral** (anyone, when the same PR contains the file move it depends on), or **Loosen** (the human only).
- Each rule constant, `phpstan.neon`, and `deptrac.yaml` now say which direction their edits go and point at the table.
- Removes every sentence that offered allowlist widening as an option: `CLAUDE.md`, `phpstan.neon`, the `bin/check-baseline-shrink` error text, the manifest's "human overrides CI" paragraph.
- `do-next` now forbids every Loosen edit outright; `review-slice` gains a policy-surface reviewer whose findings skip the goal-test drop rule.
- Adds a checked-in `.claude/settings.json` that prompts before any Edit/Write to the enforcement surface.

The baseline is rewritten for one shortened message (Lateral: 69 -> 69).

## Not in this PR

The rule holes found during the audit (`===` on kind cases, `switch`, variable `instanceof`, parser/lexer confinement, sibling functions, exact path matching, unlayered directories) are PR 2. That one regrows the baseline once, at the human's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
