### PR TITLE
Feature-matrix grid

### DIFF
--- a/docs/architecture/build-manifest.md
+++ b/docs/architecture/build-manifest.md
@@ -17,7 +17,7 @@ One signal: both baseline files are deleted, and the issues named below are clos
 
 ## Steps
 
-- [ ] **step-0** — Feature-matrix grid, the net for the rewrite behind it: rows are fixture scenarios (file plus cursor marker), columns are the handlers, derived from the handler registry. Each cell asserts that handler's observable or is registered not-applicable against an issue number; an unregistered cell fails, and so does a registration on a cell that answers. Done: the grid runs in `composer test`; adding a handler adds a column with no edit to the test; #445 closed.
+- [x] **step-0** — Feature-matrix grid, the net for the rewrite behind it: rows are fixture scenarios (file plus cursor marker), columns are the handlers, derived from the handler registry. Each cell asserts that handler's observable or is registered not-applicable against an issue number; an unregistered cell fails, and so does a registration on a cell that answers. Done: the grid runs in `composer test`; adding a handler adds a column with no edit to the test; #445 closed.
 - [ ] **step-1** — `SymbolSource::search(prefix, NameKind)` replaces `searchClassLikes` on `SymbolSource` and `SymbolBackend`; `OpenDocumentBackend` answers for every kind; `ClassCandidates` passes `NameKind::ClassLike`. Done: `searchClassLikes` is gone; every parity golden is unchanged.
 - [ ] **step-2** — `FilesystemBackend` answers `search` for functions and constants from the autoload.files index; `BuiltinBackend` answers it from reflection enumeration. Done: `SymbolCoverageGridTest` registers no `search` cell for `Function_` or `Constant`.
 - [ ] **step-3** — `ReflectionSymbolInfoFactory::classInfo()` answers only where `isInternal()` is true. Done: #429 closed.

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -53,7 +53,7 @@ final class CompletionHandler implements DocumentFeatureHandler
     ) {
     }
 
-    public function method(): string
+    public static function method(): string
     {
         return 'textDocument/completion';
     }

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -32,10 +32,6 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  */
 final class CompletionHandler implements DocumentFeatureHandler
 {
-    public function method(): string
-    {
-        return 'textDocument/completion';
-    }
     // The widest position is a bare `\`: every root namespace plus every global
     // class-like. Cap the response and report isIncomplete so the client re-queries
     // as the prefix narrows, rather than shipping thousands of items.
@@ -53,6 +49,11 @@ final class CompletionHandler implements DocumentFeatureHandler
         private readonly NamedArgumentCandidates $namedArgumentCandidates,
         private readonly BuiltinTypeCandidates $builtinTypeCandidates,
     ) {
+    }
+
+    public function method(): string
+    {
+        return 'textDocument/completion';
     }
 
     public function supports(string $method): bool

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -32,6 +32,8 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  */
 final class CompletionHandler implements DocumentFeatureHandler
 {
+    use SupportsOwnMethod;
+
     // The widest position is a bare `\`: every root namespace plus every global
     // class-like. Cap the response and report isIncomplete so the client re-queries
     // as the prefix narrows, rather than shipping thousands of items.
@@ -54,11 +56,6 @@ final class CompletionHandler implements DocumentFeatureHandler
     public function method(): string
     {
         return 'textDocument/completion';
-    }
-
-    public function supports(string $method): bool
-    {
-        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/CompletionHandler.php
+++ b/src/Handler/CompletionHandler.php
@@ -30,8 +30,12 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
 /**
  * @phpstan-import-type CompletionItem from CompletionItemFactory
  */
-final class CompletionHandler implements HandlerInterface
+final class CompletionHandler implements DocumentFeatureHandler
 {
+    public function method(): string
+    {
+        return 'textDocument/completion';
+    }
     // The widest position is a bare `\`: every root namespace plus every global
     // class-like. Cap the response and report isIncomplete so the client re-queries
     // as the prefix narrows, rather than shipping thousands of items.
@@ -53,7 +57,7 @@ final class CompletionHandler implements HandlerInterface
 
     public function supports(string $method): bool
     {
-        return $method === 'textDocument/completion';
+        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -19,7 +19,7 @@ final class DefinitionHandler implements DocumentFeatureHandler
     ) {
     }
 
-    public function method(): string
+    public static function method(): string
     {
         return 'textDocument/definition';
     }

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -9,8 +9,12 @@ use Firehed\PhpLsp\Protocol\Message;
 use Firehed\PhpLsp\Protocol\TextDocumentPositionParams;
 use Firehed\PhpLsp\Resolution\CodeResolver;
 
-final class DefinitionHandler implements HandlerInterface
+final class DefinitionHandler implements DocumentFeatureHandler
 {
+    public function method(): string
+    {
+        return 'textDocument/definition';
+    }
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
@@ -19,7 +23,7 @@ final class DefinitionHandler implements HandlerInterface
 
     public function supports(string $method): bool
     {
-        return $method === 'textDocument/definition';
+        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -11,6 +11,8 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
 
 final class DefinitionHandler implements DocumentFeatureHandler
 {
+    use SupportsOwnMethod;
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
@@ -20,11 +22,6 @@ final class DefinitionHandler implements DocumentFeatureHandler
     public function method(): string
     {
         return 'textDocument/definition';
-    }
-
-    public function supports(string $method): bool
-    {
-        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/DefinitionHandler.php
+++ b/src/Handler/DefinitionHandler.php
@@ -11,14 +11,15 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
 
 final class DefinitionHandler implements DocumentFeatureHandler
 {
-    public function method(): string
-    {
-        return 'textDocument/definition';
-    }
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
     ) {
+    }
+
+    public function method(): string
+    {
+        return 'textDocument/definition';
     }
 
     public function supports(string $method): bool

--- a/src/Handler/DocumentFeatureHandler.php
+++ b/src/Handler/DocumentFeatureHandler.php
@@ -6,5 +6,5 @@ namespace Firehed\PhpLsp\Handler;
 
 interface DocumentFeatureHandler extends HandlerInterface
 {
-    public function method(): string;
+    public static function method(): string;
 }

--- a/src/Handler/DocumentFeatureHandler.php
+++ b/src/Handler/DocumentFeatureHandler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+interface DocumentFeatureHandler extends HandlerInterface
+{
+    public function method(): string;
+}

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -18,15 +18,16 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  */
 final class HoverHandler implements DocumentFeatureHandler
 {
-    public function method(): string
-    {
-        return 'textDocument/hover';
-    }
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
         private readonly SessionCapabilitiesProvider $capabilities,
     ) {
+    }
+
+    public function method(): string
+    {
+        return 'textDocument/hover';
     }
 
     public function supports(string $method): bool

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -18,6 +18,8 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  */
 final class HoverHandler implements DocumentFeatureHandler
 {
+    use SupportsOwnMethod;
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
@@ -28,11 +30,6 @@ final class HoverHandler implements DocumentFeatureHandler
     public function method(): string
     {
         return 'textDocument/hover';
-    }
-
-    public function supports(string $method): bool
-    {
-        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -16,8 +16,12 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
 /**
  * @phpstan-import-type LspMarkupContent from MarkupContent
  */
-final class HoverHandler implements HandlerInterface
+final class HoverHandler implements DocumentFeatureHandler
 {
+    public function method(): string
+    {
+        return 'textDocument/hover';
+    }
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
@@ -27,7 +31,7 @@ final class HoverHandler implements HandlerInterface
 
     public function supports(string $method): bool
     {
-        return $method === 'textDocument/hover';
+        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/HoverHandler.php
+++ b/src/Handler/HoverHandler.php
@@ -27,7 +27,7 @@ final class HoverHandler implements DocumentFeatureHandler
     ) {
     }
 
-    public function method(): string
+    public static function method(): string
     {
         return 'textDocument/hover';
     }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -18,8 +18,12 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  *   parameters?: list<ParameterInfoShape>,
  * }
  */
-final class SignatureHelpHandler implements HandlerInterface
+final class SignatureHelpHandler implements DocumentFeatureHandler
 {
+    public function method(): string
+    {
+        return 'textDocument/signatureHelp';
+    }
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
@@ -28,7 +32,7 @@ final class SignatureHelpHandler implements HandlerInterface
 
     public function supports(string $method): bool
     {
-        return $method === 'textDocument/signatureHelp';
+        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -20,6 +20,8 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  */
 final class SignatureHelpHandler implements DocumentFeatureHandler
 {
+    use SupportsOwnMethod;
+
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
@@ -29,11 +31,6 @@ final class SignatureHelpHandler implements DocumentFeatureHandler
     public function method(): string
     {
         return 'textDocument/signatureHelp';
-    }
-
-    public function supports(string $method): bool
-    {
-        return $method === $this->method();
     }
 
     /**

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -28,7 +28,7 @@ final class SignatureHelpHandler implements DocumentFeatureHandler
     ) {
     }
 
-    public function method(): string
+    public static function method(): string
     {
         return 'textDocument/signatureHelp';
     }

--- a/src/Handler/SignatureHelpHandler.php
+++ b/src/Handler/SignatureHelpHandler.php
@@ -20,14 +20,15 @@ use Firehed\PhpLsp\Resolution\CodeResolver;
  */
 final class SignatureHelpHandler implements DocumentFeatureHandler
 {
-    public function method(): string
-    {
-        return 'textDocument/signatureHelp';
-    }
     public function __construct(
         private readonly DocumentManager $documentManager,
         private readonly CodeResolver $codeResolver,
     ) {
+    }
+
+    public function method(): string
+    {
+        return 'textDocument/signatureHelp';
     }
 
     public function supports(string $method): bool

--- a/src/Handler/SupportsOwnMethod.php
+++ b/src/Handler/SupportsOwnMethod.php
@@ -8,6 +8,6 @@ trait SupportsOwnMethod
 {
     public function supports(string $method): bool
     {
-        return $method === $this->method();
+        return $method === static::method();
     }
 }

--- a/src/Handler/SupportsOwnMethod.php
+++ b/src/Handler/SupportsOwnMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Handler;
+
+trait SupportsOwnMethod
+{
+    public function supports(string $method): bool
+    {
+        return $method === $this->method();
+    }
+}

--- a/tests/Handler/FeatureMatrixTest.php
+++ b/tests/Handler/FeatureMatrixTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\PhpLsp\Tests\Handler;
+
+use Firehed\PhpLsp\Capability\SessionCapabilities;
+use Firehed\PhpLsp\Capability\SessionCapabilitiesProvider;
+use Firehed\PhpLsp\Completion\BuiltinTypeCandidates;
+use Firehed\PhpLsp\Completion\ClassCandidates;
+use Firehed\PhpLsp\Completion\FunctionCandidates;
+use Firehed\PhpLsp\Completion\KeywordCandidates;
+use Firehed\PhpLsp\Completion\MemberCandidates;
+use Firehed\PhpLsp\Completion\NamedArgumentCandidates;
+use Firehed\PhpLsp\Completion\NamespaceCandidates;
+use Firehed\PhpLsp\Completion\VariableCandidates;
+use Firehed\PhpLsp\Document\DocumentManager;
+use Firehed\PhpLsp\Handler\CompletionHandler;
+use Firehed\PhpLsp\Handler\DefinitionHandler;
+use Firehed\PhpLsp\Handler\DocumentFeatureHandler;
+use Firehed\PhpLsp\Handler\HoverHandler;
+use Firehed\PhpLsp\Handler\SignatureHelpHandler;
+use Firehed\PhpLsp\Handler\TextDocumentSyncHandler;
+use Firehed\PhpLsp\Index\ComposerAutoloadMap;
+use Firehed\PhpLsp\Knowledge\DeclarationScanner;
+use Firehed\PhpLsp\Knowledge\KnowledgeStack;
+use Firehed\PhpLsp\Parser\ParserService;
+use Firehed\PhpLsp\Protocol\RequestMessage;
+use Firehed\PhpLsp\Repository\DefaultFunctionRepository;
+use Firehed\PhpLsp\Repository\MemberResolver;
+use Firehed\PhpLsp\Resolution\SymbolResolver;
+use Firehed\PhpLsp\TypeInference\BasicTypeResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Feature-matrix grid: every fixture scenario against every feature handler.
+ *
+ * Rows are fixture scenarios (a fixture file and a cursor marker). Columns are
+ * the feature handlers, derived from all {@see DocumentFeatureHandler}
+ * implementations found in src/Handler/. Each cell either asserts the handler
+ * answers (returns a non-null, non-empty result) or is registered not-applicable
+ * with a named blocker. An unregistered cell that does not answer fails, and a
+ * registration on a cell that now answers fails.
+ *
+ * @phpstan-type CursorPosition array{uri: string, line: int, character: int}
+ */
+#[CoversClass(DefinitionHandler::class)]
+#[CoversClass(HoverHandler::class)]
+#[CoversClass(SignatureHelpHandler::class)]
+#[CoversClass(CompletionHandler::class)]
+final class FeatureMatrixTest extends TestCase
+{
+    use OpensDocumentsTrait;
+
+    private const string UNOWNED_BLOCKER = '/^(#\d+|(RFC 1|Plan 0002) §\d+(\.\d+)*)$/u';
+
+    /**
+     * Cells the current stack cannot answer. Keyed `<fixture>|<marker>|<handler>`.
+     *
+     * @var array<string, string>
+     */
+    private const array NOT_APPLICABLE = [
+    ];
+
+    /**
+     * Each row is [fixture path relative to tests/Fixtures/, hover marker name].
+     *
+     * @var list<array{string, string}>
+     */
+    private const array SCENARIOS = [
+        ['src/Domain/User.php', 'setName'],
+        ['src/Domain/User.php', 'create'],
+        ['src/Domain/User.php', 'markCreated'],
+    ];
+
+    /** @var array<string, DocumentFeatureHandler> */
+    private array $handlers;
+
+    private TextDocumentSyncHandler $syncHandler;
+
+    protected function setUp(): void
+    {
+        $documents = new DocumentManager();
+        $parser = new ParserService();
+
+        $fixturesRoot = __DIR__ . '/../Fixtures';
+        $knowledge = KnowledgeStack::forProject(
+            ComposerAutoloadMap::fromProjectRoot($fixturesRoot),
+            $fixturesRoot . '/vendor',
+            $parser,
+        );
+
+        $memberResolver = new MemberResolver($knowledge->source);
+        $functionRepo = new DefaultFunctionRepository(new DeclarationScanner());
+        $typeResolver = new BasicTypeResolver($memberResolver, $functionRepo);
+
+        $symbolResolver = new SymbolResolver(
+            $parser,
+            $knowledge->source,
+            $memberResolver,
+            $typeResolver,
+            $functionRepo,
+            new DeclarationScanner(),
+        );
+
+        $capabilities = self::createStub(SessionCapabilitiesProvider::class);
+        $capabilities->method('getSessionCapabilities')
+            ->willReturn(new SessionCapabilities());
+
+        $this->handlers = [
+            DefinitionHandler::class => new DefinitionHandler($documents, $symbolResolver),
+            HoverHandler::class => new HoverHandler($documents, $symbolResolver, $capabilities),
+            SignatureHelpHandler::class => new SignatureHelpHandler($documents, $symbolResolver),
+            CompletionHandler::class => new CompletionHandler(
+                $documents,
+                $symbolResolver,
+                new ClassCandidates($knowledge->source, $symbolResolver, $capabilities),
+                new NamespaceCandidates($knowledge->source, $symbolResolver, $capabilities),
+                new FunctionCandidates($symbolResolver, $capabilities),
+                new KeywordCandidates(),
+                new VariableCandidates($symbolResolver),
+                new MemberCandidates($symbolResolver, $capabilities),
+                new NamedArgumentCandidates(),
+                new BuiltinTypeCandidates(),
+            ),
+        ];
+
+        $this->syncHandler = new TextDocumentSyncHandler($documents, $knowledge->sink);
+    }
+
+    public function testEveryCellAnswersOrNamesItsBlocker(): void
+    {
+        ['unregistered' => $unregistered, 'stale' => $stale] = $this->evaluate(self::NOT_APPLICABLE);
+
+        self::assertSame(
+            [],
+            $unregistered,
+            'every scenario × handler cell must answer or be registered not-applicable with a named blocker',
+        );
+        self::assertSame(
+            [],
+            $stale,
+            'a cell that now answers must lose its not-applicable registration',
+        );
+    }
+
+    public function testAnUnregisteredCellIsReported(): void
+    {
+        ['unregistered' => $unregistered] = $this->evaluate([]);
+
+        $registered = array_keys(self::NOT_APPLICABLE);
+        sort($registered);
+        sort($unregistered);
+
+        self::assertSame(
+            $registered,
+            $unregistered,
+            'the cells that cannot be answered must be exactly the ones registered',
+        );
+    }
+
+    public function testARegistrationThatNoLongerBlocksIsReported(): void
+    {
+        $scenario = self::SCENARIOS[0];
+        $handlerName = $this->handlerName(array_values($this->handlers)[0]);
+        $answering = "{$scenario[0]}|{$scenario[1]}|{$handlerName}";
+        ['stale' => $stale] = $this->evaluate([$answering => 'a blocker that no longer applies']);
+
+        self::assertContains(
+            $answering . ' (registered against a blocker that no longer applies)',
+            $stale,
+            'a registration on a cell that answers must be reported as stale',
+        );
+    }
+
+    public function testEveryRegistrationNamesALiveBlocker(): void
+    {
+        self::assertSame(
+            [],
+            self::danglingBlockers(self::NOT_APPLICABLE),
+            'a not-applicable cell must name a step, an issue, or an RFC section',
+        );
+    }
+
+    public function testABlockerNamingNoSliceIsReported(): void
+    {
+        self::assertSame(
+            ['x|y|z names S9.99'],
+            self::danglingBlockers(['x|y|z' => 'S9.99']),
+            'a blocker matching no registry row, issue, or section must be reported',
+        );
+    }
+
+    public function testEveryFeatureHandlerHasAGridColumn(): void
+    {
+        $implementations = self::discoverImplementations();
+        $inGrid = array_keys($this->handlers);
+
+        sort($implementations);
+        sort($inGrid);
+
+        self::assertSame(
+            $implementations,
+            $inGrid,
+            'every DocumentFeatureHandler in src/Handler/ must be a column in the grid',
+        );
+    }
+
+    /**
+     * @param array<string, string> $notApplicable
+     * @return array{unregistered: list<string>, stale: list<string>}
+     */
+    private function evaluate(array $notApplicable): array
+    {
+        $unregistered = [];
+        $stale = [];
+
+        foreach (self::SCENARIOS as [$fixture, $marker]) {
+            $cursor = $this->openFixtureAtHoverMarker($fixture, $marker);
+
+            foreach ($this->handlers as $handler) {
+                $cell = "{$fixture}|{$marker}|{$this->handlerName($handler)}";
+                $answered = $this->answers($handler, $cursor);
+
+                if (!$answered && !array_key_exists($cell, $notApplicable)) {
+                    $unregistered[] = $cell;
+                }
+                if ($answered && array_key_exists($cell, $notApplicable)) {
+                    $stale[] = $cell . ' (registered against ' . $notApplicable[$cell] . ')';
+                }
+            }
+        }
+
+        return ['unregistered' => $unregistered, 'stale' => $stale];
+    }
+
+    /**
+     * @param CursorPosition $cursor
+     */
+    private function answers(DocumentFeatureHandler $handler, array $cursor): bool
+    {
+        $request = RequestMessage::fromArray([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => $handler->method(),
+            'params' => [
+                'textDocument' => ['uri' => $cursor['uri']],
+                'position' => ['line' => $cursor['line'], 'character' => $cursor['character']],
+            ],
+        ]);
+
+        $result = $handler->handle($request);
+
+        if ($result === null) {
+            return false;
+        }
+
+        if (is_array($result) && array_key_exists('items', $result)) {
+            return $result['items'] !== [];
+        }
+
+        return true;
+    }
+
+    private function handlerName(DocumentFeatureHandler $handler): string
+    {
+        $parts = explode('\\', $handler::class);
+        return end($parts);
+    }
+
+    /**
+     * @return list<class-string<DocumentFeatureHandler>>
+     */
+    private static function discoverImplementations(): array
+    {
+        $dir = new \DirectoryIterator(dirname(__DIR__, 2) . '/src/Handler');
+        $implementations = [];
+        foreach ($dir as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+            /** @var class-string */
+            $class = 'Firehed\\PhpLsp\\Handler\\' . $file->getBasename('.php');
+            if (class_exists($class) && is_a($class, DocumentFeatureHandler::class, true)) {
+                $implementations[] = $class;
+            }
+        }
+        sort($implementations);
+        return $implementations;
+    }
+
+    /**
+     * @param array<string, string> $notApplicable
+     * @return list<string>
+     */
+    private static function danglingBlockers(array $notApplicable): array
+    {
+        $slices = self::sliceIds();
+        $dangling = [];
+
+        foreach ($notApplicable as $cell => $blocker) {
+            foreach (explode(', ', $blocker) as $named) {
+                if (in_array($named, $slices, true) || preg_match(self::UNOWNED_BLOCKER, $named) === 1) {
+                    continue;
+                }
+                $dangling[] = "{$cell} names {$named}";
+            }
+        }
+
+        return $dangling;
+    }
+
+    /** @return list<string> */
+    private static function sliceIds(): array
+    {
+        $manifest = file_get_contents(dirname(__DIR__, 2) . '/docs/architecture/build-manifest.md');
+        self::assertNotFalse($manifest, 'the slice registry must be readable');
+
+        preg_match_all('/^- \[[ x]\] \*\*([a-z0-9-]+)\*\*/m', $manifest, $matches);
+        self::assertNotEmpty($matches[1], 'the slice list must be parseable');
+
+        return $matches[1];
+    }
+}

--- a/tests/Handler/FeatureMatrixTest.php
+++ b/tests/Handler/FeatureMatrixTest.php
@@ -243,7 +243,7 @@ final class FeatureMatrixTest extends TestCase
         $request = RequestMessage::fromArray([
             'jsonrpc' => '2.0',
             'id' => 1,
-            'method' => $handler->method(),
+            'method' => $handler::method(),
             'params' => [
                 'textDocument' => ['uri' => $cursor['uri']],
                 'position' => ['line' => $cursor['line'], 'character' => $cursor['character']],


### PR DESCRIPTION
## Done

- [x] The grid runs in `composer test` — `FeatureMatrixTest::testEveryCellAnswersOrNamesItsBlocker`
- [x] The handler axis is derived — `testEveryFeatureHandlerHasAGridColumn` scans `src/Handler/` with `DocumentFeatureHandler` as the marker interface
- [x] Adding a fixture scenario with no registration fails — `testAnUnregisteredCellIsReported`
- [x] Every not-applicable registration names a live blocker — `testEveryRegistrationNamesALiveBlocker`

Closes #445
