### PR TITLE
Add remaining M×N guards

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -280,6 +280,15 @@ parameters:
 
     disallowedClasses:
         -
+            class: 'Firehed\PhpLsp\Knowledge\SymbolSource'
+            message: 'handlers resolve symbols through CodeResolver (RFC 1 §4.2); SymbolSource is the knowledge tier one layer down'
+            allowIn:
+                - src/Completion/* # completion sources own their lookups
+                - src/Knowledge/*
+                - src/Repository/*
+                - src/Resolution/*
+                - tests/*
+        -
             class:
                 - 'DirectoryIterator'
                 - 'RecursiveDirectoryIterator'
@@ -362,6 +371,10 @@ services:
             - phpstan.rules.rule
     -
         class: Firehed\PhpLsp\Tests\Architecture\FileInclusionRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Firehed\PhpLsp\Tests\Architecture\FormatComparisonRule
         tags:
             - phpstan.rules.rule
     -

--- a/tests/Architecture/FormatComparisonRule.php
+++ b/tests/Architecture/FormatComparisonRule.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Comparing a formatted type string (`$type->format() === 'int'`) branches on
+ * the type's display representation, which can diverge from the type's actual
+ * identity. Use Type predicates or instanceof checks (which the existing rules
+ * confine) instead.
+ *
+ * @implements Rule<BinaryOp>
+ */
+final class FormatComparisonRule implements Rule
+{
+    /**
+     * Adding an entry loosens (human only). See
+     * docs/architecture/enforcement-edits.md.
+     *
+     * @var list<string>
+     */
+    private const array ALLOWED_FILES = [];
+
+    public function getNodeType(): string
+    {
+        return BinaryOp::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$this->isEquality($node)) {
+            return [];
+        }
+
+        $hasFormatCall = $this->isFormatCall($node->left) || $this->isFormatCall($node->right);
+        if (!$hasFormatCall) {
+            return [];
+        }
+
+        if (ConfinedFile::isExempt($scope->getFile(), self::ALLOWED_FILES)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'comparing format() output branches on display representation; use Type predicates (RFC 1 §4.5).',
+            )
+                ->identifier('phpLsp.formatComparison')
+                ->build(),
+        ];
+    }
+
+    private function isEquality(BinaryOp $node): bool
+    {
+        return $node instanceof BinaryOp\Identical
+            || $node instanceof BinaryOp\NotIdentical
+            || $node instanceof BinaryOp\Equal
+            || $node instanceof BinaryOp\NotEqual;
+    }
+
+    private function isFormatCall(Node $node): bool
+    {
+        if (!$node instanceof MethodCall) {
+            return false;
+        }
+        if (!$node->name instanceof Identifier) {
+            return false;
+        }
+
+        return $node->name->toLowerString() === 'format';
+    }
+}

--- a/tests/Architecture/FormatComparisonRuleTest.php
+++ b/tests/Architecture/FormatComparisonRuleTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<FormatComparisonRule>
+ */
+class FormatComparisonRuleTest extends RuleTestCase
+{
+    public function testFormatComparisonIsReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/compares-format.php'],
+            [
+                ['comparing format() output branches on display representation; use Type predicates (RFC 1 §4.5).', 17],
+                ['comparing format() output branches on display representation; use Type predicates (RFC 1 §4.5).', 22],
+                ['comparing format() output branches on display representation; use Type predicates (RFC 1 §4.5).', 27],
+                ['comparing format() output branches on display representation; use Type predicates (RFC 1 §4.5).', 32],
+            ],
+        );
+    }
+
+    protected function getRule(): Rule
+    {
+        return new FormatComparisonRule();
+    }
+}

--- a/tests/Architecture/data/compares-format.php
+++ b/tests/Architecture/data/compares-format.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Architecture\Data;
+
+use Firehed\PhpLsp\Domain\Type;
+
+/**
+ * A consumer branching on a type's display representation rather than its
+ * identity, which can diverge from the type's actual structure.
+ */
+final class ComparesFormat
+{
+    public function identicalToString(Type $type): bool
+    {
+        return $type->format() === 'string';
+    }
+
+    public function notIdenticalToString(Type $type): bool
+    {
+        return $type->format() !== 'string';
+    }
+
+    public function looselyEqual(Type $type): bool
+    {
+        return $type->format() == 'int';
+    }
+
+    public function looselyNotEqual(Type $type): bool
+    {
+        return $type->format() != 'int';
+    }
+
+    public function concatenationIsFine(Type $type): string
+    {
+        return 'Type: ' . $type->format();
+    }
+
+    public function assignmentIsFine(Type $type): string
+    {
+        $formatted = $type->format();
+        return $formatted;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #441.

Two guards that prevent future M×N divergence patterns:

1. **FormatComparisonRule** — Comparing `$type->format() === 'string'` branches on display representation rather than type identity. The formatted string can diverge from the type's actual structure (e.g. nullable formatting). Use Type predicates instead.

2. **SymbolSource banned from handlers** — Handlers resolve symbols through `CodeResolver`; `SymbolSource` is the knowledge tier one layer down. The deptrac comment said this was enforced but no rule existed.

Neither pattern exists in the codebase today (verified with grep). No baseline growth.

## Test plan

- [ ] `composer test` passes
- [ ] FormatComparisonRuleTest catches all comparison forms
- [ ] EnforcementWiringTest confirms both are registered

---

Closes #441

Generated with [Claude Code](https://claude.com/claude-code)